### PR TITLE
chore: Remove the network DKG checks when filtering the ready to advance sessions

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -411,7 +411,6 @@ impl DWalletMPCManager {
     fn get_ready_to_advance_sessions(
         &mut self,
     ) -> DwalletMPCResult<(Vec<DWalletMPCSession>, Vec<PartyID>)> {
-        let is_manager_ready = self.is_manager_ready();
         let quorum_check_results: Vec<(DWalletMPCSession, Vec<PartyID>)> = self
             .mpc_sessions
             .iter_mut()
@@ -419,9 +418,8 @@ impl DWalletMPCManager {
                 // The manager must hold a Network key to advance.
                 // The only exception is if this is the DKG session
                 // that creates and initializes this key for the first time.
-                let is_network_dkg_tx = Self::is_network_dkg_tx(&session);
                 let quorum_check_result = session.check_quorum_for_next_crypto_round();
-                if quorum_check_result.is_ready && (is_manager_ready || is_network_dkg_tx) {
+                if quorum_check_result.is_ready {
                     // We must first clone the session, as we approve to advance the current session
                     // in the current round and then start waiting for the next round's messages
                     // until it is ready to advance or finalized.
@@ -615,23 +613,6 @@ impl DWalletMPCManager {
             )?;
         }
         Ok(())
-    }
-
-    fn is_manager_ready(&self) -> bool {
-        let mpc_network_key_status = DwalletMPCNetworkKeysStatus::Ready(HashSet::new());
-        !cfg!(feature = "with-network-dkg")
-            || matches!(
-                mpc_network_key_status,
-                // Todo (#394): Check if the current relevant key version exist
-                DwalletMPCNetworkKeysStatus::Ready(_)
-            )
-    }
-
-    fn is_network_dkg_tx(session: &DWalletMPCSession) -> bool {
-        matches!(
-            session.session_info.mpc_round,
-            MPCProtocolInitData::NetworkDkg(..)
-        )
     }
 
     /// Returns the epoch store.

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -415,9 +415,6 @@ impl DWalletMPCManager {
             .mpc_sessions
             .iter_mut()
             .filter_map(|(_, ref mut session)| {
-                // The manager must hold a Network key to advance.
-                // The only exception is if this is the DKG session
-                // that creates and initializes this key for the first time.
                 let quorum_check_result = session.check_quorum_for_next_crypto_round();
                 if quorum_check_result.is_ready {
                     // We must first clone the session, as we approve to advance the current session


### PR DESCRIPTION
In the new code Omer moved those checks to the Move code, so checking this again in the Rust code is redundant.