### PR TITLE
chore: Update `cryptography-private` version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         run: cargo fmt -- --check
       - name: Fmt Check - Wasm
         run: cargo fmt -- --check
-        working-directory: sdk/mpc-wasm
+        working-directory: sdk/ika-wasm
   clippy:
     if: github.event_name == 'push'
     name: Clippy

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ ika_config.json
 
 # TypeDoc
 sdk/typescript/docs
+move_pkg_lock_root.lock
+node-compile-cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2289,7 +2289,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "class_groups"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "commitment",
  "criterion",
@@ -2464,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "commitment"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "crypto-bigint 0.7.0-pre.6",
  "group 0.1.0",
@@ -2616,6 +2616,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
 ]
 
 [[package]]
@@ -3034,6 +3044,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.11.0-rc.0",
  "fiat-crypto",
+ "group 0.14.0-pre.0",
  "rand_core 0.9.3",
  "rustc_version",
  "serde",
@@ -3171,7 +3182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3523,7 +3534,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3631,17 +3642,22 @@ dependencies = [
  "bcs",
  "class_groups",
  "commitment",
+ "console_log",
  "dwallet-mpc-types",
  "getrandom 0.2.16",
  "group 0.1.0",
  "homomorphic_encryption",
+ "log",
  "message-digest",
  "mpc",
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
  "schemars",
  "serde",
+ "tracing",
+ "tracing-subscriber",
  "twopc_mpc",
+ "web-sys",
 ]
 
 [[package]]
@@ -3650,6 +3666,7 @@ version = "1.0.0"
 dependencies = [
  "class_groups",
  "enum_dispatch",
+ "group 0.1.0",
  "schemars",
  "serde",
  "strum_macros 0.27.1",
@@ -4367,7 +4384,7 @@ dependencies = [
  "lazy_static",
  "num-bigint 0.4.6",
  "once_cell",
- "p256",
+ "p256 0.13.2",
  "rand 0.8.5",
  "readonly",
  "rfc6979 0.4.0",
@@ -4974,7 +4991,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "crypto-bigint 0.7.0-pre.6",
  "curve25519-dalek 5.0.0-pre.0",
@@ -4982,11 +4999,13 @@ dependencies = [
  "hash2curve",
  "itertools 0.14.0",
  "k256 0.14.0-pre.9",
+ "p256 0.14.0-pre.9",
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
  "rayon",
  "serde",
  "serde_json",
+ "sha2 0.11.0-rc.0",
  "sha3 0.11.0-rc.0",
  "subtle",
  "thiserror 2.0.12",
@@ -5271,7 +5290,7 @@ dependencies = [
 [[package]]
 name = "homomorphic_encryption"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "criterion",
  "crypto-bigint 0.7.0-pre.6",
@@ -7303,7 +7322,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 [[package]]
 name = "maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "commitment",
  "crypto-bigint 0.7.0-pre.6",
@@ -8387,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "bcs",
  "commitment",
@@ -9270,8 +9289,22 @@ checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
- "primeorder",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.14.0-pre.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be97a30a85c829fdac914cebb89ef05e109f9e5eb6510f46f623be91bc39ded"
+dependencies = [
+ "ecdsa 0.17.0-rc.4",
+ "elliptic-curve 0.14.0-rc.10",
+ "hash2curve",
+ "primefield",
+ "primeorder 0.14.0-pre.7",
+ "serdect",
 ]
 
 [[package]]
@@ -9282,7 +9315,7 @@ checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
 dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
- "primeorder",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
 ]
 
@@ -9894,12 +9927,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc85f9f75dc05486f61bc61858535c0501a0ca81ca3117ab17befbead13c110"
+dependencies = [
+ "crypto-bigint 0.7.0-pre.6",
+ "ff 0.14.0-pre.0",
+ "rand_core 0.9.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0-pre.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af12dd34fc62d04416de85af032f4595369437fb7b0143d36ae60cecaf5cdddf"
+dependencies = [
+ "elliptic-curve 0.14.0-rc.10",
+ "serdect",
 ]
 
 [[package]]
@@ -10008,7 +10064,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "commitment",
  "crypto-bigint 0.7.0-pre.6",
@@ -12726,7 +12782,7 @@ dependencies = [
  "ed25519-dalek",
  "itertools 0.13.0",
  "k256 0.13.4",
- "p256",
+ "p256 0.13.2",
  "rand_core 0.6.4",
  "serde",
  "serde_derive",
@@ -15572,13 +15628,14 @@ dependencies = [
 [[package]]
 name = "twopc_mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "class_groups",
  "commitment",
  "crypto-bigint 0.7.0-pre.6",
  "group 0.1.0",
  "homomorphic_encryption",
+ "itertools 0.14.0",
  "maurer",
  "merlin",
  "mpc",
@@ -15586,6 +15643,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ members = [
     "crates/ika-network",
     "crates/ika-archival",
 ]
-
 [workspace.package]
 # This version string will be inherited by ika-core, ika-node, ika-tools, ika-sdk, and ika crates.
 version = "1.0.0"
@@ -74,13 +73,13 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
 k256 = { version = "0.14.0-pre.9", features = ["arithmetic", "critical-section", "precomputed-tables", "serde", "ecdsa", "hash2curve", "alloc"], default-features = false }
-mpc = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "bc0464c"}
-proof = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "bc0464c"}
-class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "bc0464c", features = ["threshold"] }
-commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "bc0464c" }
-twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", features = ["secp256k1", "class_groups"], rev = "bc0464c"}
-group = { git = "https://github.com/dwallet-labs/cryptography-private", features = ["os_rng"], rev = "bc0464c"}
-homomorphic_encryption = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "bc0464c"}
+mpc = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "c3faed6f11b"}
+proof = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "c3faed6f11b"}
+class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "c3faed6f11b", features = ["threshold"] }
+commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "c3faed6f11b" }
+twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", features = ["secp256k1", "class_groups"], rev = "c3faed6f11b"}
+group = { git = "https://github.com/dwallet-labs/cryptography-private", features = ["os_rng"], rev = "c3faed6f11b"}
+homomorphic_encryption = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "c3faed6f11b"}
 anyhow = "1.0.71"
 arc-swap = { version = "1.5.1", features = ["serde"] }
 assert_cmd = "2.0.6"

--- a/crates/dwallet-classgroups-types/src/lib.rs
+++ b/crates/dwallet-classgroups-types/src/lib.rs
@@ -14,7 +14,7 @@ use ika_types::committee::{ClassGroupsEncryptionKeyAndProof, ClassGroupsProof};
 use serde::{Deserialize, Serialize};
 
 pub type ClassGroupsDecryptionKey = [Uint<{ CRT_FUNDAMENTAL_DISCRIMINANT_LIMBS }>; MAX_PRIMES];
-type AsyncProtocol = twopc_mpc::secp256k1::class_groups::AsyncProtocol;
+type AsyncProtocol = twopc_mpc::secp256k1::class_groups::AsyncECDSAProtocol;
 pub type DKGDecentralizedOutput =
     <AsyncProtocol as twopc_mpc::dkg::Protocol>::DecentralizedPartyDKGOutput;
 pub type SingleEncryptionKeyAndProof = (

--- a/crates/dwallet-mpc-centralized-party/Cargo.toml
+++ b/crates/dwallet-mpc-centralized-party/Cargo.toml
@@ -6,7 +6,8 @@ version.workspace = true
 [dependencies]
 mpc.workspace = true
 twopc_mpc.workspace = true
-commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "bc0464c" }
+commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "c3faed6f11b" }
+web-sys = "0.3.77"
 message-digest = { path = "../message-digest" }
 class_groups.workspace = true
 group.workspace = true
