### PR TITLE
chore: Cache network key in TS sdk

### DIFF
--- a/sdk/typescript/src/dwallet-mpc/globals.ts
+++ b/sdk/typescript/src/dwallet-mpc/globals.ts
@@ -1,13 +1,8 @@
-;
 // Copyright (c) dWallet Labs, Inc.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 import * as fs from 'node:fs';
 import type { SuiClient } from '@mysten/sui/client';
 import type { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
-
-
-
-
 
 export const DWALLET_COORDINATOR_MOVE_MODULE_NAME = 'dwallet_2pc_mpc_coordinator';
 export const DWALLET_COORDINATOR_INNER_MOVE_MODULE_NAME = 'dwallet_2pc_mpc_coordinator_inner';


### PR DESCRIPTION
speeds up subsequent calls as there's no need to re-load the large network key from Sui every time