### PR TITLE
closes #1229 and #1137 and #1320

### DIFF
--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -254,9 +254,9 @@ where
                             key=?key_id,
                             current_epoch=?current_epoch,
                             error=?err,
-                            "failed to get network decryption key data, retrying...",
+                            "failed to get network decryption key data, skipping key",
                         );
-                        continue 'sync_network_keys;
+                        continue;
                     }
                 }
             }


### PR DESCRIPTION
Skips bad key instead of retrying added proper syntax. Closes #1229
Replace agreed protocol logic with persistent consensus rounds closes #1137
Allow running all MPC flows with given coin IDs closes #1320
