### PR TITLE
fix: Remove redundant dynamic fields fetching logic while fetching class groups keys

### DIFF
--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -334,7 +334,7 @@ where
 
                 let validators = self
                     .inner
-                    .get_validators_from_object_table(validator_ids)
+                    .get_validators(validator_ids)
                     .await
                     .map_err(|e| {
                         IkaError::SuiClientInternalError(format!(
@@ -421,7 +421,7 @@ where
     ) -> Result<Vec<StakingPool>, IkaError> {
         let validators = self
             .inner
-            .get_validators_from_object_table(validator_ids)
+            .get_validators(validator_ids)
             .await
             .map_err(|e| {
                 IkaError::SuiClientInternalError(format!(
@@ -784,7 +784,7 @@ pub trait SuiClientInner: Send + Sync {
         version: u64,
     ) -> Result<Vec<u8>, Self::Error>;
 
-    async fn get_validators_from_object_table(
+    async fn get_validators(
         &self,
         validator_ids: Vec<ObjectID>,
     ) -> Result<Vec<Vec<u8>>, Self::Error>;
@@ -1301,7 +1301,7 @@ impl SuiClientInner for SuiSdkClient {
         )))
     }
 
-    async fn get_validators_from_object_table(
+    async fn get_validators(
         &self,
         validator_ids: Vec<ObjectID>,
     ) -> Result<Vec<Vec<u8>>, Self::Error> {

--- a/crates/ika/src/ika_commands.rs
+++ b/crates/ika/src/ika_commands.rs
@@ -23,7 +23,7 @@ use tokio::runtime::Runtime;
 use tracing::info;
 
 // 24 Hours.
-const DEFAULT_EPOCH_DURATION_MS: u64 = 1000 * 60 * 2;
+const DEFAULT_EPOCH_DURATION_MS: u64 = 1000 * 60 * 60 * 24;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Parser)]


### PR DESCRIPTION
Until now all the validator's object dynamic fields has been fetched from Sui while fetching the validators, without any clear reason. This pr removes this redundant logic