### PR TITLE
fix: Stop fetching only the last network key when multiple keys are present

### DIFF
--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -221,7 +221,13 @@ where
                 network_encryption_keys
                     .into_iter()
                     .filter(|(id, key)| {
-                        key.state != DWalletNetworkEncryptionKeyState::AwaitingNetworkDKG
+                        if let Some(last_fetched_epoch) = last_fetched_network_keys.get(id) {
+                            // If the key is cached, check if it is in the awaiting state.
+                            current_epoch > *last_fetched_epoch
+                        } else {
+                            // If the key is not cached, we need to fetch it.
+                            key.state != DWalletNetworkEncryptionKeyState::AwaitingNetworkDKG
+                        }
                     })
                     .collect();
 
@@ -229,8 +235,7 @@ where
                 info!("No new network keys to fetch");
                 continue;
             }
-
-            let mut all_fetched_network_keys_data = HashMap::new();
+            let mut all_fetched_network_keys_data: HashMap<_, _> = (*network_keys_sender.borrow().clone()).clone();
             for (key_id, network_dec_key_shares) in keys_to_fetch.into_iter() {
                 match sui_client
                     .get_network_encryption_key_with_full_data_by_epoch(

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -221,13 +221,7 @@ where
                 network_encryption_keys
                     .into_iter()
                     .filter(|(id, key)| {
-                        if let Some(last_fetched_epoch) = last_fetched_network_keys.get(id) {
-                            // If the key is cached, check if it is in the awaiting state.
-                            current_epoch > *last_fetched_epoch
-                        } else {
-                            // If the key is not cached, we need to fetch it.
-                            key.state != DWalletNetworkEncryptionKeyState::AwaitingNetworkDKG
-                        }
+                        key.state != DWalletNetworkEncryptionKeyState::AwaitingNetworkDKG
                     })
                     .collect();
 

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -235,7 +235,8 @@ where
                 info!("No new network keys to fetch");
                 continue;
             }
-            let mut all_fetched_network_keys_data: HashMap<_, _> = (*network_keys_sender.borrow().clone()).clone();
+            let mut all_fetched_network_keys_data: HashMap<_, _> =
+                (*network_keys_sender.borrow().clone()).clone();
             for (key_id, network_dec_key_shares) in keys_to_fetch.into_iter() {
                 match sui_client
                     .get_network_encryption_key_with_full_data_by_epoch(

--- a/sdk/typescript/test/e2e/dwallet-mpc.test.ts
+++ b/sdk/typescript/test/e2e/dwallet-mpc.test.ts
@@ -360,12 +360,12 @@ describe('Test dWallet MPC', () => {
 
 	it('should create a network key', async () => {
 		const publisherMnemonic =
-			'invest cram swamp please luggage century include pill empty kid glove armed';
+			'whisper afford shoulder vintage seed kangaroo rifle coil because weasel gospel similar';
 		const keypair: Ed25519Keypair = Ed25519Keypair.deriveKeypair(publisherMnemonic);
 		conf.suiClientKeypair = keypair;
 		await createNetworkKey(
 			conf,
-			'0x9211a67b5c11271146c9fa886d87b9a597641f40e0a34198321515a6e856f5a5',
+			'0x4eed37337544635334398828075b8e18c37d521b8267114d08fd09604d5519fa',
 		);
 		console.log(keypair.toSuiAddress());
 	});

--- a/sdk/typescript/test/e2e/dwallet-mpc.test.ts
+++ b/sdk/typescript/test/e2e/dwallet-mpc.test.ts
@@ -360,12 +360,12 @@ describe('Test dWallet MPC', () => {
 
 	it('should create a network key', async () => {
 		const publisherMnemonic =
-			'whisper afford shoulder vintage seed kangaroo rifle coil because weasel gospel similar';
+			'invest cram swamp please luggage century include pill empty kid glove armed';
 		const keypair: Ed25519Keypair = Ed25519Keypair.deriveKeypair(publisherMnemonic);
 		conf.suiClientKeypair = keypair;
 		await createNetworkKey(
 			conf,
-			'0x4eed37337544635334398828075b8e18c37d521b8267114d08fd09604d5519fa',
+			'0x9211a67b5c11271146c9fa886d87b9a597641f40e0a34198321515a6e856f5a5',
 		);
 		console.log(keypair.toSuiAddress());
 	});


### PR DESCRIPTION
## Description 

Until now, when the network had more than one network key, only the last one that completed DKG was fetched by the network syncer. This occurred due to a bug in the key caching system — only new keys were fetched, but instead of continuing to send already-fetched keys to the channel, they were dropped. This PR mitigates the issue by building the all-keys map from the existing keys, rather than reconstructing it from scratch as was previously done.

## Test plan 

I ran the chain and let it complete multiple reconfigurations with multiple network keys. Previously, when more than one key was present, the network stopped switching epochs. This PR fixes that issue.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
