### PR TITLE
Test: Add an integration test in which one N parties behave maliciously #1385

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -190,6 +190,10 @@ impl DWalletMPCService {
         }
     }
 
+    pub(crate) fn dwallet_mpc_manager(&self) -> &DWalletMPCManager {
+        &self.dwallet_mpc_manager
+    }
+
     async fn sync_last_session_to_complete_in_current_epoch(&mut self) {
         let (ika_current_epoch_on_sui, last_session_to_complete_in_current_epoch) = self
             .sui_data_receivers

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/malicious_behavior.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/malicious_behavior.rs
@@ -1,0 +1,117 @@
+use crate::dwallet_mpc::integration_tests::utils;
+use ika_types::committee::Committee;
+use ika_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
+use ika_types::messages_dwallet_mpc::{
+    DBSuiEvent, DWalletNetworkDKGEncryptionKeyRequestEvent, DWalletSessionEvent,
+    DWalletSessionEventTrait, IkaNetworkConfig,
+};
+use tracing::info;
+
+#[tokio::test]
+#[cfg(test)]
+async fn test_some_malicious_validators_flows_succeed() {
+    let committee_size = 7;
+    let malicious_parties = [1, 2];
+
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (committee, _) = Committee::new_simple_test_committee();
+    assert!(
+        committee_size - malicious_parties.len() > committee.quorum_threshold as usize,
+        "There should be a quorum of honest parties for the flow to succeed"
+    );
+    let ika_network_config = IkaNetworkConfig::new_for_testing();
+    let epoch_id = 1;
+    let (
+        mut dwallet_mpc_services,
+        sui_data_senders,
+        mut sent_consensus_messages_collectors,
+        mut epoch_stores,
+        mut notify_services,
+    ) = utils::create_dwallet_mpc_services(committee_size);
+    sui_data_senders.iter().for_each(|mut sui_data_sender| {
+        let _ = sui_data_sender.uncompleted_events_sender.send((
+            vec![DBSuiEvent {
+                type_: DWalletSessionEvent::<DWalletNetworkDKGEncryptionKeyRequestEvent>::type_(
+                    &ika_network_config,
+                ),
+                // The base64 encoding of an actual start network DKG event.
+                contents: base64::decode("Z7MmXd0I4lvGWLDA969YOVo7wrZlXr21RMvixIFabCqAU3voWC2pRFG3QwPYD+ta0sX5poLEkq77ovCi3BBQDgEAAAAAAAAAgFN76FgtqURRt0MD2A/rWtLF+aaCxJKu+6LwotwQUA4BAQAAAAAAAAAggZwXRQsb/ha4mk5xZZfqItaokplduZGMnsuEQzdm7UTt2Z+ktotfGXHn2YVaxxqVhDM8UaafXejIDXnaPLxaMAA=").unwrap(),
+                pulled: true,
+            }],
+            epoch_id,
+        ));
+    });
+    let mut mpc_round = 1;
+    utils::advance_all_parties_and_wait_for_completions(
+        &committee,
+        &mut dwallet_mpc_services,
+        &mut sent_consensus_messages_collectors,
+        &epoch_stores,
+        &notify_services,
+    )
+    .await;
+
+    for malicious_party_index in malicious_parties {
+        // Create a malicious message for round 1, and set it as the patty's message.
+        let mut original_message = sent_consensus_messages_collectors[malicious_party_index]
+            .submitted_messages
+            .lock()
+            .unwrap()
+            .remove(0);
+        let ConsensusTransactionKind::DWalletMPCMessage(ref mut msg) = original_message.kind else {
+            panic!("Network DKG first round should produce a DWalletMPCMessage");
+        };
+        let mut new_message: Vec<u8> = vec![0];
+        new_message.extend(bcs::to_bytes::<u64>(&1).unwrap());
+        new_message.extend([3; 48]);
+        msg.message = new_message;
+        sent_consensus_messages_collectors[malicious_party_index]
+            .submitted_messages
+            .lock()
+            .unwrap()
+            .push(original_message);
+    }
+
+    utils::send_advance_results_between_parties(
+        &committee,
+        &mut sent_consensus_messages_collectors,
+        &mut epoch_stores,
+        mpc_round,
+    );
+    mpc_round += 1;
+    info!("Starting malicious behavior test");
+    loop {
+        if let Some(pending_checkpoint) = utils::advance_all_parties_and_wait_for_completions(
+            &committee,
+            &mut dwallet_mpc_services,
+            &mut sent_consensus_messages_collectors,
+            &epoch_stores,
+            &notify_services,
+        )
+        .await
+        {
+            assert_eq!(mpc_round, 5, "Network DKG should complete after 4 rounds");
+            info!(?pending_checkpoint, "MPC flow completed successfully");
+            break;
+        }
+        info!(?mpc_round, "Advanced MPC round");
+        utils::send_advance_results_between_parties(
+            &committee,
+            &mut sent_consensus_messages_collectors,
+            &mut epoch_stores,
+            mpc_round,
+        );
+        info!(?mpc_round, "Sent advance results for MPC round");
+        mpc_round += 1;
+    }
+    for malicious_party_index in malicious_parties {
+        let malicious_actor_name = dwallet_mpc_services[malicious_party_index].name;
+        assert!(
+            dwallet_mpc_services.iter().all(|service| service
+                .dwallet_mpc_manager()
+                .is_malicious_actor(&malicious_actor_name)),
+            "All services should recognize the malicious actor: {}",
+            malicious_actor_name
+        );
+    }
+}

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
@@ -1,3 +1,4 @@
+mod malicious_behavior;
 #[cfg(test)]
 mod network_dkg;
 mod utils;

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg.rs
@@ -41,7 +41,7 @@ async fn test_network_dkg_full_flow() {
         mut sent_consensus_messages_collectors,
         mut epoch_stores,
         mut notify_services,
-    ) = utils::create_dwallet_mpc_services();
+    ) = utils::create_dwallet_mpc_services(4);
     sui_data_senders.iter().for_each(|mut sui_data_sender| {
         let _ = sui_data_sender.uncompleted_events_sender.send((
             vec![DBSuiEvent {
@@ -57,7 +57,7 @@ async fn test_network_dkg_full_flow() {
     });
     let mut mpc_round = 1;
     loop {
-        if let Some(pending_checkpoint) = advance_all_parties_and_wait_for_completions(
+        if let Some(pending_checkpoint) = utils::advance_all_parties_and_wait_for_completions(
             &committee,
             &mut dwallet_mpc_services,
             &mut sent_consensus_messages_collectors,
@@ -71,7 +71,7 @@ async fn test_network_dkg_full_flow() {
             break;
         }
 
-        send_advance_results_between_parties(
+        utils::send_advance_results_between_parties(
             &committee,
             &mut sent_consensus_messages_collectors,
             &mut epoch_stores,
@@ -79,120 +79,4 @@ async fn test_network_dkg_full_flow() {
         );
         mpc_round += 1;
     }
-}
-
-fn send_advance_results_between_parties(
-    committee: &Committee,
-    sent_consensus_messages_collectors: &mut Vec<Arc<TestingSubmitToConsensus>>,
-    epoch_stores: &mut Vec<Arc<TestingAuthorityPerEpochStore>>,
-    new_data_round: Round,
-) {
-    for i in 0..committee.voting_rights.len() {
-        let consensus_messages_store = sent_consensus_messages_collectors[i]
-            .submitted_messages
-            .clone();
-        let consensus_messages = consensus_messages_store.lock().unwrap().clone();
-        consensus_messages_store.lock().unwrap().clear();
-        let dwallet_messages: Vec<_> = consensus_messages
-            .clone()
-            .into_iter()
-            .filter_map(|message| {
-                if let ConsensusTransactionKind::DWalletMPCMessage(message) = message.kind {
-                    Some(message)
-                } else {
-                    None
-                }
-            })
-            .collect();
-        let dwallet_outputs: Vec<_> = consensus_messages
-            .into_iter()
-            .filter_map(|message| {
-                if let ConsensusTransactionKind::DWalletMPCOutput(message) = message.kind {
-                    Some(message)
-                } else {
-                    None
-                }
-            })
-            .collect();
-        for j in 0..committee.voting_rights.len() {
-            let other_epoch_store = epoch_stores.get(j).unwrap();
-            other_epoch_store
-                .round_to_messages
-                .lock()
-                .unwrap()
-                .entry(new_data_round)
-                .or_default()
-                .extend(dwallet_messages.clone());
-            other_epoch_store
-                .round_to_outputs
-                .lock()
-                .unwrap()
-                .entry(new_data_round)
-                .or_default()
-                .extend(dwallet_outputs.clone());
-
-            // The DWalletMPCService every round will have entries in all the round-specific DB tables.
-            other_epoch_store
-                .round_to_verified_checkpoint
-                .lock()
-                .unwrap()
-                .insert(new_data_round, vec![]);
-        }
-    }
-}
-
-async fn advance_all_parties_and_wait_for_completions(
-    committee: &Committee,
-    dwallet_mpc_services: &mut Vec<DWalletMPCService>,
-    sent_consensus_messages_collectors: &mut Vec<Arc<TestingSubmitToConsensus>>,
-    testing_epoch_stores: &Vec<Arc<TestingAuthorityPerEpochStore>>,
-    notify_services: &Vec<Arc<TestingDWalletCheckpointNotify>>,
-) -> Option<PendingDWalletCheckpoint> {
-    let mut pending_checkpoints = vec![];
-    for i in 0..committee.voting_rights.len() {
-        let mut dwallet_mpc_service = dwallet_mpc_services.get_mut(i).unwrap();
-        let _ = dwallet_mpc_service.run_service_loop_iteration().await;
-        let consensus_messages_store = sent_consensus_messages_collectors[i]
-            .submitted_messages
-            .clone();
-        let pending_checkpoints_store = testing_epoch_stores[i].pending_checkpoints.clone();
-        let notify_service = notify_services[i].clone();
-        loop {
-            if !consensus_messages_store.lock().unwrap().is_empty() {
-                break;
-            }
-            if *notify_service
-                .checkpoints_notification_count
-                .lock()
-                .unwrap()
-                > 0
-            {
-                let pending_checkpoint = pending_checkpoints_store.lock().unwrap().pop();
-                assert!(
-                    pending_checkpoint.is_some(),
-                    "received a checkpoint notification, but no pending checkpoint was found"
-                );
-                let pending_dwallet_checkpoint = pending_checkpoint.unwrap();
-                info!(?pending_dwallet_checkpoint, party_id=?i+1, "Pending checkpoint found");
-                pending_checkpoints.push(pending_dwallet_checkpoint);
-                break;
-            }
-
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            let _ = dwallet_mpc_service.run_service_loop_iteration().await;
-        }
-    }
-    if pending_checkpoints.len() == committee.voting_rights.len()
-        && pending_checkpoints
-            .iter()
-            .all(|x| x.clone() == pending_checkpoints[0].clone())
-    {
-        return Some(pending_checkpoints[0].clone());
-    }
-    assert!(
-        pending_checkpoints.is_empty(),
-        "Pending checkpoints are not equal across all parties: {:?}",
-        pending_checkpoints
-    );
-    None
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -12,15 +12,17 @@ use ika_types::committee::Committee;
 use ika_types::crypto::AuthorityName;
 use ika_types::error::IkaResult;
 use ika_types::message::DWalletCheckpointMessageKind;
-use ika_types::messages_consensus::ConsensusTransaction;
+use ika_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
 use ika_types::messages_dwallet_checkpoint::DWalletCheckpointSignatureMessage;
 use ika_types::messages_dwallet_mpc::{
     DWalletMPCMessage, DWalletMPCOutput, IkaNetworkConfig, SessionIdentifier,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use sui_types::base_types::ObjectID;
 use sui_types::messages_consensus::Round;
+use tracing::info;
 
 /// A testing implementation of the `AuthorityPerEpochStoreTrait`.
 /// Records all received data for testing purposes.
@@ -215,7 +217,9 @@ impl DWalletCheckpointServiceNotify for TestingDWalletCheckpointNotify {
 }
 
 #[cfg(test)]
-pub fn create_dwallet_mpc_services() -> (
+pub fn create_dwallet_mpc_services(
+    size: usize,
+) -> (
     Vec<DWalletMPCService>,
     Vec<SuiDataSenders>,
     Vec<Arc<TestingSubmitToConsensus>>,
@@ -223,7 +227,7 @@ pub fn create_dwallet_mpc_services() -> (
     Vec<Arc<TestingDWalletCheckpointNotify>>,
 ) {
     let mut seeds: HashMap<AuthorityName, RootSeed> = Default::default();
-    let (mut committee, _) = Committee::new_simple_test_committee();
+    let (mut committee, _) = Committee::new_simple_test_committee_of_size(size);
     for (authority_name, _) in committee.voting_rights.iter() {
         let seed = RootSeed::random_seed();
         seeds.insert(authority_name.clone(), seed.clone());
@@ -306,4 +310,120 @@ fn create_dwallet_mpc_service(
         epoch_store,
         checkpoint_notify,
     )
+}
+
+pub(crate) fn send_advance_results_between_parties(
+    committee: &Committee,
+    sent_consensus_messages_collectors: &mut Vec<Arc<TestingSubmitToConsensus>>,
+    epoch_stores: &mut Vec<Arc<TestingAuthorityPerEpochStore>>,
+    new_data_round: Round,
+) {
+    for i in 0..committee.voting_rights.len() {
+        let consensus_messages_store = sent_consensus_messages_collectors[i]
+            .submitted_messages
+            .clone();
+        let consensus_messages = consensus_messages_store.lock().unwrap().clone();
+        consensus_messages_store.lock().unwrap().clear();
+        let dwallet_messages: Vec<_> = consensus_messages
+            .clone()
+            .into_iter()
+            .filter_map(|message| {
+                if let ConsensusTransactionKind::DWalletMPCMessage(message) = message.kind {
+                    Some(message)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let dwallet_outputs: Vec<_> = consensus_messages
+            .into_iter()
+            .filter_map(|message| {
+                if let ConsensusTransactionKind::DWalletMPCOutput(message) = message.kind {
+                    Some(message)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for j in 0..committee.voting_rights.len() {
+            let other_epoch_store = epoch_stores.get(j).unwrap();
+            other_epoch_store
+                .round_to_messages
+                .lock()
+                .unwrap()
+                .entry(new_data_round)
+                .or_default()
+                .extend(dwallet_messages.clone());
+            other_epoch_store
+                .round_to_outputs
+                .lock()
+                .unwrap()
+                .entry(new_data_round)
+                .or_default()
+                .extend(dwallet_outputs.clone());
+
+            // The DWalletMPCService every round will have entries in all the round-specific DB tables.
+            other_epoch_store
+                .round_to_verified_checkpoint
+                .lock()
+                .unwrap()
+                .insert(new_data_round, vec![]);
+        }
+    }
+}
+
+pub(crate) async fn advance_all_parties_and_wait_for_completions(
+    committee: &Committee,
+    dwallet_mpc_services: &mut Vec<DWalletMPCService>,
+    sent_consensus_messages_collectors: &mut Vec<Arc<TestingSubmitToConsensus>>,
+    testing_epoch_stores: &Vec<Arc<TestingAuthorityPerEpochStore>>,
+    notify_services: &Vec<Arc<TestingDWalletCheckpointNotify>>,
+) -> Option<PendingDWalletCheckpoint> {
+    let mut pending_checkpoints = vec![];
+    for i in 0..committee.voting_rights.len() {
+        let mut dwallet_mpc_service = dwallet_mpc_services.get_mut(i).unwrap();
+        let _ = dwallet_mpc_service.run_service_loop_iteration().await;
+        let consensus_messages_store = sent_consensus_messages_collectors[i]
+            .submitted_messages
+            .clone();
+        let pending_checkpoints_store = testing_epoch_stores[i].pending_checkpoints.clone();
+        let notify_service = notify_services[i].clone();
+        loop {
+            if !consensus_messages_store.lock().unwrap().is_empty() {
+                break;
+            }
+            if *notify_service
+                .checkpoints_notification_count
+                .lock()
+                .unwrap()
+                > 0
+            {
+                let pending_checkpoint = pending_checkpoints_store.lock().unwrap().pop();
+                assert!(
+                    pending_checkpoint.is_some(),
+                    "received a checkpoint notification, but no pending checkpoint was found"
+                );
+                let pending_dwallet_checkpoint = pending_checkpoint.unwrap();
+                info!(?pending_dwallet_checkpoint, party_id=?i+1, "Pending checkpoint found");
+                pending_checkpoints.push(pending_dwallet_checkpoint);
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let _ = dwallet_mpc_service.run_service_loop_iteration().await;
+        }
+    }
+    if pending_checkpoints.len() == committee.voting_rights.len()
+        && pending_checkpoints
+            .iter()
+            .all(|x| x.clone() == pending_checkpoints[0].clone())
+    {
+        return Some(pending_checkpoints[0].clone());
+    }
+    assert!(
+        pending_checkpoints.is_empty(),
+        "Pending checkpoints are not equal across all parties: {:?}",
+        pending_checkpoints
+    );
+    None
 }


### PR DESCRIPTION
## Description 

Add an integration test in which N parties send an invalid message for MPC round no. 1. Those parties are expected to be marked by all the validators as malicious, and the flow completes successfully.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
