### PR TITLE
fix: Make `party_id_to_authority_name` not panic on zero input

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -96,6 +96,10 @@ pub(crate) fn party_id_to_authority_name(
     party_id: PartyID,
     committee: &Committee,
 ) -> Option<AuthorityName> {
+    if party_id == 0 {
+        // Party IDs are 1-based, so 0 is not a valid party ID.
+        return None;
+    }
     // A tangible party ID is of type `PartyID` and in the range `1..=number_of_tangible_parties`.
     // Convert it to an index to the committee authority names, which is in the range `0..number_of_tangible_parties`,
     // Decrement the index to transform it from 1-based to 0-based.
@@ -129,10 +133,8 @@ pub(crate) fn party_ids_to_authority_names(
 
 mod tests {
     use super::*;
-    use fastcrypto::bls12381::min_sig::BLS12381PublicKey;
-    use fastcrypto::traits::{KeyPair, ToFromBytes};
+    use fastcrypto::traits::KeyPair;
     use ika_types::crypto::AuthorityPublicKeyBytes;
-    use std::collections::BTreeMap;
 
     #[test]
     fn test_party_id_to_authority_name() {
@@ -162,5 +164,12 @@ mod tests {
                 keypairs[3].public().pubkey.to_bytes()
             ))
         );
+    }
+
+    #[test]
+    fn test_party_id_to_authority_name_not_existing_party() {
+        let (committee, _keypairs) = Committee::new_simple_test_committee();
+
+        assert_eq!(party_id_to_authority_name(0, &committee), None);
     }
 }

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -126,3 +126,41 @@ pub(crate) fn party_ids_to_authority_names(
         })
         .collect()
 }
+
+mod tests {
+    use super::*;
+    use fastcrypto::bls12381::min_sig::BLS12381PublicKey;
+    use fastcrypto::traits::{KeyPair, ToFromBytes};
+    use ika_types::crypto::AuthorityPublicKeyBytes;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_party_id_to_authority_name() {
+        let (committee, keypairs) = Committee::new_simple_test_committee();
+
+        assert_eq!(
+            party_id_to_authority_name(1, &committee),
+            Some(AuthorityPublicKeyBytes::new(
+                keypairs[0].public().pubkey.to_bytes()
+            ))
+        );
+        assert_eq!(
+            party_id_to_authority_name(2, &committee),
+            Some(AuthorityPublicKeyBytes::new(
+                keypairs[1].public().pubkey.to_bytes()
+            ))
+        );
+        assert_eq!(
+            party_id_to_authority_name(3, &committee),
+            Some(AuthorityPublicKeyBytes::new(
+                keypairs[2].public().pubkey.to_bytes()
+            ))
+        );
+        assert_eq!(
+            party_id_to_authority_name(4, &committee),
+            Some(AuthorityPublicKeyBytes::new(
+                keypairs[3].public().pubkey.to_bytes()
+            ))
+        );
+    }
+}

--- a/crates/ika-types/src/committee.rs
+++ b/crates/ika-types/src/committee.rs
@@ -89,10 +89,10 @@ impl Committee {
     /// of the Ika System object.
     pub fn new_for_testing_with_normalized_voting_power(
         epoch: EpochId,
-        mut voting_weights: BTreeMap<AuthorityName, StakeUnit>,
+        mut voting_weights: Vec<(AuthorityName, StakeUnit)>,
     ) -> Self {
         let num_nodes = voting_weights.len();
-        let total_votes: StakeUnit = voting_weights.values().cloned().sum();
+        let total_votes: StakeUnit = voting_weights.iter().map(|(_, stake)| stake).sum();
 
         let normalization_coef = num_nodes as f64 / total_votes as f64;
         let mut total_sum = 0;


### PR DESCRIPTION
## Description 

I added some unit tests to the `party_id_to_authority_name` function, and while working on them I find that bug & fixed it.

## Test plan 

I ran the unit tests I introduced in this PR.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
