### PR TITLE
fix: Use the latest network key reconfiguration output instead of the initial DKG output

### DIFF
--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -621,6 +621,7 @@ fn protocol_public_parameters_from_reconfiguration_output(
         VersionedDecryptionKeyReconfigurationOutput::V2(public_output_bytes) => {
             let public_output: <twopc_mpc::decentralized_party::reconfiguration::Party as mpc::Party>::PublicOutput =
                 bcs::from_bytes(public_output_bytes)?;
+            // TODO (#1530): Add support for all the curves the network supports.
             let secp256k1_protocol_public_parameters =
                 twopc_mpc::decentralized_party::reconfiguration::PublicOutput::secp256k1_protocol_public_parameters(
                     &public_output,

--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -583,6 +583,7 @@ fn protocol_public_parameters_from_reconfiguration_output(
     let reconfiguration_dkg_public_output: VersionedDecryptionKeyReconfigurationOutput =
         bcs::from_bytes(&reconfiguration_dkg_public_output)?;
 
+    // Every member has a voting power of 1 in the current Move code.
     let access_structure = WeightedThresholdAccessStructure::new(
         quorum_threshold as Weight,
         (1..=committee_size).map(|i| (i as PartyID, 1)).collect(),

--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -18,7 +18,7 @@ use class_groups::{
 use dwallet_mpc_types::dwallet_mpc::{
     DKGDecentralizedPartyOutputSecp256k1, DKGDecentralizedPartyVersionedOutputSecp256k1,
     DWalletCurve, NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicDataV1,
-    NetworkEncryptionKeyPublicDataV2, ReconfigurationParty, SerializedWrappedMPCPublicOutput,
+    NetworkEncryptionKeyPublicDataV2, SerializedWrappedMPCPublicOutput,
     VersionedCentralizedDKGPublicOutput, VersionedDecryptionKeyReconfigurationOutput,
     VersionedDwalletDKGFirstRoundPublicOutput, VersionedDwalletDKGSecondRoundPublicOutput,
     VersionedDwalletUserSecretShare, VersionedEncryptedUserShare,
@@ -590,7 +590,7 @@ fn protocol_public_parameters_from_reconfiguration(
 
     match &reconfiguration_dkg_public_output {
         VersionedDecryptionKeyReconfigurationOutput::V1(public_output_bytes) => {
-            let public_output: <ReconfigurationParty as mpc::Party>::PublicOutput =
+            let public_output: <class_groups::reconfiguration::Secp256k1Party as mpc::Party>::PublicOutput =
                 bcs::from_bytes(public_output_bytes)?;
 
             let decryption_key_share_public_parameters = public_output

--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -93,7 +93,7 @@ pub fn reconfiguration_public_output_to_protocol_pp_inner(
     committee_size: usize,
     quorum_threshold: usize,
 ) -> anyhow::Result<Vec<u8>> {
-    let public_parameters = protocol_public_parameters_from_reconfiguration(
+    let public_parameters = protocol_public_parameters_from_reconfiguration_output(
         reconfiguration_dkg_public_output,
         committee_size,
         quorum_threshold,
@@ -575,7 +575,7 @@ fn protocol_public_parameters(
     }
 }
 
-fn protocol_public_parameters_from_reconfiguration(
+fn protocol_public_parameters_from_reconfiguration_output(
     reconfiguration_dkg_public_output: SerializedWrappedMPCPublicOutput,
     committee_size: usize,
     quorum_threshold: usize,

--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -581,6 +581,7 @@ fn protocol_public_parameters_from_reconfiguration_output(
         bcs::from_bytes(&reconfiguration_dkg_public_output)?;
 
     match &reconfiguration_dkg_public_output {
+        // TODO (#1487): Remove temporary support for V1 reconfiguration keys.
         VersionedDecryptionKeyReconfigurationOutput::V1(public_output_bytes) => {
             let network_dkg_pp = protocol_public_parameters(versioned_network_dkg_output)?;
             let public_output: <class_groups::reconfiguration::Secp256k1Party as mpc::Party>::PublicOutput =

--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -583,40 +583,7 @@ fn protocol_public_parameters_from_reconfiguration_output(
     match &reconfiguration_dkg_public_output {
         // TODO (#1487): Remove temporary support for V1 reconfiguration keys.
         VersionedDecryptionKeyReconfigurationOutput::V1(public_output_bytes) => {
-            let network_dkg_pp = protocol_public_parameters(versioned_network_dkg_output)?;
-            let public_output: <class_groups::reconfiguration::Secp256k1Party as mpc::Party>::PublicOutput =
-                bcs::from_bytes(public_output_bytes)?;
-
-            let encryption_scheme_public_parameters =
-                network_dkg_pp.encryption_scheme_public_parameters;
-
-            let neutral_group_value =
-                group::secp256k1::GroupElement::neutral_from_public_parameters(
-                    &group::secp256k1::group_element::PublicParameters::default(),
-                )
-                .map_err(twopc_mpc::Error::from)?
-                .value();
-            let neutral_ciphertext_value =
-                ::class_groups::CiphertextSpaceGroupElement::neutral_from_public_parameters(
-                    encryption_scheme_public_parameters.ciphertext_space_public_parameters(),
-                )
-                .map_err(twopc_mpc::Error::from)?
-                .value();
-
-            let protocol_public_parameters = twopc_mpc::ProtocolPublicParameters::new::<
-                { secp256k1::SCALAR_LIMBS },
-                { FUNDAMENTAL_DISCRIMINANT_LIMBS },
-                { NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
-                secp256k1::GroupElement,
-            >(
-                neutral_group_value,
-                neutral_group_value,
-                neutral_ciphertext_value,
-                neutral_ciphertext_value,
-                encryption_scheme_public_parameters,
-            );
-
-            Ok(protocol_public_parameters)
+            protocol_public_parameters(versioned_network_dkg_output)
         }
         VersionedDecryptionKeyReconfigurationOutput::V2(public_output_bytes) => {
             let public_output: <twopc_mpc::decentralized_party::reconfiguration::Party as mpc::Party>::PublicOutput =

--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -1,12 +1,12 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
+use class_groups::reconfiguration::Secp256k1Party;
 use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use twopc_mpc::class_groups::{DKGDecentralizedPartyOutput, DKGDecentralizedPartyVersionedOutput};
 use twopc_mpc::secp256k1::class_groups::ProtocolPublicParameters;
-use class_groups::reconfiguration::Secp256k1Party;
 
 /// Alias for an MPC message.
 pub type MPCMessage = Vec<u8>;

--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use twopc_mpc::class_groups::{DKGDecentralizedPartyOutput, DKGDecentralizedPartyVersionedOutput};
 use twopc_mpc::secp256k1::class_groups::ProtocolPublicParameters;
+use class_groups::reconfiguration::Secp256k1Party;
 
 /// Alias for an MPC message.
 pub type MPCMessage = Vec<u8>;
@@ -518,3 +519,6 @@ impl NetworkEncryptionKeyPublicDataTrait for NetworkEncryptionKeyPublicDataV2 {
             .clone())
     }
 }
+
+pub type ReconfigurationParty = Secp256k1Party;
+pub type ReconfigurationV2Party = twopc_mpc::decentralized_party::reconfiguration::Party;

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations.rs
@@ -3,14 +3,14 @@
 
 use crate::dwallet_mpc::crytographic_computation::MPC_SIGN_SECOND_ROUND;
 use crate::dwallet_mpc::dwallet_dkg::{
-    compute_dwallet_dkg, DWalletDKGAdvanceRequestByCurve, DWalletDKGFirstParty,
-    DWalletDKGPublicInputByCurve, DWalletImportedKeyVerificationParty, Secp256K1DWalletDKGParty,
+    DWalletDKGAdvanceRequestByCurve, DWalletDKGFirstParty, DWalletDKGPublicInputByCurve,
+    DWalletImportedKeyVerificationParty, Secp256K1DWalletDKGParty, compute_dwallet_dkg,
 };
 use crate::dwallet_mpc::dwallet_mpc_metrics::DWalletMPCMetrics;
 use crate::dwallet_mpc::encrypt_user_share::verify_encrypted_share;
 use crate::dwallet_mpc::mpc_session::PublicInput;
 use crate::dwallet_mpc::network_dkg::{
-    advance_network_dkg_v1, advance_network_dkg_v2, DwalletMPCNetworkKeys,
+    DwalletMPCNetworkKeys, advance_network_dkg_v1, advance_network_dkg_v2,
 };
 use crate::dwallet_mpc::presign::PresignParty;
 use crate::dwallet_mpc::protocol_cryptographic_data::ProtocolCryptographicData;
@@ -24,7 +24,12 @@ use crate::request_protocol_data::{
 use class_groups::dkg::Secp256k1Party;
 use commitment::CommitmentSizedNumber;
 use dwallet_classgroups_types::ClassGroupsDecryptionKey;
-use dwallet_mpc_types::dwallet_mpc::{DKGDecentralizedPartyVersionedOutputSecp256k1, DWalletSignatureScheme, ReconfigurationParty, ReconfigurationV2Party, VersionedDWalletImportedKeyVerificationOutput, VersionedDecryptionKeyReconfigurationOutput, VersionedDwalletDKGFirstRoundPublicOutput, VersionedDwalletDKGSecondRoundPublicOutput, VersionedPresignOutput, VersionedSignOutput};
+use dwallet_mpc_types::dwallet_mpc::{
+    DKGDecentralizedPartyVersionedOutputSecp256k1, DWalletSignatureScheme, ReconfigurationParty,
+    ReconfigurationV2Party, VersionedDWalletImportedKeyVerificationOutput,
+    VersionedDecryptionKeyReconfigurationOutput, VersionedDwalletDKGFirstRoundPublicOutput,
+    VersionedDwalletDKGSecondRoundPublicOutput, VersionedPresignOutput, VersionedSignOutput,
+};
 use dwallet_rng::RootSeed;
 use group::PartyID;
 use ika_protocol_config::ProtocolConfig;

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations.rs
@@ -3,20 +3,18 @@
 
 use crate::dwallet_mpc::crytographic_computation::MPC_SIGN_SECOND_ROUND;
 use crate::dwallet_mpc::dwallet_dkg::{
-    DWalletDKGAdvanceRequestByCurve, DWalletDKGFirstParty, DWalletDKGPublicInputByCurve,
-    DWalletImportedKeyVerificationParty, Secp256K1DWalletDKGParty, compute_dwallet_dkg,
+    compute_dwallet_dkg, DWalletDKGAdvanceRequestByCurve, DWalletDKGFirstParty,
+    DWalletDKGPublicInputByCurve, DWalletImportedKeyVerificationParty, Secp256K1DWalletDKGParty,
 };
 use crate::dwallet_mpc::dwallet_mpc_metrics::DWalletMPCMetrics;
 use crate::dwallet_mpc::encrypt_user_share::verify_encrypted_share;
 use crate::dwallet_mpc::mpc_session::PublicInput;
 use crate::dwallet_mpc::network_dkg::{
-    DwalletMPCNetworkKeys, advance_network_dkg_v1, advance_network_dkg_v2,
+    advance_network_dkg_v1, advance_network_dkg_v2, DwalletMPCNetworkKeys,
 };
 use crate::dwallet_mpc::presign::PresignParty;
 use crate::dwallet_mpc::protocol_cryptographic_data::ProtocolCryptographicData;
-use crate::dwallet_mpc::reconfiguration::{
-    ReconfigurationParty, ReconfigurationV1toV2Party, ReconfigurationV2Party,
-};
+use crate::dwallet_mpc::reconfiguration::ReconfigurationV1toV2Party;
 use crate::dwallet_mpc::sign::SignParty;
 use crate::dwallet_session_request::DWalletSessionRequestMetricData;
 use crate::request_protocol_data::{
@@ -26,12 +24,7 @@ use crate::request_protocol_data::{
 use class_groups::dkg::Secp256k1Party;
 use commitment::CommitmentSizedNumber;
 use dwallet_classgroups_types::ClassGroupsDecryptionKey;
-use dwallet_mpc_types::dwallet_mpc::{
-    DKGDecentralizedPartyVersionedOutputSecp256k1, DWalletSignatureScheme,
-    VersionedDWalletImportedKeyVerificationOutput, VersionedDecryptionKeyReconfigurationOutput,
-    VersionedDwalletDKGFirstRoundPublicOutput, VersionedDwalletDKGSecondRoundPublicOutput,
-    VersionedPresignOutput, VersionedSignOutput,
-};
+use dwallet_mpc_types::dwallet_mpc::{DKGDecentralizedPartyVersionedOutputSecp256k1, DWalletSignatureScheme, ReconfigurationParty, ReconfigurationV2Party, VersionedDWalletImportedKeyVerificationOutput, VersionedDecryptionKeyReconfigurationOutput, VersionedDwalletDKGFirstRoundPublicOutput, VersionedDwalletDKGSecondRoundPublicOutput, VersionedPresignOutput, VersionedSignOutput};
 use dwallet_rng::RootSeed;
 use group::PartyID;
 use ika_protocol_config::ProtocolConfig;

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -7,24 +7,16 @@
 //! the network DKG protocol.
 
 use crate::dwallet_mpc::mpc_session::PublicInput;
-use crate::dwallet_mpc::reconfiguration::{
-    ReconfigurationParty,
-    instantiate_dwallet_mpc_network_encryption_key_public_data_from_reconfiguration_public_output,
-};
+use crate::dwallet_mpc::reconfiguration::instantiate_dwallet_mpc_network_encryption_key_public_data_from_reconfiguration_public_output;
 use class_groups::dkg::{Secp256k1Party, Secp256k1PublicInput};
 use class_groups::{
-    DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER, Secp256k1DecryptionKeySharePublicParameters,
-    SecretKeyShareSizedInteger,
+    Secp256k1DecryptionKeySharePublicParameters, SecretKeyShareSizedInteger,
+    DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
 };
 use commitment::CommitmentSizedNumber;
 use dwallet_classgroups_types::ClassGroupsDecryptionKey;
-use dwallet_mpc_types::dwallet_mpc::{
-    DWalletCurve, NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicDataTrait,
-    NetworkEncryptionKeyPublicDataV1, NetworkEncryptionKeyPublicDataV2,
-    SerializedWrappedMPCPublicOutput, VersionedDecryptionKeyReconfigurationOutput,
-    VersionedNetworkDkgOutput, VersionedNetworkEncryptionKeyPublicData,
-};
-use group::{GroupElement, OsCsRng, PartyID, secp256k1};
+use dwallet_mpc_types::dwallet_mpc::{DWalletCurve, NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicDataTrait, NetworkEncryptionKeyPublicDataV1, NetworkEncryptionKeyPublicDataV2, ReconfigurationParty, SerializedWrappedMPCPublicOutput, VersionedDecryptionKeyReconfigurationOutput, VersionedNetworkDkgOutput, VersionedNetworkEncryptionKeyPublicData};
+use group::{secp256k1, GroupElement, OsCsRng, PartyID};
 use homomorphic_encryption::GroupsPublicParametersAccessors;
 use ika_protocol_config::ProtocolConfig;
 use ika_types::committee::ClassGroupsEncryptionKeyAndProof;

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -10,13 +10,18 @@ use crate::dwallet_mpc::mpc_session::PublicInput;
 use crate::dwallet_mpc::reconfiguration::instantiate_dwallet_mpc_network_encryption_key_public_data_from_reconfiguration_public_output;
 use class_groups::dkg::{Secp256k1Party, Secp256k1PublicInput};
 use class_groups::{
-    Secp256k1DecryptionKeySharePublicParameters, SecretKeyShareSizedInteger,
-    DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+    DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER, Secp256k1DecryptionKeySharePublicParameters,
+    SecretKeyShareSizedInteger,
 };
 use commitment::CommitmentSizedNumber;
 use dwallet_classgroups_types::ClassGroupsDecryptionKey;
-use dwallet_mpc_types::dwallet_mpc::{DWalletCurve, NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicDataTrait, NetworkEncryptionKeyPublicDataV1, NetworkEncryptionKeyPublicDataV2, ReconfigurationParty, SerializedWrappedMPCPublicOutput, VersionedDecryptionKeyReconfigurationOutput, VersionedNetworkDkgOutput, VersionedNetworkEncryptionKeyPublicData};
-use group::{secp256k1, GroupElement, OsCsRng, PartyID};
+use dwallet_mpc_types::dwallet_mpc::{
+    DWalletCurve, NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicDataTrait,
+    NetworkEncryptionKeyPublicDataV1, NetworkEncryptionKeyPublicDataV2, ReconfigurationParty,
+    SerializedWrappedMPCPublicOutput, VersionedDecryptionKeyReconfigurationOutput,
+    VersionedNetworkDkgOutput, VersionedNetworkEncryptionKeyPublicData,
+};
+use group::{GroupElement, OsCsRng, PartyID, secp256k1};
 use homomorphic_encryption::GroupsPublicParametersAccessors;
 use ika_protocol_config::ProtocolConfig;
 use ika_types::committee::ClassGroupsEncryptionKeyAndProof;

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -6,10 +6,15 @@ use crate::dwallet_mpc::{
 };
 use class_groups::reconfiguration::PublicInput;
 use class_groups::{
-    Secp256k1DecryptionKeySharePublicParameters, DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
+    DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER, Secp256k1DecryptionKeySharePublicParameters,
 };
-use dwallet_mpc_types::dwallet_mpc::{NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicDataV1, NetworkEncryptionKeyPublicDataV2, ReconfigurationParty, ReconfigurationV2Party, SerializedWrappedMPCPublicOutput, VersionedDecryptionKeyReconfigurationOutput, VersionedNetworkDkgOutput, VersionedNetworkEncryptionKeyPublicData};
-use group::{secp256k1, GroupElement, PartyID};
+use dwallet_mpc_types::dwallet_mpc::{
+    NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicDataV1,
+    NetworkEncryptionKeyPublicDataV2, ReconfigurationParty, ReconfigurationV2Party,
+    SerializedWrappedMPCPublicOutput, VersionedDecryptionKeyReconfigurationOutput,
+    VersionedNetworkDkgOutput, VersionedNetworkEncryptionKeyPublicData,
+};
+use group::{GroupElement, PartyID, secp256k1};
 use homomorphic_encryption::GroupsPublicParametersAccessors;
 use ika_types::committee::ClassGroupsEncryptionKeyAndProof;
 use ika_types::committee::Committee;

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -4,17 +4,12 @@
 use crate::dwallet_mpc::{
     authority_name_to_party_id_from_committee, generate_access_structure_from_committee,
 };
-use class_groups::reconfiguration::{PublicInput, Secp256k1Party};
+use class_groups::reconfiguration::PublicInput;
 use class_groups::{
-    DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER, Secp256k1DecryptionKeySharePublicParameters, dkg,
+    Secp256k1DecryptionKeySharePublicParameters, DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER,
 };
-use dwallet_mpc_types::dwallet_mpc::{
-    NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicDataV1,
-    NetworkEncryptionKeyPublicDataV2, SerializedWrappedMPCPublicOutput,
-    VersionedDecryptionKeyReconfigurationOutput, VersionedNetworkDkgOutput,
-    VersionedNetworkEncryptionKeyPublicData,
-};
-use group::{GroupElement, PartyID, secp256k1};
+use dwallet_mpc_types::dwallet_mpc::{NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicDataV1, NetworkEncryptionKeyPublicDataV2, ReconfigurationParty, ReconfigurationV2Party, SerializedWrappedMPCPublicOutput, VersionedDecryptionKeyReconfigurationOutput, VersionedNetworkDkgOutput, VersionedNetworkEncryptionKeyPublicData};
+use group::{secp256k1, GroupElement, PartyID};
 use homomorphic_encryption::GroupsPublicParametersAccessors;
 use ika_types::committee::ClassGroupsEncryptionKeyAndProof;
 use ika_types::committee::Committee;
@@ -26,10 +21,8 @@ use twopc_mpc::secp256k1::class_groups::{
     FUNDAMENTAL_DISCRIMINANT_LIMBS, NON_FUNDAMENTAL_DISCRIMINANT_LIMBS,
 };
 
-pub(crate) type ReconfigurationParty = Secp256k1Party;
 pub(crate) type ReconfigurationV1toV2Party =
     twopc_mpc::decentralized_party::reconfiguration_v1_to_v2::Party;
-pub(crate) type ReconfigurationV2Party = twopc_mpc::decentralized_party::reconfiguration::Party;
 
 pub(crate) trait ReconfigurationPartyPublicInputGenerator: Party {
     /// Generates the public input required for the reconfiguration protocol.

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/protocol_cryptographic_data.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/protocol_cryptographic_data.rs
@@ -5,9 +5,7 @@ use crate::dwallet_mpc::dwallet_dkg::{
 use crate::dwallet_mpc::mpc_manager::DWalletMPCManager;
 use crate::dwallet_mpc::mpc_session::{PublicInput, SessionComputationType};
 use crate::dwallet_mpc::presign::PresignParty;
-use crate::dwallet_mpc::reconfiguration::{
-    ReconfigurationParty, ReconfigurationV1toV2Party, ReconfigurationV2Party,
-};
+use crate::dwallet_mpc::reconfiguration::ReconfigurationV1toV2Party;
 use crate::dwallet_mpc::sign::SignParty;
 use crate::request_protocol_data::{
     DKGFirstData, DKGSecondData, DWalletDKGData, EncryptedShareVerificationData,
@@ -23,6 +21,7 @@ use group::PartyID;
 use ika_types::dwallet_mpc_error::DwalletMPCError;
 use mpc::guaranteed_output_delivery::AdvanceRequest;
 use std::collections::HashMap;
+use dwallet_mpc_types::dwallet_mpc::{ReconfigurationParty, ReconfigurationV2Party};
 
 pub enum ProtocolCryptographicData {
     ImportedKeyVerification {

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/protocol_cryptographic_data.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/protocol_cryptographic_data.rs
@@ -17,11 +17,11 @@ use crate::request_protocol_data::{
 use class_groups::SecretKeyShareSizedInteger;
 use class_groups::dkg::Secp256k1Party;
 use dwallet_classgroups_types::ClassGroupsDecryptionKey;
+use dwallet_mpc_types::dwallet_mpc::{ReconfigurationParty, ReconfigurationV2Party};
 use group::PartyID;
 use ika_types::dwallet_mpc_error::DwalletMPCError;
 use mpc::guaranteed_output_delivery::AdvanceRequest;
 use std::collections::HashMap;
-use dwallet_mpc_types::dwallet_mpc::{ReconfigurationParty, ReconfigurationV2Party};
 
 pub enum ProtocolCryptographicData {
     ImportedKeyVerification {

--- a/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
@@ -2,24 +2,26 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 use crate::dwallet_mpc::dwallet_dkg::{
-    dwallet_dkg_first_public_input, dwallet_dkg_second_public_input, DWalletDKGFirstParty,
-    DWalletDKGPublicInputByCurve, DWalletImportedKeyVerificationParty, Secp256K1DWalletDKGParty,
+    DWalletDKGFirstParty, DWalletDKGPublicInputByCurve, DWalletImportedKeyVerificationParty,
+    Secp256K1DWalletDKGParty, dwallet_dkg_first_public_input, dwallet_dkg_second_public_input,
 };
 use crate::dwallet_mpc::network_dkg::{
-    network_dkg_v1_public_input, network_dkg_v2_public_input, DwalletMPCNetworkKeys,
+    DwalletMPCNetworkKeys, network_dkg_v1_public_input, network_dkg_v2_public_input,
 };
-use crate::dwallet_mpc::presign::{presign_public_input, PresignParty};
+use crate::dwallet_mpc::presign::{PresignParty, presign_public_input};
 use crate::dwallet_mpc::reconfiguration::{
-    ReconfigurationPartyPublicInputGenerator,
-    ReconfigurationV1ToV2PartyPublicInputGenerator, ReconfigurationV1toV2Party,
-    ReconfigurationV2PartyPublicInputGenerator,
+    ReconfigurationPartyPublicInputGenerator, ReconfigurationV1ToV2PartyPublicInputGenerator,
+    ReconfigurationV1toV2Party, ReconfigurationV2PartyPublicInputGenerator,
 };
-use crate::dwallet_mpc::sign::{sign_session_public_input, SignParty};
+use crate::dwallet_mpc::sign::{SignParty, sign_session_public_input};
 use crate::dwallet_session_request::DWalletSessionRequest;
 use crate::request_protocol_data::ProtocolData;
 use class_groups::dkg;
 use commitment::CommitmentSizedNumber;
-use dwallet_mpc_types::dwallet_mpc::{MPCPrivateInput, ReconfigurationParty, ReconfigurationV2Party, VersionedImportedDWalletPublicOutput};
+use dwallet_mpc_types::dwallet_mpc::{
+    MPCPrivateInput, ReconfigurationParty, ReconfigurationV2Party,
+    VersionedImportedDWalletPublicOutput,
+};
 use group::PartyID;
 use ika_protocol_config::ProtocolConfig;
 use ika_types::committee::{ClassGroupsEncryptionKeyAndProof, Committee};

--- a/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
@@ -2,24 +2,24 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 use crate::dwallet_mpc::dwallet_dkg::{
-    DWalletDKGFirstParty, DWalletDKGPublicInputByCurve, DWalletImportedKeyVerificationParty,
-    Secp256K1DWalletDKGParty, dwallet_dkg_first_public_input, dwallet_dkg_second_public_input,
+    dwallet_dkg_first_public_input, dwallet_dkg_second_public_input, DWalletDKGFirstParty,
+    DWalletDKGPublicInputByCurve, DWalletImportedKeyVerificationParty, Secp256K1DWalletDKGParty,
 };
 use crate::dwallet_mpc::network_dkg::{
-    DwalletMPCNetworkKeys, network_dkg_v1_public_input, network_dkg_v2_public_input,
+    network_dkg_v1_public_input, network_dkg_v2_public_input, DwalletMPCNetworkKeys,
 };
-use crate::dwallet_mpc::presign::{PresignParty, presign_public_input};
+use crate::dwallet_mpc::presign::{presign_public_input, PresignParty};
 use crate::dwallet_mpc::reconfiguration::{
-    ReconfigurationParty, ReconfigurationPartyPublicInputGenerator,
+    ReconfigurationPartyPublicInputGenerator,
     ReconfigurationV1ToV2PartyPublicInputGenerator, ReconfigurationV1toV2Party,
-    ReconfigurationV2Party, ReconfigurationV2PartyPublicInputGenerator,
+    ReconfigurationV2PartyPublicInputGenerator,
 };
-use crate::dwallet_mpc::sign::{SignParty, sign_session_public_input};
+use crate::dwallet_mpc::sign::{sign_session_public_input, SignParty};
 use crate::dwallet_session_request::DWalletSessionRequest;
 use crate::request_protocol_data::ProtocolData;
 use class_groups::dkg;
 use commitment::CommitmentSizedNumber;
-use dwallet_mpc_types::dwallet_mpc::{MPCPrivateInput, VersionedImportedDWalletPublicOutput};
+use dwallet_mpc_types::dwallet_mpc::{MPCPrivateInput, ReconfigurationParty, ReconfigurationV2Party, VersionedImportedDWalletPublicOutput};
 use group::PartyID;
 use ika_protocol_config::ProtocolConfig;
 use ika_types::committee::{ClassGroupsEncryptionKeyAndProof, Committee};

--- a/sdk/ika-wasm/src/lib.rs
+++ b/sdk/ika-wasm/src/lib.rs
@@ -7,8 +7,8 @@ use dwallet_mpc_centralized_party::{
     create_imported_dwallet_centralized_step_inner, decrypt_user_share_inner,
     encrypt_secret_key_share_and_prove, generate_secp256k1_cg_keypair_from_seed_internal,
     network_dkg_public_output_to_protocol_pp_inner, public_key_from_dwallet_output_inner,
-    sample_dwallet_keypair_inner, verify_secp_signature_inner, verify_secret_share,
-    reconfiguration_public_output_to_protocol_pp_inner
+    reconfiguration_public_output_to_protocol_pp_inner, sample_dwallet_keypair_inner,
+    verify_secp_signature_inner, verify_secret_share,
 };
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::*;
@@ -86,8 +86,12 @@ pub fn reconfiguration_public_output_to_protocol_pp(
     committee_size: usize,
     quorum_threshold: usize,
 ) -> Result<JsValue, JsError> {
-    let protocol_pp = reconfiguration_public_output_to_protocol_pp_inner(network_dkg_public_output, committee_size, quorum_threshold)
-        .map_err(to_js_err)?;
+    let protocol_pp = reconfiguration_public_output_to_protocol_pp_inner(
+        network_dkg_public_output,
+        committee_size,
+        quorum_threshold,
+    )
+    .map_err(to_js_err)?;
     Ok(serde_wasm_bindgen::to_value(&protocol_pp)?)
 }
 

--- a/sdk/ika-wasm/src/lib.rs
+++ b/sdk/ika-wasm/src/lib.rs
@@ -8,6 +8,7 @@ use dwallet_mpc_centralized_party::{
     encrypt_secret_key_share_and_prove, generate_secp256k1_cg_keypair_from_seed_internal,
     network_dkg_public_output_to_protocol_pp_inner, public_key_from_dwallet_output_inner,
     sample_dwallet_keypair_inner, verify_secp_signature_inner, verify_secret_share,
+    reconfiguration_public_output_to_protocol_pp_inner
 };
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::*;
@@ -82,8 +83,10 @@ pub fn network_dkg_public_output_to_protocol_pp(
 #[wasm_bindgen]
 pub fn reconfiguration_public_output_to_protocol_pp(
     network_dkg_public_output: Vec<u8>,
+    committee_size: usize,
+    quorum_threshold: usize,
 ) -> Result<JsValue, JsError> {
-    let protocol_pp = reconfiguration_public_output_to_protocol_pp_inner(network_dkg_public_output)
+    let protocol_pp = reconfiguration_public_output_to_protocol_pp_inner(network_dkg_public_output, committee_size, quorum_threshold)
         .map_err(to_js_err)?;
     Ok(serde_wasm_bindgen::to_value(&protocol_pp)?)
 }

--- a/sdk/ika-wasm/src/lib.rs
+++ b/sdk/ika-wasm/src/lib.rs
@@ -82,14 +82,12 @@ pub fn network_dkg_public_output_to_protocol_pp(
 
 #[wasm_bindgen]
 pub fn reconfiguration_public_output_to_protocol_pp(
+    reconfig_public_output: Vec<u8>,
     network_dkg_public_output: Vec<u8>,
-    committee_size: usize,
-    quorum_threshold: usize,
 ) -> Result<JsValue, JsError> {
     let protocol_pp = reconfiguration_public_output_to_protocol_pp_inner(
+        reconfig_public_output,
         network_dkg_public_output,
-        committee_size,
-        quorum_threshold,
     )
     .map_err(to_js_err)?;
     Ok(serde_wasm_bindgen::to_value(&protocol_pp)?)

--- a/sdk/ika-wasm/src/lib.rs
+++ b/sdk/ika-wasm/src/lib.rs
@@ -80,6 +80,15 @@ pub fn network_dkg_public_output_to_protocol_pp(
 }
 
 #[wasm_bindgen]
+pub fn reconfiguration_public_output_to_protocol_pp(
+    network_dkg_public_output: Vec<u8>,
+) -> Result<JsValue, JsError> {
+    let protocol_pp = reconfiguration_public_output_to_protocol_pp_inner(network_dkg_public_output)
+        .map_err(to_js_err)?;
+    Ok(serde_wasm_bindgen::to_value(&protocol_pp)?)
+}
+
+#[wasm_bindgen]
 pub fn centralized_and_decentralized_parties_dkg_output_match(
     centralized_dkg_output: Vec<u8>,
     decentralized_dkg_output: Vec<u8>,

--- a/sdk/typescript/src/client/cryptography.ts
+++ b/sdk/typescript/src/client/cryptography.ts
@@ -365,19 +365,21 @@ export async function networkDkgPublicOutputToProtocolPublicParameters(
 }
 
 /**
- * Convert a network DKG public output to the protocol public parameters.
+ * Convert a reconfiguration DKG public output to the protocol public parameters.
  *
- * @param network_dkg_public_output - The network DKG public output
+ * @param reconfiguration_dkg_public_output - The reconfiguration DKG public output
+ * @param committee_size - The size of the committee
+ * @param threshold - The threshold value
  * @returns The protocol public parameters
  */
 export async function reconfigurationPublicOutputToProtocolPublicParameters(
-	network_dkg_public_output: Uint8Array,
+	reconfiguration_dkg_public_output: Uint8Array,
 	committee_size: number,
 	threshold: number,
 ): Promise<Uint8Array> {
 	return Uint8Array.from(
 		await reconfiguration_public_output_to_protocol_pp(
-			network_dkg_public_output,
+			reconfiguration_dkg_public_output,
 			committee_size,
 			threshold,
 		),

--- a/sdk/typescript/src/client/cryptography.ts
+++ b/sdk/typescript/src/client/cryptography.ts
@@ -367,21 +367,18 @@ export async function networkDkgPublicOutputToProtocolPublicParameters(
 /**
  * Convert a reconfiguration DKG public output to the protocol public parameters.
  *
- * @param reconfiguration_dkg_public_output - The reconfiguration DKG public output
- * @param committee_size - The size of the committee
- * @param threshold - The threshold value
  * @returns The protocol public parameters
+ * @param reconfiguration_public_output
+ * @param network_dkg_public_output
  */
 export async function reconfigurationPublicOutputToProtocolPublicParameters(
-	reconfiguration_dkg_public_output: Uint8Array,
-	committee_size: number,
-	threshold: number,
+	reconfiguration_public_output: Uint8Array,
+	network_dkg_public_output: Uint8Array,
 ): Promise<Uint8Array> {
 	return Uint8Array.from(
 		await reconfiguration_public_output_to_protocol_pp(
-			reconfiguration_dkg_public_output,
-			committee_size,
-			threshold,
+			reconfiguration_public_output,
+			network_dkg_public_output,
 		),
 	);
 }

--- a/sdk/typescript/src/client/cryptography.ts
+++ b/sdk/typescript/src/client/cryptography.ts
@@ -1,7 +1,6 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-import { reconfiguration_public_output_to_protocol_pp } from '@ika.xyz/ika-wasm';
 import { bcs } from '@mysten/sui/bcs';
 import { decodeSuiPrivateKey, SIGNATURE_FLAG_TO_SCHEME } from '@mysten/sui/cryptography';
 import type { Keypair, PublicKey } from '@mysten/sui/cryptography';
@@ -23,6 +22,7 @@ import {
 	generate_secp_cg_keypair_from_seed,
 	network_dkg_public_output_to_protocol_pp,
 	public_key_from_dwallet_output,
+	reconfiguration_public_output_to_protocol_pp,
 	verify_secp_signature,
 	verify_user_share,
 } from './wasm-loader.js';

--- a/sdk/typescript/src/client/cryptography.ts
+++ b/sdk/typescript/src/client/cryptography.ts
@@ -1,6 +1,7 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
+import { reconfiguration_public_output_to_protocol_pp } from '@ika.xyz/ika-wasm';
 import { bcs } from '@mysten/sui/bcs';
 import { decodeSuiPrivateKey, SIGNATURE_FLAG_TO_SCHEME } from '@mysten/sui/cryptography';
 import type { Keypair, PublicKey } from '@mysten/sui/cryptography';
@@ -361,6 +362,26 @@ export async function networkDkgPublicOutputToProtocolPublicParameters(
 	network_dkg_public_output: Uint8Array,
 ): Promise<Uint8Array> {
 	return Uint8Array.from(await network_dkg_public_output_to_protocol_pp(network_dkg_public_output));
+}
+
+/**
+ * Convert a network DKG public output to the protocol public parameters.
+ *
+ * @param network_dkg_public_output - The network DKG public output
+ * @returns The protocol public parameters
+ */
+export async function reconfigurationPublicOutputToProtocolPublicParameters(
+	network_dkg_public_output: Uint8Array,
+	committee_size: number,
+	threshold: number,
+): Promise<Uint8Array> {
+	return Uint8Array.from(
+		await reconfiguration_public_output_to_protocol_pp(
+			network_dkg_public_output,
+			committee_size,
+			threshold,
+		),
+	);
 }
 
 /**

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -8,7 +8,6 @@ import { toHex } from '@mysten/sui/utils';
 import * as CoordinatorInnerModule from '../generated/ika_dwallet_2pc_mpc/coordinator_inner.js';
 import * as CoordinatorModule from '../generated/ika_dwallet_2pc_mpc/coordinator.js';
 import { TableVec } from '../generated/ika_system/deps/sui/table_vec';
-import { Table } from '../generated/ika_system/deps/sui/table.js';
 import * as SystemModule from '../generated/ika_system/system.js';
 import { getActiveEncryptionKey as getActiveEncryptionKeyFromCoordinator } from '../tx/coordinator.js';
 import {

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -181,9 +181,9 @@ export class IkaClient {
 	 * @throws {NetworkError} If the encryption keys cannot be fetched
 	 */
 	async getAllNetworkEncryptionKeys(): Promise<NetworkEncryptionKey[]> {
-		if (!this.cache) {
+		// if (!this.cache) {
 			return this.#fetchEncryptionKeys();
-		}
+		// }
 
 		if (this.cachedEncryptionKeys.size > 0) {
 			return Array.from(this.cachedEncryptionKeys.values());

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -34,6 +34,7 @@ import type {
 	SystemInner,
 } from './types.js';
 import { objResToBcs } from './utils.js';
+import { Table } from '../generated/ika_system/deps/sui/table';
 
 /**
  * IkaClient provides a high-level interface for interacting with the Ika network.
@@ -904,6 +905,22 @@ export class IkaClient {
 				const keyParsed = CoordinatorInnerModule.DWalletNetworkEncryptionKey.fromBase64(
 					objResToBcs(keyObject),
 				);
+
+				let reconfigOutputsDFs = await this.client.getDynamicFields({
+					parentId: keyParsed.reconfiguration_public_outputs.id.id,
+				});
+
+				for (const reconfigDF of reconfigOutputsDFs.data) {
+					const reconfigName = reconfigDF.name.value as string;
+					const reconfigObject = await this.client.getObject({
+						id: reconfigDF.objectId,
+						options: { showBcs: true },
+					});
+
+					const reconfigTableParsed = Table.fromBase64(
+						objResToBcs(reconfigObject),
+					);
+				}
 
 				const encryptionKey: NetworkEncryptionKey = {
 					id: keyName,

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -595,7 +595,7 @@ export class IkaClient {
 
 		// Check if the cached parameters match the current key state
 		if (
-			cachedParams.networkEncryptionKeyPublicOutputID === currentKey.publicOutputID &&
+			cachedParams.networkEncryptionKeyPublicOutputID === currentKey.networkDKGOutputID &&
 			cachedParams.epoch === currentKey.epoch
 		) {
 			return cachedParams.protocolPublicParameters;
@@ -667,7 +667,7 @@ export class IkaClient {
 		}
 
 		const encryptionKeyID = networkEncryptionKey.id;
-		const networkEncryptionKeyPublicOutputID = networkEncryptionKey.publicOutputID;
+		const networkEncryptionKeyPublicOutputID = networkEncryptionKey.networkDKGOutputID;
 		const epoch = networkEncryptionKey.epoch;
 
 		// Check if we have cached parameters for this specific encryption key
@@ -687,9 +687,8 @@ export class IkaClient {
 						await this.#readTableVecAsRawBytes(networkEncryptionKeyPublicOutputID),
 					)
 				: await reconfigurationPublicOutputToProtocolPublicParameters(
+						await this.#readTableVecAsRawBytes(networkEncryptionKey.reconfigurationOutputID!),
 						await this.#readTableVecAsRawBytes(networkEncryptionKeyPublicOutputID),
-						objects.systemInner.validator_set.active_committee.members.length,
-						Number(objects.systemInner.validator_set.active_committee.quorum_threshold),
 					);
 
 		// Cache the parameters by encryption key ID
@@ -946,9 +945,8 @@ export class IkaClient {
 				const encryptionKey: NetworkEncryptionKey = {
 					id: keyName,
 					epoch: Number(keyParsed.dkg_at_epoch),
-					publicOutputID:
-						lastReconfigOutput?.parsedValue.value.contents.id.id ||
-						keyParsed.network_dkg_public_output.contents.id.id,
+					networkDKGOutputID: keyParsed.network_dkg_public_output.contents.id.id,
+					reconfigurationOutputID: lastReconfigOutput?.parsedValue.value.contents.id.id,
 				};
 
 				encryptionKeys.push(encryptionKey);

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -1,4 +1,3 @@
-;
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
@@ -6,19 +5,39 @@ import type { SuiClient } from '@mysten/sui/client';
 import { Transaction } from '@mysten/sui/transactions';
 import { toHex } from '@mysten/sui/utils';
 
-
-
 import * as CoordinatorInnerModule from '../generated/ika_dwallet_2pc_mpc/coordinator_inner.js';
 import * as CoordinatorModule from '../generated/ika_dwallet_2pc_mpc/coordinator.js';
 import { TableVec } from '../generated/ika_system/deps/sui/table_vec.js';
 import * as SystemModule from '../generated/ika_system/system.js';
 import { getActiveEncryptionKey as getActiveEncryptionKeyFromCoordinator } from '../tx/coordinator.js';
-import { networkDkgPublicOutputToProtocolPublicParameters, reconfigurationPublicOutputToProtocolPublicParameters } from './cryptography.js';
+import {
+	networkDkgPublicOutputToProtocolPublicParameters,
+	reconfigurationPublicOutputToProtocolPublicParameters,
+} from './cryptography.js';
 import { InvalidObjectError, NetworkError, ObjectNotFoundError } from './errors.js';
 import { CoordinatorInnerDynamicField, DynamicField, SystemInnerDynamicField } from './types.js';
-import type { CoordinatorInner, DWallet, DWalletCap, DWalletInternal, DWalletKind, DWalletState, EncryptedUserSecretKeyShare, EncryptedUserSecretKeyShareState, EncryptionKey, EncryptionKeyOptions, IkaClientOptions, IkaConfig, NetworkEncryptionKey, PartialUserSignature, PartialUserSignatureState, Presign, PresignState, SharedObjectOwner, SystemInner } from './types.js';
+import type {
+	CoordinatorInner,
+	DWallet,
+	DWalletCap,
+	DWalletInternal,
+	DWalletKind,
+	DWalletState,
+	EncryptedUserSecretKeyShare,
+	EncryptedUserSecretKeyShareState,
+	EncryptionKey,
+	EncryptionKeyOptions,
+	IkaClientOptions,
+	IkaConfig,
+	NetworkEncryptionKey,
+	PartialUserSignature,
+	PartialUserSignatureState,
+	Presign,
+	PresignState,
+	SharedObjectOwner,
+	SystemInner,
+} from './types.js';
 import { fetchAllDynamicFields, objResToBcs } from './utils.js';
-
 
 /**
  * IkaClient provides a high-level interface for interacting with the Ika network.

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -929,9 +929,10 @@ export class IkaClient {
 							};
 						}),
 					)
-				)
-					.sort((a, b) => (a.name > b.name ? 1 : -1))
-					.at(-1);
+				).find(
+					(reconfigOutput) =>
+						Number(reconfigOutput.name) === Number(objects.coordinatorInner.current_epoch) - 1,
+				);
 
 				const encryptionKey: NetworkEncryptionKey = {
 					id: keyName,

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -7,6 +7,7 @@ import { toHex } from '@mysten/sui/utils';
 
 import * as CoordinatorInnerModule from '../generated/ika_dwallet_2pc_mpc/coordinator_inner.js';
 import * as CoordinatorModule from '../generated/ika_dwallet_2pc_mpc/coordinator.js';
+import { TableVec } from '../generated/ika_system/deps/sui/table_vec';
 import { Table } from '../generated/ika_system/deps/sui/table.js';
 import * as SystemModule from '../generated/ika_system/system.js';
 import { getActiveEncryptionKey as getActiveEncryptionKeyFromCoordinator } from '../tx/coordinator.js';
@@ -921,9 +922,12 @@ export class IkaClient {
 							});
 
 							const parsedValue = Table.fromBase64(objResToBcs(reconfigObject));
+							const tableVec = await this.client.getObject({ id: parsedValue.id.id });
+							const parsedVec = TableVec.fromBase64(objResToBcs(tableVec));
+
 							return {
 								name,
-								parsedValue,
+								parsedVec,
 							};
 						}),
 					)
@@ -935,7 +939,7 @@ export class IkaClient {
 					id: keyName,
 					epoch: Number(keyParsed.dkg_at_epoch),
 					publicOutputID:
-						lastReconfigOutput?.parsedValue.id.id ||
+						lastReconfigOutput?.parsedVec.contents.id.id ||
 						keyParsed.network_dkg_public_output.contents.id.id,
 				};
 

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -921,13 +921,11 @@ export class IkaClient {
 								options: { showBcs: true },
 							});
 
-							const parsedValue = Table.fromBase64(objResToBcs(reconfigObject));
-							const tableVec = await this.client.getObject({ id: parsedValue.id.id });
-							const parsedVec = TableVec.fromBase64(objResToBcs(tableVec));
+							const parsedValue = TableVec.fromBase64(objResToBcs(reconfigObject));
 
 							return {
 								name,
-								parsedVec,
+								parsedValue,
 							};
 						}),
 					)
@@ -939,7 +937,7 @@ export class IkaClient {
 					id: keyName,
 					epoch: Number(keyParsed.dkg_at_epoch),
 					publicOutputID:
-						lastReconfigOutput?.parsedVec.contents.id.id ||
+						lastReconfigOutput?.parsedValue.contents.id.id ||
 						keyParsed.network_dkg_public_output.contents.id.id,
 				};
 

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -13,7 +13,7 @@ import * as SystemModule from '../generated/ika_system/system.js';
 import { getActiveEncryptionKey as getActiveEncryptionKeyFromCoordinator } from '../tx/coordinator.js';
 import { networkDkgPublicOutputToProtocolPublicParameters } from './cryptography.js';
 import { InvalidObjectError, NetworkError, ObjectNotFoundError } from './errors.js';
-import { CoordinatorInnerDynamicField, SystemInnerDynamicField } from './types.js';
+import { CoordinatorInnerDynamicField, DynamicField, SystemInnerDynamicField } from './types.js';
 import type {
 	CoordinatorInner,
 	DWallet,
@@ -921,7 +921,7 @@ export class IkaClient {
 								options: { showBcs: true },
 							});
 
-							const parsedValue = TableVec.fromBase64(objResToBcs(reconfigObject));
+							const parsedValue = DynamicField(TableVec).fromBase64(objResToBcs(reconfigObject));
 
 							return {
 								name,
@@ -937,7 +937,7 @@ export class IkaClient {
 					id: keyName,
 					epoch: Number(keyParsed.dkg_at_epoch),
 					publicOutputID:
-						lastReconfigOutput?.parsedValue.contents.id.id ||
+						lastReconfigOutput?.parsedValue.value.contents.id.id ||
 						keyParsed.network_dkg_public_output.contents.id.id,
 				};
 

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -687,7 +687,7 @@ export class IkaClient {
 				? await networkDkgPublicOutputToProtocolPublicParameters(
 						await this.#readTableVecAsRawBytes(networkEncryptionKeyPublicOutputID),
 					)
-				: reconfigurationPublicOutputToProtocolPublicParameters(
+				: await reconfigurationPublicOutputToProtocolPublicParameters(
 						await this.#readTableVecAsRawBytes(networkEncryptionKeyPublicOutputID),
 						objects.systemInner.validator_set.active_committee.members.length,
 						Number(objects.systemInner.validator_set.active_committee.quorum_threshold),

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -1,3 +1,4 @@
+;
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
@@ -5,39 +6,19 @@ import type { SuiClient } from '@mysten/sui/client';
 import { Transaction } from '@mysten/sui/transactions';
 import { toHex } from '@mysten/sui/utils';
 
+
+
 import * as CoordinatorInnerModule from '../generated/ika_dwallet_2pc_mpc/coordinator_inner.js';
 import * as CoordinatorModule from '../generated/ika_dwallet_2pc_mpc/coordinator.js';
 import { TableVec } from '../generated/ika_system/deps/sui/table_vec.js';
 import * as SystemModule from '../generated/ika_system/system.js';
 import { getActiveEncryptionKey as getActiveEncryptionKeyFromCoordinator } from '../tx/coordinator.js';
-import {
-	networkDkgPublicOutputToProtocolPublicParameters,
-	reconfigurationPublicOutputToProtocolPublicParameters,
-} from './cryptography.js';
+import { networkDkgPublicOutputToProtocolPublicParameters, reconfigurationPublicOutputToProtocolPublicParameters } from './cryptography.js';
 import { InvalidObjectError, NetworkError, ObjectNotFoundError } from './errors.js';
 import { CoordinatorInnerDynamicField, DynamicField, SystemInnerDynamicField } from './types.js';
-import type {
-	CoordinatorInner,
-	DWallet,
-	DWalletCap,
-	DWalletInternal,
-	DWalletKind,
-	DWalletState,
-	EncryptedUserSecretKeyShare,
-	EncryptedUserSecretKeyShareState,
-	EncryptionKey,
-	EncryptionKeyOptions,
-	IkaClientOptions,
-	IkaConfig,
-	NetworkEncryptionKey,
-	PartialUserSignature,
-	PartialUserSignatureState,
-	Presign,
-	PresignState,
-	SharedObjectOwner,
-	SystemInner,
-} from './types.js';
+import type { CoordinatorInner, DWallet, DWalletCap, DWalletInternal, DWalletKind, DWalletState, EncryptedUserSecretKeyShare, EncryptedUserSecretKeyShareState, EncryptionKey, EncryptionKeyOptions, IkaClientOptions, IkaConfig, NetworkEncryptionKey, PartialUserSignature, PartialUserSignatureState, Presign, PresignState, SharedObjectOwner, SystemInner } from './types.js';
 import { fetchAllDynamicFields, objResToBcs } from './utils.js';
+
 
 /**
  * IkaClient provides a high-level interface for interacting with the Ika network.

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -7,7 +7,7 @@ import { toHex } from '@mysten/sui/utils';
 
 import * as CoordinatorInnerModule from '../generated/ika_dwallet_2pc_mpc/coordinator_inner.js';
 import * as CoordinatorModule from '../generated/ika_dwallet_2pc_mpc/coordinator.js';
-import { Table } from '../generated/ika_system/deps/sui/table';
+import { Table } from '../generated/ika_system/deps/sui/table.js';
 import * as SystemModule from '../generated/ika_system/system.js';
 import { getActiveEncryptionKey as getActiveEncryptionKeyFromCoordinator } from '../tx/coordinator.js';
 import { networkDkgPublicOutputToProtocolPublicParameters } from './cryptography.js';

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -906,9 +906,13 @@ export class IkaClient {
 					objResToBcs(keyObject),
 				);
 
+
+
 				let reconfigOutputsDFs = await this.client.getDynamicFields({
 					parentId: keyParsed.reconfiguration_public_outputs.id.id,
 				});
+
+				let reconfigOutputs = reconfigOutputsDFs.map((df) => df.name.value as string);
 
 				for (const reconfigDF of reconfigOutputsDFs.data) {
 					const reconfigName = reconfigDF.name.value as string;

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -181,9 +181,9 @@ export class IkaClient {
 	 * @throws {NetworkError} If the encryption keys cannot be fetched
 	 */
 	async getAllNetworkEncryptionKeys(): Promise<NetworkEncryptionKey[]> {
-		// if (!this.cache) {
+		if (!this.cache) {
 			return this.#fetchEncryptionKeys();
-		// }
+		}
 
 		if (this.cachedEncryptionKeys.size > 0) {
 			return Array.from(this.cachedEncryptionKeys.values());

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -7,7 +7,7 @@ import { toHex } from '@mysten/sui/utils';
 
 import * as CoordinatorInnerModule from '../generated/ika_dwallet_2pc_mpc/coordinator_inner.js';
 import * as CoordinatorModule from '../generated/ika_dwallet_2pc_mpc/coordinator.js';
-import { TableVec } from '../generated/ika_system/deps/sui/table_vec';
+import { TableVec } from '../generated/ika_system/deps/sui/table_vec.js';
 import * as SystemModule from '../generated/ika_system/system.js';
 import { getActiveEncryptionKey as getActiveEncryptionKeyFromCoordinator } from '../tx/coordinator.js';
 import {

--- a/sdk/typescript/src/client/types.ts
+++ b/sdk/typescript/src/client/types.ts
@@ -42,7 +42,9 @@ export interface NetworkEncryptionKey {
 	/** The epoch when this encryption key was created */
 	epoch: number;
 	/** The public output ID for this encryption key */
-	publicOutputID: string;
+	networkDKGOutputID: string;
+	/** The reconfiguration output ID associated with this encryption key */
+	reconfigurationOutputID: string | undefined;
 }
 
 /**

--- a/sdk/typescript/src/client/utils.ts
+++ b/sdk/typescript/src/client/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-import type { SuiObjectResponse } from '@mysten/sui/client';
+import type { DynamicFieldInfo, SuiClient, SuiObjectResponse } from '@mysten/sui/client';
 
 import { InvalidObjectError } from './errors.js';
 
@@ -21,6 +21,25 @@ export function objResToBcs(resp: SuiObjectResponse): string {
 	}
 
 	return resp.data.bcs.bcsBytes;
+}
+
+export async function fetchAllDynamicFields(
+	suiClient: SuiClient,
+	parentId: string,
+): Promise<DynamicFieldInfo[]> {
+	const allFields: any[] = [];
+	let cursor: string | null = null;
+
+	do {
+		const response = await suiClient.getDynamicFields({
+			parentId,
+			cursor,
+		});
+		allFields.push(...response.data);
+		cursor = response.nextCursor;
+	} while (cursor !== null);
+
+	return allFields;
 }
 
 /**

--- a/sdk/typescript/src/client/utils.ts
+++ b/sdk/typescript/src/client/utils.ts
@@ -30,14 +30,18 @@ export async function fetchAllDynamicFields(
 	const allFields: any[] = [];
 	let cursor: string | null = null;
 
-	do {
+	// eslint-disable-next-line no-constant-condition
+	while (true) {
 		const response = await suiClient.getDynamicFields({
 			parentId,
 			cursor,
 		});
 		allFields.push(...response.data);
+		if (response.nextCursor === cursor) {
+			break;
+		}
 		cursor = response.nextCursor;
-	} while (cursor !== null);
+	}
 
 	return allFields;
 }

--- a/sdk/typescript/src/client/wasm-loader.ts
+++ b/sdk/typescript/src/client/wasm-loader.ts
@@ -126,15 +126,13 @@ export async function public_key_from_dwallet_output(
 }
 
 export async function reconfiguration_public_output_to_protocol_pp(
+	reconfig_public_output: Uint8Array,
 	network_dkg_public_output: Uint8Array,
-	committee_size: number,
-	quorum_threshold: number,
 ): Promise<Uint8Array> {
 	const wasm = await getWasmModule();
 	return wasm.reconfiguration_public_output_to_protocol_pp(
+		reconfig_public_output,
 		network_dkg_public_output,
-		committee_size,
-		quorum_threshold,
 	);
 }
 

--- a/sdk/typescript/src/client/wasm-loader.ts
+++ b/sdk/typescript/src/client/wasm-loader.ts
@@ -125,6 +125,19 @@ export async function public_key_from_dwallet_output(
 	return wasm.public_key_from_dwallet_output(dWalletOutput);
 }
 
+export async function reconfiguration_public_output_to_protocol_pp(
+	network_dkg_public_output: Uint8Array,
+	committee_size: number,
+	quorum_threshold: number,
+): Promise<Uint8Array> {
+	const wasm = await getWasmModule();
+	return wasm.reconfiguration_public_output_to_protocol_pp(
+		network_dkg_public_output,
+		committee_size,
+		quorum_threshold,
+	);
+}
+
 export async function centralized_and_decentralized_parties_dkg_output_match(
 	userPublicOutput: Uint8Array,
 	networkDKGOutput: Uint8Array,


### PR DESCRIPTION
## Description

Until now, the TS SDK always used the network's first DKG output to derive the protocol's public parameters. This is problematic because the network key upgrade requires users to use the latest reconfiguration output to derive them. This PR fixes the issue by using the most recent reconfiguration output when it is available.

## Test Plan

I created a dWallet before and after a successful reconfiguration, verifying that the post-reconfiguration flow uses the latest reconfiguration key with the debugger.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