@@ -19,6 +20,10 @@ rand_core = { version = "0.9", default-features = false }
 rand_chacha = { version = "0.9", default-features = false }
 getrandom = { version = "0.2.16", features = ["js"], optional = true } # TODO: idk why, but we need this, also this is old version
 serde = { version = "1.0", features = ["derive"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"
+log = "0.4.27"
+console_log = "1.0.0"
 
 [features]
 wasm_js = ["group/wasm_js", "dep:getrandom"]

--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -347,6 +347,7 @@ pub fn advance_centralized_sign_party(
         bcs::from_bytes(&centralized_party_secret_key_share)?;
     let VersionedDwalletUserSecretShare::V1(centralized_party_secret_key_share) =
         centralized_party_secret_key_share;
+    // TODO (#1478): Use From to convert the decentralized DKG output to centralized public output.
     let decentralized_output = match decentralized_dkg_output {
         DKGDecentralizedPartyVersionedOutput::<
             { group::secp256k1::SCALAR_LIMBS },

--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -170,7 +170,7 @@ pub fn create_dkg_output_v1(
     protocol_pp: Vec<u8>,
     decentralized_first_round_public_output: SerializedWrappedMPCPublicOutput,
 ) -> anyhow::Result<CentralizedDKGWasmResult> {
-    let public_parameters: ProtocolPublicParameters = bcs::from_bytes(&protocol_pp)?;
+    let protocol_public_parameters: ProtocolPublicParameters = bcs::from_bytes(&protocol_pp)?;
     let decentralized_first_round_public_output =
         bcs::from_bytes(&decentralized_first_round_public_output)?;
     match decentralized_first_round_public_output {
@@ -194,7 +194,7 @@ pub fn create_dkg_output_v1(
                 second_second_part,
                 first_first_part,
                 second_first_part,
-                public_parameters
+                protocol_public_parameters
                     .encryption_scheme_public_parameters
                     .clone(),
             );

--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -109,12 +109,12 @@ pub fn create_dkg_output_v2(
     protocol_pp: Vec<u8>,
     session_id: Vec<u8>,
 ) -> anyhow::Result<CentralizedDKGWasmResult> {
-    let public_parameters: ProtocolPublicParameters = bcs::from_bytes(&protocol_pp)?;
+    let protocol_public_parameters: ProtocolPublicParameters = bcs::from_bytes(&protocol_pp)?;
     let session_identifier = CommitmentSizedNumber::from_le_slice(&session_id);
     let round_result = DKGCentralizedParty::advance(
         (),
         &(),
-        &(public_parameters, session_identifier).into(),
+        &(protocol_public_parameters, session_identifier).into(),
         &mut OsCsRng,
     )
     .context("advance() failed on the DKGCentralizedParty")?;

--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -496,7 +496,7 @@ fn protocol_public_parameters_by_key_scheme(
                     )?;
 
                     let setup_parameters =
-                        class_groups::setup::SetupParameters::SetupParameters::<
+                        class_groups::setup::SetupParameters::<
                             SECP256K1_SCALAR_LIMBS,
                             SECP256K1_FUNDAMENTAL_DISCRIMINANT_LIMBS,
                             SECP256K1_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
@@ -605,13 +605,13 @@ pub fn verify_secret_share(
     let secret_share: VersionedDwalletUserSecretShare = bcs::from_bytes(&secret_share)?;
     Ok(
         <twopc_mpc::secp256k1::class_groups::AsyncECDSAProtocol as twopc_mpc::dkg::Protocol>::verify_centralized_party_secret_key_share(
-                &protocol_public_params,
-                decentralized_dkg_output,
-                match secret_share {
-                    VersionedDwalletUserSecretShare::V1(secret_share) => bcs::from_bytes(&secret_share)?
-                },
-            )
-                .is_ok())
+            &protocol_public_params,
+            decentralized_dkg_output,
+            match secret_share {
+                VersionedDwalletUserSecretShare::V1(secret_share) => bcs::from_bytes(&secret_share)?
+            },
+        )
+            .is_ok())
 }
 
 /// Decrypts the given encrypted user share using the given decryption key.

--- a/crates/dwallet-mpc-types/Cargo.toml
+++ b/crates/dwallet-mpc-types/Cargo.toml
@@ -9,6 +9,7 @@ thiserror.workspace = true
 schemars.workspace = true
 twopc_mpc.workspace = true
 class_groups.workspace = true
+group.workspace = true
 enum_dispatch.workspace = true
 strum_macros.workspace = true
 

--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -4,6 +4,7 @@
 use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use twopc_mpc::class_groups::{DKGDecentralizedPartyOutput, DKGDecentralizedPartyVersionedOutput};
 
 /// Alias for an MPC message.
 pub type MPCMessage = Vec<u8>;
@@ -25,6 +26,20 @@ pub enum NetworkDecryptionKeyPublicOutputType {
     NetworkDkg,
     Reconfiguration,
 }
+
+pub type DKGDecentralizedPartyOutputSecp256k1 = DKGDecentralizedPartyOutput<
+    { twopc_mpc::secp256k1::SCALAR_LIMBS },
+    { twopc_mpc::secp256k1::class_groups::FUNDAMENTAL_DISCRIMINANT_LIMBS },
+    { twopc_mpc::secp256k1::class_groups::NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+    group::secp256k1::GroupElement,
+>;
+
+pub type DKGDecentralizedPartyVersionedOutputSecp256k1 = DKGDecentralizedPartyVersionedOutput<
+    { twopc_mpc::secp256k1::SCALAR_LIMBS },
+    { twopc_mpc::secp256k1::class_groups::FUNDAMENTAL_DISCRIMINANT_LIMBS },
+    { twopc_mpc::secp256k1::class_groups::NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+    group::secp256k1::GroupElement,
+>;
 
 /// The public output of the DKG and/or Reconfiguration protocols, which holds the (encrypted) decryption key shares.
 /// Created for each DKG protocol and modified for each Reconfiguration Protocol.
@@ -140,6 +155,7 @@ pub enum VersionedDwalletDKGFirstRoundPublicOutput {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum VersionedDwalletDKGSecondRoundPublicOutput {
     V1(MPCPublicOutput),
+    V2(MPCPublicOutput),
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -170,6 +186,7 @@ pub enum VersionedPublicKeyShareAndProof {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum VersionedCentralizedDKGPublicOutput {
     V1(MPCPublicOutput),
+    V2(MPCPublicOutput),
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -384,42 +384,52 @@ fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_dkg_public_ou
         bcs::from_bytes(public_output_bytes).map_err(DwalletMPCError::BcsError)?;
 
     match key_scheme {
-        DWalletMPCNetworkKeyScheme::Secp256k1 => match &mpc_public_output {
-            VersionedNetworkDkgOutput::V1(public_output_bytes) => {
-                let public_output: <Secp256k1Party as mpc::Party>::PublicOutput =
-                    bcs::from_bytes(public_output_bytes)?;
+        DWalletMPCNetworkKeyScheme::Secp256k1 => {
+            match &mpc_public_output {
+                VersionedNetworkDkgOutput::V1(public_output_bytes) => {
+                    let public_output: <Secp256k1Party as mpc::Party>::PublicOutput =
+                        bcs::from_bytes(public_output_bytes)?;
 
-                let decryption_key_share_public_parameters = public_output
-                    .default_decryption_key_share_public_parameters::<secp256k1::GroupElement>(
-                        access_structure,
-                    )
-                    .map_err(DwalletMPCError::from)?;
+                    let decryption_key_share_public_parameters = public_output
+                        .default_decryption_key_share_public_parameters::<secp256k1::GroupElement>(
+                            access_structure,
+                        )
+                        .map_err(DwalletMPCError::from)?;
 
-                let protocol_public_parameters = ProtocolPublicParameters::new::<
-                    { secp256k1::SCALAR_LIMBS },
-                    { FUNDAMENTAL_DISCRIMINANT_LIMBS },
-                    { NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
-                    secp256k1::GroupElement,
-                >(
-                    Default::default(),
-                    Default::default(),
-                    Default::default(),
-                    Default::default(),
-                    decryption_key_share_public_parameters
-                        .encryption_scheme_public_parameters
-                        .clone(),
-                );
+                    let neutral_group_value =
+                        group::secp256k1::GroupElement::neutral_from_public_parameters(
+                            &group::secp256k1::group_element::PublicParameters::default(),
+                        )
+                        .map_err(twopc_mpc::Error::from)?
+                        .value();
+                    let neutral_ciphertext_value = ::class_groups::CiphertextSpaceGroupElement::neutral_from_public_parameters(decryption_key_share_public_parameters.encryption_scheme_public_parameters.ciphertext_space_public_parameters()).map_err(twopc_mpc::Error::from)?.value();
 
-                Ok(NetworkEncryptionKeyPublicData {
-                    epoch,
-                    state: NetworkDecryptionKeyPublicOutputType::NetworkDkg,
-                    latest_public_output: mpc_public_output.clone(),
-                    decryption_key_share_public_parameters,
-                    network_dkg_output: mpc_public_output,
-                    protocol_public_parameters,
-                })
+                    let protocol_public_parameters = ProtocolPublicParameters::new::<
+                        { secp256k1::SCALAR_LIMBS },
+                        { FUNDAMENTAL_DISCRIMINANT_LIMBS },
+                        { NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+                        secp256k1::GroupElement,
+                    >(
+                        neutral_group_value,
+                        neutral_group_value,
+                        neutral_ciphertext_value,
+                        neutral_ciphertext_value,
+                        decryption_key_share_public_parameters
+                            .encryption_scheme_public_parameters
+                            .clone(),
+                    );
+
+                    Ok(NetworkEncryptionKeyPublicData {
+                        epoch,
+                        state: NetworkDecryptionKeyPublicOutputType::NetworkDkg,
+                        latest_public_output: mpc_public_output.clone(),
+                        decryption_key_share_public_parameters,
+                        network_dkg_output: mpc_public_output,
+                        protocol_public_parameters,
+                    })
+                }
             }
-        },
+        }
         DWalletMPCNetworkKeyScheme::Ristretto => todo!("Ristretto key scheme"),
     }
 }

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -22,8 +22,10 @@ use dwallet_mpc_types::dwallet_mpc::{
     DWalletMPCNetworkKeyScheme, NetworkDecryptionKeyPublicOutputType,
     NetworkEncryptionKeyPublicData, SerializedWrappedMPCPublicOutput, VersionedNetworkDkgOutput,
 };
-use group::{OsCsRng, PartyID, secp256k1};
-use homomorphic_encryption::AdditivelyHomomorphicDecryptionKeyShare;
+use group::{GroupElement, OsCsRng, PartyID, secp256k1};
+use homomorphic_encryption::{
+    AdditivelyHomomorphicDecryptionKeyShare, GroupsPublicParametersAccessors,
+};
 use ika_types::committee::ClassGroupsEncryptionKeyAndProof;
 use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use ika_types::messages_dwallet_mpc::AsyncProtocol;
@@ -399,6 +401,10 @@ fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_dkg_public_ou
                     { NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
                     secp256k1::GroupElement,
                 >(
+                    Default::default(),
+                    Default::default(),
+                    Default::default(),
+                    Default::default(),
                     decryption_key_share_public_parameters
                         .encryption_scheme_public_parameters
                         .clone(),

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -136,16 +136,30 @@ pub(crate) fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_re
             let encryption_scheme_public_parameters = decryption_key_share_public_parameters
                 .encryption_scheme_public_parameters
                 .clone();
+
+            let neutral_group_value =
+                group::secp256k1::GroupElement::neutral_from_public_parameters(
+                    &group::secp256k1::group_element::PublicParameters::default(),
+                )
+                .map_err(twopc_mpc::Error::from)?
+                .value();
+            let neutral_ciphertext_value =
+                ::class_groups::CiphertextSpaceGroupElement::neutral_from_public_parameters(
+                    encryption_scheme_public_parameters.ciphertext_space_public_parameters(),
+                )
+                .map_err(twopc_mpc::Error::from)?
+                .value();
+
             let protocol_public_parameters = ProtocolPublicParameters::new::<
                 { secp256k1::SCALAR_LIMBS },
                 { FUNDAMENTAL_DISCRIMINANT_LIMBS },
                 { NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
                 secp256k1::GroupElement,
             >(
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
+                neutral_group_value,
+                neutral_group_value,
+                neutral_ciphertext_value,
+                neutral_ciphertext_value,
                 decryption_key_share_public_parameters
                     .encryption_scheme_public_parameters
                     .clone(),

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -12,7 +12,8 @@ use dwallet_mpc_types::dwallet_mpc::{
     NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicData,
     SerializedWrappedMPCPublicOutput, VersionedNetworkDkgOutput,
 };
-use group::{PartyID, secp256k1};
+use group::{GroupElement, PartyID, secp256k1};
+use homomorphic_encryption::GroupsPublicParametersAccessors;
 use ika_types::committee::ClassGroupsEncryptionKeyAndProof;
 use ika_types::committee::Committee;
 use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
@@ -132,13 +133,19 @@ pub(crate) fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_re
                     access_structure,
                 )
                 .map_err(DwalletMPCError::from)?;
-
+            let encryption_scheme_public_parameters = decryption_key_share_public_parameters
+                .encryption_scheme_public_parameters
+                .clone();
             let protocol_public_parameters = ProtocolPublicParameters::new::<
                 { secp256k1::SCALAR_LIMBS },
                 { FUNDAMENTAL_DISCRIMINANT_LIMBS },
                 { NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
                 secp256k1::GroupElement,
             >(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
                 decryption_key_share_public_parameters
                     .encryption_scheme_public_parameters
                     .clone(),

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/sign.rs
@@ -8,10 +8,11 @@
 use crate::dwallet_mpc::dwallet_mpc_metrics::DWalletMPCMetrics;
 use crate::dwallet_mpc::network_dkg::DwalletMPCNetworkKeys;
 use dwallet_mpc_types::dwallet_mpc::{
+    DKGDecentralizedPartyOutputSecp256k1, DKGDecentralizedPartyVersionedOutputSecp256k1,
     SerializedWrappedMPCPublicOutput, VersionedDwalletDKGSecondRoundPublicOutput,
     VersionedPresignOutput, VersionedUserSignedMessage,
 };
-use group::PartyID;
+use group::{HashType, OsCsRng, PartyID};
 use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use ika_types::messages_dwallet_mpc::{AsyncProtocol, SessionIdentifier};
 use message_digest::message_digest::{Hash, message_digest};
@@ -21,8 +22,8 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use sui_types::base_types::ObjectID;
 use twopc_mpc::dkg::Protocol;
-use twopc_mpc::secp256k1;
 use twopc_mpc::secp256k1::class_groups::ProtocolPublicParameters;
+use twopc_mpc::{secp256k1, sign};
 
 pub(crate) type SignParty = <AsyncProtocol as twopc_mpc::sign::Protocol>::SignDecentralizedParty;
 pub(crate) type SignPublicInput =
@@ -83,18 +84,12 @@ pub(crate) fn sign_session_public_input(
     <SignParty as SignPartyPublicInputGenerator>::generate_public_input(
         protocol_public_parameters,
         dwallet_decentralized_public_output,
-        bcs::to_bytes(
-            &message_digest(
-                &message.clone(),
-                &Hash::try_from(hash_scheme)
-                    .map_err(|e| DwalletMPCError::SignatureVerificationFailed(e.to_string()))?,
-            )
-            .map_err(|e| DwalletMPCError::SignatureVerificationFailed(e.to_string()))?,
-        )?,
+        message,
         presign,
         message_centralized_signature,
         decryption_pp,
         expected_decrypters,
+        hash_scheme,
     )
 }
 
@@ -136,6 +131,7 @@ pub(crate) trait SignPartyPublicInputGenerator: Party {
         centralized_signed_message: &Vec<u8>,
         decryption_key_share_public_parameters: <AsyncProtocol as twopc_mpc::sign::Protocol>::DecryptionKeySharePublicParameters,
         expected_decrypters: HashSet<PartyID>,
+        hash_scheme: Hash,
     ) -> DwalletMPCResult<<SignParty as Party>::PublicInput>;
 }
 
@@ -148,36 +144,38 @@ impl SignPartyPublicInputGenerator for SignParty {
         centralized_signed_message: &SerializedWrappedMPCPublicOutput,
         decryption_key_share_public_parameters: <AsyncProtocol as twopc_mpc::sign::Protocol>::DecryptionKeySharePublicParameters,
         expected_decrypters: HashSet<PartyID>,
+        hash_scheme: Hash,
     ) -> DwalletMPCResult<<SignParty as Party>::PublicInput> {
         let dkg_output = bcs::from_bytes(dkg_output)?;
         let presign = bcs::from_bytes(presign)?;
         let centralized_signed_message = bcs::from_bytes(centralized_signed_message)?;
-        match dkg_output {
+        let decentralized_dkg_output = match dkg_output {
             VersionedDwalletDKGSecondRoundPublicOutput::V1(output) => {
-                let VersionedPresignOutput::V1(presign) = presign;
-                let VersionedUserSignedMessage::V1(centralized_signed_message) =
-                    centralized_signed_message;
-                let public_input = SignPublicInput::from((
-                    expected_decrypters,
-                    protocol_public_parameters,
-                    bcs::from_bytes::<<AsyncProtocol as twopc_mpc::sign::Protocol>::HashedMessage>(
-                        &message,
-                    )?,
-                    bcs::from_bytes::<<AsyncProtocol as Protocol>::DecentralizedPartyDKGOutput>(
-                        &output,
-                    )?,
-                    bcs::from_bytes::<<AsyncProtocol as twopc_mpc::presign::Protocol>::Presign>(
-                        &presign,
-                    )?,
-                    bcs::from_bytes::<<AsyncProtocol as twopc_mpc::sign::Protocol>::SignMessage>(
-                        &centralized_signed_message,
-                    )?,
-                    decryption_key_share_public_parameters,
-                ));
-
-                Ok(public_input)
+                bcs::from_bytes::<DKGDecentralizedPartyOutputSecp256k1>(output.as_slice())?.into()
             }
-        }
+            VersionedDwalletDKGSecondRoundPublicOutput::V2(output) => {
+                bcs::from_bytes::<DKGDecentralizedPartyVersionedOutputSecp256k1>(output.as_slice())?
+            }
+        };
+
+        let VersionedPresignOutput::V1(presign) = presign;
+        let VersionedUserSignedMessage::V1(centralized_signed_message) = centralized_signed_message;
+        let public_input = SignPublicInput::from((
+            expected_decrypters,
+            protocol_public_parameters,
+            vec![],
+            message,
+            HashType::try_from(hash_scheme as u32)
+                .map_err(|_| DwalletMPCError::InvalidHashScheme)?,
+            decentralized_dkg_output,
+            bcs::from_bytes::<<AsyncProtocol as twopc_mpc::presign::Protocol>::Presign>(&presign)?,
+            bcs::from_bytes::<<AsyncProtocol as twopc_mpc::sign::Protocol>::SignMessage>(
+                &centralized_signed_message,
+            )?,
+            decryption_key_share_public_parameters,
+        ));
+
+        Ok(public_input)
     }
 }
 
@@ -185,7 +183,8 @@ impl SignPartyPublicInputGenerator for SignParty {
 /// client side in the 2PC-MPC protocol — is valid regarding the given dWallet DKG output.
 /// Returns Ok if the message is valid, Err otherwise.
 pub(crate) fn verify_partial_signature(
-    hashed_message: &[u8],
+    message: &[u8],
+    hash_type: &HashType,
     dwallet_decentralized_output: &SerializedWrappedMPCPublicOutput,
     presign: &SerializedWrappedMPCPublicOutput,
     partially_signed_message: &SerializedWrappedMPCPublicOutput,
@@ -193,29 +192,34 @@ pub(crate) fn verify_partial_signature(
 ) -> DwalletMPCResult<()> {
     let dkg_output: VersionedDwalletDKGSecondRoundPublicOutput =
         bcs::from_bytes(dwallet_decentralized_output)?;
+    let decentralized_dkg_output = match dkg_output {
+        VersionedDwalletDKGSecondRoundPublicOutput::V1(output) => {
+            bcs::from_bytes::<DKGDecentralizedPartyOutputSecp256k1>(output.as_slice())?.into()
+        }
+        VersionedDwalletDKGSecondRoundPublicOutput::V2(output) => {
+            bcs::from_bytes::<DKGDecentralizedPartyVersionedOutputSecp256k1>(output.as_slice())?
+        }
+    };
+
     let presign: VersionedPresignOutput = bcs::from_bytes(presign)?;
     let partially_signed_message: VersionedUserSignedMessage =
         bcs::from_bytes(partially_signed_message)?;
-    match dkg_output {
-        VersionedDwalletDKGSecondRoundPublicOutput::V1(dkg_output) => {
-            let VersionedPresignOutput::V1(presign) = presign;
-            let VersionedUserSignedMessage::V1(partially_signed_message) = partially_signed_message;
-            let message: secp256k1::Scalar = bcs::from_bytes(hashed_message)?;
-            let dkg_output = bcs::from_bytes::<
-                <AsyncProtocol as Protocol>::DecentralizedPartyDKGOutput,
-            >(&dkg_output)?;
-            let presign: <AsyncProtocol as twopc_mpc::presign::Protocol>::Presign =
-                bcs::from_bytes(&presign)?;
-            let partial: <AsyncProtocol as twopc_mpc::sign::Protocol>::SignMessage =
-                bcs::from_bytes(&partially_signed_message)?;
+    let VersionedPresignOutput::V1(presign) = presign;
+    let VersionedUserSignedMessage::V1(partially_signed_message) = partially_signed_message;
+    let presign: <AsyncProtocol as twopc_mpc::presign::Protocol>::Presign =
+        bcs::from_bytes(&presign)?;
+    let partial: <AsyncProtocol as twopc_mpc::sign::Protocol>::SignMessage =
+        bcs::from_bytes(&partially_signed_message)?;
 
-            twopc_mpc::sign::decentralized_party::signature_partial_decryption_round::Party::verify_encryption_of_signature_parts_prehash_class_groups(
-                protocol_public_parameters,
-                dkg_output,
-                presign,
-                partial,
-                message,
-            ).map_err(DwalletMPCError::from)
-        }
-    }
+    <AsyncProtocol as sign::Protocol>::verify_centralized_party_partial_signature(
+        &[],
+        message,
+        hash_type.clone(),
+        decentralized_dkg_output,
+        presign,
+        partial,
+        protocol_public_parameters,
+        &mut OsCsRng,
+    )
+    .map_err(DwalletMPCError::from)
 }

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/native_computations/encrypt_user_share.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/native_computations/encrypt_user_share.rs
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 use dwallet_mpc_types::dwallet_mpc::{
+    DKGDecentralizedPartyOutputSecp256k1, DKGDecentralizedPartyVersionedOutputSecp256k1,
     SerializedWrappedMPCPublicOutput, VersionedDwalletDKGSecondRoundPublicOutput,
     VersionedEncryptedUserShare,
 };
 use group::OsCsRng;
 use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use twopc_mpc::dkg::Protocol;
-use twopc_mpc::secp256k1::class_groups::AsyncProtocol;
+use twopc_mpc::secp256k1::class_groups::AsyncECDSAProtocol;
 
 /// Verifies that the given encrypted secret key share matches the encryption of the dWallet's
 /// secret share, validates the signature on the dWallet's public share,
@@ -41,17 +42,21 @@ fn verify_centralized_secret_key_share_proof(
     protocol_public_parameters: twopc_mpc::secp256k1::class_groups::ProtocolPublicParameters,
 ) -> anyhow::Result<()> {
     let dkg_public_output = bcs::from_bytes(serialized_dkg_public_output)?;
-    match dkg_public_output {
-        VersionedDwalletDKGSecondRoundPublicOutput::V1(dkg_public_output) => {
-            <AsyncProtocol as Protocol>::verify_encryption_of_centralized_party_share_proof(
-                &protocol_public_parameters,
-                bcs::from_bytes(&dkg_public_output)?,
-                bcs::from_bytes(encryption_key)?,
-                bcs::from_bytes(encrypted_centralized_secret_share_and_proof)?,
-                &mut OsCsRng,
-            )
-            .map_err(Into::<anyhow::Error>::into)?;
-            Ok(())
+    let decentralized_dkg_output = match dkg_public_output {
+        VersionedDwalletDKGSecondRoundPublicOutput::V1(output) => {
+            bcs::from_bytes::<DKGDecentralizedPartyOutputSecp256k1>(output.as_slice())?.into()
         }
-    }
+        VersionedDwalletDKGSecondRoundPublicOutput::V2(output) => {
+            bcs::from_bytes::<DKGDecentralizedPartyVersionedOutputSecp256k1>(output.as_slice())?
+        }
+    };
+    <AsyncECDSAProtocol as Protocol>::verify_encryption_of_centralized_party_share_proof(
+        &protocol_public_parameters,
+        decentralized_dkg_output,
+        bcs::from_bytes(encryption_key)?,
+        bcs::from_bytes(encrypted_centralized_secret_share_and_proof)?,
+        &mut OsCsRng,
+    )
+    .map_err(Into::<anyhow::Error>::into)?;
+    Ok(())
 }

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/native_computations/make_dwallet_user_secret_key_shares_public.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/native_computations/make_dwallet_user_secret_key_shares_public.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 use dwallet_mpc_types::dwallet_mpc::{
+    DKGDecentralizedPartyOutputSecp256k1, DKGDecentralizedPartyVersionedOutputSecp256k1,
     SerializedWrappedMPCPublicOutput, VersionedDwalletDKGSecondRoundPublicOutput,
     VersionedImportedSecretShare,
 };
-use twopc_mpc::secp256k1::class_groups::AsyncProtocol;
+use twopc_mpc::secp256k1::class_groups::AsyncECDSAProtocol;
 
 /// Verifies the given secret share matches the given dWallets`
 /// DKG output centralized_party_public_key_share.
@@ -17,14 +18,18 @@ pub fn verify_secret_share(
     let secret_share: VersionedImportedSecretShare = bcs::from_bytes(&secret_share)?;
     let VersionedImportedSecretShare::V1(secret_share) = secret_share;
     let dkg_output = bcs::from_bytes(&dkg_output)?;
-    match dkg_output {
-        VersionedDwalletDKGSecondRoundPublicOutput::V1(dkg_output) => {
-            <AsyncProtocol as twopc_mpc::dkg::Protocol>::verify_centralized_party_secret_key_share(
-                &protocol_public_parameters,
-                bcs::from_bytes(&dkg_output)?,
-                bcs::from_bytes(&secret_share)?,
-            )
-            .map_err(Into::into)
+    let decentralized_dkg_output = match dkg_output {
+        VersionedDwalletDKGSecondRoundPublicOutput::V1(output) => {
+            bcs::from_bytes::<DKGDecentralizedPartyOutputSecp256k1>(output.as_slice())?.into()
         }
-    }
+        VersionedDwalletDKGSecondRoundPublicOutput::V2(output) => {
+            bcs::from_bytes::<DKGDecentralizedPartyVersionedOutputSecp256k1>(output.as_slice())?
+        }
+    };
+    <AsyncECDSAProtocol as twopc_mpc::dkg::Protocol>::verify_centralized_party_secret_key_share(
+        &protocol_public_parameters,
+        decentralized_dkg_output,
+        bcs::from_bytes(&secret_share)?,
+    )
+    .map_err(Into::into)
 }

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/protocol_cryptographic_data.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/protocol_cryptographic_data.rs
@@ -19,6 +19,7 @@ use ika_types::dwallet_mpc_error::DwalletMPCError;
 use ika_types::messages_dwallet_mpc::AsyncProtocol;
 use mpc::guaranteed_output_delivery::AdvanceRequest;
 use std::collections::HashMap;
+use sui_types::base_types::ObjectID;
 use twopc_mpc::sign::Protocol;
 
 pub enum ProtocolCryptographicData {
@@ -43,6 +44,7 @@ pub enum ProtocolCryptographicData {
         data: DKGSecondData,
         public_input: <DWalletDKGSecondParty as mpc::Party>::PublicInput,
         advance_request: AdvanceRequest<<DWalletDKGSecondParty as mpc::Party>::Message>,
+        first_round_output: Vec<u8>,
     },
 
     Presign {

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/create_dwallet.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/create_dwallet.rs
@@ -299,10 +299,9 @@ pub(crate) async fn create_dwallet_test(
     };
     info!("DWallet DKG first round completed");
     let protocol_pp = network_dkg_public_output_to_protocol_pp_inner(network_key_bytes).unwrap();
-    let centralized_dwallet_dkg_result = dwallet_mpc_centralized_party::create_dkg_output(
+    let centralized_dwallet_dkg_result = dwallet_mpc_centralized_party::create_dkg_output_v1(
         protocol_pp.clone(),
         dwallet_dkg_first_round_output.output.clone(),
-        SessionIdentifier::new(SessionType::User, dwallet_dkg_session_identifier).to_vec(),
     )
     .unwrap();
     let (encryption_key, decryption_key) =

--- a/crates/ika-types/src/dwallet_mpc_error.rs
+++ b/crates/ika-types/src/dwallet_mpc_error.rs
@@ -174,6 +174,12 @@ pub enum DwalletMPCError {
 
     #[error("Invalid dWallet protocol type")]
     InvalidDWalletProtocolType,
+
+    #[error("Invalid hash scheme")]
+    InvalidHashScheme,
+
+    #[error("Internal error: {0}")]
+    InternalError(String),
 }
 
 /// A wrapper type for the result of a runtime operation.

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -230,7 +230,7 @@ impl Ord for SessionIdentifier {
     }
 }
 
-pub type AsyncProtocol = twopc_mpc::secp256k1::class_groups::AsyncProtocol;
+pub type AsyncProtocol = twopc_mpc::secp256k1::class_groups::AsyncECDSAProtocol;
 
 /// Represents the Rust version of the Move struct `ika_system::dwallet_2pc_mpc_coordinator_inner::DWalletSessionEvent`.
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Eq, PartialEq, Hash)]

--- a/sdk/ika-wasm/Cargo.lock
+++ b/sdk/ika-wasm/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 [[package]]
 name = "class_groups"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=29d2bcf#29d2bcf8a8bd2c9576b65fa2c42a0dd777c88603"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -100,13 +100,23 @@ dependencies = [
 [[package]]
 name = "commitment"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=29d2bcf#29d2bcf8a8bd2c9576b65fa2c42a0dd777c88603"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "crypto-bigint",
  "group 0.1.0",
  "merlin",
  "serde",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
 ]
 
 [[package]]
@@ -173,6 +183,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
+ "group 0.14.0-pre.0",
  "rand_core 0.9.3",
  "rustc_version",
  "serde",
@@ -220,17 +231,22 @@ dependencies = [
  "bcs",
  "class_groups",
  "commitment",
+ "console_log",
  "dwallet-mpc-types",
  "getrandom 0.2.16",
  "group 0.1.0",
  "homomorphic_encryption",
+ "log",
  "message-digest",
  "mpc",
  "rand_chacha",
  "rand_core 0.9.3",
  "schemars",
  "serde",
+ "tracing",
+ "tracing-subscriber",
  "twopc_mpc",
+ "web-sys",
 ]
 
 [[package]]
@@ -239,8 +255,10 @@ version = "1.0.0"
 dependencies = [
  "class_groups",
  "enum_dispatch",
+ "group 0.1.0",
  "schemars",
  "serde",
+ "strum_macros",
  "thiserror 2.0.12",
  "twopc_mpc",
 ]
@@ -367,7 +385,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=29d2bcf#29d2bcf8a8bd2c9576b65fa2c42a0dd777c88603"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "crypto-bigint",
  "curve25519-dalek",
@@ -375,10 +393,12 @@ dependencies = [
  "hash2curve",
  "itertools",
  "k256",
+ "p256",
  "rand_chacha",
  "rand_core 0.9.3",
  "serde",
  "serde_json",
+ "sha2",
  "sha3",
  "subtle",
  "thiserror 2.0.12",
@@ -408,6 +428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hmac"
 version = "0.13.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,7 +445,7 @@ dependencies = [
 [[package]]
 name = "homomorphic_encryption"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=29d2bcf#29d2bcf8a8bd2c9576b65fa2c42a0dd777c88603"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "crypto-bigint",
  "group 0.1.0",
@@ -497,6 +523,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,7 +549,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 [[package]]
 name = "maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=29d2bcf#29d2bcf8a8bd2c9576b65fa2c42a0dd777c88603"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -563,12 +595,13 @@ dependencies = [
  "serde",
  "sha2",
  "sha3",
+ "strum_macros",
 ]
 
 [[package]]
 name = "mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=29d2bcf#29d2bcf8a8bd2c9576b65fa2c42a0dd777c88603"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "bcs",
  "commitment",
@@ -582,6 +615,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -602,6 +645,32 @@ dependencies = [
  "critical-section",
  "portable-atomic",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p256"
+version = "0.14.0-pre.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be97a30a85c829fdac914cebb89ef05e109f9e5eb6510f46f623be91bc39ded"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "hash2curve",
+ "primefield",
+ "primeorder",
+ "serdect",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkcs8"
@@ -629,6 +698,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc85f9f75dc05486f61bc61858535c0501a0ca81ca3117ab17befbead13c110"
+dependencies = [
+ "crypto-bigint",
+ "ff",
+ "rand_core 0.9.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0-pre.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af12dd34fc62d04416de85af032f4595369437fb7b0143d36ae60cecaf5cdddf"
+dependencies = [
+ "elliptic-curve",
+ "serdect",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,7 +732,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=29d2bcf#29d2bcf8a8bd2c9576b65fa2c42a0dd777c88603"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -863,6 +955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signature"
 version = "3.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +974,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "spki"
 version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +987,18 @@ checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -940,15 +1059,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "twopc_mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=29d2bcf#29d2bcf8a8bd2c9576b65fa2c42a0dd777c88603"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "class_groups",
  "commitment",
  "crypto-bigint",
  "group 0.1.0",
  "homomorphic_encryption",
+ "itertools",
  "maurer",
  "merlin",
  "mpc",
@@ -956,6 +1142,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]
@@ -969,6 +1156,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"
@@ -1042,6 +1235,38 @@ checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/sdk/ika-wasm/Cargo.lock
+++ b/sdk/ika-wasm/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 [[package]]
 name = "class_groups"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -100,13 +100,23 @@ dependencies = [
 [[package]]
 name = "commitment"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "crypto-bigint",
  "group 0.1.0",
  "merlin",
  "serde",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
 ]
 
 [[package]]
@@ -173,6 +183,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
+ "group 0.14.0-pre.0",
  "rand_core 0.9.3",
  "rustc_version",
  "serde",
@@ -220,17 +231,22 @@ dependencies = [
  "bcs",
  "class_groups",
  "commitment",
+ "console_log",
  "dwallet-mpc-types",
  "getrandom 0.2.16",
  "group 0.1.0",
  "homomorphic_encryption",
+ "log",
  "message-digest",
  "mpc",
  "rand_chacha",
  "rand_core 0.9.3",
  "schemars",
  "serde",
+ "tracing",
+ "tracing-subscriber",
  "twopc_mpc",
+ "web-sys",
 ]
 
 [[package]]
@@ -239,6 +255,7 @@ version = "1.0.0"
 dependencies = [
  "class_groups",
  "enum_dispatch",
+ "group 0.1.0",
  "schemars",
  "serde",
  "strum_macros",
@@ -368,7 +385,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "crypto-bigint",
  "curve25519-dalek",
@@ -376,10 +393,12 @@ dependencies = [
  "hash2curve",
  "itertools",
  "k256",
+ "p256",
  "rand_chacha",
  "rand_core 0.9.3",
  "serde",
  "serde_json",
+ "sha2",
  "sha3",
  "subtle",
  "thiserror 2.0.12",
@@ -426,7 +445,7 @@ dependencies = [
 [[package]]
 name = "homomorphic_encryption"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "crypto-bigint",
  "group 0.1.0",
@@ -504,6 +523,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,7 +549,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 [[package]]
 name = "maurer"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -576,7 +601,7 @@ dependencies = [
 [[package]]
 name = "mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "bcs",
  "commitment",
@@ -590,6 +615,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -610,6 +644,26 @@ dependencies = [
  "critical-section",
  "portable-atomic",
 ]
+
+[[package]]
+name = "p256"
+version = "0.14.0-pre.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be97a30a85c829fdac914cebb89ef05e109f9e5eb6510f46f623be91bc39ded"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "hash2curve",
+ "primefield",
+ "primeorder",
+ "serdect",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkcs8"
@@ -637,6 +691,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc85f9f75dc05486f61bc61858535c0501a0ca81ca3117ab17befbead13c110"
+dependencies = [
+ "crypto-bigint",
+ "ff",
+ "rand_core 0.9.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0-pre.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af12dd34fc62d04416de85af032f4595369437fb7b0143d36ae60cecaf5cdddf"
+dependencies = [
+ "elliptic-curve",
+ "serdect",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,7 +725,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -871,6 +948,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signature"
 version = "3.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +965,12 @@ dependencies = [
  "digest",
  "rand_core 0.9.3",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spki"
@@ -960,15 +1052,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "twopc_mpc"
 version = "0.1.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=bc0464c#bc0464cac946f42477b4f6c7fde198452db0bca5"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=c3faed6f11b#c3faed6f11bd77d756a01e11b2c7b1cde4492766"
 dependencies = [
  "class_groups",
  "commitment",
  "crypto-bigint",
  "group 0.1.0",
  "homomorphic_encryption",
+ "itertools",
  "maurer",
  "merlin",
  "mpc",
@@ -976,6 +1135,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]
@@ -989,6 +1149,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"
@@ -1062,6 +1228,89 @@ checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/sdk/ika-wasm/Cargo.toml
+++ b/sdk/ika-wasm/Cargo.toml
@@ -49,7 +49,6 @@ publish = false
 #    "--flexible-inline-max-function-size",
 #    "4294967295",
 #]
-
 [dependencies]
 dwallet-mpc-centralized-party = { path = "../../crates/dwallet-mpc-centralized-party", features = ["wasm_js"] }
 anyhow = "1.0.95"

--- a/sdk/ika-wasm/src/lib.rs
+++ b/sdk/ika-wasm/src/lib.rs
@@ -3,8 +3,9 @@
 
 use dwallet_mpc_centralized_party::{
     advance_centralized_sign_party, centralized_and_decentralized_parties_dkg_output_match_inner,
-    create_dkg_output, create_imported_dwallet_centralized_step_inner, decrypt_user_share_inner,
-    encrypt_secret_key_share_and_prove, generate_secp256k1_cg_keypair_from_seed_internal,
+    create_dkg_output_v1, create_dkg_output_v2, create_imported_dwallet_centralized_step_inner,
+    decrypt_user_share_inner, encrypt_secret_key_share_and_prove,
+    generate_secp256k1_cg_keypair_from_seed_internal,
     network_dkg_public_output_to_protocol_pp_inner, public_key_from_dwallet_output_inner,
     sample_dwallet_keypair_inner, verify_secp_signature_inner, verify_secret_share,
 };
@@ -12,17 +13,28 @@ use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub fn create_dkg_centralized_output(
+pub fn create_dkg_centralized_output_v1(
     protocol_pp: Vec<u8>,
     decentralized_first_round_public_output: Vec<u8>,
+) -> Result<JsValue, JsError> {
+    let dkg_centralized_result =
+        &create_dkg_output_v1(protocol_pp, decentralized_first_round_public_output)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+    serde_wasm_bindgen::to_value(&(
+        dkg_centralized_result.public_key_share_and_proof.clone(),
+        dkg_centralized_result.public_output.clone(),
+        dkg_centralized_result.centralized_secret_output.clone(),
+    ))
+    .map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[wasm_bindgen]
+pub fn create_dkg_centralized_output_v2(
+    protocol_pp: Vec<u8>,
     session_identifier: Vec<u8>,
 ) -> Result<JsValue, JsError> {
-    let dkg_centralized_result = &create_dkg_output(
-        protocol_pp,
-        decentralized_first_round_public_output,
-        session_identifier,
-    )
-    .map_err(|e| JsError::new(&e.to_string()))?;
+    let dkg_centralized_result = &create_dkg_output_v2(protocol_pp, session_identifier)
+        .map_err(|e| JsError::new(&e.to_string()))?;
     serde_wasm_bindgen::to_value(&(
         dkg_centralized_result.public_key_share_and_proof.clone(),
         dkg_centralized_result.public_output.clone(),

--- a/sdk/typescript/examples/shared-dwallet/dwallet-sharing-sign.ts
+++ b/sdk/typescript/examples/shared-dwallet/dwallet-sharing-sign.ts
@@ -41,7 +41,6 @@ async function main() {
 	const dkgSecondRoundRequestInput = await prepareDKGSecondRoundAsync(
 		ikaClient,
 		dWallet,
-		sessionIdentifierPreimage,
 		userShareEncryptionKeys,
 	);
 

--- a/sdk/typescript/examples/shared-dwallet/dwallet-sharing.ts
+++ b/sdk/typescript/examples/shared-dwallet/dwallet-sharing.ts
@@ -34,7 +34,6 @@ async function main() {
 	const dkgSecondRoundRequestInput = await prepareDKGSecondRoundAsync(
 		ikaClient,
 		dWallet,
-		sessionIdentifierPreimage,
 		userShareEncryptionKeys,
 	);
 

--- a/sdk/typescript/examples/zero-trust-dwallet/creating-dwallet.ts
+++ b/sdk/typescript/examples/zero-trust-dwallet/creating-dwallet.ts
@@ -33,7 +33,6 @@ async function main() {
 	const dkgSecondRoundRequestInput = await prepareDKGSecondRoundAsync(
 		ikaClient,
 		dWallet,
-		sessionIdentifierPreimage,
 		userShareEncryptionKeys,
 	);
 

--- a/sdk/typescript/examples/zero-trust-dwallet/dwallet-future-sign.ts
+++ b/sdk/typescript/examples/zero-trust-dwallet/dwallet-future-sign.ts
@@ -35,7 +35,6 @@ async function main() {
 	const dkgSecondRoundRequestInput = await prepareDKGSecondRoundAsync(
 		ikaClient,
 		dWallet,
-		sessionIdentifierPreimage,
 		userShareEncryptionKeys,
 	);
 

--- a/sdk/typescript/examples/zero-trust-dwallet/dwallet-sign.ts
+++ b/sdk/typescript/examples/zero-trust-dwallet/dwallet-sign.ts
@@ -35,7 +35,6 @@ async function main() {
 	const dkgSecondRoundRequestInput = await prepareDKGSecondRoundAsync(
 		ikaClient,
 		dWallet,
-		sessionIdentifierPreimage,
 		userShareEncryptionKeys,
 	);
 

--- a/sdk/typescript/examples/zero-trust-dwallet/transfer-secret-share.ts
+++ b/sdk/typescript/examples/zero-trust-dwallet/transfer-secret-share.ts
@@ -43,7 +43,6 @@ async function main() {
 	const dkgSecondRoundRequestInput = await prepareDKGSecondRoundAsync(
 		ikaClient,
 		dWallet,
-		sessionIdentifierPreimage,
 		sourceUserShareEncryptionKeys,
 	);
 

--- a/sdk/typescript/src/client/cryptography.ts
+++ b/sdk/typescript/src/client/cryptography.ts
@@ -14,7 +14,7 @@ import type { UserShareEncryptionKeys } from './user-share-encryption-keys.js';
 import { encodeToASCII, u64ToBytesBigEndian } from './utils.js';
 import {
 	centralized_and_decentralized_parties_dkg_output_match,
-	create_dkg_centralized_output as create_dkg_user_output,
+	create_dkg_centralized_output_v1 as create_dkg_user_output,
 	create_imported_dwallet_centralized_step as create_imported_dwallet_user_output,
 	create_sign_centralized_party_message as create_sign_user_message,
 	encrypt_secret_share,
@@ -100,7 +100,6 @@ export async function createClassGroupsKeypair(
 export async function createDKGUserOutput(
 	protocolPublicParameters: Uint8Array,
 	networkFirstRoundOutput: Uint8Array,
-	sessionIdentifier: Uint8Array,
 ): Promise<{
 	userDKGMessage: Uint8Array;
 	userPublicOutput: Uint8Array;
@@ -109,7 +108,6 @@ export async function createDKGUserOutput(
 	const [userDKGMessage, userPublicOutput, userSecretKeyShare] = await create_dkg_user_output(
 		protocolPublicParameters,
 		Uint8Array.from(networkFirstRoundOutput),
-		sessionIdentifierDigest(sessionIdentifier),
 	);
 
 	return {
@@ -156,7 +154,6 @@ export async function encryptSecretShare(
 export async function prepareDKGSecondRound(
 	protocolPublicParameters: Uint8Array,
 	dWallet: DWallet,
-	sessionIdentifier: Uint8Array,
 	encryptionKey: Uint8Array,
 ): Promise<DKGSecondRoundRequestInput> {
 	const networkFirstRoundOutput =
@@ -169,7 +166,6 @@ export async function prepareDKGSecondRound(
 	const [userDKGMessage, userPublicOutput, userSecretKeyShare] = await create_dkg_user_output(
 		protocolPublicParameters,
 		Uint8Array.from(networkFirstRoundOutput),
-		sessionIdentifierDigest(sessionIdentifier),
 	);
 
 	const encryptedUserShareAndProof = await encryptSecretShare(
@@ -199,7 +195,6 @@ export async function prepareDKGSecondRound(
 export async function prepareDKGSecondRoundAsync(
 	ikaClient: IkaClient,
 	dWallet: DWallet,
-	sessionIdentifier: Uint8Array,
 	userShareEncryptionKeys: UserShareEncryptionKeys,
 ): Promise<DKGSecondRoundRequestInput> {
 	const protocolPublicParameters = await ikaClient.getProtocolPublicParameters();
@@ -207,7 +202,6 @@ export async function prepareDKGSecondRoundAsync(
 	return prepareDKGSecondRound(
 		protocolPublicParameters,
 		dWallet,
-		sessionIdentifier,
 		userShareEncryptionKeys.encryptionKey,
 	);
 }

--- a/sdk/typescript/src/client/wasm-loader.ts
+++ b/sdk/typescript/src/client/wasm-loader.ts
@@ -65,17 +65,13 @@ export async function generate_secp_cg_keypair_from_seed(
 	return wasm.generate_secp_cg_keypair_from_seed(seed);
 }
 
-export async function create_dkg_centralized_output(
+// TODO (#1482): Add support for V2 one round DWallet creation flow
+export async function create_dkg_centralized_output_v1(
 	protocolPublicParameters: Uint8Array,
 	networkFirstRoundOutput: Uint8Array,
-	sessionIdentifier: Uint8Array,
 ): Promise<[Uint8Array, Uint8Array, Uint8Array]> {
 	const wasm = await getWasmModule();
-	return wasm.create_dkg_centralized_output(
-		protocolPublicParameters,
-		networkFirstRoundOutput,
-		sessionIdentifier,
-	);
+	return wasm.create_dkg_centralized_output_v1(protocolPublicParameters, networkFirstRoundOutput);
 }
 
 export async function create_sign_centralized_party_message(

--- a/sdk/typescript/test/helpers/dwallet-test-helpers.ts
+++ b/sdk/typescript/test/helpers/dwallet-test-helpers.ts
@@ -84,7 +84,6 @@ export async function createCompleteDWallet(
 	const dkgSecondRoundRequestInput = await prepareDKGSecondRoundAsync(
 		ikaClient,
 		dWallet,
-		sessionIdentifierPreimage,
 		userShareEncryptionKeys,
 	);
 

--- a/sdk/typescript/test/shared-dwallet/dwallet-sharing-sign.test.ts
+++ b/sdk/typescript/test/shared-dwallet/dwallet-sharing-sign.test.ts
@@ -57,7 +57,6 @@ describe('Shared DWallet Signing (public user shares)', () => {
 		const dkgSecondRoundRequestInput = await prepareDKGSecondRoundAsync(
 			ikaClient,
 			dWallet,
-			sessionIdentifierPreimage,
 			userShareEncryptionKeys,
 		);
 

--- a/sdk/typescript/test/shared-dwallet/dwallet-sharing.test.ts
+++ b/sdk/typescript/test/shared-dwallet/dwallet-sharing.test.ts
@@ -56,7 +56,6 @@ describe('Shared DWallet (make shares public)', () => {
 		const dkgSecondRoundRequestInput = await prepareDKGSecondRoundAsync(
 			ikaClient,
 			dWallet,
-			sessionIdentifierPreimage,
 			userShareEncryptionKeys,
 		);
 

--- a/sdk/typescript/test/zero-trust-dwallet/creating-dwallet.test.ts
+++ b/sdk/typescript/test/zero-trust-dwallet/creating-dwallet.test.ts
@@ -75,7 +75,6 @@ describe('DWallet Creation', () => {
 		const dkgSecondRoundRequestInput = await prepareDKGSecondRoundAsync(
 			ikaClient,
 			dWallet,
-			sessionIdentifierPreimage,
 			userShareEncryptionKeys,
 		);
 


### PR DESCRIPTION
## Description 

Update to new version of cryptography-private crate

The new version introduces breaking changes to DWallet DKG outputs. 
Version wrapping and conversion have been added to maintain backward 
compatibility.

I also updated the DWallet DKG second round to use the DWallet ID as the 
unique identifier instead of the session ID. The session ID changes 
between the first and second rounds, which caused proof verification 
to fail.

## Test plan 

I ran the chain and ran a full sign TS flow against it.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
