### PR TITLE
Upgrade Sui dependency to testnet-v1.67.1, Rust to 1.94.0

### DIFF
--- a/.github/workflows/build-and-push-binaries.yaml
+++ b/.github/workflows/build-and-push-binaries.yaml
@@ -25,7 +25,7 @@ concurrency:
 env:
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  rust_stable: 1.90
+  rust_stable: 1.94
   CARGO_NET_GIT_FETCH_WITH_CLI: true
   GH_DEPLOY_KEY: ${{ secrets.GH_DEPLOY_KEY }}
   GCP_PROJECT: common-449616

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -10,7 +10,7 @@ concurrency:
 env:
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  rust_stable: 1.90
+  rust_stable: 1.94
   CARGO_NET_GIT_FETCH_WITH_CLI: true
   GH_DEPLOY_KEY: ${{ secrets.GH_DEPLOY_KEY }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin or `stable` for the latest stable version.
-  rust_stable: 1.90
+  rust_stable: 1.94
   CARGO_NET_GIT_FETCH_WITH_CLI: true
   GH_DEPLOY_KEY: ${{ secrets.GH_DEPLOY_KEY }}
 

--- a/.github/workflows/integration-tests-ci.yaml
+++ b/.github/workflows/integration-tests-ci.yaml
@@ -10,7 +10,7 @@ concurrency:
 env:
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin or `stable` for the latest stable version.
-  rust_stable: 1.90
+  rust_stable: 1.94
   rust_nightly: nightly
   CARGO_NET_GIT_FETCH_WITH_CLI: true
   GH_DEPLOY_KEY: ${{ secrets.GH_DEPLOY_KEY }}

--- a/.github/workflows/publish-typescript-sdk.yml
+++ b/.github/workflows/publish-typescript-sdk.yml
@@ -10,7 +10,7 @@ permissions:
 env:
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  rust_stable: 1.90
+  rust_stable: 1.94
   SUI_VERSION: 'sui@mainnet'
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-multiprovider-strategy"
+version = "0.1.0"
+source = "git+https://github.com/0xsiddharthks/alloy-multiprovider-strategy?rev=0f8d034e679631a715f9eed104089430ae57283a#0f8d034e679631a715f9eed104089430ae57283a"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures",
+ "parking_lot 0.12.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "alloy-network"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,15 +906,15 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "ring",
- "rustls 0.23.27",
- "rustls-webpki 0.103.3",
+ "rustls 0.23.37",
+ "rustls-webpki 0.103.9",
  "serde",
  "serde_json",
  "socket2 0.5.8",
  "tap",
  "thiserror 1.0.69",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
  "tower 0.4.13",
  "tracing",
  "x509-parser",
@@ -1438,8 +1462,7 @@ dependencies = [
 [[package]]
 name = "async-graphql"
 version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16926f97f683ff3b47b035cc79622f3d6a374730b07a5d9051e81e88b5f1904"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#7be9351958ef7ebcbb7fed2f45dd3e9c92398df1"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -1469,13 +1492,14 @@ dependencies = [
  "static_assertions_next",
  "tempfile",
  "thiserror 1.0.69",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
 name = "async-graphql-axum"
 version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3415c9dbaf54397292da0bb81a907e2b989661ce068e4ccfebac33dc9e245e"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#7be9351958ef7ebcbb7fed2f45dd3e9c92398df1"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -1485,15 +1509,14 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
  "tower-service",
 ]
 
 [[package]]
 name = "async-graphql-derive"
 version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a7349168b79030e3172a620f4f0e0062268a954604e41475eff082380fe505"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#7be9351958ef7ebcbb7fed2f45dd3e9c92398df1"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -1509,8 +1532,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-parser"
 version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdc0adf9f53c2b65bb0ff5170cba1912299f248d0e48266f444b6f005deb1d"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#7be9351958ef7ebcbb7fed2f45dd3e9c92398df1"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -1521,8 +1543,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-value"
 version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf4d4e86208f4f9b81a503943c07e6e7f29ad3505e6c9ce6431fe64dc241681"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#7be9351958ef7ebcbb7fed2f45dd3e9c92398df1"
 dependencies = [
  "bytes",
  "indexmap 2.9.0",
@@ -1633,9 +1654,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.6.3"
+version = "1.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a18fd934af6ae7ca52410d4548b98eb895aab0f1ea417d168d85db1434a141"
+checksum = "96571e6996817bf3d58f6b569e4b9fd2e9d2fcf9f7424eed07b2ce9bb87535e5"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1663,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.3"
+version = "1.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
+checksum = "3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1675,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1685,11 +1706,10 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.29.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -1698,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.7"
+version = "1.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4063282c69991e57faab9e5cb21ae557e59f5b0fb285c196335243df8dc25c"
+checksum = "959dab27ce613e6c9658eb3621064d0e2027e5f2acb65bc526a43577facea557"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1722,15 +1742,16 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.72.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eef6a94141a43ee28404bf135828ad9bdd4936bfa2a84ad8dea355c94646a35"
+checksum = "50c74fef3d08159467cad98300f33a2e3bd1a985d527ad66ab0ea83c95e3a615"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1744,15 +1765,16 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.71.0"
+version = "1.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a4fd09d6e863655d99cd2260f271c6d1030dc6bfad68e19e126d2e4c8ceb18"
+checksum = "b7d63bd2bdeeb49aa3f9b00c15e18583503b778b2e792fc06284d54e7d5b6566"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1766,15 +1788,16 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.72.0"
+version = "1.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3224ab02ebb3074467a33d57caf6fcb487ca36f3697fdd381b0428dc72380696"
+checksum = "532d93574bf731f311bafb761366f9ece345a0416dbcc273d81d6d1a1205239b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1788,15 +1811,16 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.72.0"
+version = "1.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6933f189ed1255e78175fbd73fb200c0aae7240d220ed3346f567b0ddca3083"
+checksum = "357e9a029c7524db6a0099cd77fbd5da165540339e7296cca603531bc783b56c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1811,9 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.2"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3734aecf9ff79aa401a6ca099d076535ab465ff76b46440cf567c8e70b65dc13"
+checksum = "69e523e1c4e8e7e8ff219d732988e22bfeae8a1cafdbe6d9eca1546fa080be7c"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -1833,9 +1857,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.5"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e190749ea56f8c42bf15dd76c65e14f8f765233e6df9b0506d9d934ebef867c"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -1844,15 +1868,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.1"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
+ "futures-util",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -1864,14 +1889,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e44697a9bded898dcd0b1cb997430d949b87f4f8940d91023ae9062bf218250"
+checksum = "59e62db736db19c488966c8d787f52e6270be565727236fd5579eaa301e7bc4a"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.7",
+ "h2 0.3.26",
+ "h2 0.4.13",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -1882,37 +1908,38 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.27",
- "rustls-native-certs 0.8.1",
+ "rustls 0.23.37",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tower 0.5.2",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.3"
+version = "0.61.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92144e45819cae7dc62af23eac5a038a58aa544432d2102609654376a900bd07"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9364d5989ac4dd918e5cc4c4bdcc61c9be17dcd2586ea7f69e348fc7c6cab393"
+checksum = "ef1fcbefc7ece1d70dcce29e490f269695dfca2d2bacdeaf9e5c3f799e4e6a42"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.7"
+version = "0.60.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+checksum = "ae5d689cf437eae90460e944a58b5668530d433b4ff85789e69d2f2a556e057d"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -1920,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.3"
+version = "1.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
+checksum = "bb5b6167fcdf47399024e81ac08e795180c576a20e4d4ce67949f9a88ae37dc1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1944,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e5d9e3a80a18afa109391fb5ad09c3daf887b516c6fd805a157c6ea7994a57"
+checksum = "efce7aaaf59ad53c5412f14fc19b2d5c6ab2c3ec688d272fd31f76ec12f44fb0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -1961,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.1"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40076bd09fadbc12d5e026ae080d0930defa606856186e31d83ccc6a255eeaf3"
+checksum = "65f172bcb02424eb94425db8aed1b6d583b5104d4d5ddddf22402c661a320048"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1982,23 +2009,23 @@ dependencies = [
  "serde",
  "time",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
 ]
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.9"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.7"
+version = "1.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
+checksum = "1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -2229,10 +2256,10 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -2437,8 +2464,8 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "const-str 0.5.7",
  "git-version",
@@ -2485,15 +2512,12 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "lazycell",
- "log",
- "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.104",
- "which",
 ]
 
 [[package]]
@@ -2791,6 +2815,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bulletproofs"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "012e2e5f88332083bd4235d445ae78081c00b2558443821a9ca5adfe1070073d"
+dependencies = [
+ "byteorder",
+ "clear_on_drop",
+ "curve25519-dalek 4.2.0",
+ "digest 0.10.7",
+ "group 0.13.0",
+ "merlin",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_derive",
+ "sha3 0.10.8",
+ "subtle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,9 +2867,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -2985,10 +3030,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.11"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -3114,6 +3160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,6 +3210,15 @@ dependencies = [
  "serde_json",
  "sha3 0.11.0-rc.3",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "clear_on_drop"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3232,7 +3296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3241,7 +3305,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3283,7 +3347,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "fastcrypto",
  "mysten-network",
@@ -3295,7 +3359,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3323,7 +3387,7 @@ dependencies = [
  "prost 0.14.3",
  "quinn-proto",
  "rand 0.8.5",
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "serde",
  "shared-crypto",
  "strum_macros 0.27.1",
@@ -3336,8 +3400,8 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.13",
- "tonic 0.14.2",
+ "tokio-util 0.7.18",
+ "tonic 0.14.5",
  "tonic-build",
  "tonic-prost",
  "tonic-rustls",
@@ -3350,7 +3414,7 @@ dependencies = [
 [[package]]
 name = "consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "base64 0.21.7",
  "consensus-config",
@@ -3488,16 +3552,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -3847,7 +3901,10 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
+ "group 0.13.0",
+ "rand_core 0.6.4",
  "rustc_version 0.4.1",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -4106,7 +4163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 2.0.104",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4363,7 +4420,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e616e59155c92257e84970156f506287853355f58cd4a6eb167385722c32b790"
 dependencies = [
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
 ]
 
 [[package]]
@@ -4833,7 +4890,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -4931,7 +4988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4995,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.9"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=4db0e90c732bbf7420ca20de808b698883148d9c#4db0e90c732bbf7420ca20de808b698883148d9c"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=db643fd05a1b1c4cd52de3939766b53e12ce137e#db643fd05a1b1c4cd52de3939766b53e12ce137e"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5013,9 +5070,10 @@ dependencies = [
  "blake2",
  "blst",
  "bs58 0.4.0",
+ "bulletproofs",
  "cbc",
  "ctr",
- "curve25519-dalek-ng",
+ "curve25519-dalek 4.2.0",
  "derive_more 0.99.18",
  "digest 0.10.7",
  "ecdsa 0.16.9",
@@ -5027,6 +5085,7 @@ dependencies = [
  "hex-literal",
  "hkdf",
  "lazy_static",
+ "merlin",
  "num-bigint 0.4.6",
  "once_cell",
  "p256 0.13.2",
@@ -5045,6 +5104,7 @@ dependencies = [
  "static_assertions",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
  "typenum",
  "zeroize",
 ]
@@ -5052,7 +5112,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=4db0e90c732bbf7420ca20de808b698883148d9c#4db0e90c732bbf7420ca20de808b698883148d9c"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=db643fd05a1b1c4cd52de3939766b53e12ce137e#db643fd05a1b1c4cd52de3939766b53e12ce137e"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -5061,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=4db0e90c732bbf7420ca20de808b698883148d9c#4db0e90c732bbf7420ca20de808b698883148d9c"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=db643fd05a1b1c4cd52de3939766b53e12ce137e#db643fd05a1b1c4cd52de3939766b53e12ce137e"
 dependencies = [
  "bcs",
  "digest 0.10.7",
@@ -5081,7 +5141,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=4db0e90c732bbf7420ca20de808b698883148d9c#4db0e90c732bbf7420ca20de808b698883148d9c"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=db643fd05a1b1c4cd52de3939766b53e12ce137e#db643fd05a1b1c4cd52de3939766b53e12ce137e"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -5098,7 +5158,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=4db0e90c732bbf7420ca20de808b698883148d9c#4db0e90c732bbf7420ca20de808b698883148d9c"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=db643fd05a1b1c4cd52de3939766b53e12ce137e#db643fd05a1b1c4cd52de3939766b53e12ce137e"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -5173,7 +5233,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5251,6 +5311,12 @@ dependencies = [
  "libredox",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "findshlibs"
@@ -5748,15 +5814,15 @@ dependencies = [
  "indexmap 2.9.0",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
  "tracing",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5767,7 +5833,7 @@ dependencies = [
  "indexmap 2.9.0",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
  "tracing",
 ]
 
@@ -6135,7 +6201,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.7",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -6159,7 +6225,6 @@ dependencies = [
  "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -6175,11 +6240,11 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "log",
- "rustls 0.23.27",
- "rustls-native-certs 0.8.1",
+ "rustls 0.23.37",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 0.26.8",
 ]
@@ -6203,6 +6268,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -6210,7 +6276,9 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
  "tokio",
@@ -6405,7 +6473,7 @@ dependencies = [
  "ika-swarm",
  "ika-swarm-config",
  "ika-types",
- "msim",
+ "msim 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=9d787303d855f6cec92eb94933717d4ee1963548)",
  "serde",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
@@ -6588,7 +6656,7 @@ dependencies = [
  "tap",
  "telemetry-subscribers",
  "tokio",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tower 0.5.2",
  "tracing",
 ]
@@ -6688,8 +6756,8 @@ dependencies = [
  "protobuf",
  "rand 0.8.5",
  "reqwest",
- "rustls 0.23.27",
- "rustls-pemfile 2.2.0",
+ "rustls 0.23.37",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_with",
@@ -6727,6 +6795,7 @@ dependencies = [
  "sui",
  "sui-json-rpc-types",
  "sui-keys",
+ "sui-rpc-api",
  "sui-sdk",
  "sui-types",
  "tokio",
@@ -6786,6 +6855,7 @@ dependencies = [
  "sui-config",
  "sui-keys",
  "sui-macros",
+ "sui-rpc-api",
  "sui-sdk",
  "sui-simulator",
  "sui-types",
@@ -6847,7 +6917,7 @@ dependencies = [
  "sui-types",
  "tap",
  "thiserror 2.0.12",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tracing",
  "twopc_mpc",
  "typed-store-error",
@@ -7113,7 +7183,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7229,7 +7299,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "serde",
  "serde_json",
@@ -7281,14 +7351,14 @@ dependencies = [
  "http 1.4.0",
  "jsonrpsee-core 0.24.9",
  "pin-project",
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls 0.26.1",
- "tokio-util 0.7.13",
+ "tokio-rustls 0.26.4",
+ "tokio-util 0.7.18",
  "tracing",
  "url",
 ]
@@ -7304,14 +7374,14 @@ dependencies = [
  "http 1.4.0",
  "jsonrpsee-core 0.26.0",
  "pin-project",
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
  "thiserror 2.0.12",
  "tokio",
- "tokio-rustls 0.26.1",
- "tokio-util 0.7.13",
+ "tokio-rustls 0.26.4",
+ "tokio-util 0.7.18",
  "tracing",
  "url",
 ]
@@ -7383,7 +7453,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee-core 0.24.9",
  "jsonrpsee-types 0.24.9",
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -7407,7 +7477,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee-core 0.26.0",
  "jsonrpsee-types 0.26.0",
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -7465,7 +7535,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
  "tower 0.4.13",
  "tracing",
 ]
@@ -7492,7 +7562,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
  "tower 0.5.2",
  "tracing",
 ]
@@ -7723,7 +7793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -8065,11 +8135,11 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -8335,12 +8405,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 
 [[package]]
 name = "move-abstract-interpreter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-binary-format",
 ]
@@ -8348,12 +8418,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 
 [[package]]
 name = "move-analyzer"
 version = "1.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "clap",
@@ -8388,7 +8458,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -8404,12 +8474,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8425,7 +8495,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -8438,7 +8508,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -8449,12 +8519,13 @@ dependencies = [
  "move-regex-borrow-graph",
  "move-vm-config",
  "petgraph 0.8.2",
+ "serde",
 ]
 
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -8464,7 +8535,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -8479,7 +8550,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -8494,7 +8565,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -8509,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "clap",
@@ -8524,7 +8595,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8575,7 +8646,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8585,6 +8656,7 @@ dependencies = [
  "insta",
  "move-binary-format",
  "move-core-types",
+ "move-symbol-pool",
  "packed_struct",
  "serde",
  "sha2 0.9.9",
@@ -8595,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8630,7 +8702,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8654,7 +8726,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8679,7 +8751,7 @@ dependencies = [
 [[package]]
 name = "move-decompiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8707,7 +8779,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8728,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "clap",
@@ -8750,7 +8822,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -8768,7 +8840,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "hex",
@@ -8781,7 +8853,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -8793,7 +8865,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "codespan",
@@ -8816,7 +8888,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8840,7 +8912,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "clap",
@@ -8875,7 +8947,7 @@ dependencies = [
 [[package]]
 name = "move-package-alt"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -8918,7 +8990,7 @@ dependencies = [
 [[package]]
 name = "move-package-alt-compilation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "clap",
@@ -8946,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "enum-compat-util",
  "quote",
@@ -8956,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "move-regex-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "insta",
  "itertools 0.10.5",
@@ -8970,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -8991,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9016,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "hex",
@@ -9037,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -9052,7 +9124,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v0"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -9067,7 +9139,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v1"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -9082,7 +9154,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v2"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -9097,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "phf",
  "serde",
@@ -9106,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -9118,7 +9190,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9151,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-binary-format",
 ]
@@ -9159,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-trace-format",
  "move-vm-config",
@@ -9171,7 +9243,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "better_any",
  "fail",
@@ -9189,7 +9261,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "better_any",
  "fail",
@@ -9207,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "better_any",
  "fail",
@@ -9225,7 +9297,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "better_any",
  "fail",
@@ -9243,7 +9315,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -9256,7 +9328,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9269,7 +9341,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9281,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9293,7 +9365,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9327,6 +9399,35 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=213e543d83b91c4aa904166bef255a6c0054c8a7#213e543d83b91c4aa904166bef255a6c0054c8a7"
+dependencies = [
+ "ahash 0.7.8",
+ "async-task",
+ "bincode 1.3.3",
+ "bytes",
+ "cc",
+ "downcast-rs",
+ "erasable",
+ "futures",
+ "lazy_static",
+ "libc",
+ "msim-macros 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=213e543d83b91c4aa904166bef255a6c0054c8a7)",
+ "naive-timer",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "real_tokio 1.49.0",
+ "serde",
+ "socket2 0.4.10",
+ "tap",
+ "tokio-util 0.7.17",
+ "toml 0.5.11",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "msim"
+version = "0.1.0"
 source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=9d787303d855f6cec92eb94933717d4ee1963548#9d787303d855f6cec92eb94933717d4ee1963548"
 dependencies = [
  "ahash 0.7.8",
@@ -9339,11 +9440,11 @@ dependencies = [
  "futures",
  "lazy_static",
  "libc",
- "msim-macros",
+ "msim-macros 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=9d787303d855f6cec92eb94933717d4ee1963548)",
  "naive-timer",
  "pin-project-lite",
  "rand 0.8.5",
- "real_tokio",
+ "real_tokio 1.47.1",
  "serde",
  "socket2 0.4.10",
  "tap",
@@ -9351,6 +9452,17 @@ dependencies = [
  "toml 0.5.11",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "msim-macros"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=213e543d83b91c4aa904166bef255a6c0054c8a7#213e543d83b91c4aa904166bef255a6c0054c8a7"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9474,7 +9586,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "mysten-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "antithesis_sdk",
  "anyhow",
@@ -9497,7 +9609,7 @@ dependencies = [
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -9518,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -9541,14 +9653,14 @@ dependencies = [
  "prometheus",
  "quinn-proto",
  "rand 0.8.5",
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "serde",
  "snap",
  "sui-http",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tonic-health",
  "tower 0.5.2",
  "tower-http 0.5.2",
@@ -9558,7 +9670,7 @@ dependencies = [
 [[package]]
 name = "mysten-service"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -9753,6 +9865,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9989,34 +10110,40 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.11.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+checksum = "c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "form_urlencoded",
  "futures",
+ "http 1.4.0",
+ "http-body-util",
  "httparse",
  "humantime",
  "hyper 1.8.1",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "md-5",
  "parking_lot 0.12.5",
  "percent-encoding",
  "quick-xml",
- "rand 0.8.5",
+ "rand 0.9.0",
  "reqwest",
  "ring",
- "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
- "snafu",
+ "serde_urlencoded",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "url",
  "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -10973,9 +11100,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -10983,17 +11110,16 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.5",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "prometheus",
- "protobuf",
 ]
 
 [[package]]
@@ -11144,11 +11270,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
 dependencies = [
  "bytes",
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -11230,9 +11368,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
  "serde",
@@ -11250,7 +11388,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.0",
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "socket2 0.5.8",
  "thiserror 2.0.12",
  "tokio",
@@ -11268,7 +11406,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.1.0",
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -11288,7 +11426,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.8",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11543,8 +11681,24 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "socket2 0.6.2",
- "tokio-macros 2.5.0 (git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=c59702c3177a31405d42ec12e01fa4a445728326)",
+ "tokio-macros 2.5.0",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "real_tokio"
+version = "1.49.0"
+source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=6b1da10b18f9a4b1d42b1432415a0b3092908c77#6b1da10b18f9a4b1d42b1432415a0b3092908c77"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio 1.0.4",
+ "parking_lot 0.12.5",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2 0.6.2",
+ "tokio-macros 2.6.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11615,17 +11769,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -11680,7 +11825,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -11695,17 +11840,17 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.27",
- "rustls-native-certs 0.8.1",
- "rustls-pemfile 2.2.0",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.1",
- "tokio-util 0.7.13",
+ "tokio-rustls 0.26.4",
+ "tokio-util 0.7.18",
  "tower 0.5.2",
  "tower-service",
  "url",
@@ -11975,7 +12120,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11988,7 +12133,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12005,30 +12150,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -12040,16 +12173,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
+ "security-framework",
 ]
 
 [[package]]
@@ -12063,11 +12187,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -12076,19 +12201,19 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation 0.10.0",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.27",
- "rustls-native-certs 0.8.1",
+ "rustls 0.23.37",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.3",
- "security-framework 3.2.0",
+ "rustls-webpki 0.103.9",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12109,9 +12234,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -12442,25 +12567,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.8.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.8.0",
- "core-foundation 0.10.0",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -12842,7 +12954,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bcs",
  "eyre",
@@ -12986,27 +13098,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "snafu"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320b01e011bf8d5d7a4a4a4be966d9160968935849c83b918827f6a435e7f627"
-dependencies = [
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13128,7 +13219,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13354,8 +13445,8 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sui"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anemo",
  "anyhow",
@@ -13369,6 +13460,7 @@ dependencies = [
  "bip32",
  "camino",
  "clap",
+ "clap_complete",
  "codespan-reporting",
  "colored 2.2.0",
  "csv",
@@ -13384,6 +13476,7 @@ dependencies = [
  "move-analyzer",
  "move-binary-format",
  "move-bytecode-source-map",
+ "move-bytecode-utils",
  "move-bytecode-verifier-meter",
  "move-cli",
  "move-command-line-common",
@@ -13396,7 +13489,7 @@ dependencies = [
  "move-trace-format",
  "move-vm-config",
  "move-vm-profiler",
- "msim",
+ "msim 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=213e543d83b91c4aa904166bef255a6c0054c8a7)",
  "mysten-common",
  "normalize-line-endings",
  "num-bigint 0.4.6",
@@ -13435,6 +13528,8 @@ dependencies = [
  "sui-pg-db",
  "sui-protocol-config",
  "sui-replay-2",
+ "sui-rpc",
+ "sui-rpc-api",
  "sui-sdk",
  "sui-source-validation",
  "sui-swarm",
@@ -13460,7 +13555,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13495,7 +13590,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13523,7 +13618,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13550,7 +13645,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13577,7 +13672,7 @@ dependencies = [
 [[package]]
 name = "sui-authority-aggregation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "futures",
  "mysten-metrics",
@@ -13588,10 +13683,11 @@ dependencies = [
 
 [[package]]
 name = "sui-bridge"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "alloy",
+ "alloy-multiprovider-strategy",
  "anyhow",
  "arc-swap",
  "async-trait",
@@ -13624,6 +13720,7 @@ dependencies = [
  "sui-keys",
  "sui-metrics-push-client",
  "sui-rpc",
+ "sui-rpc-api",
  "sui-sdk",
  "sui-sdk-types",
  "sui-test-transaction-builder",
@@ -13633,7 +13730,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tower 0.5.2",
  "tracing",
  "typed-store",
@@ -13643,7 +13740,7 @@ dependencies = [
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anemo",
  "anyhow",
@@ -13676,7 +13773,7 @@ dependencies = [
 [[package]]
 name = "sui-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anemo",
  "antithesis_sdk",
@@ -13722,6 +13819,9 @@ dependencies = [
  "parking_lot 0.12.5",
  "pin-project-lite",
  "prometheus",
+ "prost 0.14.3",
+ "prost-build",
+ "protox",
  "rand 0.8.5",
  "rayon",
  "reqwest",
@@ -13744,6 +13844,7 @@ dependencies = [
  "sui-macros",
  "sui-network",
  "sui-protocol-config",
+ "sui-rpc",
  "sui-simulator",
  "sui-storage",
  "sui-swarm-config",
@@ -13757,16 +13858,17 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
  "tracing",
  "twox-hash",
  "typed-store",
+ "zstd 0.12.4",
 ]
 
 [[package]]
 name = "sui-crypto"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=9d9539e620b8b668c1a19528d9700be3f35f269e#9d9539e620b8b668c1a19528d9700be3f35f269e"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=dc3b2bf6f998282e61aeebb803d93499aee2a4a2#dc3b2bf6f998282e61aeebb803d93499aee2a4a2"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",
@@ -13791,7 +13893,7 @@ dependencies = [
 [[package]]
 name = "sui-data-ingestion-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13803,9 +13905,11 @@ dependencies = [
  "object_store",
  "once_cell",
  "prometheus",
+ "prost 0.14.3",
  "serde",
  "serde_json",
  "sui-protocol-config",
+ "sui-rpc",
  "sui-rpc-api",
  "sui-storage",
  "sui-types",
@@ -13815,12 +13919,13 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "zstd 0.12.4",
 ]
 
 [[package]]
 name = "sui-data-store"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13840,8 +13945,8 @@ dependencies = [
 
 [[package]]
 name = "sui-default-config"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -13849,8 +13954,8 @@ dependencies = [
 
 [[package]]
 name = "sui-display"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13871,7 +13976,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -13879,7 +13984,7 @@ dependencies = [
 [[package]]
 name = "sui-execution"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-interpreter-v2",
@@ -13917,8 +14022,8 @@ dependencies = [
 
 [[package]]
 name = "sui-faucet"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13933,10 +14038,11 @@ dependencies = [
  "shared-crypto",
  "sui-config",
  "sui-keys",
+ "sui-rpc-api",
  "sui-sdk",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tower 0.5.2",
  "tower-http 0.5.2",
  "tracing",
@@ -13945,16 +14051,16 @@ dependencies = [
 
 [[package]]
 name = "sui-field-count"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "sui-field-count-derive",
 ]
 
 [[package]]
 name = "sui-field-count-derive"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -13963,7 +14069,7 @@ dependencies = [
 [[package]]
 name = "sui-framework"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -13976,8 +14082,8 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13991,8 +14097,8 @@ dependencies = [
 
 [[package]]
 name = "sui-futures"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "futures",
@@ -14005,7 +14111,7 @@ dependencies = [
 [[package]]
 name = "sui-genesis-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14033,7 +14139,7 @@ dependencies = [
 [[package]]
 name = "sui-http"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -14044,16 +14150,16 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.8",
  "tokio",
- "tokio-rustls 0.26.1",
- "tokio-util 0.7.13",
+ "tokio-rustls 0.26.4",
+ "tokio-util 0.7.18",
  "tower 0.5.2",
  "tracing",
 ]
 
 [[package]]
 name = "sui-indexer-alt"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14085,19 +14191,19 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-consistent-api"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tonic-prost",
 ]
 
 [[package]]
 name = "sui-indexer-alt-consistent-store"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14122,7 +14228,6 @@ dependencies = [
  "prometheus",
  "reqwest",
  "rocksdb",
- "rustls-pemfile 2.2.0",
  "scoped-futures",
  "serde",
  "serde_json",
@@ -14137,7 +14242,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.7.8",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tonic-health",
  "tonic-reflection",
  "tower 0.5.2",
@@ -14148,8 +14253,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14163,13 +14268,15 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "futures",
+ "object_store",
  "pin-project-lite",
  "prometheus",
+ "prost 0.14.3",
  "prost-types 0.14.3",
  "rand 0.8.5",
- "reqwest",
  "scoped-futures",
  "serde",
+ "serde_json",
  "sui-field-count",
  "sui-futures",
  "sui-indexer-alt-framework-store-traits",
@@ -14184,15 +14291,16 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tracing",
  "url",
+ "zstd 0.12.4",
 ]
 
 [[package]]
 name = "sui-indexer-alt-framework-store-traits"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14202,8 +14310,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-graphql"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -14232,6 +14340,7 @@ dependencies = [
  "pin-project",
  "prometheus",
  "prost-types 0.14.3",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "shared-crypto",
@@ -14252,19 +14361,22 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "thiserror 1.0.69",
+ "timeout-tracing",
  "tokio",
  "toml 0.7.8",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tower-http 0.5.2",
  "tracing",
+ "tracing-error",
+ "tracing-subscriber",
  "url",
  "uuid",
 ]
 
 [[package]]
 name = "sui-indexer-alt-metrics"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -14279,8 +14391,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-reader"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -14308,21 +14420,23 @@ dependencies = [
  "sui-types",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "sui-indexer-alt-schema"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
  "diesel",
  "diesel_migrations",
+ "move-core-types",
  "serde",
+ "siphasher",
  "sui-field-count",
  "sui-protocol-config",
  "sui-types",
@@ -14331,7 +14445,7 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14348,7 +14462,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -14396,7 +14510,7 @@ dependencies = [
  "tap",
  "thiserror 1.0.69",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
  "tower 0.5.2",
  "tower-http 0.5.2",
  "tracing",
@@ -14406,7 +14520,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14426,7 +14540,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14460,7 +14574,7 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14485,30 +14599,35 @@ dependencies = [
 
 [[package]]
 name = "sui-kvstore"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.7",
  "bcs",
+ "bytes",
  "clap",
+ "futures",
  "gcp_auth",
+ "governor",
  "http 1.4.0",
- "humantime",
+ "num_cpus",
  "prometheus",
  "prost 0.14.3",
  "prost-types 0.14.3",
+ "rustls 0.23.37",
  "serde",
- "sui-data-ingestion-core",
+ "sui-default-config",
  "sui-indexer-alt-framework",
  "sui-indexer-alt-framework-store-traits",
  "sui-indexer-alt-metrics",
+ "sui-protocol-config",
  "sui-types",
  "telemetry-subscribers",
- "tempfile",
  "tokio",
- "tonic 0.14.2",
+ "toml 0.7.8",
+ "tonic 0.14.5",
  "tonic-prost",
  "tracing",
 ]
@@ -14516,7 +14635,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "futures",
  "once_cell",
@@ -14527,7 +14646,7 @@ dependencies = [
 [[package]]
 name = "sui-metrics-push-client"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14544,8 +14663,8 @@ dependencies = [
 
 [[package]]
 name = "sui-move"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "better_any",
@@ -14564,12 +14683,15 @@ dependencies = [
  "move-package-alt",
  "move-package-alt-compilation",
  "move-unit-test",
+ "move-vm-config",
  "move-vm-runtime",
+ "move-vm-types",
  "once_cell",
  "prometheus",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
+ "sui-adapter-latest",
  "sui-config",
  "sui-move-build",
  "sui-move-natives-latest",
@@ -14586,8 +14708,8 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14616,7 +14738,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bcs",
  "better_any",
@@ -14639,7 +14761,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bcs",
  "better_any",
@@ -14660,7 +14782,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bcs",
  "better_any",
@@ -14681,7 +14803,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bcs",
  "better_any",
@@ -14701,8 +14823,8 @@ dependencies = [
 
 [[package]]
 name = "sui-name-service"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -14714,7 +14836,7 @@ dependencies = [
 [[package]]
 name = "sui-network"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -14749,8 +14871,8 @@ dependencies = [
  "sui-types",
  "tap",
  "tokio",
- "tokio-rustls 0.26.1",
- "tonic 0.14.2",
+ "tokio-rustls 0.26.4",
+ "tonic 0.14.5",
  "tonic-build",
  "tonic-health",
  "tonic-prost",
@@ -14761,8 +14883,8 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -14819,8 +14941,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bcs",
  "schemars 0.8.21",
@@ -14832,7 +14954,7 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -14844,8 +14966,8 @@ dependencies = [
 
 [[package]]
 name = "sui-package-alt"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -14869,8 +14991,8 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -14887,7 +15009,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "async-trait",
  "bcs",
@@ -14904,8 +15026,8 @@ dependencies = [
 
 [[package]]
 name = "sui-pg-db"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14916,8 +15038,8 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "futures",
- "rustls 0.23.27",
- "rustls-pemfile 2.2.0",
+ "prometheus",
+ "rustls 0.23.37",
  "scoped-futures",
  "sui-field-count",
  "sui-indexer-alt-framework-store-traits",
@@ -14934,9 +15056,9 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
- "msim-macros",
+ "msim-macros 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=213e543d83b91c4aa904166bef255a6c0054c8a7)",
  "proc-macro2",
  "quote",
  "sui-enum-compat-util",
@@ -14946,7 +15068,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "clap",
  "fastcrypto",
@@ -14954,6 +15076,7 @@ dependencies = [
  "move-core-types",
  "move-vm-config",
  "mysten-common",
+ "rand 0.8.5",
  "schemars 0.8.21",
  "serde",
  "serde-env",
@@ -14965,7 +15088,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14975,7 +15098,7 @@ dependencies = [
 [[package]]
 name = "sui-replay-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15022,8 +15145,8 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc"
-version = "0.2.1"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=9d9539e620b8b668c1a19528d9700be3f35f269e#9d9539e620b8b668c1a19528d9700be3f35f269e"
+version = "0.2.2"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=dc3b2bf6f998282e61aeebb803d93499aee2a4a2#dc3b2bf6f998282e61aeebb803d93499aee2a4a2"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -15037,14 +15160,14 @@ dependencies = [
  "sui-sdk-types",
  "tap",
  "tokio",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tonic-prost",
 ]
 
 [[package]]
 name = "sui-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -15054,6 +15177,7 @@ dependencies = [
  "bcs",
  "bytes",
  "fastcrypto",
+ "futures",
  "http 1.4.0",
  "itertools 0.13.0",
  "mime",
@@ -15071,17 +15195,19 @@ dependencies = [
  "serde_with",
  "sui-config",
  "sui-crypto",
+ "sui-macros",
  "sui-name-service",
  "sui-package-resolver",
  "sui-protocol-config",
  "sui-rpc",
  "sui-sdk-types",
+ "sui-transaction-builder",
  "sui-types",
  "tap",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tonic-health",
  "tonic-prost",
  "tonic-prost-build",
@@ -15095,8 +15221,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15116,10 +15242,14 @@ dependencies = [
  "serde_with",
  "shared-crypto",
  "sui-config",
+ "sui-crypto",
  "sui-json",
  "sui-json-rpc-api",
  "sui-json-rpc-types",
  "sui-keys",
+ "sui-rpc",
+ "sui-rpc-api",
+ "sui-sdk-types",
  "sui-transaction-builder",
  "sui-types",
  "thiserror 1.0.69",
@@ -15129,8 +15259,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk-types"
-version = "0.2.1"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=9d9539e620b8b668c1a19528d9700be3f35f269e#9d9539e620b8b668c1a19528d9700be3f35f269e"
+version = "0.2.2"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=dc3b2bf6f998282e61aeebb803d93499aee2a4a2#dc3b2bf6f998282e61aeebb803d93499aee2a4a2"
 dependencies = [
  "base64ct",
  "bcs",
@@ -15151,7 +15281,7 @@ dependencies = [
 [[package]]
 name = "sui-simulator"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -15160,7 +15290,7 @@ dependencies = [
  "lru 0.10.1",
  "move-package-alt",
  "move-package-alt-compilation",
- "msim",
+ "msim 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=213e543d83b91c4aa904166bef255a6c0054c8a7)",
  "mysten-network",
  "rand 0.8.5",
  "serde",
@@ -15176,7 +15306,7 @@ dependencies = [
 [[package]]
 name = "sui-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -15204,8 +15334,8 @@ dependencies = [
 
 [[package]]
 name = "sui-source-validation"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "colored 2.2.0",
@@ -15219,26 +15349,27 @@ dependencies = [
  "move-package-alt",
  "move-package-alt-compilation",
  "move-symbol-pool",
- "msim",
+ "msim 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=213e543d83b91c4aa904166bef255a6c0054c8a7)",
  "serde",
- "sui-json-rpc-types",
  "sui-move-build",
  "sui-package-alt",
  "sui-package-management",
+ "sui-rpc-api",
  "sui-sdk",
  "sui-types",
  "tar",
  "tempfile",
  "thiserror 1.0.69",
  "toml 0.7.8",
+ "tonic 0.14.5",
  "tracing",
  "ureq",
 ]
 
 [[package]]
 name = "sui-sql-macro"
-version = "1.64.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+version = "1.67.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -15248,7 +15379,7 @@ dependencies = [
 [[package]]
 name = "sui-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15298,7 +15429,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "futures",
@@ -15325,7 +15456,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anemo",
  "anyhow",
@@ -15352,7 +15483,7 @@ dependencies = [
 [[package]]
 name = "sui-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "reqwest",
  "serde",
@@ -15363,13 +15494,14 @@ dependencies = [
 [[package]]
 name = "sui-test-transaction-builder"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "bcs",
  "move-core-types",
  "shared-crypto",
  "sui-genesis-builder",
  "sui-move-build",
+ "sui-rpc-api",
  "sui-sdk",
  "sui-types",
 ]
@@ -15377,7 +15509,7 @@ dependencies = [
 [[package]]
 name = "sui-tls"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -15388,10 +15520,10 @@ dependencies = [
  "pkcs8 0.10.2",
  "rcgen",
  "reqwest",
- "rustls 0.23.27",
- "rustls-webpki 0.103.3",
+ "rustls 0.23.37",
+ "rustls-webpki 0.103.9",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.4",
  "tower-layer",
  "x509-parser",
 ]
@@ -15399,7 +15531,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15416,7 +15548,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-checks"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "fastcrypto-zkp",
  "once_cell",
@@ -15431,7 +15563,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anemo",
  "anyhow",
@@ -15480,7 +15612,7 @@ dependencies = [
  "prost-types 0.14.3",
  "rand 0.8.5",
  "roaring 0.10.10",
- "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "schemars 0.8.21",
  "serde",
  "serde-name",
@@ -15498,7 +15630,7 @@ dependencies = [
  "sui-sdk-types",
  "tap",
  "thiserror 1.0.69",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tracing",
  "typed-store-error",
  "x509-parser",
@@ -15507,7 +15639,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -15523,7 +15655,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -15539,7 +15671,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -15554,7 +15686,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -15741,7 +15873,7 @@ dependencies = [
 [[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -15761,6 +15893,7 @@ dependencies = [
  "tonic 0.12.3",
  "tracing",
  "tracing-appender",
+ "tracing-error",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -15775,7 +15908,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15817,7 +15950,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "test-cluster"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "bcs",
@@ -15838,6 +15971,7 @@ dependencies = [
  "sui-keys",
  "sui-node",
  "sui-protocol-config",
+ "sui-rpc-api",
  "sui-sdk",
  "sui-simulator",
  "sui-swarm",
@@ -15846,8 +15980,8 @@ dependencies = [
  "sui-types",
  "tempfile",
  "tokio",
- "tokio-util 0.7.13",
- "tonic 0.14.2",
+ "tokio-util 0.7.18",
+ "tonic 0.14.5",
  "tracing",
 ]
 
@@ -16044,6 +16178,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "timeout-tracing"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4215a5d507354cba4bca5cd7c0dffdec3b7483758ddf4116cf21186bb73e913"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "tracing-error",
+]
+
+[[package]]
 name = "tiny-bip39"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16108,30 +16254,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio 1.0.4",
  "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2 0.6.2",
- "tokio-macros 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-macros 2.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
 version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=c59702c3177a31405d42ec12e01fa4a445728326#c59702c3177a31405d42ec12e01fa4a445728326"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16140,8 +16282,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
-source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=c59702c3177a31405d42ec12e01fa4a445728326#c59702c3177a31405d42ec12e01fa4a445728326"
+version = "2.6.0"
+source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=6b1da10b18f9a4b1d42b1432415a0b3092908c77#6b1da10b18f9a4b1d42b1432415a0b3092908c77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16170,7 +16323,7 @@ dependencies = [
  "rand 0.9.0",
  "socket2 0.5.8",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
  "whoami",
 ]
 
@@ -16181,10 +16334,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04fb792ccd6bbcd4bba408eb8a292f70fc4a3589e5d793626f45190e6454b6ab"
 dependencies = [
  "ring",
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "tokio",
  "tokio-postgres",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.4",
  "x509-certificate",
 ]
 
@@ -16200,11 +16353,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -16217,7 +16370,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
 ]
 
 [[package]]
@@ -16240,10 +16393,10 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.4",
  "tungstenite 0.26.2",
  "webpki-roots 0.26.8",
 ]
@@ -16262,22 +16415,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-util",
- "hashbrown 0.14.5",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.7.15"
 source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=c59702c3177a31405d42ec12e01fa4a445728326#c59702c3177a31405d42ec12e01fa4a445728326"
 dependencies = [
@@ -16288,8 +16425,39 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.2",
  "pin-project-lite",
- "real_tokio",
+ "real_tokio 1.47.1",
  "slab",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.17"
+source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=6b1da10b18f9a4b1d42b1432415a0b3092908c77#6b1da10b18f9a4b1d42b1432415a0b3092908c77"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-util",
+ "hashbrown 0.15.2",
+ "pin-project-lite",
+ "real_tokio 1.49.0",
+ "slab",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -16379,7 +16547,7 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.7",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -16400,15 +16568,15 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.7",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -16417,11 +16585,11 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "socket2 0.6.2",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower 0.5.2",
  "tower-layer",
@@ -16452,7 +16620,7 @@ dependencies = [
  "prost 0.14.3",
  "tokio",
  "tokio-stream",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tonic-prost",
 ]
 
@@ -16464,7 +16632,7 @@ checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
  "bytes",
  "prost 0.14.3",
- "tonic 0.14.2",
+ "tonic 0.14.5",
 ]
 
 [[package]]
@@ -16493,7 +16661,7 @@ dependencies = [
  "prost-types 0.14.3",
  "tokio",
  "tokio-stream",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tonic-prost",
 ]
 
@@ -16505,7 +16673,7 @@ checksum = "9b2874b26095e47313b6126f9e8144580a916af2151f778a4fec01a0120fed85"
 dependencies = [
  "async-stream",
  "bytes",
- "h2 0.4.7",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -16515,9 +16683,9 @@ dependencies = [
  "pin-project",
  "socket2 0.5.8",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -16536,7 +16704,7 @@ dependencies = [
  "http-body 1.0.1",
  "pin-project",
  "tokio-stream",
- "tonic 0.14.2",
+ "tonic 0.14.5",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -16557,7 +16725,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -16577,7 +16745,7 @@ dependencies = [
  "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -16606,7 +16774,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
@@ -16637,7 +16805,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.18",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -16659,9 +16827,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -16683,9 +16851,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16694,12 +16862,22 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -16708,6 +16886,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
+ "futures",
+ "futures-task",
  "pin-project",
  "tracing",
 ]
@@ -16753,14 +16933,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.50.3",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -16826,7 +17006,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.0",
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.12",
@@ -16893,7 +17073,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -16906,7 +17086,7 @@ dependencies = [
  "fdlimit",
  "hdrhistogram",
  "itertools 0.13.0",
- "msim",
+ "msim 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=213e543d83b91c4aa904166bef255a6c0054c8a7)",
  "mysten-common",
  "mysten-metrics",
  "once_cell",
@@ -16927,7 +17107,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -16938,7 +17118,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -16947,7 +17127,7 @@ dependencies = [
 [[package]]
 name = "typed-store-workspace-hack"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.64.1#e927cb3dcdf37d464df961d8b02411ab8aa7284a"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.67.1#4e8aa9ee8b307b294cc85baf7d08af1f432e3d93"
 dependencies = [
  "cc",
  "lazy_static",
@@ -17156,7 +17336,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.27",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.8",
@@ -17480,18 +17660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "whoami"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17530,7 +17698,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -17774,6 +17942,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ nonempty = "0.12.0"
 num-bigint = "0.4.6"
 num_cpus = "1.15.0"
 num_enum = "0.7.4"
-object_store = { version = "0.11.2", features = [
+object_store = { version = "0.13.0", features = [
     "aws",
     "gcp",
     "azure",
@@ -180,14 +180,14 @@ parking_lot = "0.12.5"
 pprof = { version = "0.15.0", features = ["cpp", "frame-pointer"] }
 pretty_assertions = "1.3.0"
 proc-macro2 = "1.0.47"
-prometheus = "0.13.3"
+prometheus = { version = "0.14", features = ["protobuf"] }
 quote = "1.0.23"
 rand = "0.9"
 rand_chacha = "0.9"
 prost = "0.14.3"
 prost-build = "0.14.3"
 rayon = "1.11.0"
-protobuf = { version = "2.28", features = ["with-bytes"] }
+protobuf = { version = "3.7", features = ["with-bytes"] }
 regex = "1.7.1"
 reqwest = { version = "0.12", default-features = false, features = [
     "http2",
@@ -255,18 +255,18 @@ shlex = "1.3.0"
 lazy_static = "1.5.0"
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-move-bytecode-utils = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-move-compiler = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-move-package = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-move-package-alt-compilation = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-move-symbol-pool = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
+move-binary-format = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+move-bytecode-utils = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+move-compiler = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+move-package = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+move-package-alt-compilation = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+move-symbol-pool = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
 
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "4db0e90c732bbf7420ca20de808b698883148d9c" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "4db0e90c732bbf7420ca20de808b698883148d9c" }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "4db0e90c732bbf7420ca20de808b698883148d9c", package = "fastcrypto-zkp" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "db643fd05a1b1c4cd52de3939766b53e12ce137e" }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "db643fd05a1b1c4cd52de3939766b53e12ce137e" }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "db643fd05a1b1c4cd52de3939766b53e12ce137e", package = "fastcrypto-zkp" }
 
 # anemo dependencies
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "4b5f0f1d06a31c8ef78ec2e5b446bc633e4e2f77" }
@@ -274,47 +274,48 @@ anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "4b5f0f1d
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "4b5f0f1d06a31c8ef78ec2e5b446bc633e4e2f77" }
 
 ### Sui Members ###
-bin-version =  { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-mysten-common = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-mysten-network = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-mysten-service = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-shared-crypto = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-faucet = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-graphql-rpc = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-indexer = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-json = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-json-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-metrics-push-client = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-move = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-protocol-config-macros = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-swarm = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-swarm-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-test-transaction-builder = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-tls = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-transaction-checks = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-typed-store = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-typed-store-error = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
+bin-version =  { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+mysten-common = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+mysten-network = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+mysten-service = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+shared-crypto = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-faucet = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-graphql-rpc = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-indexer = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-json = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-json-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-metrics-push-client = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-move = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-protocol-config-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-swarm = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-swarm-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-test-transaction-builder = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-tls = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-transaction-checks = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+typed-store = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+typed-store-error = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
 
-sui-execution = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
+sui-execution = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
 
-consensus-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-consensus-core = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
-consensus-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.64.1" }
+consensus-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+consensus-core = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
+consensus-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.67.1" }
 
 ### Workspace Members ###
 dwallet-rng = { path = "crates/dwallet-rng" }
@@ -338,3 +339,6 @@ ika-archival = { path = "crates/ika-archival" }
 [patch.crates-io]
 crypto-bigint = { git = "https://github.com/ycscaly/crypto-bigint.git", rev = "8aabcee5" }
 rfc6979 = { git = "https://github.com/RustCrypto/signatures", tag = "rfc6979/v0.5.0-rc.1" }
+async-graphql = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18-graphiql-4" }
+async-graphql-axum = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18-graphiql-4" }
+async-graphql-value = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18-graphiql-4" }

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -1027,7 +1027,6 @@ impl AuthorityPerEpochStore {
 
     #[instrument(level = "debug", skip_all)]
     pub(crate) async fn process_consensus_transactions_and_commit_boundary<
-        'a,
         C: DWalletCheckpointServiceNotify,
     >(
         &self,

--- a/crates/ika-core/src/consensus_adapter.rs
+++ b/crates/ika-core/src/consensus_adapter.rs
@@ -470,7 +470,7 @@ impl ConsensusAdapter {
                 // Filter out low scoring nodes
                 let high_scoring = low_scoring_authorities.get(authority).is_none();
 
-                keep || high_scoring //(connected && high_scoring)
+                keep || (connected && high_scoring)
             })
             .collect();
 
@@ -803,7 +803,10 @@ impl ConsensusAdapter {
                         .inc();
                     retries += 1;
 
-                    time::sleep(Duration::from_secs(10)).await;
+                    // Exponential backoff: 100ms, 200ms, 400ms, ..., capped at 10s
+                    let backoff =
+                        Duration::from_millis(100u64.saturating_mul(1u64 << retries.min(10)));
+                    time::sleep(backoff.min(Duration::from_secs(10))).await;
                 }
                 Ok((consensus_positions, status_waiter)) => {
                     break (consensus_positions, status_waiter);
@@ -824,7 +827,7 @@ impl ConsensusAdapter {
 
         self.metrics
             .sequencing_acknowledge_latency
-            .with_label_values(&[&bucket, tx_type])
+            .with_label_values(&[&bucket, &tx_type.to_string()])
             .observe(ack_start.elapsed().as_secs_f64());
 
         (consensus_positions, status_waiter)
@@ -1076,7 +1079,11 @@ impl Drop for InflightDropGuard<'_> {
         self.adapter
             .metrics
             .sequencing_certificate_latency
-            .with_label_values(&[&position, self.tx_type, processed_method])
+            .with_label_values(&[
+                &position.to_string(),
+                &self.tx_type.to_string(),
+                &processed_method.to_string(),
+            ])
             .observe(latency.as_secs_f64());
 
         // Only sample latency after consensus quorum is up. Otherwise, the wait for consensus

--- a/crates/ika-core/src/consensus_handler.rs
+++ b/crates/ika-core/src/consensus_handler.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use arc_swap::ArcSwap;
 use consensus_config::Committee as ConsensusCommittee;
-use consensus_core::CommitConsumerMonitor;
+use consensus_core::{CommitConsumerMonitor, CommitIndex};
 use ika_protocol_config::ProtocolConfig;
 use ika_types::crypto::AuthorityName;
 use ika_types::digests::ConsensusCommitDigest;
@@ -381,18 +381,33 @@ pub(crate) struct MysticetiConsensusHandler {
 
 impl MysticetiConsensusHandler {
     pub(crate) fn new(
+        last_processed_commit_at_startup: CommitIndex,
         mut consensus_handler: ConsensusHandler<DWalletCheckpointService>,
         mut commit_receiver: UnboundedReceiver<consensus_core::CommittedSubDag>,
         commit_consumer_monitor: Arc<CommitConsumerMonitor>,
     ) -> Self {
+        debug!(
+            last_processed_commit_at_startup,
+            "Starting consensus replay"
+        );
         let mut tasks = JoinSet::new();
         tasks.spawn(monitored_future!(async move {
             // TODO: pause when execution is overloaded, so consensus can detect the backpressure.
             while let Some(consensus_commit) = commit_receiver.recv().await {
                 let commit_index = consensus_commit.commit_ref.index;
-                consensus_handler
-                    .handle_consensus_commit(consensus_commit)
-                    .await;
+                // Skip commits that were already processed before startup.
+                // These may be replayed by consensus for crash recovery purposes.
+                if commit_index <= last_processed_commit_at_startup {
+                    debug!(
+                        commit_index,
+                        last_processed_commit_at_startup,
+                        "Skipping already-processed replayed commit"
+                    );
+                } else {
+                    consensus_handler
+                        .handle_consensus_commit(consensus_commit)
+                        .await;
+                }
                 commit_consumer_monitor.set_highest_handled_commit(commit_index);
             }
         }));

--- a/crates/ika-core/src/consensus_manager/mod.rs
+++ b/crates/ika-core/src/consensus_manager/mod.rs
@@ -138,12 +138,16 @@ impl ConsensusManager {
 
         let last_processed_commit_index =
             consensus_handler.last_processed_subdag_index() as CommitIndex;
-        let (commit_consumer, commit_receiver, _block_receiver) =
+        let (commit_consumer, commit_receiver) =
             CommitConsumerArgs::new(last_processed_commit_index, last_processed_commit_index);
         let monitor = commit_consumer.monitor();
 
-        let handler =
-            MysticetiConsensusHandler::new(consensus_handler, commit_receiver, monitor.clone());
+        let handler = MysticetiConsensusHandler::new(
+            last_processed_commit_index,
+            consensus_handler,
+            commit_receiver,
+            monitor.clone(),
+        );
 
         let mut consensus_handler = self.consensus_handler.lock().await;
         *consensus_handler = Some(handler);

--- a/crates/ika-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/ika-core/src/consensus_types/consensus_output_api.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
-use std::{cmp::Ordering, fmt::Display};
+use std::{collections::BTreeSet, fmt::Display};
 
 use consensus_core::{BlockAPI, CommitDigest, VerifiedBlock};
 use consensus_types::block::{BlockRef, TransactionIndex};
@@ -99,7 +99,7 @@ pub(crate) fn parse_block_transactions(
     let round = block.round();
     let authority = block.author().value() as AuthorityIndex;
 
-    let mut rejected_idx = 0;
+    let rejected_transaction_indices = BTreeSet::from_iter(rejected_transactions.iter().cloned());
     block
         .transactions()
         .iter().enumerate()
@@ -110,22 +110,7 @@ pub(crate) fn parse_block_transactions(
                     panic!("Failed to deserialize sequenced consensus transaction (this should not happen) {err} from {authority} at {round}");
                 },
             };
-            let rejected = if rejected_idx < rejected_transactions.len() {
-                match (index as TransactionIndex).cmp(&rejected_transactions[rejected_idx]) {
-                    Ordering::Less => {
-                        false
-                    },
-                    Ordering::Equal => {
-                        rejected_idx += 1;
-                        true
-                    },
-                    Ordering::Greater => {
-                        panic!("Rejected transaction indices are not in order. Block {block:?}, rejected transactions: {rejected_transactions:?}");
-                    },
-                }
-            } else {
-                false
-            };
+            let rejected = rejected_transaction_indices.contains(&(index as TransactionIndex));
             ParsedTransaction {
                 transaction,
                 rejected,

--- a/crates/ika-proxy/src/consumer.rs
+++ b/crates/ika-proxy/src/consumer.rs
@@ -93,7 +93,7 @@ impl ProtobufDecoder {
         let mut result: Vec<T> = vec![];
         while !self.buf.get_ref().is_empty() {
             let len = {
-                let mut is = CodedInputStream::from_buffered_reader(&mut self.buf);
+                let mut is = CodedInputStream::from_buf_read(&mut self.buf);
                 is.read_raw_varint32()
             }?;
             let mut buf = vec![0; len as usize];
@@ -116,19 +116,23 @@ pub fn populate_labels(
         .with_label_values(&["populate_labels"])
         .start_timer();
     debug!("received metrics from {name} on {inventory_hostname}");
-    // proto::LabelPair doesn't have pub fields so we can't use
-    // struct literals to construct
-    let mut network_label = proto::LabelPair::default();
-    network_label.set_name("network".into());
-    network_label.set_value(network);
+    let network_label = proto::LabelPair {
+        name: Some("network".into()),
+        value: Some(network),
+        ..Default::default()
+    };
 
-    let mut host_label = proto::LabelPair::default();
-    host_label.set_name("host".into());
-    host_label.set_value(name);
+    let host_label = proto::LabelPair {
+        name: Some("host".into()),
+        value: Some(name),
+        ..Default::default()
+    };
 
-    let mut source_label = proto::LabelPair::default();
-    source_label.set_name("metrics_source".into());
-    source_label.set_value("ika-proxy".into());
+    let source_label = proto::LabelPair {
+        name: Some("metrics_source".into()),
+        value: Some("ika-proxy".into()),
+        ..Default::default()
+    };
 
     let labels = vec![network_label, host_label, source_label];
 
@@ -136,7 +140,7 @@ pub fn populate_labels(
     // add our extra labels to our incoming metric data
     for mf in data.iter_mut() {
         for m in mf.mut_metric() {
-            m.mut_label().extend(labels.clone());
+            m.label.extend(labels.clone());
         }
     }
     timer.observe_duration();
@@ -346,7 +350,6 @@ pub async fn convert_to_remote_write(
 #[cfg(test)]
 mod tests {
     use prometheus::proto;
-    use protobuf;
 
     use crate::{
         consumer::populate_labels,
@@ -361,10 +364,10 @@ mod tests {
             "test_histogram",
             "i'm a help message",
             Some(proto::MetricType::HISTOGRAM),
-            protobuf::RepeatedField::from(vec![create_metric_histogram(
-                protobuf::RepeatedField::from_vec(create_labels(vec![])),
+            vec![create_metric_histogram(
+                create_labels(vec![]),
                 create_histogram(),
-            )]),
+            )],
         );
 
         let labeled_mf = populate_labels(

--- a/crates/ika-proxy/src/metrics.rs
+++ b/crates/ika-proxy/src/metrics.rs
@@ -76,9 +76,9 @@ async fn metrics(
     if let Some(consumer_operations_submitted) = metric_families
         .iter()
         .filter_map(|v| {
-            if v.get_name() == "consumer_operations_submitted" {
+            if v.name() == "consumer_operations_submitted" {
                 // Expecting one metric, so return the first one, as it is the only one
-                v.get_metric().first().map(|m| m.get_counter().get_value())
+                v.get_metric().first().map(|m| m.counter.value())
             } else {
                 None
             }

--- a/crates/ika-proxy/src/prom_to_mimir.rs
+++ b/crates/ika-proxy/src/prom_to_mimir.rs
@@ -4,7 +4,6 @@ use crate::remote_write;
 use crate::var;
 use itertools::Itertools;
 use prometheus::proto::{Counter, Gauge, Histogram, Metric, MetricFamily, MetricType};
-use protobuf::RepeatedField;
 use tracing::{debug, error};
 
 #[derive(Debug)]
@@ -12,21 +11,21 @@ pub struct Mimir<S> {
     state: S,
 }
 
-impl From<&Metric> for Mimir<RepeatedField<remote_write::Label>> {
+impl From<&Metric> for Mimir<Vec<remote_write::Label>> {
     fn from(m: &Metric) -> Self {
         // we consume metric labels from an owned version so we can sort them
         let mut m = m.to_owned();
         let mut sorted = m.take_label();
         sorted.sort_by(|a, b| {
-            (a.get_name(), a.get_value())
-                .partial_cmp(&(b.get_name(), b.get_value()))
+            (a.name(), a.value())
+                .partial_cmp(&(b.name(), b.value()))
                 .unwrap()
         });
-        let mut r = RepeatedField::<remote_write::Label>::default();
+        let mut r = Vec::<remote_write::Label>::default();
         for label in sorted {
             let lp = remote_write::Label {
-                name: label.get_name().into(),
-                value: label.get_value().into(),
+                name: label.name().into(),
+                value: label.value().into(),
             };
             r.push(lp);
         }
@@ -34,7 +33,7 @@ impl From<&Metric> for Mimir<RepeatedField<remote_write::Label>> {
     }
 }
 
-impl IntoIterator for Mimir<RepeatedField<remote_write::Label>> {
+impl IntoIterator for Mimir<Vec<remote_write::Label>> {
     type Item = remote_write::Label;
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
@@ -47,7 +46,7 @@ impl From<&Counter> for Mimir<remote_write::Sample> {
     fn from(c: &Counter) -> Self {
         Self {
             state: remote_write::Sample {
-                value: c.get_value(),
+                value: c.value(),
                 ..Default::default()
             },
         }
@@ -57,7 +56,7 @@ impl From<&Gauge> for Mimir<remote_write::Sample> {
     fn from(c: &Gauge) -> Self {
         Self {
             state: remote_write::Sample {
-                value: c.get_value(),
+                value: c.value(),
                 ..Default::default()
             },
         }
@@ -138,8 +137,8 @@ impl IntoIterator for Mimir<Vec<remote_write::WriteRequest>> {
     }
 }
 
-impl Mimir<RepeatedField<remote_write::TimeSeries>> {
-    pub fn repeated(self) -> RepeatedField<remote_write::TimeSeries> {
+impl Mimir<Vec<remote_write::TimeSeries>> {
+    pub fn repeated(self) -> Vec<remote_write::TimeSeries> {
         self.state
     }
 }
@@ -147,36 +146,38 @@ impl Mimir<RepeatedField<remote_write::TimeSeries>> {
 impl From<MetricFamily> for Mimir<Vec<remote_write::TimeSeries>> {
     fn from(mf: MetricFamily) -> Self {
         let mut timeseries = vec![];
-        for metric in mf.get_metric() {
+        for metric in &mf.metric {
             let mut ts = remote_write::TimeSeries::default();
             ts.labels.extend(vec![
                 // mimir requires that we use __name__ as a key that points to a value
                 // of the metric name
                 remote_write::Label {
                     name: "__name__".into(),
-                    value: mf.get_name().into(),
+                    value: mf.name().into(),
                 },
             ]);
             ts.labels
-                .extend(Mimir::<RepeatedField<remote_write::Label>>::from(metric));
+                .extend(Mimir::<Vec<remote_write::Label>>::from(metric));
 
             // assumption here is that since a MetricFamily will have one MetricType, we'll only need
             // to look for one of these types.  Setting two different types on Metric at the same time
             // in a way that is conflicting with the MetricFamily type will result in undefined mimir
             // behavior, probably an error.
-            if metric.has_counter() {
-                let mut s = Mimir::<remote_write::Sample>::from(metric.get_counter()).sample();
-                s.timestamp = metric.get_timestamp_ms();
+            if metric.counter.is_some() {
+                let counter: &Counter = &metric.counter;
+                let mut s = Mimir::<remote_write::Sample>::from(counter).sample();
+                s.timestamp = metric.timestamp_ms();
                 ts.samples.push(s);
-            } else if metric.has_gauge() {
-                let mut s = Mimir::<remote_write::Sample>::from(metric.get_gauge()).sample();
-                s.timestamp = metric.get_timestamp_ms();
+            } else if metric.gauge.is_some() {
+                let gauge: &Gauge = &metric.gauge;
+                let mut s = Mimir::<remote_write::Sample>::from(gauge).sample();
+                s.timestamp = metric.timestamp_ms();
                 ts.samples.push(s);
-            } else if metric.has_histogram() {
+            } else if metric.histogram.is_some() {
                 // TODO implement
                 // ts.mut_histograms()
                 //     .push(Mimir::<remote_write::Histogram>::from(metric.get_histogram()).histogram());
-            } else if metric.has_summary() {
+            } else if metric.summary.is_some() {
                 // TODO implement
                 error!("summary is not implemented for a metric type");
             }
@@ -197,14 +198,13 @@ pub mod tests {
     use crate::prom_to_mimir::Mimir;
     use crate::remote_write;
     use prometheus::proto;
-    use protobuf::RepeatedField;
 
     // protobuf stuff
     pub fn create_metric_family(
         name: &str,
         help: &str,
         field_type: Option<proto::MetricType>,
-        metric: RepeatedField<proto::Metric>,
+        metric: Vec<proto::Metric>,
     ) -> proto::MetricFamily {
         // no public fields, cannot use literals
         let mut mf = proto::MetricFamily::default();
@@ -219,10 +219,7 @@ pub mod tests {
         mf
     }
     #[allow(dead_code)]
-    fn create_metric_gauge(
-        labels: RepeatedField<proto::LabelPair>,
-        gauge: proto::Gauge,
-    ) -> proto::Metric {
+    fn create_metric_gauge(labels: Vec<proto::LabelPair>, gauge: proto::Gauge) -> proto::Metric {
         let mut m = proto::Metric::default();
         m.set_label(labels);
         m.set_gauge(gauge);
@@ -231,7 +228,7 @@ pub mod tests {
     }
 
     pub fn create_metric_counter(
-        labels: RepeatedField<proto::LabelPair>,
+        labels: Vec<proto::LabelPair>,
         counter: proto::Counter,
     ) -> proto::Metric {
         let mut m = proto::Metric::default();
@@ -242,7 +239,7 @@ pub mod tests {
     }
 
     pub fn create_metric_histogram(
-        labels: RepeatedField<proto::LabelPair>,
+        labels: Vec<proto::LabelPair>,
         histogram: proto::Histogram,
     ) -> proto::Metric {
         let mut m = proto::Metric::default();
@@ -259,7 +256,7 @@ pub mod tests {
         let mut b = proto::Bucket::default();
         b.set_cumulative_count(1);
         b.set_upper_bound(1.0);
-        h.mut_bucket().push(b);
+        h.bucket.push(b);
         h
     }
 
@@ -310,13 +307,13 @@ pub mod tests {
                     "test_gauge",
                     "i'm a help message",
                     Some(proto::MetricType::GAUGE),
-                    RepeatedField::from(vec![create_metric_gauge(
-                        RepeatedField::from_vec(create_labels(vec![
+                    vec![create_metric_gauge(
+                        create_labels(vec![
                             ("host", "local-test-validator"),
                             ("network", "unittest-network"),
-                        ])),
+                        ]),
                         create_gauge(2046.0),
-                    )]),
+                    )],
                 ),
                 vec![create_timeseries_with_samples(
                     vec![
@@ -344,13 +341,13 @@ pub mod tests {
                     "test_counter",
                     "i'm a help message",
                     Some(proto::MetricType::GAUGE),
-                    RepeatedField::from(vec![create_metric_counter(
-                        RepeatedField::from_vec(create_labels(vec![
+                    vec![create_metric_counter(
+                        create_labels(vec![
                             ("host", "local-test-validator"),
                             ("network", "unittest-network"),
-                        ])),
+                        ]),
                         create_counter(2046.0),
-                    )]),
+                    )],
                 ),
                 vec![create_timeseries_with_samples(
                     vec![

--- a/crates/ika-sui-client/Cargo.toml
+++ b/crates/ika-sui-client/Cargo.toml
@@ -28,6 +28,7 @@ ika-move-contracts.workspace = true
 ika-types.workspace = true
 
 sui-json-rpc-types.workspace = true
+sui-rpc-api.workspace = true
 sui-sdk.workspace = true
 sui-types.workspace = true
 backoff.workspace = true

--- a/crates/ika-sui-client/src/ika_protocol_transactions.rs
+++ b/crates/ika-sui-client/src/ika_protocol_transactions.rs
@@ -48,7 +48,7 @@ pub async fn set_approved_upgrade_by_cap(
     digest: Option<Vec<u8>>,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let protocol_cap_ref = client
         .transaction_builder()
         .get_object_ref(protocol_cap_id)
@@ -226,7 +226,7 @@ pub async fn try_migrate_system_by_cap(
     ika_system_object_id: ObjectID,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let mut ptb = ProgrammableTransactionBuilder::new();
 
     let sender = context.active_address()?;
@@ -540,7 +540,7 @@ pub async fn get_verified_protocol_cap(
     protocol_cap_id: ObjectID,
     ptb: &mut ProgrammableTransactionBuilder,
 ) -> Result<Argument, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let protocol_cap_ref = client
         .transaction_builder()
         .get_object_ref(protocol_cap_id)

--- a/crates/ika-sui-client/src/ika_validator_transactions.rs
+++ b/crates/ika-sui-client/src/ika_validator_transactions.rs
@@ -37,12 +37,14 @@ use serde::Serialize;
 use shared_crypto::intent::Intent;
 use sui::client_commands::{SuiClientCommandResult, execute_dry_run};
 use sui::fire_drill::get_gas_obj_ref;
-use sui_json_rpc_types::{ObjectChange, SuiTransactionBlockResponse};
-use sui_json_rpc_types::{SuiObjectDataOptions, SuiTransactionBlockResponseOptions};
+use sui_json_rpc_types::{
+    SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse,
+};
 use sui_keys::keystore::AccountKeystore;
 use sui_sdk::wallet_context::WalletContext;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::collection_types::Entry;
+use sui_types::effects::TransactionEffectsAPI;
 use sui_types::object::Owner;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{Argument, CallArg, ObjectArg, Transaction, TransactionKind};
@@ -114,17 +116,11 @@ pub async fn request_add_validator_candidate(
     let Some(Owner::Shared {
         initial_shared_version,
     }) = context
-        .get_client()
-        .await?
-        .read_api()
-        .get_object_with_options(
-            ika_system_object_id,
-            SuiObjectDataOptions::new().with_owner(),
-        )
-        .await?
-        .data
-        .ok_or(anyhow::Error::msg("failed to get object data"))?
-        .owner
+        .grpc_client()?
+        .get_object(ika_system_object_id)
+        .await
+        .map(|o| o.owner().clone())
+        .ok()
     else {
         bail!("Failed to get owner of object")
     };
@@ -226,36 +222,12 @@ pub async fn request_add_validator_candidate(
 
     let response = execute_transaction(context, tx).await?;
 
-    let object_changes = response
-        .object_changes
-        .clone()
-        .ok_or(anyhow::Error::msg("failed to get object changes"))?;
-
-    if !response.errors.is_empty() {
-        println!("{:?}", response.errors);
-        panic!("Become-candidate failed")
-    }
-
     let validator_cap_type = StructTag {
         address: ika_common_package_id.into(),
         module: VALIDATOR_CAP_MODULE_NAME.into(),
         name: VALIDATOR_CAP_STRUCT_NAME.into(),
         type_params: vec![],
     };
-
-    let validator_cap_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if validator_cap_type == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .ok_or(anyhow::Error::msg("failed to get validator cap object id"))?;
 
     let validator_operation_cap_type = StructTag {
         address: ika_common_package_id.into(),
@@ -264,22 +236,6 @@ pub async fn request_add_validator_candidate(
         type_params: vec![],
     };
 
-    let validator_operation_cap_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if validator_operation_cap_type == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .ok_or(anyhow::Error::msg(
-            "failed to get validator operation cap object id",
-        ))?;
-
     let validator_commission_cap_type = StructTag {
         address: ika_common_package_id.into(),
         module: VALIDATOR_CAP_MODULE_NAME.into(),
@@ -287,29 +243,56 @@ pub async fn request_add_validator_candidate(
         type_params: vec![],
     };
 
-    let validator_commission_cap_id = *object_changes
+    // Fetch created objects from the transaction effects to find cap object IDs by type.
+    let effects = response
+        .effects
+        .as_ref()
+        .ok_or(anyhow::Error::msg("failed to get transaction effects"))?;
+    let created_objects = effects
+        .created()
         .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if validator_commission_cap_type == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .ok_or(anyhow::Error::msg(
-            "failed to get validator commission cap object id",
-        ))?;
+        .map(|o| o.reference.object_id)
+        .collect::<Vec<_>>();
 
-    let validator_cap = context
-        .get_client()
-        .await?
-        .read_api()
-        .get_move_object_bcs(validator_cap_id)
-        .await?;
-    let validator_cap: ValidatorCapV1 = bcs::from_bytes(&validator_cap)?;
+    let mut grpc_client = context.grpc_client()?;
+    let mut validator_cap_id: Option<ObjectID> = None;
+    let mut validator_operation_cap_id: Option<ObjectID> = None;
+    let mut validator_commission_cap_id: Option<ObjectID> = None;
+
+    for obj_id in created_objects {
+        if let Ok(obj) = grpc_client.get_object(obj_id).await
+            && let Some(move_obj) = obj.data.try_as_move()
+        {
+            let obj_type = move_obj.type_().clone().into();
+            if validator_cap_type == obj_type {
+                validator_cap_id = Some(obj_id);
+            } else if validator_operation_cap_type == obj_type {
+                validator_operation_cap_id = Some(obj_id);
+            } else if validator_commission_cap_type == obj_type {
+                validator_commission_cap_id = Some(obj_id);
+            }
+        }
+    }
+
+    let validator_cap_id =
+        validator_cap_id.ok_or(anyhow::Error::msg("failed to get validator cap object id"))?;
+    let validator_operation_cap_id = validator_operation_cap_id.ok_or(anyhow::Error::msg(
+        "failed to get validator operation cap object id",
+    ))?;
+    let validator_commission_cap_id = validator_commission_cap_id.ok_or(anyhow::Error::msg(
+        "failed to get validator commission cap object id",
+    ))?;
+
+    let validator_cap_obj = context
+        .grpc_client()?
+        .get_object(validator_cap_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to get validator cap object: {e}"))?;
+    let validator_cap_move = validator_cap_obj
+        .data
+        .try_as_move()
+        .ok_or_else(|| anyhow::anyhow!("validator cap object is not a Move object"))?;
+    let validator_cap: ValidatorCapV1 = bcs::from_bytes(validator_cap_move.contents())?;
 
     Ok((
         response,
@@ -332,7 +315,7 @@ pub async fn stake_ika(
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
     let mut ptb = ProgrammableTransactionBuilder::new();
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let ika_supply_ref = client
         .transaction_builder()
         .get_object_ref(ika_supply_id)
@@ -375,7 +358,7 @@ pub async fn request_add_validator(
     validator_cap_id: ObjectID,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_cap_id)
@@ -410,7 +393,7 @@ pub async fn request_remove_validator(
     validator_cap_id: ObjectID,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_cap_id)
@@ -441,7 +424,7 @@ pub async fn request_remove_validator_candidate(
     validator_cap_id: ObjectID,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_cap_id)
@@ -478,7 +461,7 @@ pub async fn set_next_commission(
     new_commission_rate: u16,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -518,7 +501,7 @@ pub async fn withdraw_stake(
     staked_ika_id: ObjectID,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let staked_ika_ref = client
         .transaction_builder()
         .get_object_ref(staked_ika_id)
@@ -554,7 +537,7 @@ pub async fn request_withdraw_stake(
     staked_ika_id: ObjectID,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let staked_ika_ref = client
         .transaction_builder()
         .get_object_ref(staked_ika_id)
@@ -589,7 +572,7 @@ pub async fn report_validator(
     reportee_id: ObjectID,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -630,7 +613,7 @@ pub async fn undo_report_validator(
     reportee_id: ObjectID,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -670,7 +653,7 @@ pub async fn rotate_operation_cap(
     validator_cap_id: ObjectID,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_cap_id)
@@ -731,10 +714,7 @@ pub(crate) async fn construct_unsigned_txn(
     gas_budget: u64,
     ptb: ProgrammableTransactionBuilder,
 ) -> IkaResult<TransactionData> {
-    let sui_client = context
-        .get_client()
-        .await
-        .map_err(|_| IkaError::SuiSDKError)?;
+    let sui_client = context.grpc_client().map_err(|_| IkaError::SuiSDKError)?;
     let gas_price = context
         .get_reference_gas_price()
         .await
@@ -755,10 +735,11 @@ pub(crate) async fn construct_unsigned_txn(
     .await
     .map_err(|e| IkaError::DryRunFailed(e.to_string()))?;
     if let SuiClientCommandResult::DryRun(dry_run) = dry_run
-        && let Some(dry_run_err) = dry_run.execution_error_source
+        && dry_run.transaction.effects.status().is_err()
     {
-        println!("{}", dry_run.effects);
-        return Err(IkaError::DryRunFailed(dry_run_err));
+        let err_msg = format!("{:?}", dry_run.transaction.effects.status());
+        println!("{:?}", dry_run.transaction.effects);
+        return Err(IkaError::DryRunFailed(err_msg));
     };
 
     let gas_budget = sui::client_commands::estimate_gas_budget(
@@ -773,7 +754,6 @@ pub(crate) async fn construct_unsigned_txn(
     .unwrap_or(gas_budget);
 
     let rgp = sui_client
-        .governance_api()
         .get_reference_gas_price()
         .await
         .map_err(|_| IkaError::SuiSDKError)?;
@@ -803,19 +783,17 @@ pub async fn execute_transaction(
         .sign_secure(&sender, &tx_data, Intent::sui_transaction())
         .await?;
     let transaction = Transaction::from_data(tx_data, vec![signature]);
-    let sui_client = context.get_client().await?;
-    sui_client
-        .quorum_driver_api()
-        .execute_transaction_block(
-            transaction,
-            SuiTransactionBlockResponseOptions::new()
-                .with_input()
-                .with_effects()
-                .with_object_changes(),
-            Some(sui_types::transaction_driver_types::ExecuteTransactionRequestType::WaitForLocalExecution),
-        )
-        .await
-        .map_err(|err| anyhow::anyhow!(err.to_string()))
+    let executed = context.execute_transaction_may_fail(transaction).await?;
+    // Convert ExecutedTransaction to SuiTransactionBlockResponse for backward compatibility
+    let effects: SuiTransactionBlockEffects = executed
+        .effects
+        .try_into()
+        .map_err(|e| anyhow::anyhow!("failed to convert effects: {e}"))?;
+    Ok(SuiTransactionBlockResponse {
+        digest: *effects.transaction_digest(),
+        effects: Some(effects),
+        ..Default::default()
+    })
 }
 
 pub async fn call_ika_system(
@@ -850,7 +828,7 @@ pub async fn rotate_commission_cap(
     validator_cap_id: ObjectID,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_cap_id)
@@ -889,7 +867,7 @@ pub async fn collect_commission(
     amount: Option<u64>,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_commission_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_commission_cap_id)
@@ -932,7 +910,7 @@ pub async fn set_validator_name(
     name: String,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -1002,7 +980,7 @@ pub async fn set_validator_metadata(
     metadata: String,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -1043,7 +1021,7 @@ pub async fn set_next_epoch_network_address(
     network_address: String,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -1084,7 +1062,7 @@ pub async fn set_next_epoch_p2p_address(
     p2p_address: String,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -1125,7 +1103,7 @@ pub async fn set_next_epoch_consensus_address(
     consensus_address: String,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -1167,7 +1145,7 @@ pub async fn set_next_epoch_protocol_pubkey_bytes(
     proof_of_possession_bytes: Vec<u8>,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -1211,7 +1189,7 @@ pub async fn set_next_epoch_network_pubkey_bytes(
     network_pubkey: Vec<u8>,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -1252,7 +1230,7 @@ pub async fn set_next_epoch_consensus_pubkey_bytes(
     consensus_pubkey_bytes: Vec<u8>,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -1293,7 +1271,7 @@ pub async fn verify_validator_cap(
     validator_cap_id: ObjectID,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_cap_id)
@@ -1329,7 +1307,7 @@ pub async fn verify_operation_cap(
     validator_operation_cap_id: ObjectID,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -1365,7 +1343,7 @@ pub async fn verify_commission_cap(
     validator_commission_cap_id: ObjectID,
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_commission_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_commission_cap_id)
@@ -1399,7 +1377,7 @@ pub async fn ptb_set_next_epoch_mpc_data_bytes_inner(
     validator_operation_cap_id: ObjectID,
     next_mpc_data: &VersionedMPCData,
 ) -> Result<(ProgrammableTransactionBuilder, Argument), anyhow::Error> {
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -1537,7 +1515,7 @@ pub async fn set_pricing_vote(
     gas_budget: u64,
 ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
     let mut ptb = ProgrammableTransactionBuilder::new();
-    let client = context.get_client().await?;
+    let client = context.grpc_client()?;
     let validator_operation_cap_ref = client
         .transaction_builder()
         .get_object_ref(validator_operation_cap_id)
@@ -1645,17 +1623,11 @@ pub(crate) async fn get_dwallet_2pc_mpc_coordinator_call_arg(
     let Some(Owner::Shared {
         initial_shared_version,
     }) = context
-        .get_client()
-        .await?
-        .read_api()
-        .get_object_with_options(
-            ika_dwallet_2pc_mpc_coordinator_object_id,
-            SuiObjectDataOptions::new().with_owner(),
-        )
-        .await?
-        .data
-        .ok_or(anyhow::Error::msg("failed to get object data"))?
-        .owner
+        .grpc_client()?
+        .get_object(ika_dwallet_2pc_mpc_coordinator_object_id)
+        .await
+        .map(|o| o.owner().clone())
+        .ok()
     else {
         bail!("Failed to get owner of object")
     };
@@ -1678,17 +1650,11 @@ pub async fn add_ika_system_command_to_ptb(
     let Some(Owner::Shared {
         initial_shared_version,
     }) = context
-        .get_client()
-        .await?
-        .read_api()
-        .get_object_with_options(
-            ika_system_object_id,
-            SuiObjectDataOptions::new().with_owner(),
-        )
-        .await?
-        .data
-        .ok_or(anyhow::Error::msg("failed to get object data"))?
-        .owner
+        .grpc_client()?
+        .get_object(ika_system_object_id)
+        .await
+        .map(|o| o.owner().clone())
+        .ok()
     else {
         bail!("Failed to get owner of object")
     };

--- a/crates/ika-swarm-config/Cargo.toml
+++ b/crates/ika-swarm-config/Cargo.toml
@@ -32,6 +32,7 @@ ika-types.workspace = true
 sui.workspace = true
 sui-config.workspace = true
 sui-keys.workspace = true
+sui-rpc-api.workspace = true
 sui-sdk.workspace = true
 sui-types.workspace = true
 ika-move-contracts.workspace = true

--- a/crates/ika-swarm-config/src/main.rs
+++ b/crates/ika-swarm-config/src/main.rs
@@ -267,7 +267,9 @@ async fn main() -> Result<()> {
 
             // Create a WalletContext using the persisted SuiClientConfig.
             let context = WalletContext::new(&sui_config_path)?;
-            let client = context.get_client().await?;
+            let client: sui_sdk::SuiClient = sui_sdk::SuiClientBuilder::default()
+                .build(context.get_active_env()?.rpc.clone())
+                .await?;
 
             println!("Using SUI client configuration from: {sui_config_path:?}");
 
@@ -310,7 +312,9 @@ async fn main() -> Result<()> {
 
             // Create a WalletContext and obtain a Sui client.
             let mut context = WalletContext::new(&sui_config_path)?;
-            let client = context.get_client().await?;
+            let client: sui_sdk::SuiClient = sui_sdk::SuiClientBuilder::default()
+                .build(context.get_active_env()?.rpc.clone())
+                .await?;
 
             let mut initiation_parameters = InitiationParameters::new();
             if let Some(epoch_duration_ms) = epoch_duration_ms {
@@ -448,7 +452,9 @@ async fn main() -> Result<()> {
 
             // Create a WalletContext and Sui client.
             let mut context = WalletContext::new(&sui_config_path)?;
-            let client = context.get_client().await?;
+            let client: sui_sdk::SuiClient = sui_sdk::SuiClientBuilder::default()
+                .build(context.get_active_env()?.rpc.clone())
+                .await?;
 
             let initiation_parameters = InitiationParameters::new();
 

--- a/crates/ika-swarm-config/src/sui_client.rs
+++ b/crates/ika-swarm-config/src/sui_client.rs
@@ -39,23 +39,24 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use sui::client_commands::{
-    EphemeralArgs, PublishArgs, SuiClientCommandResult, SuiClientCommands, TestPublishArgs,
+    PublishArgs, SuiClientCommandResult, SuiClientCommands, TestPublishArgs,
     estimate_gas_budget_from_gas_cost, execute_dry_run, request_tokens_from_faucet,
 };
 use sui_config::SUI_CLIENT_CONFIG;
 use sui_keys::key_derive::generate_new_key;
 use sui_keys::keystore::{AccountKeystore, InMemKeystore, Keystore};
+use sui_rpc_api::client::ExecutedTransaction;
+use sui_rpc_api::proto;
 use sui_sdk::SuiClient;
-use sui_sdk::rpc_types::{ObjectChange, SuiObjectDataOptions, SuiTransactionBlockResponse};
-use sui_sdk::rpc_types::{
-    SuiObjectDataFilter, SuiObjectResponseQuery, SuiTransactionBlockEffectsAPI,
-};
+use sui_sdk::SuiClientBuilder;
+use sui_sdk::rpc_types::SuiObjectDataOptions;
+use sui_sdk::rpc_types::{SuiObjectDataFilter, SuiObjectResponseQuery};
 use sui_sdk::sui_client_config::{SuiClientConfig, SuiEnv};
 use sui_sdk::wallet_context::WalletContext;
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
 use sui_types::coin::TreasuryCap;
 use sui_types::crypto::{SignatureScheme, SuiKeyPair};
-use sui_types::move_package::UpgradeCap;
+use sui_types::effects::TransactionEffectsAPI;
 use sui_types::object::Owner;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{
@@ -161,7 +162,9 @@ pub async fn init_ika_on_sui(
 
     let mut context = WalletContext::new(&config_path)?;
 
-    let client = context.get_client().await?;
+    let client: SuiClient = SuiClientBuilder::default()
+        .build(context.get_active_env()?.rpc.clone())
+        .await?;
 
     let mut request_tokens_from_faucet_futures = vec![
         request_tokens_from_faucet(publisher_address, sui_faucet_url.clone()),
@@ -564,12 +567,15 @@ pub async fn set_global_presign_config(
     let tx_kind = TransactionKind::ProgrammableTransaction(ptb.finish());
 
     let response = execute_sui_transaction(publisher_address, tx_kind, context, vec![]).await?;
-    if response.errors.is_empty() {
-        println!("Transaction executed successfully. {:?}", response.digest);
+    if response.effects.status().is_ok() {
+        println!(
+            "Transaction executed successfully. {:?}",
+            response.transaction.digest()
+        );
     } else {
         panic!(
             "Errors occurred during transaction execution: {:?}",
-            response.errors
+            response.effects.status()
         );
     }
     Ok(())
@@ -843,14 +849,15 @@ pub async fn ika_system_initialize(
 
     let response = execute_sui_transaction(publisher_address, tx_kind, context, vec![]).await?;
 
-    let object_changes = response.object_changes.unwrap();
-
-    if response.errors.is_empty() {
-        println!("Transaction executed successfully. {:?}", response.digest);
+    if response.effects.status().is_ok() {
+        println!(
+            "Transaction executed successfully. {:?}",
+            response.transaction.digest()
+        );
     } else {
         panic!(
             "Errors occurred during transaction execution: {:?}",
-            response.errors
+            response.effects.status()
         );
     }
 
@@ -861,19 +868,9 @@ pub async fn ika_system_initialize(
         type_params: vec![],
     };
 
-    let dwallet_2pc_mpc_coordinator_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if dwallet_2pc_mpc_coordinator_type == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let dwallet_2pc_mpc_coordinator_id =
+        find_created_object_by_type(&response, &dwallet_2pc_mpc_coordinator_type)
+            .expect("DWallet 2PC MPC coordinator object not found");
 
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
@@ -948,10 +945,10 @@ pub async fn ika_system_set_witness_approving_advance_epoch(
 
     let response = execute_sui_transaction(publisher_address, tx_kind, context, vec![]).await?;
 
-    if !response.errors.is_empty() {
+    if !response.effects.status().is_ok() {
         return Err(anyhow::Error::msg(format!(
             "Errors occurred during transaction execution: {:?}",
-            response.errors
+            response.effects.status()
         )));
     }
 
@@ -1032,10 +1029,10 @@ pub async fn ika_system_add_upgrade_cap_by_cap(
 
     let response = execute_sui_transaction(publisher_address, tx_kind, context, vec![]).await?;
 
-    if !response.errors.is_empty() {
+    if !response.effects.status().is_ok() {
         return Err(anyhow::Error::msg(format!(
             "Errors occurred during transaction execution: {:?}",
-            response.errors
+            response.effects.status()
         )));
     }
 
@@ -1119,21 +1116,9 @@ pub async fn init_initialize(
 
     let response = execute_sui_transaction(publisher_address, tx_kind, context, vec![]).await?;
 
-    let object_changes = response.object_changes.unwrap();
-
-    let ika_system_object_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if System::type_(ika_system_package_id.into()) == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let system_type = System::type_(ika_system_package_id.into());
+    let ika_system_object_id =
+        find_created_object_by_type(&response, &system_type).expect("System object not found");
 
     let protocol_cap_type = StructTag {
         address: ika_common_package_id.into(),
@@ -1142,19 +1127,8 @@ pub async fn init_initialize(
         type_params: vec![],
     };
 
-    let protocol_cap_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if protocol_cap_type == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let protocol_cap_id = find_created_object_by_type(&response, &protocol_cap_type)
+        .expect("ProtocolCap object not found");
 
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
@@ -1235,7 +1209,9 @@ async fn stake_ika(
         mutability: sui_types::transaction::SharedObjectMutability::Mutable,
     }))?;
 
-    let client = context.get_client().await?;
+    let client: SuiClient = SuiClientBuilder::default()
+        .build(context.get_active_env()?.rpc.clone())
+        .await?;
 
     let ika_supply_ref = client
         .transaction_builder()
@@ -1413,8 +1389,6 @@ async fn request_add_validator_candidate(
 
     let response = execute_sui_transaction(validator_address, tx_kind, context, vec![]).await?;
 
-    let object_changes = response.object_changes.unwrap();
-
     let validator_cap_type = StructTag {
         address: ika_common_package_id.into(),
         module: VALIDATOR_CAP_MODULE_NAME.into(),
@@ -1422,27 +1396,16 @@ async fn request_add_validator_candidate(
         type_params: vec![],
     };
 
-    let validator_cap_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if validator_cap_type == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let validator_cap_id = find_created_object_by_type(&response, &validator_cap_type)
+        .expect("ValidatorCap object not found");
 
-    let validator_cap = context
-        .get_client()
+    let validator_cap_bcs = SuiClientBuilder::default()
+        .build(context.get_active_env()?.rpc.clone())
         .await?
         .read_api()
         .get_move_object_bcs(validator_cap_id)
         .await?;
-    let validator_cap: ValidatorCapV1 = bcs::from_bytes(&validator_cap)?;
+    let validator_cap: ValidatorCapV1 = bcs::from_bytes(&validator_cap_bcs)?;
 
     Ok((validator_cap.validator_id, validator_cap_id))
 }
@@ -1451,16 +1414,9 @@ pub async fn publish_ika_dwallet_2pc_mpc_package_to_sui(
     context: &mut WalletContext,
     contract_path: PathBuf,
 ) -> Result<(ObjectID, ObjectID, ObjectID), anyhow::Error> {
-    let object_changes = publish_package_to_sui(context, contract_path).await?;
-    let ika_dwallet_2pc_mpc_package_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Published { package_id, .. } => Some(*package_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let response = publish_package_to_sui(context, contract_path).await?;
+    let ika_dwallet_2pc_mpc_package_id =
+        find_published_package_id(&response).expect("Published package not found");
 
     let init_cap_type = StructTag {
         address: ika_dwallet_2pc_mpc_package_id.into(),
@@ -1469,33 +1425,13 @@ pub async fn publish_ika_dwallet_2pc_mpc_package_to_sui(
         type_params: vec![],
     };
 
-    let ika_dwallet_2pc_mpc_init_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if init_cap_type == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let ika_dwallet_2pc_mpc_init_id =
+        find_created_object_by_type(&response, &init_cap_type).expect("Init cap object not found");
 
-    let ika_dwallet_2pc_mpc_package_upgrade_cap_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if UpgradeCap::type_() == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let ika_dwallet_2pc_mpc_package_upgrade_cap_id = response
+        .get_new_package_upgrade_cap()
+        .expect("UpgradeCap object not found")
+        .0;
 
     Ok((
         ika_dwallet_2pc_mpc_package_id,
@@ -1508,16 +1444,9 @@ pub async fn publish_ika_system_package_to_sui(
     context: &mut WalletContext,
     contract_path: PathBuf,
 ) -> Result<(ObjectID, ObjectID, ObjectID), anyhow::Error> {
-    let object_changes = publish_package_to_sui(context, contract_path).await?;
-    let ika_system_package_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Published { package_id, .. } => Some(*package_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let response = publish_package_to_sui(context, contract_path).await?;
+    let ika_system_package_id =
+        find_published_package_id(&response).expect("Published package not found");
 
     let init_cap_type = StructTag {
         address: ika_system_package_id.into(),
@@ -1526,33 +1455,13 @@ pub async fn publish_ika_system_package_to_sui(
         type_params: vec![],
     };
 
-    let init_cap_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if init_cap_type == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let init_cap_id =
+        find_created_object_by_type(&response, &init_cap_type).expect("Init cap object not found");
 
-    let ika_system_package_upgrade_cap_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if UpgradeCap::type_() == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let ika_system_package_upgrade_cap_id = response
+        .get_new_package_upgrade_cap()
+        .expect("UpgradeCap object not found")
+        .0;
 
     Ok((
         ika_system_package_id,
@@ -1565,17 +1474,10 @@ pub async fn publish_ika_common_package_to_sui(
     context: &mut WalletContext,
     contract_path: PathBuf,
 ) -> Result<(ObjectID, ObjectID, ObjectID), anyhow::Error> {
-    let object_changes = publish_package_to_sui(context, contract_path).await?;
+    let response = publish_package_to_sui(context, contract_path).await?;
 
-    let ika_common_package_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Published { package_id, .. } => Some(*package_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let ika_common_package_id =
+        find_published_package_id(&response).expect("Published package not found");
 
     let system_object_cap_type = StructTag {
         address: ika_common_package_id.into(),
@@ -1584,33 +1486,13 @@ pub async fn publish_ika_common_package_to_sui(
         type_params: vec![],
     };
 
-    let system_object_cap_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if system_object_cap_type == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let system_object_cap_id = find_created_object_by_type(&response, &system_object_cap_type)
+        .expect("SystemObjectCap object not found");
 
-    let ika_common_package_upgrade_cap_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if UpgradeCap::type_() == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let ika_common_package_upgrade_cap_id = response
+        .get_new_package_upgrade_cap()
+        .expect("UpgradeCap object not found")
+        .0;
 
     Ok((
         ika_common_package_id,
@@ -1659,45 +1541,21 @@ pub async fn publish_ika_package_to_sui(
     context: &mut WalletContext,
     contract_path: PathBuf,
 ) -> Result<(ObjectID, ObjectID, ObjectID), anyhow::Error> {
-    let object_changes = publish_package_to_sui(context, contract_path).await?;
+    let response = publish_package_to_sui(context, contract_path).await?;
 
-    let ika_package_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Published { package_id, .. } => Some(*package_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let ika_package_id = find_published_package_id(&response).expect("Published package not found");
 
-    let treasury_cap_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if TreasuryCap::is_treasury_type(object_type) => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let treasury_cap_id = find_created_object_by_type_predicate(&response, |type_str| {
+        type_str
+            .parse::<StructTag>()
+            .map(|st| TreasuryCap::is_treasury_type(&st))
+            .unwrap_or(false)
+    })
+    .expect("TreasuryCap object not found");
 
-    let ika_package_upgrade_cap_id = *object_changes
-        .iter()
-        .filter_map(|o| match o {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } if UpgradeCap::type_() == *object_type => Some(*object_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .first()
-        .unwrap();
+    let (ika_package_upgrade_cap_id, _, _) = response
+        .get_new_package_upgrade_cap()
+        .expect("UpgradeCap object not found");
 
     Ok((ika_package_id, treasury_cap_id, ika_package_upgrade_cap_id))
 }
@@ -1705,7 +1563,7 @@ pub async fn publish_ika_package_to_sui(
 async fn publish_package_to_sui(
     context: &mut WalletContext,
     package_path: PathBuf,
-) -> Result<Vec<ObjectChange>, anyhow::Error> {
+) -> Result<ExecutedTransaction, anyhow::Error> {
     let result = SuiClientCommands::TestPublish(TestPublishArgs {
         publish_args: PublishArgs {
             package_path,
@@ -1722,6 +1580,8 @@ async fn publish_package_to_sui(
                 warnings_are_errors: true,
                 json_errors: false,
                 additional_named_addresses: Default::default(),
+                environment: Some("localnet".to_string()),
+                pubfile_path: None,
                 ..Default::default()
             },
             payment: Default::default(),
@@ -1731,10 +1591,6 @@ async fn publish_package_to_sui(
             verify_deps: false,
             with_unpublished_dependencies: false,
         },
-        ephemeral: EphemeralArgs {
-            build_env: Some("localnet".to_string()),
-            pubfile_path: None,
-        },
         publish_unpublished_deps: false,
     })
     .execute(context)
@@ -1743,8 +1599,41 @@ async fn publish_package_to_sui(
         bail!("Unexpected result type after publishing the package.");
     };
 
-    let object_changes = response.object_changes.unwrap();
-    Ok(object_changes)
+    Ok(response)
+}
+
+fn find_published_package_id(response: &ExecutedTransaction) -> Option<ObjectID> {
+    response.get_new_package_obj().map(|(id, _, _)| id)
+}
+
+fn find_created_object_by_type(
+    response: &ExecutedTransaction,
+    expected_type: &StructTag,
+) -> Option<ObjectID> {
+    find_created_object_by_type_predicate(response, |type_str| {
+        type_str
+            .parse::<StructTag>()
+            .map(|st| st == *expected_type)
+            .unwrap_or(false)
+    })
+}
+
+fn find_created_object_by_type_predicate(
+    response: &ExecutedTransaction,
+    predicate: impl Fn(&str) -> bool,
+) -> Option<ObjectID> {
+    use proto::sui::rpc::v2::ChangedObject;
+    use proto::sui::rpc::v2::changed_object::{IdOperation, OutputObjectState};
+
+    response
+        .changed_objects
+        .iter()
+        .find(|o: &&ChangedObject| {
+            o.output_state() == OutputObjectState::ObjectWrite
+                && o.id_operation() == IdOperation::Created
+                && predicate(o.object_type())
+        })
+        .and_then(|o: &ChangedObject| o.object_id().parse().ok())
 }
 
 const DEFAULT_GAS_BUDGET: u64 = 5_000_000_000; // 5 SUI
@@ -1786,7 +1675,7 @@ pub(crate) async fn execute_sui_transaction(
     tx_kind: TransactionKind,
     context: &mut WalletContext,
     gas_payment: Vec<ObjectRef>,
-) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
+) -> Result<ExecutedTransaction, anyhow::Error> {
     let gas_payment = if gas_payment.is_empty() {
         let Some(gas_ref) = context.get_one_gas_object_owned_by_address(signer).await? else {
             panic!("No gas object found in the wallet context.");
@@ -1813,7 +1702,9 @@ pub async fn estimate_gas_budget(
     gas_payment: Vec<ObjectRef>,
     sponsor: Option<SuiAddress>,
 ) -> Result<u64, anyhow::Error> {
-    let client = context.get_client().await?;
+    let client: SuiClient = SuiClientBuilder::default()
+        .build(context.get_active_env()?.rpc.clone())
+        .await?;
     let SuiClientCommandResult::DryRun(dry_run) =
         execute_dry_run(context, signer, kind, None, gas_price, gas_payment, sponsor).await?
     else {
@@ -1822,7 +1713,7 @@ pub async fn estimate_gas_budget(
     let rgp = client.read_api().get_reference_gas_price().await?;
 
     Ok(estimate_gas_budget_from_gas_cost(
-        dry_run.effects.gas_cost_summary(),
+        dry_run.transaction.effects.gas_cost_summary(),
         rgp,
     ))
 }

--- a/crates/ika/src/ika_commands.rs
+++ b/crates/ika/src/ika_commands.rs
@@ -215,11 +215,6 @@ impl IkaCommand {
                 let config_path = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                 let mut context = WalletContext::new(&config_path)?;
                 if let Some(cmd) = cmd {
-                    if let Ok(client) = context.get_client().await
-                        && let Err(e) = client.check_api_version()
-                    {
-                        eprintln!("{}", format!("[warning] {e}").yellow().bold());
-                    }
                     cmd.execute(&mut context).await?.print(!json);
                 } else {
                     // Print help
@@ -236,11 +231,6 @@ impl IkaCommand {
                 let config_path = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                 let mut context = WalletContext::new(&config_path)?;
                 if let Some(cmd) = cmd {
-                    if let Ok(client) = context.get_client().await
-                        && let Err(e) = client.check_api_version()
-                    {
-                        eprintln!("{}", format!("[warning] {e}").yellow().bold());
-                    }
                     cmd.execute(&mut context).await?.print(!json);
                 } else {
                     // Print help

--- a/crates/ika/src/validator_commands.rs
+++ b/crates/ika/src/validator_commands.rs
@@ -38,7 +38,6 @@ use ika_types::crypto::generate_proof_of_possession;
 use ika_types::messages_dwallet_mpc::IkaNetworkConfig;
 use ika_types::sui::{DEFAULT_COMMISSION_RATE, PricingInfoKey, PricingInfoValue};
 use serde::Serialize;
-use sui::validator_commands::write_transaction_response;
 use sui_config::PersistedConfig;
 use sui_keys::{
     key_derive::generate_new_key,
@@ -1228,6 +1227,30 @@ fn read_or_generate_root_seed(seed_path: PathBuf) -> Result<Box<ClassGroupsKeyPa
     let class_groups_public_key_and_proof = Box::new(ClassGroupsKeyPairAndProof::from_seed(&seed));
 
     Ok(class_groups_public_key_and_proof)
+}
+
+pub fn write_transaction_response(
+    response: &SuiTransactionBlockResponse,
+) -> Result<String, fmt::Error> {
+    let success = response.status_ok().unwrap();
+    let lines = vec![
+        String::from("----- Transaction Digest ----"),
+        response.digest.to_string(),
+        String::from("\n----- Transaction Data ----"),
+        response
+            .transaction
+            .as_ref()
+            .map(|t| serde_json::to_string_pretty(t).unwrap())
+            .unwrap_or_default(),
+        String::from("----- Transaction Effects ----"),
+        response.effects.as_ref().unwrap().to_string(),
+    ];
+    let mut writer = String::new();
+    for line in lines {
+        let colorized_line = if success { line.green() } else { line.red() };
+        writeln!(writer, "{colorized_line}")?;
+    }
+    Ok(writer)
 }
 
 pub fn write_transaction_response_without_transaction_data(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93"
+channel = "1.94"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

- Upgrade all Sui git dependencies from `mainnet-v1.64.1` to `testnet-v1.67.1`
- Upgrade Rust toolchain from 1.93 to 1.94.0
- Upgrade prometheus 0.13 → 0.14, protobuf 2 → 3.7, fastcrypto, object_store 0.11 → 0.13
- Adopt beneficial consensus changes from Sui: prior commit replay, exponential backoff, BTreeSet for rejected txns, stricter connectivity filtering
- Migrate from JSON-RPC `SuiClient` to gRPC `Client` API (`get_client()` → `grpc_client()`)
- Adapt to `ExecutedTransaction` replacing `SuiTransactionBlockResponse` in Sui CLI
- Align ika-proxy prometheus/protobuf code with [Sui PR #25535](https://github.com/MystenLabs/sui/pull/25535)

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Local network starts successfully (`ika start`)
- [ ] Integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)