### PR TITLE
fix: Stop crashing on first V2 reconfiguration

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations.rs
@@ -14,8 +14,7 @@ use crate::dwallet_mpc::network_dkg::{
 use crate::dwallet_mpc::presign::PresignParty;
 use crate::dwallet_mpc::protocol_cryptographic_data::ProtocolCryptographicData;
 use crate::dwallet_mpc::reconfiguration::{
-    ReconfigurationSecp256k1Party, ReconfigurationV1toV2Secp256k1Party,
-    ReconfigurationV2Secp256k1Party,
+    ReconfigurationParty, ReconfigurationV1toV2Party, ReconfigurationV2Party,
 };
 use crate::dwallet_mpc::sign::SignParty;
 use crate::dwallet_session_request::DWalletSessionRequestMetricData;
@@ -289,14 +288,13 @@ impl ProtocolCryptographicData {
                 dwallet_network_encryption_key_id,
             } => match public_input {
                 PublicInput::NetworkEncryptionKeyReconfigurationV1(public_input) => {
-                    let advance_request_result =
-                        Party::<ReconfigurationSecp256k1Party>::ready_to_advance(
-                            party_id,
-                            access_structure,
-                            consensus_round,
-                            HashMap::from([(3, decryption_key_reconfiguration_third_round_delay)]),
-                            &serialized_messages_by_consensus_round,
-                        )?;
+                    let advance_request_result = Party::<ReconfigurationParty>::ready_to_advance(
+                        party_id,
+                        access_structure,
+                        consensus_round,
+                        HashMap::from([(3, decryption_key_reconfiguration_third_round_delay)]),
+                        &serialized_messages_by_consensus_round,
+                    )?;
 
                     let ReadyToAdvanceResult::ReadyToAdvance(advance_request) =
                         advance_request_result
@@ -316,7 +314,7 @@ impl ProtocolCryptographicData {
                 }
                 PublicInput::NetworkEncryptionKeyReconfigurationV1ToV2(public_input) => {
                     let advance_request_result =
-                        Party::<ReconfigurationV1toV2Secp256k1Party>::ready_to_advance(
+                        Party::<ReconfigurationV1toV2Party>::ready_to_advance(
                             party_id,
                             access_structure,
                             consensus_round,
@@ -341,14 +339,13 @@ impl ProtocolCryptographicData {
                     }
                 }
                 PublicInput::NetworkEncryptionKeyReconfigurationV2(public_input) => {
-                    let advance_request_result =
-                        Party::<ReconfigurationV2Secp256k1Party>::ready_to_advance(
-                            party_id,
-                            access_structure,
-                            consensus_round,
-                            HashMap::from([(3, decryption_key_reconfiguration_third_round_delay)]),
-                            &serialized_messages_by_consensus_round,
-                        )?;
+                    let advance_request_result = Party::<ReconfigurationV2Party>::ready_to_advance(
+                        party_id,
+                        access_structure,
+                        consensus_round,
+                        HashMap::from([(3, decryption_key_reconfiguration_third_round_delay)]),
+                        &serialized_messages_by_consensus_round,
+                    )?;
 
                     let ReadyToAdvanceResult::ReadyToAdvance(advance_request) =
                         advance_request_result
@@ -786,16 +783,15 @@ impl ProtocolCryptographicData {
                 decryption_key_shares,
                 ..
             } => {
-                let result =
-                    Party::<ReconfigurationSecp256k1Party>::advance_with_guaranteed_output(
-                        session_id,
-                        party_id,
-                        access_structure,
-                        advance_request,
-                        Some(decryption_key_shares.clone()),
-                        &public_input,
-                        &mut rng,
-                    )?;
+                let result = Party::<ReconfigurationParty>::advance_with_guaranteed_output(
+                    session_id,
+                    party_id,
+                    access_structure,
+                    advance_request,
+                    Some(decryption_key_shares.clone()),
+                    &public_input,
+                    &mut rng,
+                )?;
 
                 match result {
                     GuaranteedOutputDeliveryRoundResult::Advance { message } => {
@@ -825,16 +821,15 @@ impl ProtocolCryptographicData {
                 decryption_key_shares,
                 ..
             } => {
-                let result =
-                    Party::<ReconfigurationV1toV2Secp256k1Party>::advance_with_guaranteed_output(
-                        session_id,
-                        party_id,
-                        access_structure,
-                        advance_request,
-                        Some(decryption_key_shares.clone()),
-                        &public_input,
-                        &mut rng,
-                    )?;
+                let result = Party::<ReconfigurationV1toV2Party>::advance_with_guaranteed_output(
+                    session_id,
+                    party_id,
+                    access_structure,
+                    advance_request,
+                    Some(decryption_key_shares.clone()),
+                    &public_input,
+                    &mut rng,
+                )?;
 
                 match result {
                     GuaranteedOutputDeliveryRoundResult::Advance { message } => {
@@ -864,16 +859,15 @@ impl ProtocolCryptographicData {
                 decryption_key_shares,
                 ..
             } => {
-                let result =
-                    Party::<ReconfigurationV2Secp256k1Party>::advance_with_guaranteed_output(
-                        session_id,
-                        party_id,
-                        access_structure,
-                        advance_request,
-                        Some(decryption_key_shares.clone()),
-                        &public_input,
-                        &mut rng,
-                    )?;
+                let result = Party::<ReconfigurationV2Party>::advance_with_guaranteed_output(
+                    session_id,
+                    party_id,
+                    access_structure,
+                    advance_request,
+                    Some(decryption_key_shares.clone()),
+                    &public_input,
+                    &mut rng,
+                )?;
 
                 match result {
                     GuaranteedOutputDeliveryRoundResult::Advance { message } => {

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -322,13 +322,10 @@ impl DwalletMPCNetworkKeys {
     pub fn get_last_reconfiguration_output(
         &self,
         key_id: &ObjectID,
-    ) -> DwalletMPCResult<Option<VersionedDecryptionKeyReconfigurationOutput>> {
-        Ok(self
-            .network_encryption_keys
+    ) -> Option<Option<VersionedDecryptionKeyReconfigurationOutput>> {
+        self.network_encryption_keys
             .get(key_id)
-            .ok_or(DwalletMPCError::WaitingForNetworkKey(*key_id))?
-            .latest_network_reconfiguration_public_output()
-            .clone())
+            .map(|key| key.latest_network_reconfiguration_public_output().clone())
     }
 }
 

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -322,10 +322,12 @@ impl DwalletMPCNetworkKeys {
     pub fn get_last_reconfiguration_output(
         &self,
         key_id: &ObjectID,
-    ) -> Option<Option<VersionedDecryptionKeyReconfigurationOutput>> {
-        self.network_encryption_keys
-            .get(key_id)
-            .map(|key| key.latest_network_reconfiguration_public_output().clone())
+    ) -> Option<VersionedDecryptionKeyReconfigurationOutput> {
+        let key = self.network_encryption_keys.get(key_id);
+        if key.is_none() {
+            return None;
+        }
+        key.unwrap().latest_network_reconfiguration_public_output()
     }
 }
 

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -8,7 +8,7 @@
 
 use crate::dwallet_mpc::mpc_session::PublicInput;
 use crate::dwallet_mpc::reconfiguration::{
-    ReconfigurationSecp256k1Party,
+    ReconfigurationParty,
     instantiate_dwallet_mpc_network_encryption_key_public_data_from_reconfiguration_public_output,
 };
 use class_groups::dkg::{Secp256k1Party, Secp256k1PublicInput};
@@ -127,7 +127,7 @@ async fn get_decryption_key_shares_from_public_output(
                 {
                     VersionedDecryptionKeyReconfigurationOutput::V1(public_output) => {
                         match bcs::from_bytes::<
-                            <ReconfigurationSecp256k1Party as mpc::Party>::PublicOutput,
+                            <ReconfigurationParty as mpc::Party>::PublicOutput,
                         >(&public_output)
                         {
                             Ok(public_output) => public_output

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -106,15 +106,17 @@ impl ReconfigurationV2PartyPublicInputGenerator for ReconfigurationV2Secp256k1Pa
                                 upcoming_encryption_keys_per_crt_prime_and_proofs.clone(),
                                 current_tangible_party_id_to_upcoming(current_committee, upcoming_committee)
                                     .clone(),
-                                bcs::from_bytes::<Secp256k1Party::PublicOutput>(&network_dkg_public_output)?.into(),
+                                bcs::from_bytes(&network_dkg_public_output)?,
                                 bcs::from_bytes(&latest_reconfiguration_public_output)?,
                             )
                                 .map_err(DwalletMPCError::from)?;
-                        Ok(public_input);
+                        Ok(public_input)
                     }
                 }
             }
             VersionedNetworkDkgOutput::V2(network_dkg_public_output) => {
+                let public_output: <twopc_mpc::decentralized_party::dkg::Party as mpc::Party>::PublicOutput =
+                    bcs::from_bytes(&network_dkg_public_output)?;
                 let public_input: <ReconfigurationV2Secp256k1Party as Party>::PublicInput =
                     <twopc_mpc::decentralized_party::reconfiguration::Party as Party>::PublicInput::new_from_dkg_output(
                         &current_access_structure,
@@ -123,7 +125,7 @@ impl ReconfigurationV2PartyPublicInputGenerator for ReconfigurationV2Secp256k1Pa
                         upcoming_encryption_keys_per_crt_prime_and_proofs.clone(),
                         current_tangible_party_id_to_upcoming(current_committee, upcoming_committee)
                             .clone(),
-                        bcs::from_bytes(&network_dkg_public_output)?,
+                        public_output.into(),
                     )
                         .map_err(DwalletMPCError::from)?;
 

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -26,11 +26,10 @@ use twopc_mpc::secp256k1::class_groups::{
     FUNDAMENTAL_DISCRIMINANT_LIMBS, NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
 };
 
-pub(crate) type ReconfigurationSecp256k1Party = Secp256k1Party;
-pub(crate) type ReconfigurationV1toV2Secp256k1Party =
+pub(crate) type ReconfigurationParty = Secp256k1Party;
+pub(crate) type ReconfigurationV1toV2Party =
     twopc_mpc::decentralized_party::reconfiguration_v1_to_v2::Party;
-pub(crate) type ReconfigurationV2Secp256k1Party =
-    twopc_mpc::decentralized_party::reconfiguration::Party;
+pub(crate) type ReconfigurationV2Party = twopc_mpc::decentralized_party::reconfiguration::Party;
 
 pub(crate) trait ReconfigurationPartyPublicInputGenerator: Party {
     /// Generates the public input required for the reconfiguration protocol.
@@ -39,7 +38,7 @@ pub(crate) trait ReconfigurationPartyPublicInputGenerator: Party {
         new_committee: Committee,
         decryption_key_share_public_parameters: Secp256k1DecryptionKeySharePublicParameters,
         network_dkg_public_output: VersionedNetworkDkgOutput,
-    ) -> DwalletMPCResult<<ReconfigurationSecp256k1Party as mpc::Party>::PublicInput>;
+    ) -> DwalletMPCResult<<ReconfigurationParty as mpc::Party>::PublicInput>;
 }
 
 pub(crate) trait ReconfigurationV2PartyPublicInputGenerator: Party {
@@ -49,16 +48,16 @@ pub(crate) trait ReconfigurationV2PartyPublicInputGenerator: Party {
         new_committee: Committee,
         network_dkg_public_output: VersionedNetworkDkgOutput,
         latest_reconfiguration_public_output: Option<VersionedDecryptionKeyReconfigurationOutput>,
-    ) -> DwalletMPCResult<<ReconfigurationV2Secp256k1Party as mpc::Party>::PublicInput>;
+    ) -> DwalletMPCResult<<ReconfigurationV2Party as mpc::Party>::PublicInput>;
 }
 
-impl ReconfigurationV2PartyPublicInputGenerator for ReconfigurationV2Secp256k1Party {
+impl ReconfigurationV2PartyPublicInputGenerator for ReconfigurationV2Party {
     fn generate_public_input(
         current_committee: &Committee,
         upcoming_committee: Committee,
         network_dkg_public_output: VersionedNetworkDkgOutput,
         latest_reconfiguration_public_output: Option<VersionedDecryptionKeyReconfigurationOutput>,
-    ) -> DwalletMPCResult<<ReconfigurationV2Secp256k1Party as Party>::PublicInput> {
+    ) -> DwalletMPCResult<<ReconfigurationV2Party as Party>::PublicInput> {
         let current_committee = current_committee.clone();
         let current_access_structure =
             generate_access_structure_from_committee(&current_committee)?;
@@ -89,7 +88,7 @@ impl ReconfigurationV2PartyPublicInputGenerator for ReconfigurationV2Secp256k1Pa
                                     .to_string(),
                             ));
                         };
-                        let public_input: <ReconfigurationV2Secp256k1Party as Party>::PublicInput =
+                        let public_input: <ReconfigurationV2Party as Party>::PublicInput =
                             <twopc_mpc::decentralized_party::reconfiguration::Party as Party>::PublicInput::new_from_reconfiguration_output(
                                 &current_access_structure,
                                 upcoming_access_structure,
@@ -110,7 +109,7 @@ impl ReconfigurationV2PartyPublicInputGenerator for ReconfigurationV2Secp256k1Pa
                     None => {
                         let public_output: <twopc_mpc::decentralized_party::dkg::Party as mpc::Party>::PublicOutput =
                             bcs::from_bytes(&network_dkg_public_output)?;
-                        let public_input: <ReconfigurationV2Secp256k1Party as Party>::PublicInput =
+                        let public_input: <ReconfigurationV2Party as Party>::PublicInput =
                             <twopc_mpc::decentralized_party::reconfiguration::Party as Party>::PublicInput::new_from_dkg_output(
                                 &current_access_structure,
                                 upcoming_access_structure,
@@ -136,7 +135,7 @@ impl ReconfigurationV2PartyPublicInputGenerator for ReconfigurationV2Secp256k1Pa
                         };
                         let public_output: <twopc_mpc::decentralized_party::dkg::Party as mpc::Party>::PublicOutput =
                             bcs::from_bytes(&network_dkg_public_output)?;
-                        let public_input: <ReconfigurationV2Secp256k1Party as Party>::PublicInput =
+                        let public_input: <ReconfigurationV2Party as Party>::PublicInput =
                             <twopc_mpc::decentralized_party::reconfiguration::Party as Party>::PublicInput::new_from_reconfiguration_output(
                                 &current_access_structure,
                                 upcoming_access_structure,
@@ -164,16 +163,16 @@ pub(crate) trait ReconfigurationV1ToV2PartyPublicInputGenerator: Party {
         new_committee: Committee,
         network_dkg_public_output: VersionedNetworkDkgOutput,
         decryption_key_share_public_parameters: Secp256k1DecryptionKeySharePublicParameters,
-    ) -> DwalletMPCResult<<ReconfigurationV1toV2Secp256k1Party as mpc::Party>::PublicInput>;
+    ) -> DwalletMPCResult<<ReconfigurationV1toV2Party as mpc::Party>::PublicInput>;
 }
 
-impl ReconfigurationV1ToV2PartyPublicInputGenerator for ReconfigurationV1toV2Secp256k1Party {
+impl ReconfigurationV1ToV2PartyPublicInputGenerator for ReconfigurationV1toV2Party {
     fn generate_public_input(
         current_committee: &Committee,
         upcoming_committee: Committee,
         network_dkg_public_output: VersionedNetworkDkgOutput,
         decryption_key_share_public_parameters: Secp256k1DecryptionKeySharePublicParameters,
-    ) -> DwalletMPCResult<<ReconfigurationV1toV2Secp256k1Party as mpc::Party>::PublicInput> {
+    ) -> DwalletMPCResult<<ReconfigurationV1toV2Party as mpc::Party>::PublicInput> {
         let VersionedNetworkDkgOutput::V1(network_dkg_public_output) = network_dkg_public_output
         else {
             return Err(DwalletMPCError::InternalError(
@@ -194,8 +193,8 @@ impl ReconfigurationV1ToV2PartyPublicInputGenerator for ReconfigurationV1toV2Sec
         let upcoming_encryption_keys_per_crt_prime_and_proofs =
             extract_encryption_keys_from_committee(&upcoming_committee)?;
 
-        let public_input: <ReconfigurationV1toV2Secp256k1Party as Party>::PublicInput =
-            <ReconfigurationV1toV2Secp256k1Party as Party>::PublicInput::new(
+        let public_input: <ReconfigurationV1toV2Party as Party>::PublicInput =
+            <ReconfigurationV1toV2Party as Party>::PublicInput::new(
                 &current_access_structure,
                 upcoming_access_structure,
                 current_encryption_keys_per_crt_prime_and_proofs.clone(),
@@ -232,13 +231,13 @@ fn current_tangible_party_id_to_upcoming(
         .collect()
 }
 
-impl ReconfigurationPartyPublicInputGenerator for ReconfigurationSecp256k1Party {
+impl ReconfigurationPartyPublicInputGenerator for ReconfigurationParty {
     fn generate_public_input(
         current_committee: &Committee,
         upcoming_committee: Committee,
         decryption_key_share_public_parameters: Secp256k1DecryptionKeySharePublicParameters,
         network_dkg_public_output: VersionedNetworkDkgOutput,
-    ) -> DwalletMPCResult<<ReconfigurationSecp256k1Party as mpc::Party>::PublicInput> {
+    ) -> DwalletMPCResult<<ReconfigurationParty as mpc::Party>::PublicInput> {
         let VersionedNetworkDkgOutput::V1(network_dkg_public_output) = network_dkg_public_output
         else {
             return Err(DwalletMPCError::InternalError(
@@ -261,20 +260,20 @@ impl ReconfigurationPartyPublicInputGenerator for ReconfigurationSecp256k1Party 
         let upcoming_encryption_keys_per_crt_prime_and_proofs =
             extract_encryption_keys_from_committee(&upcoming_committee)?;
 
-        let public_input: <ReconfigurationSecp256k1Party as Party>::PublicInput =
-            PublicInput::new::<secp256k1::GroupElement>(
-                &current_access_structure,
-                upcoming_access_structure,
-                plaintext_space_public_parameters.clone(),
-                current_encryption_keys_per_crt_prime_and_proofs.clone(),
-                upcoming_encryption_keys_per_crt_prime_and_proofs.clone(),
-                decryption_key_share_public_parameters,
-                DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
-                current_tangible_party_id_to_upcoming(current_committee, upcoming_committee)
-                    .clone(),
-                bcs::from_bytes(&network_dkg_public_output)?,
-            )
-            .map_err(DwalletMPCError::from)?;
+        let public_input: <ReconfigurationParty as Party>::PublicInput = PublicInput::new::<
+            secp256k1::GroupElement,
+        >(
+            &current_access_structure,
+            upcoming_access_structure,
+            plaintext_space_public_parameters.clone(),
+            current_encryption_keys_per_crt_prime_and_proofs.clone(),
+            upcoming_encryption_keys_per_crt_prime_and_proofs.clone(),
+            decryption_key_share_public_parameters,
+            DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+            current_tangible_party_id_to_upcoming(current_committee, upcoming_committee).clone(),
+            bcs::from_bytes(&network_dkg_public_output)?,
+        )
+        .map_err(DwalletMPCError::from)?;
 
         Ok(public_input)
     }
@@ -306,7 +305,7 @@ pub(crate) fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_re
 
     match &mpc_public_output {
         VersionedDecryptionKeyReconfigurationOutput::V1(public_output_bytes) => {
-            let public_output: <ReconfigurationSecp256k1Party as mpc::Party>::PublicOutput =
+            let public_output: <ReconfigurationParty as mpc::Party>::PublicOutput =
                 bcs::from_bytes(public_output_bytes)?;
 
             let decryption_key_share_public_parameters = public_output

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -94,7 +94,7 @@ impl ReconfigurationV2PartyPublicInputGenerator for ReconfigurationV2Secp256k1Pa
                         ) = latest_reconfiguration_public_output
                         else {
                             return Err(DwalletMPCError::InternalError(
-                                "V2 Reconfiguration only supports latest reconfiguration public output of version V2"
+                                "The Reconfiguration v2 protocol can only be executed after a v1-to-v2 protocol, or after another reconfiguration v2 protocol."
                                     .to_string(),
                             ));
                         };

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -48,7 +48,7 @@ pub(crate) trait ReconfigurationV2PartyPublicInputGenerator: Party {
         committee: &Committee,
         new_committee: Committee,
         network_dkg_public_output: VersionedNetworkDkgOutput,
-        latest_reconfiguration_public_output: VersionedDecryptionKeyReconfigurationOutput,
+        latest_reconfiguration_public_output: Option<VersionedDecryptionKeyReconfigurationOutput>,
     ) -> DwalletMPCResult<<ReconfigurationV2Secp256k1Party as mpc::Party>::PublicInput>;
 }
 

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/protocol_cryptographic_data.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/protocol_cryptographic_data.rs
@@ -5,8 +5,7 @@ use crate::dwallet_mpc::mpc_manager::DWalletMPCManager;
 use crate::dwallet_mpc::mpc_session::{PublicInput, SessionComputationType};
 use crate::dwallet_mpc::presign::PresignParty;
 use crate::dwallet_mpc::reconfiguration::{
-    ReconfigurationSecp256k1Party, ReconfigurationV1toV2Secp256k1Party,
-    ReconfigurationV2Secp256k1Party,
+    ReconfigurationParty, ReconfigurationV1toV2Party, ReconfigurationV2Party,
 };
 use crate::dwallet_mpc::sign::SignParty;
 use crate::request_protocol_data::{
@@ -85,22 +84,21 @@ pub enum ProtocolCryptographicData {
     // TODO (#1487): Remove temporary v1 to v2 & v1 reconfiguration code
     NetworkEncryptionKeyV1Reconfiguration {
         data: NetworkEncryptionKeyReconfigurationData,
-        public_input: <ReconfigurationSecp256k1Party as mpc::Party>::PublicInput,
-        advance_request: AdvanceRequest<<ReconfigurationSecp256k1Party as mpc::Party>::Message>,
+        public_input: <ReconfigurationParty as mpc::Party>::PublicInput,
+        advance_request: AdvanceRequest<<ReconfigurationParty as mpc::Party>::Message>,
         decryption_key_shares: HashMap<PartyID, <AsyncProtocol as Protocol>::DecryptionKeyShare>,
     },
     // TODO (#1487): Remove temporary v1 to v2 & v1 reconfiguration code
     NetworkEncryptionKeyV1ToV2Reconfiguration {
         data: NetworkEncryptionKeyV1ToV2ReconfigurationData,
-        public_input: <ReconfigurationV1toV2Secp256k1Party as mpc::Party>::PublicInput,
-        advance_request:
-            AdvanceRequest<<ReconfigurationV1toV2Secp256k1Party as mpc::Party>::Message>,
+        public_input: <ReconfigurationV1toV2Party as mpc::Party>::PublicInput,
+        advance_request: AdvanceRequest<<ReconfigurationV1toV2Party as mpc::Party>::Message>,
         decryption_key_shares: HashMap<PartyID, <AsyncProtocol as Protocol>::DecryptionKeyShare>,
     },
     NetworkEncryptionKeyV2Reconfiguration {
         data: NetworkEncryptionKeyV2ReconfigurationData,
-        public_input: <ReconfigurationV2Secp256k1Party as mpc::Party>::PublicInput,
-        advance_request: AdvanceRequest<<ReconfigurationV2Secp256k1Party as mpc::Party>::Message>,
+        public_input: <ReconfigurationV2Party as mpc::Party>::PublicInput,
+        advance_request: AdvanceRequest<<ReconfigurationV2Party as mpc::Party>::Message>,
         decryption_key_shares: HashMap<PartyID, <AsyncProtocol as Protocol>::DecryptionKeyShare>,
     },
 

--- a/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
@@ -204,7 +204,7 @@ pub(crate) fn session_input_from_request(
                         network_keys
                             .get_last_reconfiguration_output(
                                 dwallet_network_encryption_key_id,
-                            )?.ok_or(DwalletMPCError::InternalError("reconfiguration output missing".to_string()))?,
+                            ),
                     )?),
                     Some(bcs::to_bytes(
                         &class_groups_decryption_key

--- a/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
@@ -11,9 +11,9 @@ use crate::dwallet_mpc::network_dkg::{
 };
 use crate::dwallet_mpc::presign::{PresignParty, presign_public_input};
 use crate::dwallet_mpc::reconfiguration::{
-    ReconfigurationPartyPublicInputGenerator, ReconfigurationSecp256k1Party,
-    ReconfigurationV1ToV2PartyPublicInputGenerator, ReconfigurationV1toV2Secp256k1Party,
-    ReconfigurationV2PartyPublicInputGenerator, ReconfigurationV2Secp256k1Party,
+    ReconfigurationParty, ReconfigurationPartyPublicInputGenerator,
+    ReconfigurationV1ToV2PartyPublicInputGenerator, ReconfigurationV1toV2Party,
+    ReconfigurationV2Party, ReconfigurationV2PartyPublicInputGenerator,
 };
 use crate::dwallet_mpc::sign::{SignParty, sign_session_public_input};
 use crate::dwallet_session_request::DWalletSessionRequest;
@@ -47,16 +47,12 @@ pub enum PublicInput {
     EncryptedShareVerification(twopc_mpc::secp256k1::class_groups::ProtocolPublicParameters),
     PartialSignatureVerification(twopc_mpc::secp256k1::class_groups::ProtocolPublicParameters),
     // TODO (#1487): Remove temporary v1 to v2 & v1 reconfiguration code
-    NetworkEncryptionKeyReconfigurationV1(
-        <ReconfigurationSecp256k1Party as mpc::Party>::PublicInput,
-    ),
+    NetworkEncryptionKeyReconfigurationV1(<ReconfigurationParty as mpc::Party>::PublicInput),
     // TODO (#1487): Remove temporary v1 to v2 & v1 reconfiguration code
     NetworkEncryptionKeyReconfigurationV1ToV2(
-        <ReconfigurationV1toV2Secp256k1Party as mpc::Party>::PublicInput,
+        <ReconfigurationV1toV2Party as mpc::Party>::PublicInput,
     ),
-    NetworkEncryptionKeyReconfigurationV2(
-        <ReconfigurationV2Secp256k1Party as mpc::Party>::PublicInput,
-    ),
+    NetworkEncryptionKeyReconfigurationV2(<ReconfigurationV2Party as mpc::Party>::PublicInput),
     MakeDWalletUserSecretKeySharesPublic(
         twopc_mpc::secp256k1::class_groups::ProtocolPublicParameters,
     ),
@@ -176,7 +172,7 @@ pub(crate) fn session_input_from_request(
                 network_keys.get_network_key_version(dwallet_network_encryption_key_id)?;
             if (key_version == 1) && protocol_config.network_encryption_key_version == Some(2) {
                 Ok((
-                    PublicInput::NetworkEncryptionKeyReconfigurationV1ToV2(<ReconfigurationV1toV2Secp256k1Party as ReconfigurationV1ToV2PartyPublicInputGenerator>::generate_public_input(
+                    PublicInput::NetworkEncryptionKeyReconfigurationV1ToV2(<ReconfigurationV1toV2Party as ReconfigurationV1ToV2PartyPublicInputGenerator>::generate_public_input(
                         committee,
                         next_active_committee,
                         network_keys
@@ -194,7 +190,7 @@ pub(crate) fn session_input_from_request(
                 ))
             } else if protocol_config.network_encryption_key_version == Some(2) {
                 Ok((
-                    PublicInput::NetworkEncryptionKeyReconfigurationV2(<ReconfigurationV2Secp256k1Party as ReconfigurationV2PartyPublicInputGenerator>::generate_public_input(
+                    PublicInput::NetworkEncryptionKeyReconfigurationV2(<ReconfigurationV2Party as ReconfigurationV2PartyPublicInputGenerator>::generate_public_input(
                         committee,
                         next_active_committee,
                         network_keys
@@ -212,7 +208,7 @@ pub(crate) fn session_input_from_request(
                 ))
             } else {
                 Ok((
-                    PublicInput::NetworkEncryptionKeyReconfigurationV1(<ReconfigurationSecp256k1Party as ReconfigurationPartyPublicInputGenerator>::generate_public_input(
+                    PublicInput::NetworkEncryptionKeyReconfigurationV1(<ReconfigurationParty as ReconfigurationPartyPublicInputGenerator>::generate_public_input(
                         committee,
                         next_active_committee,
                         network_keys.get_decryption_key_share_public_parameters(


### PR DESCRIPTION
## Description 

Previously, the first reconfiguration of a V2 network key would crash because the public input generation function expected a reconfiguration output that didn’t exist. This PR fixes the issue by handling that case correctly.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
