### PR TITLE
chore: Read Sui events from Typescript by module instead of time range

### DIFF
--- a/sdk/typescript/src/dwallet-mpc/globals.ts
+++ b/sdk/typescript/src/dwallet-mpc/globals.ts
@@ -239,7 +239,6 @@ export async function fetchCompletedEvent<TEvent extends { session_id: string }>
 	eventType: string = '',
 ): Promise<TEvent> {
 	const startTime = Date.now();
-
 	while (Date.now() - startTime <= c.timeout) {
 		// Wait for a bit before polling again, objects might not be available immediately.
 		const interval = 500;
@@ -247,14 +246,13 @@ export async function fetchCompletedEvent<TEvent extends { session_id: string }>
 
 		const { data } = await c.client.queryEvents({
 			query: {
-				TimeRange: {
-					startTime: (Date.now() - interval * 4).toString(),
-					endTime: Date.now().toString(),
+				MoveModule: {
+					module: DWALLET_ECDSA_K1_MOVE_MODULE_NAME,
+					package: c.ikaConfig.ika_system_package_id,
 				},
 			},
 			limit: 1000,
 		});
-
 		const match = data.find(
 			(event) =>
 				(event.type === eventType || !eventType) &&


### PR DESCRIPTION
This update improves efficiency by subscribing to events from specific modules rather than listening to all Sui events across a time range.