### PR TITLE
fix: Handle reading of MPC network key reconfiguration output

### DIFF
--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -270,7 +270,9 @@ where
                         continue 'sync_network_keys;
                     }
                     Err(err) => {
-                        warn!(
+                        // DO NOT CHANGE THIS TO WARNING!
+                        // THIS IS A CRITICAL ERROR IN SOME CASES!
+                        error!(
                             key=?key_id,
                             err=?err,
                             "failed to get network decryption key data, retrying...",

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -1047,7 +1047,11 @@ impl SuiClientInner for SuiSdkClient {
             || key.state
                 == (DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration {
                     is_first: true,
-                }) {
+                })
+            || (key.reconfiguration_public_outputs.size == 1
+                && key.state
+                    == DWalletNetworkEncryptionKeyState::AwaitingNextEpochToUpdateReconfiguration)
+        {
             info!(
                 key_id = ?key.id,
                 epoch = ?key.current_epoch,

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -1047,9 +1047,10 @@ impl SuiClientInner for SuiSdkClient {
         // until the epoch is switched, since it will be endlessly waiting for the network key.
         // Warning: If we change the Move contract in the future to delete the reconfiguration outputs,
         // this function will error again.
-        let first_reconfiguration_was_completed = key.reconfiguration_public_outputs.size == 1
-            && key.state
-                == DWalletNetworkEncryptionKeyState::AwaitingNextEpochToUpdateReconfiguration;
+        let first_reconfiguration_for_next_epoch_was_completed =
+            key.reconfiguration_public_outputs.size == 1
+                && key.state
+                    == DWalletNetworkEncryptionKeyState::AwaitingNextEpochToUpdateReconfiguration;
         let awaiting_first_reconfiguration_to_complete = key.state
             == (DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration {
                 is_first: true,
@@ -1061,7 +1062,7 @@ impl SuiClientInner for SuiSdkClient {
             || key.state == DWalletNetworkEncryptionKeyState::AwaitingNetworkDKG
             || key.state == DWalletNetworkEncryptionKeyState::NetworkDKGCompleted
             || awaiting_first_reconfiguration_to_complete
-            || first_reconfiguration_was_completed
+            || first_reconfiguration_for_next_epoch_was_completed
         {
             info!(
                 key_id = ?key.id,

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -1041,23 +1041,33 @@ impl SuiClientInner for SuiSdkClient {
             .read_table_vec_as_raw_bytes(key.network_dkg_public_output.contents.id)
             .await?;
 
-        let current_reconfiguration_public_output = if key.reconfiguration_public_outputs.size == 0
+        // Note that if we try to read the reconfiguration public output during the first epoch,
+        // where we only had NetworkDKG, this function will error.
+        // In this case, the validator will be stuck in a loop where it can't process events
+        // until the epoch is switched, since it will be endlessly waiting for the network key.
+        // Warning: If we change the Move contract in the future to delete the reconfiguration outputs,
+        // this function will error again.
+        let first_reconfiguration_was_completed = key.reconfiguration_public_outputs.size == 1
+            && key.state
+                == DWalletNetworkEncryptionKeyState::AwaitingNextEpochToUpdateReconfiguration;
+        let awaiting_first_reconfiguration_to_complete = key.state
+            == (DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration {
+                is_first: true,
+            });
+        let no_reconfiguration_key_data = key.reconfiguration_public_outputs.size == 0;
+        let mut current_reconfiguration_public_output = vec![];
+
+        if no_reconfiguration_key_data
             || key.state == DWalletNetworkEncryptionKeyState::AwaitingNetworkDKG
             || key.state == DWalletNetworkEncryptionKeyState::NetworkDKGCompleted
-            || key.state
-                == (DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration {
-                    is_first: true,
-                })
-            || (key.reconfiguration_public_outputs.size == 1
-                && key.state
-                    == DWalletNetworkEncryptionKeyState::AwaitingNextEpochToUpdateReconfiguration)
+            || awaiting_first_reconfiguration_to_complete
+            || first_reconfiguration_was_completed
         {
             info!(
                 key_id = ?key.id,
                 epoch = ?key.current_epoch,
                 "Reconfiguration public output for key not is not ready for epoch",
             );
-            vec![]
         } else {
             let current_reconfiguration_public_output_id = self
                 .get_current_reconfiguration_public_output(
@@ -1065,9 +1075,9 @@ impl SuiClientInner for SuiSdkClient {
                     key.reconfiguration_public_outputs.id,
                 )
                 .await?;
-
-            self.read_table_vec_as_raw_bytes(current_reconfiguration_public_output_id)
-                .await?
+            current_reconfiguration_public_output = self
+                .read_table_vec_as_raw_bytes(current_reconfiguration_public_output_id)
+                .await?;
         };
 
         Ok(DWalletNetworkDecryptionKeyData {

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -753,6 +753,7 @@ pub struct DWalletNetworkDecryptionKeyData {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DWalletNetworkEncryptionKeyState {
     AwaitingNetworkDKG,
+    // Network DKG is completed, but we didn't do Reconfiguration yet.
     NetworkDKGCompleted,
     /// Reconfiguration request was sent to the network, but didn't finish yet.
     /// `is_first` is true if this is the first reconfiguration request, false otherwise.


### PR DESCRIPTION
If a validator started running after the first network MPC key reconfiguration output had been written, it would consistently fail to read the key. As a result, it could never start an MPC session, because the session would remain permanently pending on the network key.