### PR TITLE
fix: Increase the node Tokio thread pool size

### DIFF
--- a/crates/ika-core/src/runtime.rs
+++ b/crates/ika-core/src/runtime.rs
@@ -12,7 +12,7 @@ pub struct IkaRuntimes {
     pub metrics: Runtime,
 }
 
-const IKA_NODE_TOKIO_ALLOCATED_THREADS: usize = 16;
+const IKA_NODE_TOKIO_ALLOCATED_THREADS: usize = 4;
 const METRICS_TOKIO_ALLOCATED_THREADS: usize = 2;
 
 impl IkaRuntimes {

--- a/crates/ika-core/src/runtime.rs
+++ b/crates/ika-core/src/runtime.rs
@@ -47,7 +47,7 @@ pub fn get_rayon_thread_pool_size() -> DwalletMPCResult<usize> {
     if tokio_threads + 1 >= available_cores_for_computations {
         warn!(
             ?available_cores_for_computations,
-            "there are not enough logical cores for the Tokio thread pool; time slicing with the Rayon thread pool may cause unexpected behaviour"
+            "there are not enough logical cores for the Rayon thread pool; time slicing with the Tokio thread pool may cause unexpected behaviour"
         );
         return Ok(1);
     }


### PR DESCRIPTION
The current thread pool size (1) is way to small, and causes the consensus mechanism to stuck