### PR TITLE
chore: add support for multiple network key versions in DWalletMPCManager

### DIFF
--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -29,7 +29,7 @@ pub enum NetworkDecryptionKeyPublicOutputType {
 /// The public output of the DKG and/or Reconfiguration protocols, which holds the (encrypted) decryption key shares.
 /// Created for each DKG protocol and modified for each Reconfiguration Protocol.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NetworkEncryptionKeyPublicData {
+pub struct NetworkEncryptionKeyPublicDataV1 {
     /// The epoch of the last version update.
     pub epoch: u64,
 

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -77,7 +77,7 @@ pub struct ValidatorPrivateDecryptionKeyData {
         HashMap<ObjectID, HashMap<PartyID, <AsyncProtocol as Protocol>::DecryptionKeyShare>>,
 }
 
-async fn get_decryption_key_shares_from_public_output(
+async fn get_decryption_key_shares_from_public_output_v1(
     shares: NetworkEncryptionKeyPublicDataV1,
     party_id: PartyID,
     personal_decryption_key: ClassGroupsDecryptionKey,
@@ -140,13 +140,13 @@ impl ValidatorPrivateDecryptionKeyData {
     /// Stores the new decryption key shares of the validator.
     /// Decrypts the decryption key shares (for all the virtual parties)
     /// from the public output of the network DKG protocol.
-    pub async fn decrypt_and_store_secret_key_shares(
+    pub async fn decrypt_and_store_secret_key_shares_v1(
         &mut self,
         key_id: ObjectID,
         key: NetworkEncryptionKeyPublicDataV1,
         access_structure: &WeightedThresholdAccessStructure,
     ) -> DwalletMPCResult<()> {
-        let secret_key_shares = get_decryption_key_shares_from_public_output(
+        let secret_key_shares = get_decryption_key_shares_from_public_output_v1(
             key.clone(),
             self.party_id,
             self.class_groups_decryption_key,
@@ -194,7 +194,7 @@ impl DwalletMPCNetworkKeys {
         }
     }
 
-    pub async fn update_network_key(
+    pub async fn update_network_key_v1(
         &mut self,
         key_id: ObjectID,
         key: &NetworkEncryptionKeyPublicDataV1,
@@ -205,7 +205,7 @@ impl DwalletMPCNetworkKeys {
             VersionedNetworkEncryptionKeyPublicData::V1(key.clone()),
         );
         self.validator_private_dec_key_data
-            .decrypt_and_store_secret_key_shares(key_id, key.clone(), access_structure)
+            .decrypt_and_store_secret_key_shares_v1(key_id, key.clone(), access_structure)
             .await
     }
 

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -20,7 +20,7 @@ use commitment::CommitmentSizedNumber;
 use dwallet_classgroups_types::ClassGroupsDecryptionKey;
 use dwallet_mpc_types::dwallet_mpc::{
     DWalletMPCNetworkKeyScheme, NetworkDecryptionKeyPublicOutputType,
-    NetworkEncryptionKeyPublicData, SerializedWrappedMPCPublicOutput, VersionedNetworkDkgOutput,
+    NetworkEncryptionKeyPublicDataV1, SerializedWrappedMPCPublicOutput, VersionedNetworkDkgOutput,
 };
 use group::{OsCsRng, PartyID, secp256k1};
 use homomorphic_encryption::AdditivelyHomomorphicDecryptionKeyShare;
@@ -45,11 +45,16 @@ use twopc_mpc::secp256k1::class_groups::{
 };
 use twopc_mpc::sign::Protocol;
 
+#[derive(Debug)]
+pub enum VersionedNetworkEncryptionKeyPublicData {
+    V1(NetworkEncryptionKeyPublicDataV1),
+}
+
 /// Holds the network (decryption) keys of the network MPC protocols.
 pub struct DwalletMPCNetworkKeys {
     /// Holds all network (decryption) keys for the current network in encrypted form.
     /// This data is identical for all the Validator nodes.
-    pub(crate) network_encryption_keys: HashMap<ObjectID, NetworkEncryptionKeyPublicData>,
+    pub(crate) network_encryption_keys: HashMap<ObjectID, VersionedNetworkEncryptionKeyPublicData>,
     pub(crate) validator_private_dec_key_data: ValidatorPrivateDecryptionKeyData,
 }
 
@@ -73,7 +78,7 @@ pub struct ValidatorPrivateDecryptionKeyData {
 }
 
 async fn get_decryption_key_shares_from_public_output(
-    shares: NetworkEncryptionKeyPublicData,
+    shares: NetworkEncryptionKeyPublicDataV1,
     party_id: PartyID,
     personal_decryption_key: ClassGroupsDecryptionKey,
     access_structure: WeightedThresholdAccessStructure,
@@ -138,7 +143,7 @@ impl ValidatorPrivateDecryptionKeyData {
     pub async fn decrypt_and_store_secret_key_shares(
         &mut self,
         key_id: ObjectID,
-        key: NetworkEncryptionKeyPublicData,
+        key: NetworkEncryptionKeyPublicDataV1,
         access_structure: &WeightedThresholdAccessStructure,
     ) -> DwalletMPCResult<()> {
         let secret_key_shares = get_decryption_key_shares_from_public_output(
@@ -192,10 +197,13 @@ impl DwalletMPCNetworkKeys {
     pub async fn update_network_key(
         &mut self,
         key_id: ObjectID,
-        key: &NetworkEncryptionKeyPublicData,
+        key: &NetworkEncryptionKeyPublicDataV1,
         access_structure: &WeightedThresholdAccessStructure,
     ) -> DwalletMPCResult<()> {
-        self.network_encryption_keys.insert(key_id, key.clone());
+        self.network_encryption_keys.insert(
+            key_id,
+            VersionedNetworkEncryptionKeyPublicData::V1(key.clone()),
+        );
         self.validator_private_dec_key_data
             .decrypt_and_store_secret_key_shares(key_id, key.clone(), access_structure)
             .await
@@ -205,12 +213,18 @@ impl DwalletMPCNetworkKeys {
         &self,
         key_id: &ObjectID,
     ) -> DwalletMPCResult<Secp256k1DecryptionKeySharePublicParameters> {
-        Ok(self
-            .network_encryption_keys
-            .get(key_id)
-            .ok_or(DwalletMPCError::WaitingForNetworkKey(*key_id))?
-            .decryption_key_share_public_parameters
-            .clone())
+        let Some(result) = self.network_encryption_keys.get(key_id) else {
+            error!(
+                ?key_id,
+                "failed to fetch the network decryption key shares for key ID"
+            );
+            return Err(DwalletMPCError::WaitingForNetworkKey(*key_id));
+        };
+        match result {
+            VersionedNetworkEncryptionKeyPublicData::V1(network_key_data) => Ok(network_key_data
+                .decryption_key_share_public_parameters
+                .clone()),
+        }
     }
 
     /// Retrieves the decryption key shares for the current authority.
@@ -241,19 +255,29 @@ impl DwalletMPCNetworkKeys {
             );
             return Err(DwalletMPCError::WaitingForNetworkKey(*key_id));
         };
-        Ok(result.protocol_public_parameters.clone())
+        match result {
+            VersionedNetworkEncryptionKeyPublicData::V1(network_key_data) => {
+                Ok(network_key_data.protocol_public_parameters.clone())
+            }
+        }
     }
 
     pub fn get_network_dkg_public_output(
         &self,
         key_id: &ObjectID,
     ) -> DwalletMPCResult<VersionedNetworkDkgOutput> {
-        Ok(self
-            .network_encryption_keys
-            .get(key_id)
-            .ok_or(DwalletMPCError::WaitingForNetworkKey(*key_id))?
-            .network_dkg_output
-            .clone())
+        let Some(result) = self.network_encryption_keys.get(key_id) else {
+            error!(
+                ?key_id,
+                "failed to fetch the network decryption key shares for key ID"
+            );
+            return Err(DwalletMPCError::WaitingForNetworkKey(*key_id));
+        };
+        match result {
+            VersionedNetworkEncryptionKeyPublicData::V1(network_key_data) => {
+                Ok(network_key_data.network_dkg_output.clone())
+            }
+        }
     }
 }
 
@@ -338,7 +362,7 @@ pub(crate) async fn instantiate_dwallet_mpc_network_encryption_key_public_data_f
     key_scheme: DWalletMPCNetworkKeyScheme,
     access_structure: WeightedThresholdAccessStructure,
     key_data: DWalletNetworkEncryptionKeyData,
-) -> DwalletMPCResult<NetworkEncryptionKeyPublicData> {
+) -> DwalletMPCResult<VersionedNetworkEncryptionKeyPublicData> {
     let (key_public_data_sender, key_public_data_receiver) = oneshot::channel();
 
     rayon::spawn_fifo(move || {
@@ -377,7 +401,7 @@ fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_dkg_public_ou
     key_scheme: DWalletMPCNetworkKeyScheme,
     access_structure: &WeightedThresholdAccessStructure,
     public_output_bytes: &SerializedWrappedMPCPublicOutput,
-) -> DwalletMPCResult<NetworkEncryptionKeyPublicData> {
+) -> DwalletMPCResult<VersionedNetworkEncryptionKeyPublicData> {
     let mpc_public_output: VersionedNetworkDkgOutput =
         bcs::from_bytes(public_output_bytes).map_err(DwalletMPCError::BcsError)?;
 
@@ -404,14 +428,16 @@ fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_dkg_public_ou
                         .clone(),
                 );
 
-                Ok(NetworkEncryptionKeyPublicData {
-                    epoch,
-                    state: NetworkDecryptionKeyPublicOutputType::NetworkDkg,
-                    latest_public_output: mpc_public_output.clone(),
-                    decryption_key_share_public_parameters,
-                    network_dkg_output: mpc_public_output,
-                    protocol_public_parameters,
-                })
+                Ok(VersionedNetworkEncryptionKeyPublicData::V1(
+                    NetworkEncryptionKeyPublicDataV1 {
+                        epoch,
+                        state: NetworkDecryptionKeyPublicOutputType::NetworkDkg,
+                        latest_public_output: mpc_public_output.clone(),
+                        decryption_key_share_public_parameters,
+                        network_dkg_output: mpc_public_output,
+                        protocol_public_parameters,
+                    },
+                ))
             }
         },
         DWalletMPCNetworkKeyScheme::Ristretto => todo!("Ristretto key scheme"),

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -1,6 +1,7 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
+use crate::dwallet_mpc::network_dkg::VersionedNetworkEncryptionKeyPublicData;
 use crate::dwallet_mpc::{
     authority_name_to_party_id_from_committee, generate_access_structure_from_committee,
 };
@@ -9,7 +10,7 @@ use class_groups::{
     DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER, Secp256k1DecryptionKeySharePublicParameters,
 };
 use dwallet_mpc_types::dwallet_mpc::{
-    NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicData,
+    NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicDataV1,
     SerializedWrappedMPCPublicOutput, VersionedNetworkDkgOutput,
 };
 use group::{PartyID, secp256k1};
@@ -118,7 +119,7 @@ pub(crate) fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_re
     access_structure: &WeightedThresholdAccessStructure,
     public_output_bytes: &SerializedWrappedMPCPublicOutput,
     network_dkg_public_output: &SerializedWrappedMPCPublicOutput,
-) -> DwalletMPCResult<NetworkEncryptionKeyPublicData> {
+) -> DwalletMPCResult<VersionedNetworkEncryptionKeyPublicData> {
     let mpc_public_output: VersionedNetworkDkgOutput =
         bcs::from_bytes(public_output_bytes).map_err(DwalletMPCError::BcsError)?;
 
@@ -144,14 +145,16 @@ pub(crate) fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_re
                     .clone(),
             );
 
-            Ok(NetworkEncryptionKeyPublicData {
-                epoch,
-                state: NetworkDecryptionKeyPublicOutputType::Reconfiguration,
-                latest_public_output: mpc_public_output,
-                decryption_key_share_public_parameters,
-                protocol_public_parameters,
-                network_dkg_output: bcs::from_bytes(network_dkg_public_output)?,
-            })
+            Ok(VersionedNetworkEncryptionKeyPublicData::V1(
+                NetworkEncryptionKeyPublicDataV1 {
+                    epoch,
+                    state: NetworkDecryptionKeyPublicOutputType::Reconfiguration,
+                    latest_public_output: mpc_public_output,
+                    decryption_key_share_public_parameters,
+                    protocol_public_parameters,
+                    network_dkg_output: bcs::from_bytes(network_dkg_public_output)?,
+                },
+            ))
         }
     }
 }

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -566,7 +566,7 @@ impl DWalletMPCManager {
                                     info!(key_id=?key_id, "Updating (decrypting new shares) network key for key_id");
                                     if let Err(e) = self
                                         .network_keys
-                                        .update_network_key(key_id, &key, &self.access_structure)
+                                        .update_network_key_v1(key_id, &key, &self.access_structure)
                                         .await
                                     {
                                         error!(error=?e, key_id=?key_id, "failed to update the network key");


### PR DESCRIPTION
## Description 

Previously, the `network_keys` field in `DWalletMPCManager` could store keys of only one specific version at a time.  
This PR updates it to allow storing multiple versions of network keys using an enum.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
