### PR TITLE
chore: Use the correct timestamp when constructing a checkpoint

### DIFF
--- a/crates/ika-core/src/dwallet_checkpoints/mod.rs
+++ b/crates/ika-core/src/dwallet_checkpoints/mod.rs
@@ -542,7 +542,7 @@ impl DWalletCheckpointBuilder {
         // Stores the transactions that should be included in the checkpoint. Transactions will be recorded in the checkpoint
         // in this order.
         let mut sorted_tx_effects_included_in_checkpoint = Vec::new();
-        let next = next_checkpoint_to_build.into_v1();
+        let next = next_checkpoint_to_build.clone().into_v1();
         // let txn_in_checkpoint = self
         //     .resolve_checkpoint_transactions(pending.roots, &mut effects_in_current_checkpoint)
         //     .await?;

--- a/crates/ika-core/src/dwallet_checkpoints/mod.rs
+++ b/crates/ika-core/src/dwallet_checkpoints/mod.rs
@@ -548,10 +548,16 @@ impl DWalletCheckpointBuilder {
         //     .await?;
         sorted_tx_effects_included_in_checkpoint.extend(next.messages);
         let new_checkpoint = self
-            .create_checkpoints(sorted_tx_effects_included_in_checkpoint, &next_checkpoint_to_build.details())
+            .create_checkpoints(
+                sorted_tx_effects_included_in_checkpoint,
+                &next_checkpoint_to_build.details(),
+            )
             .await?;
-        self.write_checkpoints(next_checkpoint_to_build.details().checkpoint_height, new_checkpoint)
-            .await?;
+        self.write_checkpoints(
+            next_checkpoint_to_build.details().checkpoint_height,
+            new_checkpoint,
+        )
+        .await?;
         Ok(())
     }
 


### PR DESCRIPTION
Until now the timestamp of the last pending checkpoint stored to the local DB was used for the new checkpoint, but this timestamp can be the timestamp of a future, different checkpoint. This PR mitigates this issue by changing the `make_checkpoint` function to make one checkpoint at a time, and use its timestamp.