### PR TITLE
 docs: add AI skills documentation and update Sui signing examples

### DIFF
--- a/docs/app/docs/layout.tsx
+++ b/docs/app/docs/layout.tsx
@@ -1,5 +1,5 @@
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
-import { Blocks, BookOpen, Code2, FileCode, Server } from 'lucide-react';
+import { Blocks, BookOpen, Bot, Code2, FileCode, Server } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 import { source } from '@/lib/source';
@@ -37,6 +37,12 @@ const tabConfig: Record<string, TabConfig> = {
 		description: 'Run and operate Ika nodes',
 		color: 'text-purple-500 dark:text-purple-400',
 		bgColor: 'bg-purple-500/10 dark:bg-purple-500/20',
+	},
+	skills: {
+		icon: <Bot className="size-4" />,
+		description: 'AI skills for coding agents',
+		color: 'text-amber-500 dark:text-amber-400',
+		bgColor: 'bg-amber-500/10 dark:bg-amber-500/20',
 	},
 	'code-examples': {
 		icon: <FileCode className="size-4" />,

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -1,4 +1,4 @@
 {
 	"title": "Documentation",
-	"pages": ["sdk", "move-integration", "core-concepts", "operators", "code-examples"]
+	"pages": ["sdk", "move-integration", "core-concepts", "operators", "skills", "code-examples"]
 }

--- a/docs/content/docs/move-integration/examples/multisig-bitcoin.mdx
+++ b/docs/content/docs/move-integration/examples/multisig-bitcoin.mdx
@@ -448,7 +448,7 @@ tx.moveCall({
 });
 
 // 3. Execute
-await suiClient.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
 ```
 
 ## Security Considerations

--- a/docs/content/docs/move-integration/protocols/signing.mdx
+++ b/docs/content/docs/move-integration/protocols/signing.mdx
@@ -239,7 +239,7 @@ async function signMessage(
 		],
 	});
 
-	const result = await suiClient.signAndExecuteTransaction({
+	const result = await suiClient.core.signAndExecuteTransaction({
 		transaction: tx,
 		signer: keypair,
 	});

--- a/docs/content/docs/skills/index.mdx
+++ b/docs/content/docs/skills/index.mdx
@@ -1,0 +1,119 @@
+---
+id: skills
+title: AI Skills
+description: Install Ika skills for Claude Code and other AI coding agents to get expert-level assistance with dWallet development, Move integration, and node operations.
+sidebar_position: 1
+sidebar_label: AI Skills
+---
+
+import { Info, Note } from '@/components/InfoBox';
+
+# AI Skills
+
+Ika provides a set of [agent skills](https://github.com/vercel-labs/skills) — reusable instruction sets that give AI coding agents expert knowledge about the Ika network. When installed, your AI agent automatically loads the right context when you work with Ika.
+
+Skills work with 40+ AI coding agents including **Claude Code**, **Cursor**, **Cline**, **GitHub Copilot**, **Windsurf**, and more.
+
+## Available Skills
+
+| Skill | Description |
+|---|---|
+| **ika-sdk** | Building with the `@ika.xyz/sdk` TypeScript SDK — IkaClient, IkaTransaction, cryptography, dWallet lifecycle |
+| **ika-move** | Integrating with Ika dWallet contracts in Sui Move — DKG, presign, signing, key import, treasury patterns |
+| **ika-operator** | Operating Ika network nodes — validator setup, fullnode/notifier configuration, monitoring, recovery |
+
+## Install
+
+Install skills using the [skills CLI](https://github.com/vercel-labs/skills):
+
+### All Skills
+
+```bash
+npx skills add dwallet-labs/ika
+```
+
+### Specific Skill
+
+```bash
+npx skills add dwallet-labs/ika -s ika-sdk
+npx skills add dwallet-labs/ika -s ika-move
+npx skills add dwallet-labs/ika -s ika-operator
+```
+
+### Global Install
+
+By default, skills are installed into your current project. To install globally (available across all projects):
+
+```bash
+npx skills add dwallet-labs/ika -g
+```
+
+<Info title="Agent Auto-Detection">
+The skills CLI automatically detects which AI agents you have installed and prompts you to choose where to install. You can also target a specific agent with the `-a` flag, e.g. `-a claude`.
+</Info>
+
+## What Each Skill Provides
+
+### ika-sdk
+
+Everything needed to build with the Ika TypeScript SDK:
+
+- **IkaClient** — Setup, querying dWallets/presigns/signs, polling, caching, encryption keys
+- **IkaTransaction** — DKG, presign, sign, future sign, key import, transfer, session management
+- **Cryptography** — prepareDKG, signing functions, key derivation, signature verification
+- **UserShareEncryptionKeys** — Key creation, serialization, decryption, proof of ownership
+- **Type system** — Curve/SignatureAlgorithm/Hash enums, validation, state narrowing generics
+- **End-to-end flows** — Shared dWallet, zero-trust, imported key, transfer, future sign, KeySpring
+
+### ika-move
+
+Everything needed to integrate Ika dWallet into Sui Move contracts:
+
+- **Contract patterns** — Treasury with ACL, DAO governance, presign pool management
+- **All protocols** — DKG, presign, message approval, signing, future signing, key import
+- **Coordinator API** — Complete function signatures with parameters and return types
+- **TypeScript integration** — Calling Move contracts from the SDK
+- **Working examples** — Multisig Bitcoin Taproot treasury with full code
+
+### ika-operator
+
+Everything needed to deploy and operate Ika network nodes:
+
+- **Validator setup** — Step-by-step mainnet validator registration and launch
+- **Node types** — Validator, fullnode, and notifier configuration
+- **Complete config reference** — All NodeConfig YAML fields with defaults
+- **Monitoring** — Prometheus metrics, admin API, health checks
+- **Operations** — Recovery procedures, checkpoint pinning, key management
+
+## How Skills Work
+
+Each skill consists of a `SKILL.md` file with optional `references/` for detailed documentation. When your AI agent encounters a relevant task (e.g., writing code that imports `@ika.xyz/sdk`), the skill is automatically loaded into context.
+
+```
+skills/ika-sdk/
+├── SKILL.md              # Quick reference (loaded on trigger)
+└── references/           # Detailed docs (loaded on demand)
+    ├── api-reference.md
+    ├── flows.md
+    └── types-and-validation.md
+```
+
+<Note title="Open Source">
+Skills are maintained in the [Ika repository](https://github.com/dwallet-labs/ika/tree/main/skills) and follow the [Agent Skills specification](https://github.com/vercel-labs/skills). Contributions welcome!
+</Note>
+
+## Managing Skills
+
+```bash
+# List installed skills
+npx skills list
+
+# Check for updates
+npx skills check
+
+# Update all skills
+npx skills update
+
+# Remove a skill
+npx skills remove ika-sdk
+```

--- a/docs/content/docs/skills/meta.json
+++ b/docs/content/docs/skills/meta.json
@@ -1,0 +1,5 @@
+{
+	"title": "AI Skills",
+	"root": true,
+	"pages": ["index"]
+}

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,44 @@
+# Ika Claude Code Skills
+
+[Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) for working with the Ika network. Each skill provides compressed, LLM-optimized reference material that Claude Code loads on demand.
+
+## Available Skills
+
+| Skill | Description |
+|---|---|
+| [ika-move](./ika-move/) | Integrating with Ika dWallet contracts in Sui Move — DKG, presign, signing, key import, treasury patterns |
+| [ika-sdk](./ika-sdk/) | Building with the `@ika.xyz/sdk` TypeScript SDK — IkaClient, IkaTransaction, cryptography, dWallet lifecycle |
+| [ika-operator](./ika-operator/) | Operating Ika network nodes — validator setup, fullnode/notifier config, monitoring, recovery |
+
+## Installation
+
+### For this repo (automatic)
+
+Skills in this directory are automatically available to Claude Code when working in this repository.
+
+### For other projects
+
+Copy the desired skill folder into your project's `skills/` directory or into `~/.claude/skills/` for global availability:
+
+```bash
+# Project-local
+cp -r skills/ika-sdk /path/to/your-project/skills/
+
+# Global
+cp -r skills/ika-sdk ~/.claude/skills/
+```
+
+## Structure
+
+Each skill follows the same pattern:
+
+```
+skills/<skill-name>/
+├── SKILL.md              # Main reference (loaded into context on trigger)
+└── references/           # Detailed docs (loaded on demand)
+    ├── *.md
+    └── ...
+```
+
+- **SKILL.md** — Quick reference with the most common patterns and APIs
+- **references/** — Complete details: full API signatures, end-to-end flows, configuration reference

--- a/skills/ika-move/SKILL.md
+++ b/skills/ika-move/SKILL.md
@@ -1,0 +1,582 @@
+---
+name: ika-move
+description: Guide for integrating Ika dWallet 2PC-MPC protocol into Sui Move contracts. Use when building Move contracts that need cross-chain signing, dWallet creation, presigning, signing, future signing, key importing, or any Ika on-chain integration. Triggers on Move/Sui contract tasks involving dWallets, cross-chain signing, or Ika protocol operations.
+---
+
+# Ika Move Integration
+
+Build Sui Move contracts integrating Ika dWallet 2PC-MPC for programmable cross-chain signing.
+
+## References (detailed patterns and complete code)
+
+- `references/protocols-detailed.md` - All coordinator function signatures with full parameter lists
+- `references/patterns.md` - Complete integration patterns: treasury, DAO governance, imported key wallet, presign pool, events, enums
+- `references/typescript-integration.md` - Full TypeScript SDK flows: DKG prep, signing, key import, polling, IkaTransaction API
+
+## Setup
+
+### Move.toml
+
+```toml
+[package]
+name = "my_project"
+edition = "2024.beta"
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+ika_dwallet_2pc_mpc = { git = "https://github.com/dwallet-labs/ika.git", subdir = "deployed_contracts/testnet/ika_dwallet_2pc_mpc", rev = "main" }
+ika = { git = "https://github.com/dwallet-labs/ika.git", subdir = "deployed_contracts/testnet/ika", rev = "main" }
+
+[addresses]
+my_project = "0x0"
+```
+
+For mainnet: change `testnet` to `mainnet` in paths.
+
+### TypeScript SDK
+
+```bash
+pnpm add @ika.xyz/sdk
+```
+
+```typescript
+import { getNetworkConfig, IkaClient } from '@ika.xyz/sdk';
+import { getJsonRpcFullnodeUrl, SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+const suiClient = new SuiJsonRpcClient({ url: getJsonRpcFullnodeUrl('testnet'), network: 'testnet' });
+const ikaClient = new IkaClient({ suiClient, config: getNetworkConfig('testnet'), cache: true });
+await ikaClient.initialize();
+```
+
+## Crypto Constants
+
+### Curves
+- `0` = SECP256K1 (Bitcoin, Ethereum)
+- `1` = SECP256R1 (WebAuthn)
+- `2` = ED25519 (Solana, Substrate)
+- `3` = RISTRETTO (Privacy)
+
+### Signature Algorithms (relative to curve)
+- SECP256K1: `0`=ECDSA, `1`=Taproot
+- SECP256R1: `0`=ECDSA
+- ED25519: `0`=EdDSA
+- RISTRETTO: `0`=Schnorrkel
+
+### Hash Schemes (relative to curve+algo)
+- SECP256K1+ECDSA: `0`=KECCAK256(Ethereum), `1`=SHA256, `2`=DoubleSHA256(Bitcoin)
+- SECP256K1+Taproot: `0`=SHA256
+- SECP256R1+ECDSA: `0`=SHA256
+- ED25519+EdDSA: `0`=SHA512
+- RISTRETTO+Schnorrkel: `0`=Merlin
+
+## Core Imports
+
+```rust
+use ika::ika::IKA;
+use ika_dwallet_2pc_mpc::{
+    coordinator::DWalletCoordinator,
+    coordinator_inner::{
+        DWalletCap, ImportedKeyDWalletCap,
+        UnverifiedPresignCap, VerifiedPresignCap,
+        UnverifiedPartialUserSignatureCap, VerifiedPartialUserSignatureCap,
+        MessageApproval, ImportedKeyMessageApproval
+    },
+    sessions_manager::SessionIdentifier
+};
+use sui::{balance::Balance, coin::Coin, sui::SUI};
+```
+
+## Contract Template
+
+```rust
+public struct MyContract has key, store {
+    id: UID,
+    dwallet_cap: DWalletCap,
+    presigns: vector<UnverifiedPresignCap>,
+    ika_balance: Balance<IKA>,
+    sui_balance: Balance<SUI>,
+    dwallet_network_encryption_key_id: ID,
+}
+```
+
+### Required Helpers
+
+```rust
+fun random_session(coordinator: &mut DWalletCoordinator, ctx: &mut TxContext): SessionIdentifier {
+    coordinator.register_session_identifier(ctx.fresh_object_address().to_bytes(), ctx)
+}
+
+fun withdraw_payment_coins(self: &mut MyContract, ctx: &mut TxContext): (Coin<IKA>, Coin<SUI>) {
+    let ika = self.ika_balance.withdraw_all().into_coin(ctx);
+    let sui = self.sui_balance.withdraw_all().into_coin(ctx);
+    (ika, sui)
+}
+
+fun return_payment_coins(self: &mut MyContract, ika: Coin<IKA>, sui: Coin<SUI>) {
+    self.ika_balance.join(ika.into_balance());
+    self.sui_balance.join(sui.into_balance());
+}
+
+public fun add_ika_balance(self: &mut MyContract, coin: Coin<IKA>) {
+    self.ika_balance.join(coin.into_balance());
+}
+
+public fun add_sui_balance(self: &mut MyContract, coin: Coin<SUI>) {
+    self.sui_balance.join(coin.into_balance());
+}
+```
+
+## DWalletCoordinator
+
+Central shared object for all operations. Pass as `&mut DWalletCoordinator` for mutations, `&DWalletCoordinator` for reads.
+
+Get ID in TypeScript: `ikaClient.ikaConfig.objects.ikaDWalletCoordinator.objectID`
+
+## Capabilities
+
+| Capability | Purpose | Created By |
+|---|---|---|
+| `DWalletCap` | Authorize signing | DKG |
+| `ImportedKeyDWalletCap` | Authorize imported key signing | Import verification |
+| `UnverifiedPresignCap` | Presign reference (needs verify) | Presign request |
+| `VerifiedPresignCap` | Ready for signing | `verify_presign_cap()` |
+| `UnverifiedPartialUserSignatureCap` | Partial sig (needs verify) | Future sign |
+| `VerifiedPartialUserSignatureCap` | Ready for completion | `verify_partial_user_signature_cap()` |
+| `MessageApproval` | Auth to sign specific message | `approve_message()` |
+| `ImportedKeyMessageApproval` | Auth for imported keys | `approve_imported_key_message()` |
+
+## SessionIdentifier
+
+Every protocol op needs a unique `SessionIdentifier`. Create via:
+
+```rust
+let session = coordinator.register_session_identifier(ctx.fresh_object_address().to_bytes(), ctx);
+```
+
+Rules: create just before use, never reuse, one per operation.
+
+## Payment Pattern
+
+All ops require IKA+SUI fees. Pattern: withdraw all -> perform ops (fees auto-deducted from `&mut Coin`) -> return remainder.
+
+## Protocol: DKG (Create dWallet)
+
+### Shared dWallet (recommended for contracts)
+Public user share, network signs without user interaction.
+
+```rust
+let (dwallet_cap, _) = coordinator.request_dwallet_dkg_with_public_user_secret_key_share(
+    dwallet_network_encryption_key_id, curve,
+    centralized_public_key_share_and_proof, user_public_output, public_user_secret_key_share,
+    option::none(), // sign_during_dkg_request
+    session, &mut ika, &mut sui, ctx,
+);
+```
+
+### Zero-Trust dWallet
+Encrypted user share, user must participate in every signature.
+
+```rust
+let (dwallet_cap, _) = coordinator.request_dwallet_dkg(
+    dwallet_network_encryption_key_id, curve,
+    centralized_public_key_share_and_proof, encrypted_centralized_secret_share_and_proof,
+    encryption_key_address, user_public_output, signer_public_key,
+    option::none(), session, &mut ika, &mut sui, ctx,
+);
+```
+
+**Important:** After zero-trust DKG (or key import), the dWallet is in `AwaitingKeyHolderSignature` state. The user must call `acceptEncryptedUserShare` to transition the dWallet to `Active` state before it can be used for signing:
+
+```typescript
+// Wait for DKG to complete and dWallet to reach AwaitingKeyHolderSignature state
+const awaitingDWallet = await ikaClient.getDWalletInParticularState(dwalletId, 'AwaitingKeyHolderSignature');
+// The encrypted user secret key share ID comes from the DKG transaction event,
+// NOT from the dWallet ID.
+const encryptedShare = await ikaClient.getEncryptedUserSecretKeyShare(encryptedUserSecretKeyShareId);
+
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+await ikaTx.acceptEncryptedUserShare({
+    dWallet: awaitingDWallet,
+    encryptedUserSecretKeyShareId: encryptedShare.id,
+    userPublicOutput: new Uint8Array(dkgData.userPublicOutput),
+});
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+
+// dWallet is now Active and ready for signing
+const activeDWallet = await ikaClient.getDWalletInParticularState(dwalletId, 'Active');
+```
+
+This step is NOT needed for shared dWallets (created with `request_dwallet_dkg_with_public_user_secret_key_share`).
+
+### TypeScript DKG Prep
+
+```typescript
+import { prepareDKGAsync, UserShareEncryptionKeys, Curve, createRandomSessionIdentifier } from '@ika.xyz/sdk';
+const keys = await UserShareEncryptionKeys.fromRootSeedKey(seed, Curve.SECP256K1);
+const bytesToHash = createRandomSessionIdentifier(); // bytes hashed to derive the session identifier
+const dkgData = await prepareDKGAsync(ikaClient, Curve.SECP256K1, keys, bytesToHash, signerAddress);
+const networkKey = await ikaClient.getLatestNetworkEncryptionKey();
+// dkgData has: userDKGMessage, userPublicOutput, encryptedUserShareAndProof, userSecretKeyShare
+```
+
+### Sign During DKG (optional)
+Pass existing presign to get signature during DKG:
+
+```rust
+let sign_req = coordinator.sign_during_dkg_request(verified_presign, hash_scheme, message, msg_sig);
+// Pass option::some(sign_req) instead of option::none() in DKG call
+```
+
+## Protocol: Presigning
+
+Each signature consumes one presign. Manage a pool.
+
+### Global Presign (most common: Taproot, EdDSA, Schnorr, ECDSA)
+
+```rust
+let cap = coordinator.request_global_presign(
+    dwallet_network_encryption_key_id, curve, signature_algorithm,
+    session, &mut ika, &mut sui, ctx,
+);
+self.presigns.push_back(cap);
+```
+
+### dWallet-Specific Presign (ECDSA with imported keys)
+
+```rust
+let cap = coordinator.request_presign(
+    dwallet_id, signature_algorithm, session, &mut ika, &mut sui, ctx,
+);
+```
+
+### Verify Before Use
+
+```rust
+let is_ready = coordinator.is_presign_valid(&unverified_cap);
+let verified = coordinator.verify_presign_cap(unverified_cap, ctx); // fails if not ready
+```
+
+### Pool Management
+
+```rust
+// Pop from pool
+let unverified = self.presigns.swap_remove(0);
+
+// Auto-replenish after signing
+if (self.presigns.length() < MIN_POOL) {
+    let s = random_session(coordinator, ctx);
+    self.presigns.push_back(coordinator.request_global_presign(
+        self.dwallet_network_encryption_key_id, curve, sig_algo, s, &mut ika, &mut sui, ctx,
+    ));
+};
+
+// Batch add
+let mut i = 0;
+while (i < count) {
+    let s = random_session(coordinator, ctx);
+    self.presigns.push_back(coordinator.request_global_presign(..., s, &mut ika, &mut sui, ctx));
+    i = i + 1;
+};
+```
+
+## Protocol: Direct Signing
+
+Single-phase, immediate signature. Use when no governance needed.
+
+```rust
+// 1. Verify presign
+let verified = coordinator.verify_presign_cap(self.presigns.swap_remove(0), ctx);
+
+// 2. Approve message
+let approval = coordinator.approve_message(&self.dwallet_cap, sig_algo, hash_scheme, message);
+
+// 3. Sign
+let sign_id = coordinator.request_sign_and_return_id(
+    verified, approval, message_centralized_signature, session, &mut ika, &mut sui, ctx,
+);
+// Also: coordinator.request_sign(...) without return ID
+```
+
+### TypeScript: Create User Signature
+
+```typescript
+import { createUserSignMessageWithPublicOutput, Curve, SignatureAlgorithm, Hash } from '@ika.xyz/sdk';
+const completedPresign = await ikaClient.getPresignInParticularState(presignId, 'Completed');
+const protocolPublicParameters = await ikaClient.getProtocolPublicParameters(undefined, Curve.SECP256K1);
+const msgSig = await createUserSignMessageWithPublicOutput(
+    protocolPublicParameters,
+    dWallet.state.Active!.public_output,
+    dWallet.public_user_secret_key_share,
+    completedPresign.presign,
+    message,
+    Hash.SHA256,
+    SignatureAlgorithm.Taproot,
+    Curve.SECP256K1,
+);
+// Pass msgSig as message_centralized_signature to Move
+```
+
+### Retrieve Signature
+
+```typescript
+const signSession = await ikaClient.getSignInParticularState(
+    signId, Curve.SECP256K1, SignatureAlgorithm.Taproot, 'Completed',
+);
+const sig = await parseSignatureFromSignOutput(Curve.SECP256K1, SignatureAlgorithm.Taproot, signSession.signature);
+```
+
+## Protocol: Future Signing (Two-Phase)
+
+Separates commitment from execution. For governance/multisig/delayed signing.
+
+### Phase 1: Create Partial Signature
+
+```rust
+let partial_cap = coordinator.request_future_sign(
+    self.dwallet_cap.dwallet_id(), verified_presign, message, hash_scheme,
+    message_centralized_signature, session, &mut ika, &mut sui, ctx,
+);
+// Store partial_cap with request for later
+```
+
+### Phase 2: Complete After Approval
+
+```rust
+// Verify partial sig
+let verified_partial = coordinator.verify_partial_user_signature_cap(partial_cap, ctx);
+
+// Create approval
+let approval = coordinator.approve_message(&self.dwallet_cap, sig_algo, hash_scheme, message);
+
+// Complete signature
+let sign_id = coordinator.request_sign_with_partial_user_signature_and_return_id(
+    verified_partial, approval, session, &mut ika, &mut sui, ctx,
+);
+```
+
+### Check/Match
+
+```rust
+let ready = coordinator.is_partial_user_signature_valid(&unverified_cap);
+let matches = coordinator.match_partial_user_signature_with_message_approval(&verified, &approval);
+```
+
+## Protocol: Key Importing
+
+Import existing private key into dWallet system. Returns `ImportedKeyDWalletCap`.
+
+```rust
+let imported_cap = coordinator.request_imported_key_dwallet_verification(
+    dwallet_network_encryption_key_id, curve, centralized_party_message,
+    encrypted_centralized_secret_share_and_proof, encryption_key_address,
+    user_public_output, signer_public_key, session, &mut ika, &mut sui, ctx,
+);
+```
+
+### Imported Key Differences
+- Use `ImportedKeyDWalletCap` instead of `DWalletCap`
+- Use `coordinator.approve_imported_key_message(...)` instead of `approve_message`
+- Use `coordinator.request_imported_key_sign_and_return_id(...)` for signing
+- Use `coordinator.request_presign(dwallet_id, ...)` for ECDSA presigns (dWallet-specific)
+- Future sign completion: `request_imported_key_sign_with_partial_user_signature_and_return_id`
+
+## Protocol: Convert Zero-Trust to Shared
+
+Irreversible. Makes user secret key share public, enabling contract-owned signing.
+
+```rust
+coordinator.request_make_dwallet_user_secret_key_shares_public(
+    dwallet_id, public_user_secret_key_shares, session, &mut ika, &mut sui, ctx,
+);
+```
+
+TypeScript: save `dkgData.userSecretKeyShare` during DKG for potential later conversion.
+
+## Complete Example: Bitcoin Taproot Treasury
+
+```rust
+module my_protocol::treasury;
+
+use ika::ika::IKA;
+use ika_dwallet_2pc_mpc::{
+    coordinator::DWalletCoordinator,
+    coordinator_inner::{DWalletCap, UnverifiedPresignCap, UnverifiedPartialUserSignatureCap}
+};
+use sui::{balance::Balance, coin::Coin, sui::SUI, table::{Self, Table}};
+
+const SECP256K1: u32 = 0;
+const TAPROOT: u32 = 1;
+const SHA256: u32 = 0;
+const MIN_PRESIGNS: u64 = 3;
+
+public struct Treasury has key, store {
+    id: UID,
+    dwallet_cap: DWalletCap,
+    presigns: vector<UnverifiedPresignCap>,
+    members: vector<address>,
+    approval_threshold: u64,
+    proposals: Table<u64, Proposal>,
+    next_id: u64,
+    ika_balance: Balance<IKA>,
+    sui_balance: Balance<SUI>,
+    dwallet_network_encryption_key_id: ID,
+}
+
+public struct Proposal has store {
+    message: vector<u8>,
+    partial_cap: Option<UnverifiedPartialUserSignatureCap>,
+    approvals: u64,
+    voters: Table<address, bool>,
+    executed: bool,
+}
+
+// Create treasury with shared dWallet
+public fun create(
+    coordinator: &mut DWalletCoordinator,
+    mut ika: Coin<IKA>, mut sui: Coin<SUI>,
+    enc_key_id: ID,
+    dkg_msg: vector<u8>, user_output: vector<u8>, user_share: vector<u8>,
+    session_bytes: vector<u8>,
+    members: vector<address>, threshold: u64,
+    ctx: &mut TxContext,
+) {
+    let session = coordinator.register_session_identifier(session_bytes, ctx);
+    let (dwallet_cap, _) = coordinator.request_dwallet_dkg_with_public_user_secret_key_share(
+        enc_key_id, SECP256K1, dkg_msg, user_output, user_share,
+        option::none(), session, &mut ika, &mut sui, ctx,
+    );
+
+    let treasury = Treasury {
+        id: object::new(ctx), dwallet_cap, presigns: vector::empty(),
+        members, approval_threshold: threshold,
+        proposals: table::new(ctx), next_id: 0,
+        ika_balance: ika.into_balance(), sui_balance: sui.into_balance(),
+        dwallet_network_encryption_key_id: enc_key_id,
+    };
+    transfer::public_share_object(treasury);
+}
+
+// Create proposal with future sign (Phase 1)
+public fun propose(
+    self: &mut Treasury, coordinator: &mut DWalletCoordinator,
+    message: vector<u8>, msg_sig: vector<u8>, ctx: &mut TxContext,
+): u64 {
+    assert!(self.members.contains(&ctx.sender()), 0);
+    let (mut ika, mut sui) = self.withdraw_payment_coins(ctx);
+
+    let verified = coordinator.verify_presign_cap(self.presigns.swap_remove(0), ctx);
+    let session = random_session(coordinator, ctx);
+    let partial = coordinator.request_future_sign(
+        self.dwallet_cap.dwallet_id(), verified, message, SHA256,
+        msg_sig, session, &mut ika, &mut sui, ctx,
+    );
+
+    let id = self.next_id;
+    self.next_id = id + 1;
+    self.proposals.add(id, Proposal {
+        message, partial_cap: option::some(partial),
+        approvals: 0, voters: table::new(ctx), executed: false,
+    });
+
+    // Auto-replenish
+    if (self.presigns.length() < MIN_PRESIGNS) {
+        let s = random_session(coordinator, ctx);
+        self.presigns.push_back(coordinator.request_global_presign(
+            self.dwallet_network_encryption_key_id, SECP256K1, TAPROOT, s,
+            &mut ika, &mut sui, ctx,
+        ));
+    };
+    self.return_payment_coins(ika, sui);
+    id
+}
+
+// Vote
+public fun vote(self: &mut Treasury, id: u64, approve: bool, ctx: &TxContext) {
+    assert!(self.members.contains(&ctx.sender()), 0);
+    let p = self.proposals.borrow_mut(id);
+    assert!(!p.voters.contains(ctx.sender()) && !p.executed, 1);
+    p.voters.add(ctx.sender(), approve);
+    if (approve) { p.approvals = p.approvals + 1; };
+}
+
+// Execute after approval (Phase 2)
+public fun execute(
+    self: &mut Treasury, coordinator: &mut DWalletCoordinator,
+    id: u64, ctx: &mut TxContext,
+): ID {
+    let p = self.proposals.borrow_mut(id);
+    assert!(p.approvals >= self.approval_threshold && !p.executed, 2);
+    let (mut ika, mut sui) = self.withdraw_payment_coins(ctx);
+
+    let verified = coordinator.verify_partial_user_signature_cap(p.partial_cap.extract(), ctx);
+    let approval = coordinator.approve_message(&self.dwallet_cap, TAPROOT, SHA256, p.message);
+    let session = random_session(coordinator, ctx);
+    let sign_id = coordinator.request_sign_with_partial_user_signature_and_return_id(
+        verified, approval, session, &mut ika, &mut sui, ctx,
+    );
+    p.executed = true;
+    self.return_payment_coins(ika, sui);
+    sign_id
+}
+
+fun random_session(c: &mut DWalletCoordinator, ctx: &mut TxContext): SessionIdentifier {
+    c.register_session_identifier(ctx.fresh_object_address().to_bytes(), ctx)
+}
+fun withdraw_payment_coins(self: &mut Treasury, ctx: &mut TxContext): (Coin<IKA>, Coin<SUI>) {
+    (self.ika_balance.withdraw_all().into_coin(ctx), self.sui_balance.withdraw_all().into_coin(ctx))
+}
+fun return_payment_coins(self: &mut Treasury, ika: Coin<IKA>, sui: Coin<SUI>) {
+    self.ika_balance.join(ika.into_balance());
+    self.sui_balance.join(sui.into_balance());
+}
+```
+
+## TypeScript: Calling Move Functions
+
+```typescript
+const tx = new Transaction();
+tx.moveCall({
+    target: `${PACKAGE_ID}::treasury::create`,
+    arguments: [
+        tx.object(coordinatorId),
+        tx.object(ikaCoinId),
+        tx.splitCoins(tx.gas, [1000000]),
+        tx.pure.id(networkKeyId),
+        tx.pure.vector('u8', Array.from(dkgData.userDKGMessage)),
+        tx.pure.vector('u8', Array.from(dkgData.userPublicOutput)),
+        tx.pure.vector('u8', Array.from(dkgData.userSecretKeyShare)),
+        tx.pure.vector('u8', Array.from(sessionIdentifier)),
+        tx.pure.vector('address', members),
+        tx.pure.u64(threshold),
+    ],
+});
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+```
+
+## Key Decision Points
+
+- **Shared vs Zero-Trust**: Use shared for contract-owned signing (DAOs, treasuries, bots). Use zero-trust for user-held wallets.
+- **Direct vs Future Sign**: Direct for immediate signing. Future for governance/multisig (two-phase).
+- **Global vs dWallet-Specific Presign**: Global for most cases. dWallet-specific only for ECDSA with imported keys.
+- **DKG vs Import**: DKG generates new distributed key (more secure). Import brings existing private key.
+
+## Constants Module Pattern (Bitcoin Taproot)
+
+```rust
+module my_protocol::constants;
+public macro fun curve(): u32 { 0 }
+public macro fun signature_algorithm(): u32 { 1 }
+public macro fun hash_scheme(): u32 { 0 }
+```
+
+## Chain-Specific Config Quick Reference
+
+| Chain | Curve | Sig Algo | Hash |
+|---|---|---|---|
+| Bitcoin (Taproot) | 0 | 1 | 0 (SHA256) |
+| Bitcoin (Legacy) | 0 | 0 | 2 (DoubleSHA256) |
+| Ethereum | 0 | 0 | 0 (KECCAK256) |
+| Solana | 2 | 0 | 0 (SHA512) |
+| WebAuthn | 1 | 0 | 0 (SHA256) |
+| Substrate | 3 | 0 | 0 (Merlin) |
+

--- a/skills/ika-move/references/patterns.md
+++ b/skills/ika-move/references/patterns.md
@@ -1,0 +1,577 @@
+# Integration Patterns Reference
+
+Complete patterns for building production contracts with Ika.
+
+## Pattern: Shared dWallet Contract
+
+Contract owns `DWalletCap`, controls signing through business logic. Uses public user share so network can sign without user interaction.
+
+### Full Treasury with Access Control
+
+```rust
+module my_protocol::treasury;
+
+use ika::ika::IKA;
+use ika_dwallet_2pc_mpc::{
+    coordinator::DWalletCoordinator,
+    coordinator_inner::{DWalletCap, UnverifiedPresignCap}
+};
+use sui::{balance::Balance, coin::Coin, sui::SUI};
+
+const SECP256K1: u32 = 0;
+const TAPROOT: u32 = 1;
+const SHA256: u32 = 0;
+const ENotAuthorized: u64 = 1;
+const ENoPresigns: u64 = 2;
+
+public struct Treasury has key, store {
+    id: UID,
+    dwallet_cap: DWalletCap,
+    presigns: vector<UnverifiedPresignCap>,
+    authorized_signers: vector<address>,
+    ika_balance: Balance<IKA>,
+    sui_balance: Balance<SUI>,
+    dwallet_network_encryption_key_id: ID,
+}
+
+// === Initialization ===
+
+public fun create_treasury(
+    coordinator: &mut DWalletCoordinator,
+    initial_ika: Coin<IKA>,
+    initial_sui: Coin<SUI>,
+    dwallet_network_encryption_key_id: ID,
+    centralized_public_key_share_and_proof: vector<u8>,
+    user_public_output: vector<u8>,
+    public_user_secret_key_share: vector<u8>,
+    session_identifier_bytes: vector<u8>,
+    authorized_signers: vector<address>,
+    ctx: &mut TxContext,
+) {
+    let mut ika = initial_ika;
+    let mut sui = initial_sui;
+
+    let session = coordinator.register_session_identifier(session_identifier_bytes, ctx);
+    let (dwallet_cap, _) = coordinator.request_dwallet_dkg_with_public_user_secret_key_share(
+        dwallet_network_encryption_key_id, SECP256K1,
+        centralized_public_key_share_and_proof, user_public_output, public_user_secret_key_share,
+        option::none(), session, &mut ika, &mut sui, ctx,
+    );
+
+    let treasury = Treasury {
+        id: object::new(ctx),
+        dwallet_cap, presigns: vector::empty(),
+        authorized_signers,
+        ika_balance: ika.into_balance(),
+        sui_balance: sui.into_balance(),
+        dwallet_network_encryption_key_id,
+    };
+    transfer::public_share_object(treasury);
+}
+
+// === Access Control ===
+
+fun assert_authorized(self: &Treasury, ctx: &TxContext) {
+    assert!(self.authorized_signers.contains(&ctx.sender()), ENotAuthorized);
+}
+
+public fun add_signer(self: &mut Treasury, new_signer: address, ctx: &TxContext) {
+    assert_authorized(self, ctx);
+    if (!self.authorized_signers.contains(&new_signer)) {
+        self.authorized_signers.push_back(new_signer);
+    };
+}
+
+public fun remove_signer(self: &mut Treasury, signer: address, ctx: &TxContext) {
+    assert_authorized(self, ctx);
+    let (found, idx) = self.authorized_signers.index_of(&signer);
+    if (found) { self.authorized_signers.swap_remove(idx); };
+}
+
+// === Direct Signing ===
+
+public fun sign_message(
+    self: &mut Treasury,
+    coordinator: &mut DWalletCoordinator,
+    message: vector<u8>,
+    message_centralized_signature: vector<u8>,
+    ctx: &mut TxContext,
+): ID {
+    assert_authorized(self, ctx);
+    assert!(self.presigns.length() > 0, ENoPresigns);
+    let (mut ika, mut sui) = withdraw_payment_coins(self, ctx);
+
+    let verified = coordinator.verify_presign_cap(self.presigns.swap_remove(0), ctx);
+    let approval = coordinator.approve_message(&self.dwallet_cap, TAPROOT, SHA256, message);
+    let session = random_session(coordinator, ctx);
+    let sign_id = coordinator.request_sign_and_return_id(
+        verified, approval, message_centralized_signature, session,
+        &mut ika, &mut sui, ctx,
+    );
+
+    // Auto-replenish
+    let s = random_session(coordinator, ctx);
+    self.presigns.push_back(coordinator.request_global_presign(
+        self.dwallet_network_encryption_key_id, SECP256K1, TAPROOT, s,
+        &mut ika, &mut sui, ctx,
+    ));
+
+    return_payment_coins(self, ika, sui);
+    sign_id
+}
+
+// === Balance Management ===
+
+public fun add_ika_balance(self: &mut Treasury, coin: Coin<IKA>) {
+    self.ika_balance.join(coin.into_balance());
+}
+public fun add_sui_balance(self: &mut Treasury, coin: Coin<SUI>) {
+    self.sui_balance.join(coin.into_balance());
+}
+public fun ika_balance(self: &Treasury): u64 { self.ika_balance.value() }
+public fun sui_balance(self: &Treasury): u64 { self.sui_balance.value() }
+
+// === Helpers ===
+
+fun random_session(c: &mut DWalletCoordinator, ctx: &mut TxContext): SessionIdentifier {
+    c.register_session_identifier(ctx.fresh_object_address().to_bytes(), ctx)
+}
+fun withdraw_payment_coins(self: &mut Treasury, ctx: &mut TxContext): (Coin<IKA>, Coin<SUI>) {
+    (self.ika_balance.withdraw_all().into_coin(ctx), self.sui_balance.withdraw_all().into_coin(ctx))
+}
+fun return_payment_coins(self: &mut Treasury, ika: Coin<IKA>, sui: Coin<SUI>) {
+    self.ika_balance.join(ika.into_balance());
+    self.sui_balance.join(sui.into_balance());
+}
+```
+
+## Pattern: DAO Governance with Future Signing
+
+Full governance: propose -> vote -> execute. Uses future signing to separate commitment from execution.
+
+```rust
+module my_protocol::dao;
+
+use ika::ika::IKA;
+use ika_dwallet_2pc_mpc::{
+    coordinator::DWalletCoordinator,
+    coordinator_inner::{
+        DWalletCap, UnverifiedPresignCap,
+        UnverifiedPartialUserSignatureCap
+    }
+};
+use sui::{balance::Balance, coin::Coin, sui::SUI, table::{Self, Table}};
+
+const TAPROOT: u32 = 1;
+const SHA256: u32 = 0;
+const MIN_POOL: u64 = 3;
+const ENotMember: u64 = 0;
+const EAlreadyVoted: u64 = 1;
+const EAlreadyExecuted: u64 = 2;
+const EInsufficientVotes: u64 = 3;
+const ENoPresigns: u64 = 4;
+
+public struct DAO has key, store {
+    id: UID,
+    dwallet_cap: DWalletCap,
+    presigns: vector<UnverifiedPresignCap>,
+    members: vector<address>,
+    voting_threshold: u64,
+    proposals: Table<u64, Proposal>,
+    next_id: u64,
+    ika_balance: Balance<IKA>,
+    sui_balance: Balance<SUI>,
+    dwallet_network_encryption_key_id: ID,
+}
+
+public struct Proposal has store {
+    message: vector<u8>,
+    description: vector<u8>,
+    partial_sig_cap: Option<UnverifiedPartialUserSignatureCap>,
+    votes_for: u64,
+    votes_against: u64,
+    voters: Table<address, bool>,
+    executed: bool,
+}
+
+/// Phase 1: Create proposal with partial signature
+public fun create_proposal(
+    self: &mut DAO,
+    coordinator: &mut DWalletCoordinator,
+    message: vector<u8>,
+    description: vector<u8>,
+    message_centralized_signature: vector<u8>,
+    ctx: &mut TxContext,
+): u64 {
+    assert!(self.members.contains(&ctx.sender()), ENotMember);
+    assert!(self.presigns.length() > 0, ENoPresigns);
+    let (mut ika, mut sui) = withdraw_payment_coins(self, ctx);
+
+    // Future sign Phase 1
+    let verified = coordinator.verify_presign_cap(self.presigns.swap_remove(0), ctx);
+    let session = random_session(coordinator, ctx);
+    let partial_cap = coordinator.request_future_sign(
+        self.dwallet_cap.dwallet_id(), verified, message, SHA256,
+        message_centralized_signature, session, &mut ika, &mut sui, ctx,
+    );
+
+    let id = self.next_id;
+    self.next_id = id + 1;
+
+    let proposal = Proposal {
+        message, description,
+        partial_sig_cap: option::some(partial_cap),
+        votes_for: 1, votes_against: 0,  // Proposer auto-votes yes
+        voters: table::new(ctx),
+        executed: false,
+    };
+    proposal.voters.add(ctx.sender(), true);
+    self.proposals.add(id, proposal);
+
+    // Replenish if low
+    if (self.presigns.length() < MIN_POOL) {
+        let s = random_session(coordinator, ctx);
+        self.presigns.push_back(coordinator.request_global_presign(
+            self.dwallet_network_encryption_key_id, 0, TAPROOT, s,
+            &mut ika, &mut sui, ctx,
+        ));
+    };
+
+    return_payment_coins(self, ika, sui);
+    id
+}
+
+/// Vote on proposal
+public fun vote(
+    self: &mut DAO, proposal_id: u64, approve: bool, ctx: &TxContext,
+) {
+    assert!(self.members.contains(&ctx.sender()), ENotMember);
+    let p = self.proposals.borrow_mut(proposal_id);
+    assert!(!p.voters.contains(ctx.sender()), EAlreadyVoted);
+    assert!(!p.executed, EAlreadyExecuted);
+    p.voters.add(ctx.sender(), approve);
+    if (approve) { p.votes_for = p.votes_for + 1; }
+    else { p.votes_against = p.votes_against + 1; };
+}
+
+/// Phase 2: Execute after approval
+public fun execute(
+    self: &mut DAO,
+    coordinator: &mut DWalletCoordinator,
+    proposal_id: u64,
+    ctx: &mut TxContext,
+): ID {
+    let p = self.proposals.borrow_mut(proposal_id);
+    assert!(p.votes_for >= self.voting_threshold, EInsufficientVotes);
+    assert!(!p.executed, EAlreadyExecuted);
+    let (mut ika, mut sui) = withdraw_payment_coins(self, ctx);
+
+    let verified = coordinator.verify_partial_user_signature_cap(p.partial_sig_cap.extract(), ctx);
+    let approval = coordinator.approve_message(&self.dwallet_cap, TAPROOT, SHA256, p.message);
+    let session = random_session(coordinator, ctx);
+    let sign_id = coordinator.request_sign_with_partial_user_signature_and_return_id(
+        verified, approval, session, &mut ika, &mut sui, ctx,
+    );
+
+    p.executed = true;
+    return_payment_coins(self, ika, sui);
+    sign_id
+}
+
+// Helpers (same pattern as treasury)
+fun random_session(c: &mut DWalletCoordinator, ctx: &mut TxContext): SessionIdentifier {
+    c.register_session_identifier(ctx.fresh_object_address().to_bytes(), ctx)
+}
+fun withdraw_payment_coins(self: &mut DAO, ctx: &mut TxContext): (Coin<IKA>, Coin<SUI>) {
+    (self.ika_balance.withdraw_all().into_coin(ctx), self.sui_balance.withdraw_all().into_coin(ctx))
+}
+fun return_payment_coins(self: &mut DAO, ika: Coin<IKA>, sui: Coin<SUI>) {
+    self.ika_balance.join(ika.into_balance());
+    self.sui_balance.join(sui.into_balance());
+}
+```
+
+## Pattern: Presign Pool Management
+
+### Batch Replenishment
+
+```rust
+const TARGET_POOL: u64 = 10;
+const BATCH_SIZE: u64 = 5;
+
+public fun batch_replenish(
+    self: &mut MyContract,
+    coordinator: &mut DWalletCoordinator,
+    ctx: &mut TxContext,
+) {
+    let current = self.presigns.length();
+    if (current >= TARGET_POOL) { return };
+    let needed = TARGET_POOL - current;
+    let to_add = if (needed > BATCH_SIZE) { BATCH_SIZE } else { needed };
+    let (mut ika, mut sui) = withdraw_payment_coins(self, ctx);
+    let mut i = 0;
+    while (i < to_add) {
+        let s = random_session(coordinator, ctx);
+        self.presigns.push_back(coordinator.request_global_presign(
+            self.dwallet_network_encryption_key_id, 0, 1, s,
+            &mut ika, &mut sui, ctx,
+        ));
+        i = i + 1;
+    };
+    return_payment_coins(self, ika, sui);
+}
+```
+
+### Pool Monitoring Events
+
+```rust
+use sui::event;
+
+public struct PresignPoolLow has copy, drop {
+    contract_id: ID,
+    current_size: u64,
+    min_size: u64,
+}
+
+public struct PresignAdded has copy, drop {
+    contract_id: ID,
+    new_size: u64,
+}
+
+fun emit_pool_warning(self: &MyContract, min_size: u64) {
+    if (self.presigns.length() < min_size) {
+        event::emit(PresignPoolLow {
+            contract_id: self.id.to_inner(),
+            current_size: self.presigns.length(),
+            min_size,
+        });
+    };
+}
+```
+
+## Pattern: Imported Key Wallet
+
+Complete flow for importing existing private key and signing.
+
+```rust
+module my_protocol::imported_wallet;
+
+use ika::ika::IKA;
+use ika_dwallet_2pc_mpc::{
+    coordinator::DWalletCoordinator,
+    coordinator_inner::{ImportedKeyDWalletCap, UnverifiedPresignCap}
+};
+use sui::{balance::Balance, coin::Coin, sui::SUI};
+
+public struct ImportedWallet has key, store {
+    id: UID,
+    imported_dwallet_cap: ImportedKeyDWalletCap,
+    presigns: vector<UnverifiedPresignCap>,
+    ika_balance: Balance<IKA>,
+    sui_balance: Balance<SUI>,
+    dwallet_network_encryption_key_id: ID,
+}
+
+// Create wallet by importing existing key
+public fun import_wallet(
+    coordinator: &mut DWalletCoordinator,
+    initial_ika: Coin<IKA>, initial_sui: Coin<SUI>,
+    enc_key_id: ID,
+    centralized_party_message: vector<u8>,
+    encrypted_share_and_proof: vector<u8>,
+    encryption_key_address: address,
+    user_public_output: vector<u8>,
+    signer_public_key: vector<u8>,
+    session_bytes: vector<u8>,
+    ctx: &mut TxContext,
+) {
+    let mut ika = initial_ika;
+    let mut sui = initial_sui;
+    let session = coordinator.register_session_identifier(session_bytes, ctx);
+    let imported_cap = coordinator.request_imported_key_dwallet_verification(
+        enc_key_id, 0, centralized_party_message,
+        encrypted_share_and_proof, encryption_key_address,
+        user_public_output, signer_public_key,
+        session, &mut ika, &mut sui, ctx,
+    );
+    let wallet = ImportedWallet {
+        id: object::new(ctx), imported_dwallet_cap: imported_cap,
+        presigns: vector::empty(),
+        ika_balance: ika.into_balance(), sui_balance: sui.into_balance(),
+        dwallet_network_encryption_key_id: enc_key_id,
+    };
+    transfer::public_share_object(wallet);
+}
+
+// IMPORTANT: Use request_presign (dWallet-specific), NOT request_global_presign
+public fun add_presign(
+    self: &mut ImportedWallet,
+    coordinator: &mut DWalletCoordinator,
+    ctx: &mut TxContext,
+) {
+    let (mut ika, mut sui) = withdraw_payment_coins(self, ctx);
+    let session = random_session(coordinator, ctx);
+    let cap = coordinator.request_presign(
+        self.imported_dwallet_cap.imported_key_dwallet_id(),
+        0,  // ECDSA
+        session, &mut ika, &mut sui, ctx,
+    );
+    self.presigns.push_back(cap);
+    return_payment_coins(self, ika, sui);
+}
+
+// IMPORTANT: Use approve_imported_key_message and request_imported_key_sign
+public fun sign(
+    self: &mut ImportedWallet,
+    coordinator: &mut DWalletCoordinator,
+    message: vector<u8>,
+    msg_sig: vector<u8>,
+    ctx: &mut TxContext,
+): ID {
+    let (mut ika, mut sui) = withdraw_payment_coins(self, ctx);
+    let verified = coordinator.verify_presign_cap(self.presigns.swap_remove(0), ctx);
+    let approval = coordinator.approve_imported_key_message(
+        &self.imported_dwallet_cap, 0, 0, message,
+    );
+    let session = random_session(coordinator, ctx);
+    let sign_id = coordinator.request_imported_key_sign_and_return_id(
+        verified, approval, msg_sig, session, &mut ika, &mut sui, ctx,
+    );
+    return_payment_coins(self, ika, sui);
+    sign_id
+}
+
+fun random_session(c: &mut DWalletCoordinator, ctx: &mut TxContext): SessionIdentifier {
+    c.register_session_identifier(ctx.fresh_object_address().to_bytes(), ctx)
+}
+fun withdraw_payment_coins(self: &mut ImportedWallet, ctx: &mut TxContext): (Coin<IKA>, Coin<SUI>) {
+    (self.ika_balance.withdraw_all().into_coin(ctx), self.sui_balance.withdraw_all().into_coin(ctx))
+}
+fun return_payment_coins(self: &mut ImportedWallet, ika: Coin<IKA>, sui: Coin<SUI>) {
+    self.ika_balance.join(ika.into_balance());
+    self.sui_balance.join(sui.into_balance());
+}
+```
+
+## Pattern: Request Types with Enum (Multisig)
+
+For contracts that handle multiple request types:
+
+```rust
+public enum RequestType has copy, drop, store {
+    Transaction(vector<u8>, vector<u8>, vector<u8>),  // preimage, sig, psbt
+    AddMember(address),
+    RemoveMember(address),
+    ChangeApprovalThreshold(u64),
+    ChangeRejectionThreshold(u64),
+    ChangeExpirationDuration(u64),
+}
+
+public enum RequestStatus has copy, drop, store {
+    Pending,
+    Approved(RequestResult),
+    Rejected,
+}
+
+public enum RequestResult has copy, drop, store {
+    TransactionResult(ID),  // sign session ID
+    GovernanceResult,
+}
+
+public struct Request has store {
+    id: u64,
+    request_type: RequestType,
+    status: RequestStatus,
+    partial_sig_cap: Option<UnverifiedPartialUserSignatureCap>,
+    approvers_count: u64,
+    rejecters_count: u64,
+    votes: Table<address, bool>,
+    created_at: u64,
+}
+```
+
+## Pattern: Expiration and Rejection
+
+```rust
+use sui::clock::Clock;
+
+const EXPIRATION_MS: u64 = 86400000; // 24 hours
+
+public fun vote_request(
+    self: &mut Multisig,
+    request_id: u64,
+    vote: bool,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    let request = self.requests.borrow_mut(request_id);
+
+    // Check expiration first
+    if (clock.timestamp_ms() > request.created_at + self.expiration_duration) {
+        reject_request(self, request_id);
+        return
+    };
+
+    // Check voting eligibility
+    assert!(self.members.contains(&ctx.sender()), ENotMember);
+    assert!(!request.votes.contains(ctx.sender()), EAlreadyVoted);
+
+    // Irrevocable vote
+    request.votes.add(ctx.sender(), vote);
+    if (vote) { request.approvers_count = request.approvers_count + 1; }
+    else { request.rejecters_count = request.rejecters_count + 1; };
+
+    // Auto-reject if rejection threshold met
+    if (request.rejecters_count >= self.rejection_threshold) {
+        reject_request(self, request_id);
+    };
+}
+```
+
+## Pattern: Constants Module
+
+Isolate chain-specific constants for cleanliness:
+
+```rust
+module my_protocol::constants;
+
+/// Bitcoin secp256k1
+public macro fun curve(): u32 { 0 }
+/// Taproot
+public macro fun signature_algorithm(): u32 { 1 }
+/// SHA256
+public macro fun hash_scheme(): u32 { 0 }
+```
+
+Usage: `constants::curve!()`, `constants::signature_algorithm!()`, `constants::hash_scheme!()`.
+
+## Pattern: Events
+
+```rust
+module my_protocol::events;
+
+use sui::event;
+
+public struct WalletCreated has copy, drop { wallet_id: ID }
+public struct RequestCreated has copy, drop { wallet_id: ID, request_id: u64 }
+public struct VoteCast has copy, drop { wallet_id: ID, request_id: u64, voter: address, approve: bool }
+public struct RequestExecuted has copy, drop { wallet_id: ID, request_id: u64, sign_id: ID }
+public struct PresignAdded has copy, drop { wallet_id: ID }
+public struct BalanceAdded has copy, drop { wallet_id: ID, amount: u64, token: vector<u8> }
+
+public fun wallet_created(id: ID) { event::emit(WalletCreated { wallet_id: id }); }
+public fun request_created(wallet_id: ID, request_id: u64) {
+    event::emit(RequestCreated { wallet_id, request_id });
+}
+// ... etc
+```
+
+## Pattern: Member Deduplication
+
+```rust
+use sui::vec_set;
+
+// In initialization:
+let members = vec_set::from_keys(members).into_keys();
+// Removes duplicates, produces sorted vector
+```

--- a/skills/ika-move/references/protocols-detailed.md
+++ b/skills/ika-move/references/protocols-detailed.md
@@ -1,0 +1,306 @@
+# Protocol Complete Reference
+
+All coordinator function signatures and detailed flows.
+
+## DKG Functions
+
+### Shared dWallet (public user share)
+```rust
+public fun request_dwallet_dkg_with_public_user_secret_key_share(
+    self: &mut DWalletCoordinator,
+    dwallet_network_encryption_key_id: ID,
+    curve: u32,
+    centralized_public_key_share_and_proof: vector<u8>,
+    user_public_output: vector<u8>,
+    public_user_secret_key_share: vector<u8>,
+    sign_during_dkg_request: Option<SignDuringDKGRequest>,
+    session_identifier: SessionIdentifier,
+    payment_ika: &mut Coin<IKA>,
+    payment_sui: &mut Coin<SUI>,
+    ctx: &mut TxContext,
+): (DWalletCap, Option<ID>)
+```
+Returns: `DWalletCap` for signing auth + optional sign session ID if sign-during-DKG was requested.
+
+### Zero-Trust dWallet (encrypted user share)
+```rust
+public fun request_dwallet_dkg(
+    self: &mut DWalletCoordinator,
+    dwallet_network_encryption_key_id: ID,
+    curve: u32,
+    centralized_public_key_share_and_proof: vector<u8>,
+    encrypted_centralized_secret_share_and_proof: vector<u8>,
+    encryption_key_address: address,
+    user_public_output: vector<u8>,
+    signer_public_key: vector<u8>,
+    sign_during_dkg_request: Option<SignDuringDKGRequest>,
+    session_identifier: SessionIdentifier,
+    payment_ika: &mut Coin<IKA>,
+    payment_sui: &mut Coin<SUI>,
+    ctx: &mut TxContext,
+): (DWalletCap, Option<ID>)
+```
+Additional params vs shared: `encrypted_centralized_secret_share_and_proof`, `encryption_key_address`, `signer_public_key`.
+
+### Sign During DKG
+```rust
+public fun sign_during_dkg_request(
+    self: &mut DWalletCoordinator,
+    presign_cap: VerifiedPresignCap,
+    hash_scheme: u32,
+    message: vector<u8>,
+    message_centralized_signature: vector<u8>,
+): SignDuringDKGRequest
+```
+Requires an existing verified presign. Pass result as `option::some(req)` to DKG call. The returned `Option<ID>` from DKG will contain the sign session ID.
+
+## Presign Functions
+
+### Global Presign (Taproot, EdDSA, Schnorr, ECDSA with DKG wallets)
+```rust
+public fun request_global_presign(
+    self: &mut DWalletCoordinator,
+    dwallet_network_encryption_key_id: ID,
+    curve: u32,
+    signature_algorithm: u32,
+    session_identifier: SessionIdentifier,
+    payment_ika: &mut Coin<IKA>,
+    payment_sui: &mut Coin<SUI>,
+    ctx: &mut TxContext,
+): UnverifiedPresignCap
+```
+
+### dWallet-Specific Presign (ECDSA with imported keys only)
+```rust
+public fun request_presign(
+    self: &mut DWalletCoordinator,
+    dwallet_id: ID,
+    signature_algorithm: u32,
+    session_identifier: SessionIdentifier,
+    payment_ika: &mut Coin<IKA>,
+    payment_sui: &mut Coin<SUI>,
+    ctx: &mut TxContext,
+): UnverifiedPresignCap
+```
+
+### Presign Verification
+```rust
+public fun verify_presign_cap(
+    self: &mut DWalletCoordinator,
+    cap: UnverifiedPresignCap,
+    ctx: &mut TxContext,
+): VerifiedPresignCap
+
+public fun is_presign_valid(
+    self: &DWalletCoordinator,
+    presign_cap: &UnverifiedPresignCap,
+): bool
+```
+`verify_presign_cap` fails if network hasn't completed presign. Check with `is_presign_valid` first or ensure sufficient time.
+
+## Message Approval Functions
+
+### Standard dWallet
+```rust
+public fun approve_message(
+    self: &mut DWalletCoordinator,
+    dwallet_cap: &DWalletCap,
+    signature_algorithm: u32,
+    hash_scheme: u32,
+    message: vector<u8>,
+): MessageApproval
+```
+
+### Imported Key dWallet
+```rust
+public fun approve_imported_key_message(
+    self: &mut DWalletCoordinator,
+    imported_dwallet_cap: &ImportedKeyDWalletCap,
+    signature_algorithm: u32,
+    hash_scheme: u32,
+    message: vector<u8>,
+): ImportedKeyMessageApproval
+```
+
+## Signing Functions
+
+### Direct Sign (no return)
+```rust
+public fun request_sign(
+    self: &mut DWalletCoordinator,
+    presign_cap: VerifiedPresignCap,
+    message_approval: MessageApproval,
+    message_centralized_signature: vector<u8>,
+    session_identifier: SessionIdentifier,
+    payment_ika: &mut Coin<IKA>,
+    payment_sui: &mut Coin<SUI>,
+    ctx: &mut TxContext,
+)
+```
+
+### Direct Sign (returns sign session ID)
+```rust
+public fun request_sign_and_return_id(
+    self: &mut DWalletCoordinator,
+    presign_cap: VerifiedPresignCap,
+    message_approval: MessageApproval,
+    message_centralized_signature: vector<u8>,
+    session_identifier: SessionIdentifier,
+    payment_ika: &mut Coin<IKA>,
+    payment_sui: &mut Coin<SUI>,
+    ctx: &mut TxContext,
+): ID
+```
+
+### Imported Key Sign
+```rust
+public fun request_imported_key_sign_and_return_id(
+    self: &mut DWalletCoordinator,
+    presign_cap: VerifiedPresignCap,
+    message_approval: ImportedKeyMessageApproval,
+    message_centralized_signature: vector<u8>,
+    session_identifier: SessionIdentifier,
+    payment_ika: &mut Coin<IKA>,
+    payment_sui: &mut Coin<SUI>,
+    ctx: &mut TxContext,
+): ID
+```
+
+## Future Signing Functions
+
+### Phase 1: Request Future Sign
+```rust
+public fun request_future_sign(
+    self: &mut DWalletCoordinator,
+    dwallet_id: ID,
+    presign_cap: VerifiedPresignCap,
+    message: vector<u8>,
+    hash_scheme: u32,
+    message_centralized_signature: vector<u8>,
+    session_identifier: SessionIdentifier,
+    payment_ika: &mut Coin<IKA>,
+    payment_sui: &mut Coin<SUI>,
+    ctx: &mut TxContext,
+): UnverifiedPartialUserSignatureCap
+```
+Note: takes `dwallet_id` directly (not `DWalletCap`). Get via `dwallet_cap.dwallet_id()`.
+
+### Partial Signature Verification
+```rust
+public fun verify_partial_user_signature_cap(
+    self: &mut DWalletCoordinator,
+    cap: UnverifiedPartialUserSignatureCap,
+    ctx: &mut TxContext,
+): VerifiedPartialUserSignatureCap
+
+public fun is_partial_user_signature_valid(
+    self: &DWalletCoordinator,
+    cap: &UnverifiedPartialUserSignatureCap,
+): bool
+```
+
+### Phase 2: Complete with Partial Signature
+```rust
+public fun request_sign_with_partial_user_signature_and_return_id(
+    self: &mut DWalletCoordinator,
+    partial_user_signature_cap: VerifiedPartialUserSignatureCap,
+    message_approval: MessageApproval,
+    session_identifier: SessionIdentifier,
+    payment_ika: &mut Coin<IKA>,
+    payment_sui: &mut Coin<SUI>,
+    ctx: &mut TxContext,
+): ID
+```
+Note: no `message_centralized_signature` param - the partial sig already contains it.
+
+### Imported Key Phase 2
+```rust
+public fun request_imported_key_sign_with_partial_user_signature_and_return_id(
+    self: &mut DWalletCoordinator,
+    partial_user_signature_cap: VerifiedPartialUserSignatureCap,
+    message_approval: ImportedKeyMessageApproval,
+    session_identifier: SessionIdentifier,
+    payment_ika: &mut Coin<IKA>,
+    payment_sui: &mut Coin<SUI>,
+    ctx: &mut TxContext,
+): ID
+```
+
+### Matching Partial Signatures
+```rust
+public fun match_partial_user_signature_with_message_approval(
+    self: &DWalletCoordinator,
+    cap: &VerifiedPartialUserSignatureCap,
+    approval: &MessageApproval,
+): bool
+
+public fun match_partial_user_signature_with_imported_key_message_approval(
+    self: &DWalletCoordinator,
+    cap: &VerifiedPartialUserSignatureCap,
+    approval: &ImportedKeyMessageApproval,
+): bool
+```
+Use to verify partial sig matches intended message before completing.
+
+## Key Import Functions
+
+```rust
+public fun request_imported_key_dwallet_verification(
+    self: &mut DWalletCoordinator,
+    dwallet_network_encryption_key_id: ID,
+    curve: u32,
+    centralized_party_message: vector<u8>,
+    encrypted_centralized_secret_share_and_proof: vector<u8>,
+    encryption_key_address: address,
+    user_public_output: vector<u8>,
+    signer_public_key: vector<u8>,
+    session_identifier: SessionIdentifier,
+    payment_ika: &mut Coin<IKA>,
+    payment_sui: &mut Coin<SUI>,
+    ctx: &mut TxContext,
+): ImportedKeyDWalletCap
+```
+
+## Convert to Shared
+
+```rust
+public fun request_make_dwallet_user_secret_key_shares_public(
+    self: &mut DWalletCoordinator,
+    dwallet_id: ID,
+    public_user_secret_key_shares: vector<u8>,
+    session_identifier: SessionIdentifier,
+    payment_ika: &mut Coin<IKA>,
+    payment_sui: &mut Coin<SUI>,
+    ctx: &mut TxContext,
+)
+```
+Irreversible. The `public_user_secret_key_shares` must be the original user secret key share from DKG.
+
+## Query Functions
+
+```rust
+public fun has_dwallet(self: &DWalletCoordinator, dwallet_id: ID): bool
+public fun get_dwallet(self: &DWalletCoordinator, dwallet_id: ID): &DWallet
+public fun current_pricing(self: &DWalletCoordinator): PricingInfo
+```
+
+## Session Management
+
+```rust
+public fun register_session_identifier(
+    self: &mut DWalletCoordinator,
+    bytes: vector<u8>,
+    ctx: &mut TxContext,
+): SessionIdentifier
+```
+Bytes must be globally unique. Recommended: `ctx.fresh_object_address().to_bytes()`.
+
+## Capability Accessors
+
+```rust
+// DWalletCap
+public fun dwallet_id(cap: &DWalletCap): ID
+
+// ImportedKeyDWalletCap
+public fun imported_key_dwallet_id(cap: &ImportedKeyDWalletCap): ID
+```

--- a/skills/ika-move/references/typescript-integration.md
+++ b/skills/ika-move/references/typescript-integration.md
@@ -1,0 +1,352 @@
+# TypeScript Integration Reference
+
+Complete patterns for TypeScript SDK interaction with Move contracts.
+
+## SDK Setup
+
+```typescript
+import { getNetworkConfig, IkaClient } from '@ika.xyz/sdk';
+import { getJsonRpcFullnodeUrl, SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+
+const suiClient = new SuiJsonRpcClient({
+    url: getJsonRpcFullnodeUrl('testnet'),
+    network: 'testnet',
+});
+
+const ikaClient = new IkaClient({
+    suiClient,
+    config: getNetworkConfig('testnet'),
+    cache: true,
+});
+await ikaClient.initialize();
+
+// Key references
+const coordinatorId = ikaClient.ikaConfig.objects.ikaDWalletCoordinator.objectID;
+const networkKey = await ikaClient.getLatestNetworkEncryptionKey();
+```
+
+## DKG: Prepare and Call Move
+
+```typescript
+import {
+    createRandomSessionIdentifier, Curve, prepareDKGAsync, UserShareEncryptionKeys,
+} from '@ika.xyz/sdk';
+import { Transaction } from '@mysten/sui/transactions';
+
+// 1. Create encryption keys from seed
+const keys = await UserShareEncryptionKeys.fromRootSeedKey(
+    new TextEncoder().encode('your-seed'), Curve.SECP256K1,
+);
+
+// 2. Create bytes to hash (hashed internally to derive the session identifier)
+const bytesToHash = createRandomSessionIdentifier();
+
+// 3. Prepare DKG data
+const dkgData = await prepareDKGAsync(
+    ikaClient, Curve.SECP256K1, keys, bytesToHash, signerAddress,
+);
+// dkgData contains:
+//   .userDKGMessage (= centralized_public_key_share_and_proof)
+//   .userPublicOutput
+//   .encryptedUserShareAndProof
+//   .userSecretKeyShare (= public_user_secret_key_share for shared mode, SAVE for later conversion)
+
+// 4. Get network encryption key
+const networkKey = await ikaClient.getLatestNetworkEncryptionKey();
+
+// 5. Call Move function
+const tx = new Transaction();
+tx.moveCall({
+    target: `${PACKAGE_ID}::treasury::create_treasury`,
+    arguments: [
+        tx.object(coordinatorId),
+        tx.object(ikaCoinId),                                           // Coin<IKA>
+        tx.splitCoins(tx.gas, [1000000]),                               // Coin<SUI>
+        tx.pure.id(networkKey.id),                                      // encryption key ID
+        tx.pure.vector('u8', Array.from(dkgData.userDKGMessage)),       // DKG message
+        tx.pure.vector('u8', Array.from(dkgData.userPublicOutput)),     // public output
+        tx.pure.vector('u8', Array.from(dkgData.userSecretKeyShare)),   // secret share (public for shared mode)
+        tx.pure.vector('u8', Array.from(bytesToHash)),                   // bytes to hash for session
+        tx.pure.vector('address', members),                             // members
+        tx.pure.u64(threshold),                                         // threshold
+    ],
+});
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+```
+
+## Accept Encrypted User Share (Zero-Trust / Imported Key Only)
+
+After zero-trust DKG or key import, the dWallet is in `AwaitingKeyHolderSignature` state. The user must call `acceptEncryptedUserShare` to transition it to `Active`:
+
+```typescript
+import { IkaTransaction } from '@ika.xyz/sdk';
+
+// Wait for dWallet to reach AwaitingKeyHolderSignature state
+const awaitingDWallet = await ikaClient.getDWalletInParticularState(dwalletId, 'AwaitingKeyHolderSignature');
+// The encrypted user secret key share ID comes from the DKG transaction event,
+// NOT from the dWallet ID.
+const encryptedShare = await ikaClient.getEncryptedUserSecretKeyShare(encryptedUserSecretKeyShareId);
+
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+await ikaTx.acceptEncryptedUserShare({
+    dWallet: awaitingDWallet,
+    encryptedUserSecretKeyShareId: encryptedShare.id,
+    userPublicOutput: new Uint8Array(dkgData.userPublicOutput),
+});
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+
+// dWallet is now Active
+const activeDWallet = await ikaClient.getDWalletInParticularState(dwalletId, 'Active');
+```
+
+This step is NOT needed for shared dWallets (created with `request_dwallet_dkg_with_public_user_secret_key_share`).
+
+## Get dWallet Public Key After DKG
+
+```typescript
+import { publicKeyFromDWalletOutput, Curve } from '@ika.xyz/sdk';
+
+const dWallet = await ikaClient.getDWallet(dwalletId);
+const publicKey = await publicKeyFromDWalletOutput(Curve.SECP256K1, dWallet.state.Active!.public_output);
+// Use publicKey to derive Bitcoin/Ethereum address
+```
+
+## Signing: Prepare User Signature and Call Move
+
+```typescript
+import {
+    createUserSignMessageWithPublicOutput, Curve,
+    SignatureAlgorithm, Hash, parseSignatureFromSignOutput,
+} from '@ika.xyz/sdk';
+
+// 1. Wait for presign completion
+const completedPresign = await ikaClient.getPresignInParticularState(presignId, 'Completed');
+
+// 2. Create user's partial signature (for shared dWallets)
+const protocolPublicParameters = await ikaClient.getProtocolPublicParameters(undefined, Curve.SECP256K1);
+const msgSig = await createUserSignMessageWithPublicOutput(
+    protocolPublicParameters,
+    dWallet.state.Active!.public_output,
+    dWallet.public_user_secret_key_share,   // available because shared mode
+    completedPresign.presign,
+    message,                            // the message bytes to sign
+    Hash.SHA256,                        // hash scheme
+    SignatureAlgorithm.Taproot,         // signature algorithm
+    Curve.SECP256K1,                    // curve
+);
+
+// 3. Call Move sign function
+const tx = new Transaction();
+tx.moveCall({
+    target: `${PACKAGE_ID}::treasury::sign_message`,
+    arguments: [
+        tx.object(treasuryId),
+        tx.object(coordinatorId),
+        tx.pure.vector('u8', Array.from(message)),
+        tx.pure.vector('u8', Array.from(msgSig)),
+    ],
+});
+const result = await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+
+// 4. Extract sign ID from transaction events
+const signId = extractSignIdFromEvents(result.events);
+```
+
+## Retrieve Completed Signature
+
+```typescript
+// Poll for sign completion
+const signSession = await ikaClient.getSignInParticularState(
+    signId, Curve.SECP256K1, SignatureAlgorithm.Taproot, 'Completed',
+);
+
+// Parse the raw signature
+const signature = await parseSignatureFromSignOutput(
+    Curve.SECP256K1,
+    SignatureAlgorithm.Taproot,
+    signSession.signature,
+);
+
+// signature is now ready to broadcast on target chain (Bitcoin, Ethereum, etc.)
+```
+
+## Key Import: TypeScript Side
+
+```typescript
+import { prepareImportedKeyDWalletVerification, Curve } from '@ika.xyz/sdk';
+
+const importData = await prepareImportedKeyDWalletVerification(
+    ikaClient,
+    Curve.SECP256K1,
+    bytesToHash,      // bytes hashed to derive the session identifier
+    signerAddress,
+    keys,
+    privateKey,       // Uint8Array of existing private key
+);
+// importData contains:
+//   .userPublicOutput
+//   .userMessage (= centralized_party_message)
+//   .encryptedUserShareAndProof (= encrypted_centralized_secret_share_and_proof)
+
+const tx = new Transaction();
+tx.moveCall({
+    target: `${PACKAGE_ID}::imported_wallet::import_wallet`,
+    arguments: [
+        tx.object(coordinatorId),
+        tx.object(ikaCoinId),
+        tx.splitCoins(tx.gas, [1000000]),
+        tx.pure.id(networkKey.id),
+        tx.pure.vector('u8', Array.from(importData.userMessage)),
+        tx.pure.vector('u8', Array.from(importData.encryptedUserShareAndProof)),
+        tx.pure.address(keys.getSuiAddress()),
+        tx.pure.vector('u8', Array.from(importData.userPublicOutput)),
+        tx.pure.vector('u8', Array.from(keys.getSigningPublicKeyBytes())),
+        tx.pure.vector('u8', Array.from(bytesToHash)),
+    ],
+});
+```
+
+## Convert to Shared Mode: TypeScript Side
+
+```typescript
+import { IkaTransaction } from '@ika.xyz/sdk';
+
+// You must have saved userSecretKeyShare from original DKG or import
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+ikaTx.makeDWalletUserSecretKeySharesPublic({
+    dWallet: zeroTrustDWallet,           // ZeroTrustDWallet or ImportedKeyDWallet
+    secretShare: savedUserSecretKeyShare, // Uint8Array from original DKG
+    ikaCoin: tx.object(ikaCoinId),       // Coin<IKA> object
+    suiCoin: tx.splitCoins(tx.gas, [1_000_000]),  // Coin<SUI> from gas
+});
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+```
+
+## Polling dWallet State
+
+```typescript
+// Wait for dWallet to reach specific state
+const dWallet = await ikaClient.getDWalletInParticularState(dwalletId, 'Completed');
+
+// Check dWallet type
+// Returns: 'zero-trust' | 'shared' | 'imported-key' | 'imported-key-shared'
+
+// Check if converted to shared
+if (dWallet.public_user_secret_key_share) {
+    // dWallet is in shared mode
+}
+```
+
+## IkaTransaction (High-Level API)
+
+For SDK-only flows (no custom Move), use `IkaTransaction`:
+
+```typescript
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+
+// DKG
+await ikaTx.requestDWalletDKG({ dkgInput, sessionIdentifier, ... });
+
+// Presign
+await ikaTx.requestPresign({ dWallet, ... });
+await ikaTx.requestGlobalPresign({ ... });
+
+// Sign
+await ikaTx.requestSign({
+    dWallet, messageApproval, hashScheme: Hash.KECCAK256,
+    verifiedPresignCap, presign, encryptedUserSecretKeyShare,
+    message, signatureScheme: SignatureAlgorithm.ECDSASecp256k1, ...
+});
+
+// Future Sign
+await ikaTx.requestFutureSign({ ... });
+
+// Accept encrypted user share (zero-trust / imported key DKG only)
+await ikaTx.acceptEncryptedUserShare({ dWallet, encryptedUserSecretKeyShareId, userPublicOutput });
+
+// Session identifiers
+const session = ikaTx.createSessionIdentifier();                    // auto-generate random session
+const session2 = ikaTx.registerSessionIdentifier(bytesToHash);      // register specific bytes as session
+```
+
+## Common TypeScript Argument Patterns
+
+```typescript
+// Pass bytes
+tx.pure.vector('u8', Array.from(uint8Array))
+
+// Pass ID
+tx.pure.id(objectIdString)
+
+// Pass u32/u64
+tx.pure.u32(0)
+tx.pure.u64(3)
+
+// Pass address
+tx.pure.address('0x...')
+
+// Pass vector of addresses
+tx.pure.vector('address', ['0x...', '0x...'])
+
+// Split coins for payment
+tx.splitCoins(tx.gas, [amount])  // Split SUI from gas
+tx.object(coinObjectId)           // Use existing coin object
+
+// Pass shared object
+tx.object(sharedObjectId)
+```
+
+## Network Config
+
+```typescript
+import { getNetworkConfig } from '@ika.xyz/sdk';
+
+const config = getNetworkConfig('testnet'); // or 'mainnet'
+// config.packages.ikaPackage
+// config.packages.ikaCommonPackage
+// config.packages.ikaSystemPackage
+// config.packages.ikaDwallet2pcMpcPackage
+// config.objects.ikaSystemObject.objectID
+// config.objects.ikaDWalletCoordinator.objectID
+// config.objects.ikaDWalletCoordinator.initialSharedVersion
+```
+
+## Encryption Keys
+
+```typescript
+import { UserShareEncryptionKeys, Curve } from '@ika.xyz/sdk';
+
+// Create from seed
+const keys = await UserShareEncryptionKeys.fromRootSeedKey(
+    new TextEncoder().encode('seed'), Curve.SECP256K1,
+);
+
+// Serialize for storage
+const bytes = keys.toShareEncryptionKeysBytes();
+
+// Deserialize
+const restored = UserShareEncryptionKeys.fromShareEncryptionKeysBytes(bytes);
+
+// Properties
+keys.getSuiAddress()              // address for registration
+keys.getSigningPublicKeyBytes()   // ed25519 public key
+keys.getEncryptionKeySignature()  // proof of ownership
+```
+
+## KeySpring Pattern (Cross-Chain Wallet from Any Auth)
+
+Architecture: Use any wallet signature or passkey as seed -> derive encryption keys -> DKG creates Ethereum address.
+
+```
+Wallet/Passkey -> sign message -> seed bytes -> UserShareEncryptionKeys -> DKG -> ETH address
+```
+
+Key insight: The seed for `UserShareEncryptionKeys.fromRootSeedKey()` can come from any deterministic source:
+- Wallet signature of a fixed message
+- WebAuthn PRF extension output
+- Any deterministic 32+ byte secret
+
+The resulting dWallet public key maps to an Ethereum/Bitcoin address via standard derivation.

--- a/skills/ika-operator/SKILL.md
+++ b/skills/ika-operator/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: ika-operator
+description: Guide for operating Ika network nodes - validators, fullnodes, and notifiers. Use when deploying, configuring, monitoring, or troubleshooting Ika infrastructure. Triggers on tasks involving ika-node, ika-validator, ika-fullnode, ika-notifier, NodeConfig, consensus setup, P2P networking, validator registration, or Ika node operations.
+---
+
+# Ika Node Operator Guide
+
+Deploy and operate Ika network nodes (validators, fullnodes, notifiers).
+
+## References (detailed configuration and operations)
+
+- `references/configuration.md` - Complete NodeConfig YAML reference, all fields with defaults
+- `references/operations.md` - Deployment, monitoring, admin API, recovery, metrics proxy
+- `references/validator-setup.md` - Step-by-step mainnet validator setup with CLI commands
+
+## Node Types
+
+| Binary | Mode | Purpose | Key Config |
+|---|---|---|---|
+| `ika-node` | Auto-detect | Selects mode from config | Detects automatically |
+| `ika-validator` | Validator | Consensus + MPC signing | Requires `consensus-config` |
+| `ika-fullnode` | Fullnode | State sync via P2P, no consensus | No `consensus-config`, no `notifier-client-key-pair` |
+| `ika-notifier` | Notifier | Submits checkpoints to Sui | Requires `notifier-client-key-pair` |
+
+**Auto-detection order**: `consensus-config` present → Validator; else `notifier-client-key-pair` present → Notifier; else → Fullnode.
+
+## Hardware Requirements (Validator)
+
+| Resource | Minimum |
+|---|---|
+| CPU | 16 physical cores / 16 vCPUs |
+| Memory | 128 GB |
+| Storage | 4 TB NVMe |
+| Network | 1 Gbps |
+| OS | Linux Ubuntu/Debian x64 (or Docker on x64 Linux) |
+
+**Warning**: Hetzner has strict crypto ToS and may close validators without notice.
+
+## Connectivity (Validator Ports)
+
+| Protocol/Port | Direction | Purpose |
+|---|---|---|
+| TCP/8080 | Inbound | Protocol / Transaction Interface |
+| UDP/8081 | Inbound/Outbound | Consensus Interface |
+| UDP/8084 | Inbound/Outbound | Peer-to-Peer State Sync |
+| TCP/8443 | Outbound | Metrics Pushing |
+| TCP/9184 | Inbound/Outbound | Metrics Scraping (both Sui fullnode and Ika node) |
+
+**Critical**: Ports 8080-8084 and 9184 must be open with correct protocols (TCP/UDP).
+
+## Prerequisites
+
+- DNS address for your validator (e.g., `ika-mainnet-1.<your-domain>`)
+- Your own Sui fullnode on Sui mainnet, fully synced (at least 2 latest epochs). Use separate DNS for Sui node.
+- Sui CLI installed, configured for mainnet, active address with at least 10 SUI
+- Minimum 40 million IKA stake to join the committee
+
+## Quick Start: Mainnet Validator
+
+Download binaries from: https://github.com/dwallet-labs/ika/releases
+
+### Step 1: Configure Ika Environment
+
+Get the latest package/object IDs from the canonical source:
+- **Mainnet**: `deployed_contracts/mainnet/address.yaml` ([GitHub](https://github.com/dwallet-labs/ika/blob/main/deployed_contracts/mainnet/address.yaml))
+- **Testnet**: `deployed_contracts/testnet/address.yaml` ([GitHub](https://github.com/dwallet-labs/ika/blob/main/deployed_contracts/testnet/address.yaml))
+
+```bash
+./ika validator config-env \
+  --ika-package-id                    <ika_package_id> \
+  --ika-common-package-id             <ika_common_package_id> \
+  --ika-dwallet-2pc-mpc-package-id    <ika_dwallet_2pc_mpc_package_id> \
+  --ika-system-package-id             <ika_system_package_id> \
+  --ika-system-object-id              <ika_system_object_id>
+# Creates: ~/.ika/ika_config/ika_sui_config.yaml
+# Note: ika-dwallet-coordinator-object-id is not set at this stage (defaults to zero);
+# it must be configured later in the node's validator.yaml under sui-connector-config.
+```
+
+### Step 2: Generate Validator Info & Keys
+
+```bash
+./ika validator make-validator-info \
+  "My Validator" "Description" \
+  "https://example.com/image.png" "https://example.com" \
+  "ika-mainnet-1.example.com" \
+  10000 \
+  <YOUR_SUI_ADDRESS>
+# Generates: protocol.key, network.key, consensus.key, root-seed.key, validator.info
+```
+
+**CRITICAL**: Back up ALL generated keys. `root-seed.key` is SECRET and IRREPLACEABLE. If lost, it cannot be updated via contract. Other keys (protocol, network, consensus) can be rotated on-chain.
+
+### Step 3: Register as Validator Candidate
+
+```bash
+./ika validator become-candidate ./validator.info
+# Returns: Validator ID, Validator Cap ID, Validator Operation Cap ID, and Validator Commission Cap ID
+```
+
+### Step 4: Stake into Validator
+
+Stake at least 40 million IKA via: https://ika-mainnet-validators-staking.pages.dev/
+
+Verify your Validator ID matches the CLI output.
+
+### Step 5: Join Committee
+
+```bash
+./ika validator join-committee --validator-cap-id <VALIDATOR_CAP_ID>
+```
+
+You become a pending validator and join the committee at the next epoch.
+
+### Step 6: Run the Validator Node
+
+Directory structure:
+
+```
+/opt/ika/
+├── bin/ika-node
+├── config/validator.yaml
+├── key-pairs/
+│   ├── protocol.key
+│   ├── network.key
+│   ├── consensus.key
+│   └── root-seed.key
+└── db/                        # Created at runtime
+    ├── authorities_db/
+    └── consensus_db/
+```
+
+Before running, edit `validator.yaml`:
+- Set `ika-dwallet-coordinator-object-id` to the value from `deployed_contracts/mainnet/address.yaml`
+- Ensure: `sui-chain-identifier: mainnet`
+- Set metrics: `push-url: "https://mainnet.metrics.ika-network.net:8443/publish/metrics"`
+
+```bash
+ika-node --config-path /opt/ika/config/validator.yaml
+```
+
+**Logging**: Set `RUST_LOG` for log levels, `RUST_LOG_JSON=1` for JSON output.
+
+### Step 7: Verify
+
+Wait a couple minutes, check logs for:
+
+```
+ika_core::checkpoints: Creating checkpoint(s) for 0 messages next_checkpoint_seq=1
+```
+
+This confirms the node is running. Additional checkpoints appear only during/after MPC sessions.
+
+## Package & Object IDs
+
+Always get the latest IDs from the canonical source files in the repo:
+
+- **Mainnet**: `deployed_contracts/mainnet/address.yaml` ([GitHub](https://github.com/dwallet-labs/ika/blob/main/deployed_contracts/mainnet/address.yaml))
+- **Testnet**: `deployed_contracts/testnet/address.yaml` ([GitHub](https://github.com/dwallet-labs/ika/blob/main/deployed_contracts/testnet/address.yaml))
+
+## Keypairs
+
+| Key | Type | Purpose | Required By | Recoverable? |
+|---|---|---|---|---|
+| `protocol-key-pair` | AuthorityKeyPair | Protocol signatures | All | Yes (rotate on-chain) |
+| `consensus-key-pair` | Ed25519 | Consensus communication | All | Yes (rotate on-chain) |
+| `network-key-pair` | Ed25519 | P2P networking | All | Yes (rotate on-chain) |
+| `account-key-pair` | SuiKeyPair | Sui interactions | All | Yes |
+| `root-seed-key-pair` | RootSeed | MPC cryptographic operations | Validators | **NO - IRREPLACEABLE** |
+| `notifier-client-key-pair` | SuiKeyPair | Submit checkpoints to Sui | Notifiers | Yes |
+
+## Validator Config Essentials
+
+```yaml
+# Mainnet validator must have:
+sui-connector-config:
+  sui-chain-identifier: mainnet
+  sui-rpc-url: 'http://<your-sui-fullnode>:9000'
+  # Get all IDs from deployed_contracts/mainnet/address.yaml
+  ika-package-id: '<from address.yaml>'
+  ika-dwallet-coordinator-object-id: '<from address.yaml>'
+  # ... other package/object IDs
+
+consensus-config:                         # Presence triggers validator mode
+  db-path: '/opt/ika/consensus_db'
+  db-retention-epochs: 0
+  db-pruner-period-secs: 3600
+  max-pending-transactions: 20000
+
+root-seed-key-pair:
+  path: /opt/ika/key-pairs/root-seed.key
+
+metrics:
+  push-url: "https://mainnet.metrics.ika-network.net:8443/publish/metrics"
+```
+
+## Admin API (localhost only)
+
+```bash
+curl http://127.0.0.1:1337/logging                    # View log filter
+curl -X POST 'http://127.0.0.1:1337/enable-tracing?filter=debug&duration=10s'
+curl -X POST http://127.0.0.1:1337/reset-tracing      # Reset to env var
+curl http://127.0.0.1:1337/node-config                 # View config (keys masked)
+curl http://127.0.0.1:1337/capabilities                # View capabilities
+```
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `IKA_CONFIG_DIR` | Override config directory | `~/.ika/ika_config/` |
+| `RUST_LOG` | Log level filter | — |
+| `RUST_LOG_JSON` | JSON log output (`1` to enable) | — |
+| `TRACE_FILTER` | Tracing log filter | — |
+
+## Services by Node Type
+
+| Service | Validator | Fullnode | Notifier |
+|---|---|---|---|
+| AuthorityState | Y | Y | Y |
+| ConsensusManager | Y | — | — |
+| DWalletMPCService | Y | — | — |
+| SuiConnectorService | Y | Y | Y |
+| CheckpointServices | Y | Y | Y |
+| P2P + StateSync | Y | Y | Y |
+| Discovery | Y | Y | Y |
+
+## Key Operational Notes
+
+- **Release mode required**: Always build with `--release` for crypto operations
+- **Sui fullnode required**: Run your own Sui fullnode, fully synced (2+ latest epochs)
+- **Package IDs must match**: Contract IDs in config must match deployed contracts
+- **Minimum stake**: 40 million IKA to join the committee
+- **Root seed is sacred**: Back it up securely. Cannot be regenerated or rotated on-chain.
+- **Updates**: Monitor `#nodes-updates-mainnet` channel for new releases
+- **Recovery**: Use `--run-with-range-epoch` or `--run-with-range-checkpoint` for disaster recovery
+- **Checkpoint pinning**: Use `pinned-dwallet-checkpoints` in state-sync config for fork recovery
+- **Graceful shutdown**: Send `SIGTERM` or `SIGINT`

--- a/skills/ika-operator/references/configuration.md
+++ b/skills/ika-operator/references/configuration.md
@@ -1,0 +1,293 @@
+# Complete Configuration Reference
+
+All NodeConfig fields with types, defaults, and descriptions. Config is YAML with `kebab-case` keys.
+
+## NodeConfig (Top-Level)
+
+```yaml
+# === KEYPAIRS ===
+
+protocol-key-pair:                    # AuthorityKeyPair (required)
+  path: /path/to/key                  # OR inline: value: <base64>
+
+consensus-key-pair:                   # Ed25519 only (required)
+  path: /path/to/key
+
+network-key-pair:                     # Ed25519 only (required)
+  path: /path/to/key
+
+account-key-pair:                     # Any SuiKeyPair (required)
+  path: /path/to/key
+
+root-seed-key-pair:                   # RootSeed (validators only, optional in config)
+  path: /path/to/seed
+
+# === PATHS ===
+
+db-path: '/opt/ika/db'                # Base database directory (required)
+# Derived paths:
+#   <db-path>/live/          → active epoch store
+#   <db-path>/db_checkpoints → DB snapshots
+#   <db-path>/snapshot       → state snapshots
+#   <db-path>/archive        → archived state
+
+# === NETWORK ===
+
+network-address: '/ip4/0.0.0.0/tcp/8080'  # gRPC listen address (Multiaddr)
+                                            # Default: /ip4/0.0.0.0/tcp/8080
+
+metrics-address: '0.0.0.0:9184'       # Prometheus metrics endpoint
+                                       # Default: 0.0.0.0:9184
+
+admin-interface-port: 1337             # Admin HTTP (localhost only)
+                                       # Default: 1337
+
+# === SUB-CONFIGS ===
+
+sui-connector-config: { ... }          # Required (see below)
+consensus-config: { ... }             # Validators only (see below)
+p2p-config: { ... }                   # P2P networking (see below)
+authority-overload-config: { ... }     # Overload protection (see below)
+
+# === OPTIONAL ===
+
+metrics:                               # Metrics push config
+  push-interval-seconds: 60
+  push-url: 'http://metrics.example.com/api/v1/push'
+
+state-archive-write-config: { ... }    # Archive writer (see below)
+state-archive-read-config: [{ ... }]   # Archive readers (list, see below)
+
+end-of-epoch-broadcast-channel-capacity: 128  # Default: 128
+remove-deprecated-tables: false               # Default: false
+
+# Disaster recovery only:
+run-with-range:
+  Epoch: 42                            # OR Checkpoint: 12345
+```
+
+---
+
+## SuiConnectorConfig
+
+```yaml
+sui-connector-config:
+  # Sui fullnode RPC endpoint
+  sui-rpc-url: 'http://127.0.0.1:9000'    # Default: http://127.0.0.1:9000
+
+  # Chain validation
+  sui-chain-identifier: testnet            # Values: mainnet | testnet | custom (kebab-case)
+
+  # Move package IDs (must match deployed contracts)
+  ika-package-id: '0x...'
+  ika-common-package-id: '0x...'
+  ika-dwallet-2pc-mpc-package-id: '0x...'
+  ika-dwallet-2pc-mpc-package-id-v2: '0x...'  # Optional v2 package
+  ika-system-package-id: '0x...'
+
+  # System object IDs
+  ika-system-object-id: '0x...'
+  ika-dwallet-coordinator-object-id: '0x...'
+
+  # Notifier mode only: Sui keypair for submitting checkpoints
+  notifier-client-key-pair:                # Optional (triggers Notifier mode)
+    path: /path/to/sui-key
+
+  # Override event cursor (advanced, rarely used)
+  sui-ika-system-module-last-processed-event-id-override:  # Optional
+    tx_digest: '<digest>'
+    event_seq: 0
+```
+
+---
+
+## ConsensusConfig (Validators Only)
+
+Presence of this section triggers Validator mode.
+
+```yaml
+consensus-config:
+  db-path: '/opt/ika/consensus_db'       # Consensus state directory (required)
+
+  # Retention policy
+  db-retention-epochs: 0                  # Epochs to keep (default: 0 = drop immediately)
+  db-pruner-period-secs: 3600            # Pruner check interval (default: 3600 = 1 hour)
+
+  # Transaction limits
+  max-pending-transactions: 20000         # Default: 20,000
+  max-submit-position: null               # Optional cap on submission position
+  submit-delay-step-override-millis: null  # Override backoff logic (ms)
+
+  # Advanced consensus parameters (rarely needed)
+  parameters: null                        # ConsensusParameters struct
+```
+
+---
+
+## P2pConfig
+
+```yaml
+p2p-config:
+  # Binding
+  listen-address: '0.0.0.0:8080'          # Default: 0.0.0.0:8080
+  external-address: '/dns/my-node.net/tcp/8080'  # Advertised to peers (optional)
+
+  # Peer connections
+  seed-peers:                              # Always maintain connection to these
+    - address: /dns/validator-1.net/tcp/8080
+      peer-id: '<optional_anemo_peer_id>'
+    - address: /ip4/1.2.3.4/tcp/8080
+
+  fixed-peers: null                        # If set, ONLY connect to these (no discovery)
+
+  # Message limits
+  excessive-message-size: 33554432         # Default: 32 MiB (logged, not rejected)
+
+  # Sub-configs
+  state-sync: { ... }                     # See StateSyncConfig below
+  discovery: { ... }                      # See DiscoveryConfig below
+```
+
+---
+
+## StateSyncConfig
+
+```yaml
+p2p-config:
+  state-sync:
+    # Polling
+    interval-period-ms: 5000               # Query peers interval (default: 5000)
+    mailbox-capacity: 1024                 # Actor mailbox size (default: 1024)
+
+    # dWallet checkpoint sync
+    dwallet-checkpoint-header-download-concurrency: 400    # Default: 400
+    dwallet-checkpoint-content-download-concurrency: 400   # Default: 400
+    dwallet-checkpoint-content-download-tx-concurrency: 50000  # Default: 50,000
+
+    # System checkpoint sync
+    system-checkpoint-header-download-concurrency: 400     # Default: 400
+    system-checkpoint-content-download-concurrency: 400    # Default: 400
+    system-checkpoint-content-download-tx-concurrency: 50000  # Default: 50,000
+
+    # Timeouts
+    timeout-ms: 10000                      # General RPC timeout (default: 10s)
+    dwallet-checkpoint-content-timeout-ms: 60000  # Content timeout (default: 60s)
+    system-checkpoint-content-timeout-ms: 10000   # Default: 10s
+
+    # Rate limiting (all default: unlimited)
+    push-dwallet-checkpoint-message-rate-limit: null
+    get-dwallet-checkpoint-message-rate-limit: null
+    get-dwallet-checkpoint-message-inflight-limit: null
+    get-dwallet-checkpoint-message-per-checkpoint-limit: null
+    push-system-checkpoint-message-rate-limit: null
+    get-system-checkpoint-message-rate-limit: null
+    get-system-checkpoint-message-inflight-limit: null
+    get-system-checkpoint-message-per-checkpoint-limit: null
+
+    # Broadcast channels
+    synced-dwallet-checkpoint-broadcast-channel-capacity: 1024   # Default: 1024
+    synced-system-checkpoint-broadcast-channel-capacity: 1024    # Default: 1024
+
+    # No-peer wait interval
+    wait-interval-when-no-peer-to-sync-content-ms: 10000  # Default: 10s
+
+    # Checkpoint pinning (fork recovery / network stall)
+    pinned-dwallet-checkpoints:            # List of [seq_num, digest]
+      - [123, '0xabcdef...']
+    pinned-system-checkpoints:
+      - [456, '0x123456...']
+```
+
+---
+
+## DiscoveryConfig
+
+```yaml
+p2p-config:
+  discovery:
+    interval-period-ms: 5000               # Peer query interval (default: 5000)
+    target-concurrent-connections: 4       # Target connections (default: 4)
+    peers-to-query: 1                      # Peers queried per interval (default: 1)
+    get-known-peers-rate-limit: null       # Per-peer rate limit (default: unlimited)
+
+    # Access control
+    access-type: Public                    # Public | Private
+    # Public: advertised to all peers
+    # Private: only visible to allowlisted/seed peers
+
+    allowlisted-peers:                     # Always allowed regardless of concurrency limit
+      - peer-id: '4e2f113e...'
+        address: /dns/trusted.net/tcp/8080  # Optional
+```
+
+---
+
+## AuthorityOverloadConfig
+
+```yaml
+authority-overload-config:
+  max-txn-age-in-queue: 500ms                    # Default: 500ms
+  overload-monitor-interval: 10s                  # Default: 10s
+  execution-queue-latency-soft-limit: 1s          # Enter load shedding (default: 1s)
+  execution-queue-latency-hard-limit: 10s         # Aggressive shedding (default: 10s)
+  max-load-shedding-percentage: 95                # Max % to shed (default: 95)
+  min-load-shedding-percentage-above-hard-limit: 50  # Min % above hard (default: 50)
+  safe-transaction-ready-rate: 100                # Below = no shedding (default: 100)
+  check-system-overload-at-signing: true          # Default: true
+  check-system-overload-at-execution: false        # Default: false
+  max-transaction-manager-queue-length: 100000     # Default: 100,000
+  max-transaction-manager-per-object-queue-length: 20  # Default: 20
+```
+
+---
+
+## StateArchiveConfig
+
+### Write (archiving node state)
+
+```yaml
+state-archive-write-config:
+  object-store-config:
+    object-store: 'S3'                    # S3 | GCS | File
+    bucket: 'my-ika-archives'
+    aws-region: 'us-west-2'
+    aws-access-key-id: '...'             # Or use no-sign-request: true
+    aws-secret-access-key: '...'
+    no-sign-request: false
+    object-store-connection-limit: 20
+  concurrency: 5
+  use-for-pruning-watermark: false
+```
+
+### Read (syncing from archive)
+
+```yaml
+state-archive-read-config:
+  - object-store-config:
+      object-store: 'S3'
+      bucket: 'mysten-testnet-archives'    # Or mainnet
+      no-sign-request: true
+      aws-region: 'us-west-2'
+      object-store-connection-limit: 20
+    concurrency: 5
+    use-for-pruning-watermark: false
+```
+
+---
+
+## Genesis Config (Initiation Parameters)
+
+Used during network genesis setup:
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `protocol-version` | MAX | Current max supported |
+| `epoch-duration-ms` | 86,400,000 (24h) | Epoch length |
+| `min-validator-count` | 4 | Range: 4-102 |
+| `max-validator-count` | 102 | Range: 4-102 |
+| `min-validator-joining-stake` | 40M IKA | Minimum stake (mainnet) |
+| `stake-subsidy-start-epoch` | 1 | When subsidies begin |
+| `stake-subsidy-rate` | 1000 bps (10%) | Subsidy rate |
+| `stake-subsidy-period-length` | 365 | Epochs per period |
+| `max-validator-change-count` | 10 | Per epoch |
+| `reward-slashing-rate` | 10000 bps (100%) | Slashing severity |

--- a/skills/ika-operator/references/operations.md
+++ b/skills/ika-operator/references/operations.md
@@ -1,0 +1,341 @@
+# Operations Reference
+
+Deployment, monitoring, admin API, recovery, and metrics proxy.
+
+## Deployment
+
+### Prerequisites
+
+- Rust 1.94+ toolchain (see `rust-toolchain.toml`)
+- Access to a Sui fullnode RPC endpoint
+- Ika contract package/object IDs for the target network
+- Generated keypairs for the node type
+
+### Build
+
+```bash
+# Always release mode (crypto is extremely slow in debug)
+cargo build --release
+
+# Binaries produced:
+# target/release/ika-validator
+# target/release/ika-fullnode
+# target/release/ika-notifier
+# target/release/ika-node        (auto-detect mode)
+```
+
+### Keypair Generation
+
+Keys are Base64-encoded. Store in files referenced by config:
+
+```
+protocol-key-pair:    AuthorityKeyPair (BLS12-381)
+consensus-key-pair:   Ed25519
+network-key-pair:     Ed25519
+account-key-pair:     Any SuiKeyPair (Ed25519, Secp256k1, or Secp256r1)
+root-seed-key-pair:   RootSeed (loaded from file, validators only)
+notifier-client-key-pair: Any SuiKeyPair (notifiers only)
+```
+
+### Directory Setup
+
+```bash
+mkdir -p /opt/ika/{db,consensus_db,keys,config}
+
+# Place keypair files
+# Place config YAML in /opt/ika/config/
+
+# Validator
+./target/release/ika-validator --config-path /opt/ika/config/validator.yaml
+
+# Fullnode
+./target/release/ika-fullnode --config-path /opt/ika/config/fullnode.yaml
+
+# Notifier
+./target/release/ika-notifier --config-path /opt/ika/config/notifier.yaml
+```
+
+### Systemd Service (Example)
+
+```ini
+[Unit]
+Description=Ika Validator
+After=network.target
+
+[Service]
+Type=simple
+User=ika
+ExecStart=/opt/ika/bin/ika-validator --config-path /opt/ika/config/validator.yaml
+Restart=on-failure
+RestartSec=10
+LimitNOFILE=65536
+
+# 16 MB stack for RocksDB and crypto operations
+Environment="RUST_MIN_STACK=16777216"
+
+[Install]
+WantedBy=multi-user.target
+```
+
+---
+
+## Startup Sequence
+
+1. Load config YAML and validate against node mode
+2. Initialize Prometheus metrics registry
+3. Start metrics HTTP server (separate Tokio runtime)
+4. Initialize RocksDB databases
+5. Create P2P network (Anemo/QUIC)
+6. Create AuthorityState
+7. Start SuiConnectorService (event sync from Sui)
+8. Start validator-specific components (if validator):
+   - ConsensusManager (Mysticeti consensus)
+   - ConsensusAdapter
+   - DWalletMPCService (2PC-MPC protocol)
+9. Start admin HTTP interface
+10. Wait for shutdown signal (SIGTERM/SIGINT)
+
+**Runtime configuration**: Multiple Tokio runtimes with 16 MB thread stacks.
+
+---
+
+## Monitoring
+
+### Prometheus Metrics
+
+Default endpoint: `http://0.0.0.0:9184/metrics`
+
+Scrape with Prometheus/Grafana. Key metric categories:
+- **Consensus**: Round progress, latency, pending transactions
+- **MPC**: DKG sessions, presign sessions, sign sessions
+- **P2P**: Connection count, message rates, peer states
+- **Sui Connector**: Event processing lag, checkpoint progress
+- **State Sync**: Checkpoint download rates, sync lag
+- **Authority**: Transaction queue lengths, execution latency, load shedding
+
+### Metrics Push
+
+```yaml
+metrics:
+  push-interval-seconds: 60
+  push-url: 'http://mimir.example.com/api/v1/push'
+```
+
+---
+
+## Admin API
+
+Bound to `127.0.0.1:<admin-interface-port>` (default: 1337). Localhost only.
+
+### Endpoints
+
+```bash
+# View current log filter
+curl http://127.0.0.1:1337/logging
+
+# Enable debug tracing temporarily (auto-resets after duration)
+curl -X POST 'http://127.0.0.1:1337/enable-tracing?filter=debug&duration=10s'
+
+# More specific filter
+curl -X POST 'http://127.0.0.1:1337/enable-tracing?filter=ika_core=debug,ika_network=trace&duration=30s'
+
+# Reset tracing to TRACE_FILTER env var
+curl -X POST http://127.0.0.1:1337/reset-tracing
+
+# View node config (keypairs masked)
+curl http://127.0.0.1:1337/node-config
+
+# View all received capabilities
+curl http://127.0.0.1:1337/capabilities
+
+# Buffer stake override (advanced, for validators)
+curl -X POST 'http://127.0.0.1:1337/set-override-buffer-stake?buffer_bps=1500&epoch=2'
+curl -X POST 'http://127.0.0.1:1337/clear-override-buffer-stake?epoch=2'
+```
+
+---
+
+## Recovery Procedures
+
+### Replay to Specific Point
+
+For disaster recovery debugging only:
+
+```bash
+# Stop at specific epoch
+./target/release/ika-validator --config-path config.yaml --run-with-range-epoch 42
+
+# Stop at specific checkpoint
+./target/release/ika-validator --config-path config.yaml --run-with-range-checkpoint 12345
+```
+
+### Checkpoint Pinning (Fork Recovery)
+
+If the network forks or stalls, pin known-good checkpoints:
+
+```yaml
+p2p-config:
+  state-sync:
+    pinned-dwallet-checkpoints:
+      - [123, '0xabcdef...']    # [sequence_number, digest]
+    pinned-system-checkpoints:
+      - [456, '0x123456...']
+```
+
+Pinned checkpoints skip verification and reject mismatched digests.
+
+### Database Recovery
+
+If database is corrupted:
+
+```bash
+# Stop the node
+# Remove the database directory
+rm -rf /opt/ika/db/live
+
+# Restart - node will resync from peers via state sync
+./target/release/ika-fullnode --config-path config.yaml
+```
+
+For validators, also clear consensus DB:
+
+```bash
+rm -rf /opt/ika/consensus_db/*
+```
+
+### Event Cursor Override
+
+If Sui event processing is stuck:
+
+```yaml
+sui-connector-config:
+  sui-ika-system-module-last-processed-event-id-override:
+    tx_digest: '<valid_tx_digest>'
+    event_seq: 0
+```
+
+**Warning**: The EventID must exist and match the filter. An invalid cursor will cause missed events.
+
+---
+
+## Metrics Proxy (ika-proxy)
+
+Separate binary for collecting metrics from validators and routing to monitoring backends.
+
+### Config
+
+```yaml
+network: joenet
+listen-address: '127.0.0.1:8080'
+metrics-address: 'localhost:9184'
+histogram-address: 'localhost:9185'
+
+remote-write:
+  url: 'http://mimir.example.com/api/v1/push'
+  username: user
+  password: pass
+  pool-max-idle-per-host: 8
+
+# Dynamic peer discovery from Sui chain
+dynamic-peers:
+  url: 'http://127.0.0.1:9000'         # Sui RPC
+  interval: 30s
+  hostname: 'localhost'                  # optional; default 'localhost'
+  certificate-file: /path/to/cert.pem   # optional
+  private-key: /path/to/key.pem         # optional
+  # Contract addresses — copy from deployed_contracts/{mainnet,testnet}/address.yaml
+  ika-package-id: '0x...'
+  ika-common-package-id: '0x...'
+  ika-dwallet-2pc-mpc-package-id: '0x...'
+  ika-dwallet-2pc-mpc-package-id-v2: '0x...'   # optional; omit if not yet deployed
+  ika-system-package-id: '0x...'
+  ika-system-object-id: '0x...'
+  ika-dwallet-coordinator-object-id: '0x...'
+
+# OR static peer list
+static-peers:
+  pub-keys:
+    - name: validator-1
+      peer-id: '4e2f113e...'
+```
+
+### Proxy Environment Variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `IKA_PROXY_VERBOSE_HTTP` | Verbose HTTP logging | false |
+| `NODE_CLIENT_TIMEOUT` | Node client timeout | 20s |
+| `MIMIR_CLIENT_TIMEOUT` | Mimir client timeout | 30s |
+| `MAX_BODY_SIZE` | Max request body size | 5 MB |
+| `INVENTORY_HOSTNAME` | Hostname label for metrics | "unknown" |
+
+---
+
+## Common Issues & Solutions
+
+| Issue | Cause | Fix |
+|---|---|---|
+| Extremely slow startup | Debug build | Build with `--release` |
+| Port conflict on 8080 | P2P port taken | Change `p2p-config.listen-address` |
+| Sui chain mismatch error | Wrong chain identifier | Verify `sui-rpc-url` matches `sui-chain-identifier` |
+| Missing package ID error | Wrong contract IDs | Update package/object IDs to match deployed contracts |
+| Consensus DB disk full | No pruning | Set `db-retention-epochs: 0`, lower `db-pruner-period-secs` |
+| State sync stalled | No peers | Add seed peers, check network connectivity |
+| Event processing stuck | Bad cursor | Use event cursor override (carefully) |
+| Node won't start | Missing keypairs | Ensure all required keypair files exist and are valid Base64 |
+| Validator mode rejected | Missing consensus-config | Add `consensus-config` section for validators |
+| Notifier mode rejected | Missing notifier key | Add `notifier-client-key-pair` to `sui-connector-config` |
+
+---
+
+## Health Check Script
+
+```bash
+#!/bin/bash
+# Basic health check for Ika node
+
+METRICS_URL="http://localhost:9184/metrics"
+ADMIN_URL="http://localhost:1337"
+
+# Check metrics endpoint
+if curl -sf "$METRICS_URL" > /dev/null 2>&1; then
+    echo "Metrics: OK"
+else
+    echo "Metrics: FAIL"
+fi
+
+# Check admin endpoint
+if curl -sf "$ADMIN_URL/logging" > /dev/null 2>&1; then
+    echo "Admin: OK"
+else
+    echo "Admin: FAIL"
+fi
+
+# Check specific metrics
+UPTIME=$(curl -sf "$METRICS_URL" | grep 'uptime' | head -1)
+echo "Uptime: $UPTIME"
+```
+
+---
+
+## Local Test Network (ika-swarm)
+
+For development/testing. Uses `ika-swarm` crate:
+
+```rust
+// Programmatic setup
+SwarmBuilder::new()
+    .committee_size(NonZeroUsize::new(4).unwrap())
+    .with_fullnode_count(2)
+    .with_epoch_duration_ms(5000)
+    .build()
+    .await;
+```
+
+The swarm builder:
+1. Generates all validator/fullnode configs with keypairs
+2. Publishes Move contracts to local Sui
+3. Initializes system state (genesis)
+4. Starts all nodes in-process
+
+For CLI-based setup, use `ika-swarm-config` crate which generates network configs.

--- a/skills/ika-operator/references/validator-setup.md
+++ b/skills/ika-operator/references/validator-setup.md
@@ -1,0 +1,320 @@
+# Mainnet Validator Setup
+
+Complete step-by-step guide for setting up an Ika mainnet validator with permissionless stake.
+
+## Overview
+
+All validator operations (registration, node management) are coordinated on Sui. You register as a validator candidate via Sui smart contracts, stake IKA, join the committee, then run your node.
+
+## Prerequisites Checklist
+
+- [ ] DNS address configured (recommended: `ika-mainnet-1.<your-domain>`)
+- [ ] Own Sui fullnode on Sui mainnet, fully synced (2+ latest epochs)
+  - Recommended: Restore from DB snapshot
+  - Use separate DNS for Sui node (validator subdomain must point to Ika node, not Sui node)
+- [ ] Sui CLI installed, configured for mainnet
+- [ ] Active Sui address with at least 10 SUI (for registration transactions)
+- [ ] Server meets hardware requirements
+- [ ] Ports 8080-8084 and 9184 open
+- [ ] Basic git knowledge
+- [ ] Download latest binaries from https://github.com/dwallet-labs/ika/releases
+
+## Hardware Requirements
+
+| Resource | Minimum |
+|---|---|
+| CPU | 16 physical cores / 16 vCPUs (node won't run with fewer) |
+| Memory | 128 GB |
+| Storage | 4 TB NVMe |
+| Network | 1 Gbps |
+| OS | Linux Ubuntu/Debian x64, or Docker on x64 Linux |
+
+**Warning**: Hetzner has strict crypto ToS - may close validators without notice.
+
+## Required Ports
+
+| Protocol/Port | Direction | Purpose |
+|---|---|---|
+| TCP/8080 | Inbound | Protocol / Transaction Interface |
+| UDP/8081 | Inbound/Outbound | Consensus Interface |
+| UDP/8084 | Inbound/Outbound | Peer-to-Peer State Sync |
+| TCP/8443 | Outbound | Metrics Pushing |
+| TCP/9184 | Inbound/Outbound | Metrics Scraping |
+
+**All ports 8080-8084 and 9184 must be open with correct protocols (TCP/UDP).**
+
+---
+
+## Step 1: Configure Ika Environment
+
+Generate the Ika Sui config file locally. Get the latest IDs from:
+- **Mainnet**: `deployed_contracts/mainnet/address.yaml` ([GitHub](https://github.com/dwallet-labs/ika/blob/main/deployed_contracts/mainnet/address.yaml))
+- **Testnet**: `deployed_contracts/testnet/address.yaml` ([GitHub](https://github.com/dwallet-labs/ika/blob/main/deployed_contracts/testnet/address.yaml))
+
+```bash
+./ika validator config-env \
+  --ika-package-id                    <ika_package_id> \
+  --ika-common-package-id             <ika_common_package_id> \
+  --ika-dwallet-2pc-mpc-package-id    <ika_dwallet_2pc_mpc_package_id> \
+  --ika-system-package-id             <ika_system_package_id> \
+  --ika-system-object-id              <ika_system_object_id>
+```
+
+**Output**: Creates `~/.ika/ika_config/ika_sui_config.yaml`
+
+**Note**: `ika-dwallet-coordinator-object-id` is not set at this stage (defaults to zero). It must be configured later in the node's `validator.yaml` under `sui-connector-config`.
+
+Verify:
+
+```bash
+cat ~/.ika/ika_config/ika_sui_config.yaml
+```
+
+---
+
+## Step 2: Generate Validator Info & Keys
+
+```bash
+./ika validator make-validator-info \
+  "<NAME>" \
+  "<DESCRIPTION>" \
+  "<IMAGE_URL>" \
+  "<PROJECT_URL>" \
+  "<HOST_NAME>" \
+  <GAS_PRICE> \
+  <SENDER_SUI_ADDRESS>
+```
+
+**Arguments**:
+- `NAME`: Validator display name
+- `DESCRIPTION`: Validator description
+- `IMAGE_URL`: URL to validator logo/image
+- `PROJECT_URL`: Validator project website
+- `HOST_NAME`: DNS hostname for the validator node (e.g., `ika-mainnet-1.example.com`)
+- `GAS_PRICE`: Gas price in MIST
+- `SENDER_SUI_ADDRESS`: Your active Sui mainnet address (from `~/.sui/sui_config/client.yaml`)
+
+**Options**: `--json` for JSON output
+
+**Example**:
+
+```bash
+./ika validator make-validator-info \
+  "My Validator" "Secure and fast" \
+  "https://example.com/image.png" "https://example.com" \
+  "ika-mainnet-1.example.com" \
+  10000 \
+  0x5cf353484d7f512d44feae616910972659c9e10af431323f911e612a5ce6eec7
+```
+
+**Output files**:
+- `protocol.key` - Protocol signing key
+- `network.key` - P2P network key
+- `consensus.key` - Consensus key
+- `root-seed.key` - MPC root seed key
+- `validator.info` - Validator metadata file
+
+**Note**: The error `FailedToReadCGKey` during generation is expected - it indicates the root seed file doesn't exist yet and is being generated.
+
+**Note**: Root seed key creation takes some time. The command is not stuck.
+
+### Key Management Warnings
+
+**CRITICAL - Back up ALL keys immediately**:
+
+- `root-seed.key` is **SECRET** and **IRREPLACEABLE**
+  - No way to recover if lost
+  - Cannot be updated via contract
+  - Validator must run with this exact seed (different seed = won't start)
+  - Requires network coordination if lost
+
+- `protocol.key`, `network.key`, `consensus.key`:
+  - Can be rotated on-chain if lost
+  - Ika contract includes functionality to update these keys
+  - CLI commands available for key rotation
+
+**Store keys in secure, offline storage. Treat with same caution as funds.**
+
+---
+
+## Step 3: Become a Validator Candidate
+
+Register as a candidate using the generated `validator.info`:
+
+```bash
+./ika validator become-candidate <validator-info-path>
+```
+
+**Options**:
+- `--gas-budget <gas-budget>` - Override gas budget
+- `--ika-sui-config <path>` - Path to ika_sui_config.yaml (default: `~/.ika/ika_config/ika_sui_config.yaml`)
+- `--json` - JSON output
+
+**Example**:
+
+```bash
+./ika validator become-candidate ./validator.info
+```
+
+**Output**:
+
+```
+----- Transaction Digest ----
+Gu6TeZ9dP72EDTukj1op8qfLFaE2aXyoiLiAexY8S2ke
+Validator ID: 0x8704eed3bb82c73b41ee6d63fc0f92db3419d9d0b1f8cb773723311a5a943e37
+Validator Cap ID: 0x5d558d7fd928f9bacc7adac83c4c5eabf7947a017ea22797170d9a7378f2e35c
+Validator Operation Cap ID: 0x...
+Validator Commission Cap ID: 0x...
+```
+
+**Save all four IDs** - Validator Cap ID is needed for Step 5. Operation Cap and Commission Cap are used for validator management operations (key rotation, commission changes, etc.).
+
+The cap objects are transferred to the executing account.
+
+---
+
+## Step 4: Stake into Validator
+
+**Minimum stake: 40 million IKA** (below this, cannot join committee).
+
+Staking portal: https://ika-mainnet-validators-staking.pages.dev/
+
+1. Connect your wallet
+2. Find your validator
+3. **Verify Validator ID matches** the CLI output from Step 3
+4. Stake at least 40M IKA
+
+For custody solutions (e.g., Fortuna): they have their own instructions for the staking website.
+
+---
+
+## Step 5: Join Committee
+
+Once staked with sufficient IKA:
+
+```bash
+./ika validator join-committee --validator-cap-id <VALIDATOR_CAP_ID>
+```
+
+**Options**:
+- `--gas-budget <gas-budget>`
+- `--ika-sui-config <path>`
+- `--json`
+
+**Example**:
+
+```bash
+./ika validator join-committee \
+  --validator-cap-id 0x5d558d7fd928f9bacc7adac83c4c5eabf7947a017ea22797170d9a7378f2e35c
+```
+
+**Result**: You become a **pending validator**. You join the committee starting from the **next epoch**. Meanwhile, start your node to synchronize.
+
+---
+
+## Step 6: Run the Validator Node
+
+### Directory Layout
+
+```
+/opt/ika/
+├── bin/
+│   └── ika-node
+├── config/
+│   └── validator.yaml
+├── key-pairs/
+│   ├── protocol.key
+│   ├── network.key
+│   ├── consensus.key
+│   └── root-seed.key
+└── db/                     # Created at runtime
+    ├── authorities_db/
+    └── consensus_db/
+```
+
+### Pre-Run Config Edits
+
+Edit `validator.yaml` before starting:
+
+1. **Set all package/object IDs** from `deployed_contracts/mainnet/address.yaml`
+
+2. **Ensure mainnet chain identifier**:
+   ```yaml
+   sui-chain-identifier: mainnet
+   ```
+
+3. **Set metrics push URL**:
+   ```yaml
+   push-url: "https://mainnet.metrics.ika-network.net:8443/publish/metrics"
+   ```
+
+### Start
+
+```bash
+ika-node --config-path /opt/ika/config/validator.yaml
+```
+
+**Logging**:
+- `RUST_LOG` env var controls log levels
+- `RUST_LOG_JSON=1` for JSON-formatted logs
+
+---
+
+## Step 7: Verify Operation
+
+Wait a couple of minutes, then check logs for:
+
+```
+ika_core::checkpoints: Creating checkpoint(s) for 0 messages next_checkpoint_seq=1
+```
+
+Also look for consensus output lines:
+
+```
+ika_core::consensus_handler: Received consensus output consensus_commit=CommittedSubDag(...)
+```
+
+This confirms your node is running correctly. Additional checkpoints appear only during or after MPC sessions.
+
+---
+
+## Step 8: Ongoing Operations
+
+- **Monitor** `#nodes-updates-mainnet` channel for new releases
+- **Update regularly** - download new binaries from GitHub releases
+- **Monitor metrics** at `http://localhost:9184/metrics`
+- **Admin API** at `http://localhost:1337/` (see SKILL.md for endpoints)
+
+---
+
+## CLI Command Reference
+
+```bash
+# Step 1: Configure environment
+./ika validator config-env \
+  --ika-package-id <ID> \
+  --ika-common-package-id <ID> \
+  --ika-dwallet-2pc-mpc-package-id <ID> \
+  --ika-system-package-id <ID> \
+  --ika-system-object-id <ID>
+
+# Step 2: Generate validator info
+./ika validator make-validator-info [OPTIONS] <NAME> <DESCRIPTION> <IMAGE_URL> <PROJECT_URL> <HOST_NAME> <GAS_PRICE> <SENDER_SUI_ADDRESS>
+
+# Step 3: Register as candidate
+./ika validator become-candidate [OPTIONS] <validator-info-path>
+
+# Step 5: Join committee
+./ika validator join-committee [OPTIONS] --validator-cap-id <validator-cap-id>
+```
+
+All commands support `--json` for JSON output and `--help` for usage info.
+
+---
+
+## Package & Object IDs
+
+Always get the latest IDs from the canonical source files:
+
+- **Mainnet**: `deployed_contracts/mainnet/address.yaml` ([GitHub](https://github.com/dwallet-labs/ika/blob/main/deployed_contracts/mainnet/address.yaml))
+- **Testnet**: `deployed_contracts/testnet/address.yaml` ([GitHub](https://github.com/dwallet-labs/ika/blob/main/deployed_contracts/testnet/address.yaml))

--- a/skills/ika-sdk/SKILL.md
+++ b/skills/ika-sdk/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: ika-sdk
+description: Guide for building with the Ika TypeScript SDK (@ika.xyz/sdk) on Mysten Sui v2. Use when creating dWallets, signing cross-chain transactions, managing encryption keys, or integrating with the Ika network from TypeScript/JavaScript. Triggers on tasks involving @ika.xyz/sdk, dWallet operations, IkaClient, IkaTransaction, or Ika cross-chain signing.
+---
+
+# Ika TypeScript SDK
+
+Build cross-chain signing applications with `@ika.xyz/sdk` on Sui.
+
+## References (detailed patterns and complete API)
+
+- `references/api-reference.md` - Complete API: IkaClient methods, IkaTransaction methods, cryptography functions, UserShareEncryptionKeys
+- `references/flows.md` - End-to-end flows: zero-trust dWallet, shared dWallet, imported key, transfer, future signing
+- `references/types-and-validation.md` - Type system, enums, curve/sig/hash validation, state narrowing
+
+## Install
+
+```bash
+pnpm add @ika.xyz/sdk
+# or
+npm install @ika.xyz/sdk
+```
+
+Requires: `@mysten/sui` ^2.5.0, Node >=18
+
+## Setup
+
+```typescript
+import { getNetworkConfig, IkaClient } from '@ika.xyz/sdk';
+import { getJsonRpcFullnodeUrl, SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+
+const suiClient = new SuiJsonRpcClient({
+    url: getJsonRpcFullnodeUrl('testnet'),
+    network: 'testnet',
+});
+
+const ikaClient = new IkaClient({
+    suiClient,
+    config: getNetworkConfig('testnet'), // or 'mainnet'
+    cache: true,
+});
+await ikaClient.initialize();
+```
+
+## Enums
+
+```typescript
+import { Curve, SignatureAlgorithm, Hash } from '@ika.xyz/sdk';
+
+// Curves
+Curve.SECP256K1   // Bitcoin, Ethereum
+Curve.SECP256R1   // WebAuthn, P-256
+Curve.ED25519     // Solana, Substrate
+Curve.RISTRETTO   // Privacy
+
+// Signature Algorithms
+SignatureAlgorithm.ECDSASecp256k1      // SECP256K1
+SignatureAlgorithm.Taproot             // SECP256K1
+SignatureAlgorithm.ECDSASecp256r1      // SECP256R1
+SignatureAlgorithm.EdDSA               // ED25519
+SignatureAlgorithm.SchnorrkelSubstrate // RISTRETTO
+
+// Hashes
+Hash.KECCAK256     // ECDSASecp256k1
+Hash.SHA256        // ECDSASecp256k1, Taproot, ECDSASecp256r1
+Hash.DoubleSHA256  // ECDSASecp256k1
+Hash.SHA512        // EdDSA
+Hash.Merlin        // SchnorrkelSubstrate
+```
+
+## Valid Combinations Quick Reference
+
+| Chain | Curve | SignatureAlgorithm | Hash |
+|---|---|---|---|
+| Ethereum | SECP256K1 | ECDSASecp256k1 | KECCAK256 |
+| Bitcoin Taproot | SECP256K1 | Taproot | SHA256 |
+| Bitcoin Legacy | SECP256K1 | ECDSASecp256k1 | DoubleSHA256 |
+| Solana | ED25519 | EdDSA | SHA512 |
+| WebAuthn | SECP256R1 | ECDSASecp256r1 | SHA256 |
+| Substrate | RISTRETTO | SchnorrkelSubstrate | Merlin |
+
+## dWallet Types
+
+| Kind | Description | Use Case |
+|---|---|---|
+| `zero-trust` | Encrypted user share, user must participate in signing | Personal wallets, max security |
+| `shared` | Public user share, network signs autonomously | DAOs, contracts, automation |
+| `imported-key` | Existing private key imported (encrypted share) | Migrating existing wallets |
+| `imported-key-shared` | Imported key with public share | Migrated wallets for contracts |
+
+## Core Flow: Shared dWallet (Most Common)
+
+### 1. Create Encryption Keys
+
+```typescript
+import { UserShareEncryptionKeys, Curve } from '@ika.xyz/sdk';
+
+const keys = await UserShareEncryptionKeys.fromRootSeedKey(
+    new TextEncoder().encode('your-seed'),
+    Curve.SECP256K1,
+);
+```
+
+### 2. Register Encryption Key
+
+```typescript
+import { IkaTransaction } from '@ika.xyz/sdk';
+import { Transaction } from '@mysten/sui/transactions';
+
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+await ikaTx.registerEncryptionKey({ curve: Curve.SECP256K1 });
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+```
+
+### 3. DKG (Create dWallet)
+
+```typescript
+import { prepareDKGAsync, createRandomSessionIdentifier } from '@ika.xyz/sdk';
+
+const sessionIdBytes = createRandomSessionIdentifier();
+const dkgData = await prepareDKGAsync(ikaClient, Curve.SECP256K1, keys, sessionIdBytes, senderAddress);
+const networkKey = await ikaClient.getLatestNetworkEncryptionKey();
+
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+const sessionId = ikaTx.registerSessionIdentifier(sessionIdBytes);
+const [dwalletCap, signId] = await ikaTx.requestDWalletDKG({
+    dkgRequestInput: dkgData,
+    ikaCoin: tx.splitCoins(tx.object(ikaCoinId), [1_000_000]),
+    suiCoin: tx.splitCoins(tx.gas, [1_000_000]),
+    sessionIdentifier: sessionId,
+    dwalletNetworkEncryptionKeyId: networkKey.id,
+    curve: Curve.SECP256K1,
+});
+const result = await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+```
+
+### 4. Get dWallet & Public Key
+
+```typescript
+import { publicKeyFromDWalletOutput } from '@ika.xyz/sdk';
+
+const dWallet = await ikaClient.getDWalletInParticularState(dwalletId, 'Active');
+const publicKey = await publicKeyFromDWalletOutput(Curve.SECP256K1, Uint8Array.from(dWallet.state.Active.public_output));
+```
+
+### 5. Request Presign
+
+```typescript
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx });
+ikaTx.requestGlobalPresign({
+    dwalletNetworkEncryptionKeyId: networkKey.id,
+    curve: Curve.SECP256K1,
+    signatureAlgorithm: SignatureAlgorithm.Taproot,
+    ikaCoin: tx.splitCoins(tx.object(ikaCoinId), [1_000_000]),
+    suiCoin: tx.splitCoins(tx.gas, [1_000_000]),
+});
+```
+
+### 6. Sign Message
+
+```typescript
+import { createUserSignMessageWithPublicOutput } from '@ika.xyz/sdk';
+
+// Wait for presign completion
+const presign = await ikaClient.getPresignInParticularState(presignId, 'Completed');
+const pp = await ikaClient.getProtocolPublicParameters(dWallet);
+
+// Create user signature
+const msgSig = await createUserSignMessageWithPublicOutput(
+    pp, Uint8Array.from(dWallet.state.Active.public_output),
+    Uint8Array.from(dWallet.public_user_secret_key_share),
+    Uint8Array.from(presign.state.Completed.presign),
+    message, Hash.SHA256, SignatureAlgorithm.Taproot, Curve.SECP256K1,
+);
+
+// Build & execute sign transaction
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+const signRef = await ikaTx.requestSign({
+    dWallet, messageApproval: ikaTx.approveMessage({
+        dWalletCap, curve: Curve.SECP256K1,
+        signatureAlgorithm: SignatureAlgorithm.Taproot,
+        hashScheme: Hash.SHA256, message,
+    }),
+    hashScheme: Hash.SHA256,
+    verifiedPresignCap: ikaTx.verifyPresignCap({ presign }),
+    presign, message,
+    signatureScheme: SignatureAlgorithm.Taproot,
+    ikaCoin: tx.splitCoins(tx.object(ikaCoinId), [1_000_000]),
+    suiCoin: tx.splitCoins(tx.gas, [1_000_000]),
+});
+```
+
+### 7. Retrieve Signature
+
+```typescript
+import { parseSignatureFromSignOutput } from '@ika.xyz/sdk';
+
+const sign = await ikaClient.getSignInParticularState(
+    signId, Curve.SECP256K1, SignatureAlgorithm.Taproot, 'Completed',
+);
+// sign.state.Completed.signature is already parsed
+```
+
+## IkaClient Key Methods
+
+```typescript
+// Initialization
+await ikaClient.initialize();
+
+// Query dWallets
+const dWallet = await ikaClient.getDWallet(id);
+const dWallet = await ikaClient.getDWalletInParticularState(id, 'Active', { timeout: 60000 });
+const dWallets = await ikaClient.getMultipleDWallets([id1, id2]);
+const caps = await ikaClient.getOwnedDWalletCaps(address);
+
+// Query presigns, signs, partial sigs (all support InParticularState polling)
+const presign = await ikaClient.getPresign(id);
+const presign = await ikaClient.getPresignInParticularState(id, 'Completed');
+const sign = await ikaClient.getSign(id, Curve.SECP256K1, SignatureAlgorithm.Taproot);
+const sign = await ikaClient.getSignInParticularState(id, curve, sigAlgo, 'Completed');
+
+// Encryption keys
+const key = await ikaClient.getLatestNetworkEncryptionKey();
+const keys = await ikaClient.getAllNetworkEncryptionKeys();
+
+// Protocol parameters
+const pp = await ikaClient.getProtocolPublicParameters(dWallet);
+
+// Cache management
+ikaClient.invalidateCache();
+ikaClient.invalidateObjectCache();
+ikaClient.invalidateEncryptionKeyCache();
+```
+
+## Polling Options
+
+All `*InParticularState` methods accept:
+
+```typescript
+{
+    timeout?: number,          // default: 30000ms
+    interval?: number,         // default: 1000ms (initial)
+    maxInterval?: number,      // default: 5000ms (with backoff)
+    backoffMultiplier?: number, // default: 1.5
+    signal?: AbortSignal,      // for cancellation
+}
+```
+
+## UserShareEncryptionKeys
+
+```typescript
+// Create from seed
+const keys = await UserShareEncryptionKeys.fromRootSeedKey(seed, curve);
+
+// Serialize/deserialize for storage
+const bytes = keys.toShareEncryptionKeysBytes();
+const restored = UserShareEncryptionKeys.fromShareEncryptionKeysBytes(bytes);
+
+// Properties
+keys.getSuiAddress();            // Sui address for registration
+keys.getSigningPublicKeyBytes(); // Ed25519 public key bytes
+keys.encryptionKey;              // Class-groups public key
+keys.decryptionKey;              // Class-groups private key
+keys.curve;                      // Curve used
+
+// Operations
+await keys.getEncryptionKeySignature();     // Proof of ownership
+await keys.getUserOutputSignature(dWallet, userPublicOutput); // Authorize dWallet
+await keys.decryptUserShare(dWallet, encShare, pp); // Decrypt secret share
+```
+
+## Network Config
+
+```typescript
+import { getNetworkConfig } from '@ika.xyz/sdk';
+
+const config = getNetworkConfig('testnet'); // or 'mainnet'
+// config.packages.ikaPackage
+// config.packages.ikaDwallet2pcMpcPackage
+// config.objects.ikaDWalletCoordinator.objectID
+// config.objects.ikaSystemObject.objectID
+```
+
+## Error Classes
+
+```typescript
+import {
+    IkaClientError,       // Base error
+    ObjectNotFoundError,  // Object not found on chain
+    InvalidObjectError,   // Object parsing failed
+    NetworkError,         // Network operation failure
+    CacheError,           // Caching operation failure
+} from '@ika.xyz/sdk';
+```
+
+## Low-Level Transaction Builders
+
+For direct Move call construction (bypassing IkaTransaction):
+
+```typescript
+import { coordinatorTransactions } from '@ika.xyz/sdk';
+
+// All functions follow: (ikaConfig, coordinatorObjectRef, ...params, tx)
+coordinatorTransactions.registerSessionIdentifier(config, coordRef, sessionBytes, tx);
+coordinatorTransactions.requestDWalletDKGWithPublicUserSecretKeyShare(config, coordRef, ...params, tx);
+coordinatorTransactions.requestGlobalPresign(config, coordRef, ...params, tx);
+coordinatorTransactions.requestSignAndReturnId(config, coordRef, ...params, tx);
+coordinatorTransactions.approveMessage(config, coordRef, ...params, tx);
+// ... etc (50+ functions)
+```
+
+## Key Imports Summary
+
+```typescript
+// Core
+import { IkaClient, IkaTransaction, getNetworkConfig } from '@ika.xyz/sdk';
+
+// Keys
+import { UserShareEncryptionKeys } from '@ika.xyz/sdk';
+
+// Cryptography
+import {
+    prepareDKGAsync, createRandomSessionIdentifier,
+    createUserSignMessageWithPublicOutput, publicKeyFromDWalletOutput,
+    parseSignatureFromSignOutput, prepareImportedKeyDWalletVerification,
+} from '@ika.xyz/sdk';
+
+// Types
+import { Curve, SignatureAlgorithm, Hash } from '@ika.xyz/sdk';
+import type { DWallet, SharedDWallet, ZeroTrustDWallet, ImportedKeyDWallet } from '@ika.xyz/sdk';
+import type { Presign, Sign, EncryptedUserSecretKeyShare } from '@ika.xyz/sdk';
+import type { DWalletWithState, PresignWithState, SignWithState } from '@ika.xyz/sdk';
+
+// Validation
+import {
+    validateHashSignatureCombination, validateCurveSignatureAlgorithm,
+    fromCurveToNumber, fromSignatureAlgorithmToNumber, fromHashToNumber,
+} from '@ika.xyz/sdk';
+
+// Low-level
+import { coordinatorTransactions, systemTransactions } from '@ika.xyz/sdk';
+```

--- a/skills/ika-sdk/references/api-reference.md
+++ b/skills/ika-sdk/references/api-reference.md
@@ -1,0 +1,662 @@
+# API Reference
+
+Complete API for IkaClient, IkaTransaction, cryptography functions, and UserShareEncryptionKeys.
+
+## IkaClient
+
+### Constructor
+
+```typescript
+new IkaClient({ suiClient, config, cache?, encryptionKeyOptions? }: IkaClientOptions)
+```
+
+### Properties
+
+```typescript
+public ikaConfig: IkaConfig               // The Ika network configuration (package IDs, object refs)
+public encryptionKeyOptions: EncryptionKeyOptions  // Default encryption key options
+```
+
+### Initialization
+
+```typescript
+await ikaClient.initialize(): Promise<void>
+```
+
+### Query: dWallets
+
+```typescript
+// Single dWallet
+getDWallet(dwalletID: string): Promise<DWallet>
+
+// dWallet in specific state (polls until reached)
+getDWalletInParticularState<S extends DWalletState>(
+    dwalletID: string, state: S, options?: PollingOptions
+): Promise<DWalletWithState<S>>
+
+// Batch fetch
+getMultipleDWallets(dwalletIDs: string[]): Promise<DWallet[]>
+
+// Owned capabilities (paginated)
+getOwnedDWalletCaps(address: string, cursor?: string, limit?: number): Promise<{
+    dWalletCaps: DWalletCap[];
+    cursor: string | null | undefined;
+    hasNextPage: boolean;
+}>
+```
+
+### Query: Presigns
+
+```typescript
+getPresign(presignID: string): Promise<Presign>
+getPresignInParticularState<S extends PresignState>(
+    presignID: string, state: S, options?: PollingOptions
+): Promise<PresignWithState<S>>
+```
+
+### Query: Signs
+
+```typescript
+getSign<C extends Curve>(
+    signID: string, curve: C,
+    signatureAlgorithm: ValidSignatureAlgorithmForCurve<C>
+): Promise<Sign>
+
+getSignInParticularState<S extends SignState>(
+    signID: string, curve: Curve,
+    signatureAlgorithm: SignatureAlgorithm,
+    state: S, options?: PollingOptions
+): Promise<SignWithState<S>>
+```
+
+Note: `getSign` auto-parses signature when state is `Completed`.
+
+### Query: Encrypted User Secret Key Shares
+
+```typescript
+getEncryptedUserSecretKeyShare(id: string): Promise<EncryptedUserSecretKeyShare>
+getEncryptedUserSecretKeyShareInParticularState<S extends EncryptedUserSecretKeyShareState>(
+    id: string, state: S, options?: PollingOptions
+): Promise<EncryptedUserSecretKeyShareWithState<S>>
+```
+
+### Query: Partial User Signatures
+
+```typescript
+getPartialUserSignature(id: string): Promise<PartialUserSignature>
+getPartialUserSignatureInParticularState<S extends PartialUserSignatureState>(
+    id: string, state: S, options?: PollingOptions
+): Promise<PartialUserSignatureWithState<S>>
+```
+
+### Encryption Keys
+
+```typescript
+getAllNetworkEncryptionKeys(): Promise<NetworkEncryptionKey[]>
+getLatestNetworkEncryptionKey(): Promise<NetworkEncryptionKey>
+getNetworkEncryptionKey(encryptionKeyID: string): Promise<NetworkEncryptionKey>
+getDWalletNetworkEncryptionKey(dwalletID: string): Promise<NetworkEncryptionKey>
+getConfiguredNetworkEncryptionKey(): Promise<NetworkEncryptionKey>
+getActiveEncryptionKey(address: string): Promise<EncryptionKey>
+
+// Options management
+getEncryptionKeyOptions(): EncryptionKeyOptions
+setEncryptionKeyOptions(options: EncryptionKeyOptions): void
+setEncryptionKeyID(encryptionKeyID: string): void
+```
+
+### Protocol Parameters
+
+```typescript
+// Auto-detects encryption key from dWallet or uses configured key
+getProtocolPublicParameters(dWallet?: DWallet, curve?: Curve): Promise<Uint8Array>
+
+// Cache checks
+getCachedProtocolPublicParameters(encryptionKeyID: string, curve: Curve): Uint8Array | undefined
+isProtocolPublicParametersCached(encryptionKeyID: string, curve: Curve): boolean
+```
+
+### Cache Management
+
+```typescript
+invalidateCache(): void                           // All caches
+invalidateObjectCache(): void                     // Coordinator + system objects only
+invalidateEncryptionKeyCache(): void              // Encryption keys only
+invalidateProtocolPublicParametersCache(          // Protocol params (optional filters)
+    encryptionKeyID?: string, curve?: Curve
+): void
+```
+
+---
+
+## IkaTransaction
+
+### Constructor
+
+```typescript
+new IkaTransaction({
+    ikaClient: IkaClient,
+    transaction: Transaction,            // Sui Transaction
+    userShareEncryptionKeys?: UserShareEncryptionKeys,
+})
+```
+
+### Encryption Key Registration
+
+```typescript
+registerEncryptionKey({ curve: Curve }): Promise<IkaTransaction>
+```
+
+### DKG (Create dWallet)
+
+```typescript
+// Standard DKG (zero-trust)
+requestDWalletDKG<S extends SignatureAlgorithm = never>({
+    dkgRequestInput: DKGRequestInput,
+    ikaCoin: TransactionObjectArgument,
+    suiCoin: TransactionObjectArgument,
+    sessionIdentifier: TransactionObjectArgument,
+    dwalletNetworkEncryptionKeyId: string,
+    curve: Curve,
+    signDuringDKGRequest?: {           // optional: sign during DKG
+        message: Uint8Array,
+        presign: Presign,
+        verifiedPresignCap: TransactionObjectArgument,
+        hashScheme: ValidHashForSignature<S>,
+        signatureAlgorithm: S,
+    },
+}): Promise<TransactionResult>
+// Returns [dwalletCap, signId]
+
+// DKG with public user share (shared mode)
+requestDWalletDKGWithPublicUserShare<S extends SignatureAlgorithm = never>({
+    publicKeyShareAndProof: Uint8Array,
+    publicUserSecretKeyShare: Uint8Array,
+    userPublicOutput: Uint8Array,
+    ikaCoin: TransactionObjectArgument,
+    suiCoin: TransactionObjectArgument,
+    sessionIdentifier: TransactionObjectArgument,
+    dwalletNetworkEncryptionKeyId: string,
+    curve: Curve,
+    signDuringDKGRequest?: {           // optional: sign during DKG
+        message: Uint8Array,
+        presign: Presign,
+        verifiedPresignCap: TransactionObjectArgument,
+        hashScheme: ValidHashForSignature<S>,
+        signatureAlgorithm: S,
+    },
+}): Promise<TransactionResult>
+```
+
+### Accept Encrypted User Share
+
+```typescript
+// For DKG dWallets
+acceptEncryptedUserShare({
+    dWallet: ZeroTrustDWallet | ImportedKeyDWallet,
+    userPublicOutput: Uint8Array,
+    encryptedUserSecretKeyShareId: string,
+}): Promise<IkaTransaction>
+
+// For transferred dWallets
+acceptEncryptedUserShare({
+    dWallet: ZeroTrustDWallet | ImportedKeyDWallet,
+    sourceEncryptionKey: EncryptionKey,
+    sourceEncryptedUserSecretKeyShare: EncryptedUserSecretKeyShare,
+    destinationEncryptedUserSecretKeyShare: EncryptedUserSecretKeyShare,
+}): Promise<IkaTransaction>
+```
+
+### Convert to Shared Mode
+
+```typescript
+makeDWalletUserSecretKeySharesPublic({
+    dWallet: ZeroTrustDWallet | ImportedKeyDWallet,
+    secretShare: Uint8Array,
+    ikaCoin: TransactionObjectArgument,
+    suiCoin: TransactionObjectArgument,
+}): IkaTransaction
+```
+
+### Presign
+
+```typescript
+// dWallet-specific presign (for ECDSA k1/r1 with imported key dWallets)
+requestPresign({
+    dWallet: DWallet,
+    signatureAlgorithm: SignatureAlgorithm,
+    ikaCoin: TransactionObjectArgument,
+    suiCoin: TransactionObjectArgument,
+}): TransactionObjectArgument
+
+// Global presign
+requestGlobalPresign<C extends Curve>({
+    dwalletNetworkEncryptionKeyId: string,
+    curve: C,
+    signatureAlgorithm: ValidSignatureAlgorithmForCurve<C>,
+    ikaCoin: TransactionObjectArgument,
+    suiCoin: TransactionObjectArgument,
+}): TransactionObjectArgument
+```
+
+### Message Approval
+
+```typescript
+approveMessage<C extends Curve, S extends ValidSignatureAlgorithmForCurve<C>>({
+    dWalletCap: TransactionObjectArgument | string,
+    curve: C,
+    signatureAlgorithm: S,
+    hashScheme: ValidHashForSignature<S>,
+    message: Uint8Array,
+}): TransactionObjectArgument
+
+approveImportedKeyMessage<C extends Curve, S extends ValidSignatureAlgorithmForCurve<C>>({
+    dWalletCap: TransactionObjectArgument | string,
+    curve: C,
+    signatureAlgorithm: S,
+    hashScheme: ValidHashForSignature<S>,
+    message: Uint8Array,
+}): TransactionObjectArgument
+```
+
+### Verify Presign
+
+```typescript
+// From presign object
+verifyPresignCap({ presign: Presign }): TransactionObjectArgument
+
+// From unverified cap
+verifyPresignCap({
+    unverifiedPresignCap: TransactionObjectArgument,
+}): TransactionObjectArgument
+```
+
+### Sign
+
+```typescript
+requestSign<S extends SignatureAlgorithm>({
+    dWallet: ZeroTrustDWallet | SharedDWallet,
+    messageApproval: TransactionObjectArgument,
+    hashScheme: ValidHashForSignature<S>,
+    verifiedPresignCap: TransactionObjectArgument,
+    presign: Presign,
+    message: Uint8Array,
+    signatureScheme: S,
+    ikaCoin: TransactionObjectArgument,
+    suiCoin: TransactionObjectArgument,
+    encryptedUserSecretKeyShare?: EncryptedUserSecretKeyShare,  // zero-trust option 1
+    secretShare?: Uint8Array,                                   // zero-trust option 2 (requires publicOutput)
+    publicOutput?: Uint8Array,                                  // zero-trust option 2
+    // For shared: uses public_user_secret_key_share automatically
+}): Promise<TransactionObjectArgument>
+
+requestSignWithImportedKey<S extends SignatureAlgorithm>({
+    dWallet: ImportedKeyDWallet | ImportedSharedDWallet,
+    importedKeyMessageApproval: TransactionObjectArgument,
+    hashScheme: ValidHashForSignature<S>,
+    verifiedPresignCap: TransactionObjectArgument,
+    presign: Presign,
+    message: Uint8Array,
+    signatureScheme?: S,  // optional, defaults to ECDSASecp256k1
+    ikaCoin: TransactionObjectArgument,
+    suiCoin: TransactionObjectArgument,
+    encryptedUserSecretKeyShare?: EncryptedUserSecretKeyShare,
+    secretShare?: Uint8Array,
+    publicOutput?: Uint8Array,
+}): Promise<TransactionObjectArgument>
+```
+
+### Future Sign (Two-Phase)
+
+```typescript
+// Phase 1: Request partial signature
+requestFutureSign<S extends SignatureAlgorithm>({
+    dWallet: ZeroTrustDWallet | SharedDWallet,
+    hashScheme: ValidHashForSignature<S>,
+    verifiedPresignCap: TransactionObjectArgument,
+    presign: Presign,
+    message: Uint8Array,
+    signatureScheme: S,
+    ikaCoin: TransactionObjectArgument,
+    suiCoin: TransactionObjectArgument,
+    encryptedUserSecretKeyShare?: EncryptedUserSecretKeyShare,
+    secretShare?: Uint8Array,
+    publicOutput?: Uint8Array,
+}): Promise<TransactionObjectArgument>
+
+// Phase 2: Complete with approval
+futureSign({
+    partialUserSignatureCap: TransactionObjectArgument | string,
+    messageApproval: TransactionObjectArgument,
+    ikaCoin: TransactionObjectArgument,
+    suiCoin: TransactionObjectArgument,
+}): TransactionObjectArgument
+
+// Imported key variants
+requestFutureSignWithImportedKey<S>({...}): Promise<TransactionObjectArgument>
+futureSignWithImportedKey({...}): TransactionObjectArgument
+```
+
+### Key Import
+
+```typescript
+requestImportedKeyDWalletVerification({
+    importDWalletVerificationRequestInput: ImportDWalletVerificationRequestInput,
+    curve: Curve,
+    signerPublicKey: Uint8Array,
+    sessionIdentifier: TransactionObjectArgument,
+    ikaCoin: TransactionObjectArgument,
+    suiCoin: TransactionObjectArgument,
+}): Promise<TransactionObjectArgument>
+```
+
+### Transfer (Re-Encrypt)
+
+```typescript
+// With encrypted share (auto-decrypts internally)
+requestReEncryptUserShareFor({
+    dWallet: ZeroTrustDWallet | ImportedKeyDWallet,
+    sourceEncryptedUserSecretKeyShare: EncryptedUserSecretKeyShare,
+    destinationEncryptionKeyAddress: string,
+    ikaCoin: TransactionObjectArgument,
+    suiCoin: TransactionObjectArgument,
+}): Promise<IkaTransaction>
+
+// With decrypted secret share
+requestReEncryptUserShareFor({
+    dWallet: ZeroTrustDWallet | ImportedKeyDWallet,
+    sourceSecretShare: Uint8Array,
+    sourceEncryptedUserSecretKeyShare: EncryptedUserSecretKeyShare,
+    destinationEncryptionKeyAddress: string,
+    ikaCoin: TransactionObjectArgument,
+    suiCoin: TransactionObjectArgument,
+}): Promise<IkaTransaction>
+```
+
+### Session Management
+
+```typescript
+createSessionIdentifier(): TransactionObjectArgument    // Random + register
+registerSessionIdentifier(sessionIdentifier: Uint8Array): TransactionObjectArgument
+```
+
+### Utility
+
+```typescript
+hasDWallet({ dwalletId: string }): TransactionObjectArgument
+getDWallet({ dwalletId: string }): TransactionObjectArgument
+```
+
+---
+
+## Cryptography Functions
+
+### DKG Preparation
+
+```typescript
+// Full async flow (fetches protocol params from network)
+prepareDKGAsync(
+    ikaClient: IkaClient, curve: Curve,
+    userShareEncryptionKeys: UserShareEncryptionKeys,
+    bytesToHash: Uint8Array, senderAddress: string,
+): Promise<DKGRequestInput>
+// Returns { userDKGMessage, userPublicOutput, encryptedUserShareAndProof, userSecretKeyShare }
+
+// Lower-level (requires protocol params)
+prepareDKG(
+    protocolPublicParameters: Uint8Array, curve: Curve,
+    encryptionKey: Uint8Array, bytesToHash: Uint8Array,
+    senderAddress: string,
+): Promise<DKGRequestInput>
+```
+
+### Key Import
+
+```typescript
+prepareImportedKeyDWalletVerification(
+    ikaClient: IkaClient, curve: Curve,
+    bytesToHash: Uint8Array, senderAddress: string,
+    userShareEncryptionKeys: UserShareEncryptionKeys,
+    privateKey: Uint8Array,
+): Promise<ImportDWalletVerificationRequestInput>
+// Returns { userPublicOutput, userMessage, encryptedUserShareAndProof }
+```
+
+### Signing
+
+```typescript
+// Create user's partial signature (with public DKG output)
+createUserSignMessageWithPublicOutput<C, S, H>(
+    protocolPublicParameters: Uint8Array,
+    publicOutput: Uint8Array,
+    userSecretKeyShare: Uint8Array,
+    presign: Uint8Array,
+    message: Uint8Array,
+    hash: H, signatureAlgorithm: S, curve: C,
+): Promise<Uint8Array>
+
+// Create user's partial signature (with centralized DKG output)
+createUserSignMessageWithCentralizedOutput<C, S, H>(
+    protocolPublicParameters: Uint8Array,
+    centralizedDkgOutput: Uint8Array,
+    userSecretKeyShare: Uint8Array,
+    presign: Uint8Array,
+    message: Uint8Array,
+    hash: H, signatureAlgorithm: S, curve: C,
+): Promise<Uint8Array>
+```
+
+### Public Key Extraction
+
+```typescript
+publicKeyFromDWalletOutput(curve: Curve, dWalletOutput: Uint8Array): Promise<Uint8Array>
+publicKeyFromCentralizedDKGOutput(curve: Curve, centralizedDkgOutput: Uint8Array): Promise<Uint8Array>
+```
+
+### Signature Parsing
+
+```typescript
+parseSignatureFromSignOutput<C extends Curve, S>(
+    curve: C, signatureAlgorithm: S, signatureOutput: Uint8Array,
+): Promise<Uint8Array>
+```
+
+### Verification
+
+```typescript
+verifyUserShare(
+    curve: Curve, userSecretKeyShare: Uint8Array,
+    userDKGOutput: Uint8Array, networkDkgPublicOutput: Uint8Array,
+): Promise<boolean>
+
+verifySecpSignature<C, S, H>(
+    publicKey: Uint8Array, signature: Uint8Array, message: Uint8Array,
+    networkDkgPublicOutput: Uint8Array,
+    hash: H, signatureAlgorithm: S, curve: C,
+): Promise<boolean>
+
+userAndNetworkDKGOutputMatch(
+    curve: Curve, userPublicOutput: Uint8Array, networkDKGOutput: Uint8Array,
+): Promise<boolean>
+
+verifyAndGetDWalletDKGPublicOutput(
+    dWallet: DWallet, encryptedUserSecretKeyShare: EncryptedUserSecretKeyShare,
+    publicKey: PublicKey,
+): Promise<Uint8Array>
+```
+
+### Encryption
+
+```typescript
+createClassGroupsKeypair(seed: Uint8Array, curve: Curve): Promise<{
+    encryptionKey: Uint8Array; decryptionKey: Uint8Array;
+}>
+
+encryptSecretShare(
+    curve: Curve, userSecretKeyShare: Uint8Array,
+    encryptionKey: Uint8Array, protocolPublicParameters: Uint8Array,
+): Promise<Uint8Array>
+```
+
+### Session
+
+```typescript
+createRandomSessionIdentifier(): Uint8Array        // 32 random bytes
+sessionIdentifierDigest(
+    bytesToHash: Uint8Array, senderAddressBytes: Uint8Array,
+): Uint8Array                                        // KECCAK-256 digest
+```
+
+### Protocol Parameters Conversion
+
+```typescript
+networkDkgPublicOutputToProtocolPublicParameters(
+    curve: Curve, network_dkg_public_output: Uint8Array,
+): Promise<Uint8Array>
+
+reconfigurationPublicOutputToProtocolPublicParameters(
+    curve: Curve, reconfiguration_public_output: Uint8Array,
+    network_dkg_public_output: Uint8Array,
+): Promise<Uint8Array>
+```
+
+---
+
+## UserShareEncryptionKeys
+
+### Creation
+
+```typescript
+// From seed (deterministic)
+static fromRootSeedKey(rootSeedKey: Uint8Array, curve: Curve): Promise<UserShareEncryptionKeys>
+
+// From serialized bytes
+static fromShareEncryptionKeysBytes(bytes: Uint8Array): UserShareEncryptionKeys
+```
+
+### Serialization
+
+```typescript
+toShareEncryptionKeysBytes(): Uint8Array
+```
+
+### Properties
+
+```typescript
+encryptionKey: Uint8Array       // Class-groups public key
+decryptionKey: Uint8Array       // Class-groups private key
+curve: Curve                     // Curve used for generation
+```
+
+### Identity
+
+```typescript
+getSuiAddress(): string                  // Sui address from Ed25519 signing key
+getSigningPublicKeyBytes(): Uint8Array   // Ed25519 public key raw bytes
+getPublicKey(): Ed25519PublicKey          // Full Ed25519 public key object
+```
+
+### Cryptographic Operations
+
+```typescript
+// Proof of encryption key ownership
+getEncryptionKeySignature(): Promise<Uint8Array>
+
+// Authorize dWallet after DKG (signs public output)
+getUserOutputSignature(dWallet: DWallet, userPublicOutput: Uint8Array): Promise<Uint8Array>
+
+// Authorize transferred dWallet (verifies source encryption)
+getUserOutputSignatureForTransferredDWallet(
+    dWallet: DWallet,
+    sourceEncryptedUserSecretKeyShare: EncryptedUserSecretKeyShare,
+    sourceEncryptionKey: EncryptionKey,
+): Promise<Uint8Array>
+
+// Decrypt encrypted secret share
+decryptUserShare(
+    dWallet: DWallet,
+    encryptedUserSecretKeyShare: EncryptedUserSecretKeyShare,
+    protocolPublicParameters: Uint8Array,
+): Promise<{ verifiedPublicOutput: Uint8Array; secretShare: Uint8Array; }>
+
+// Verify a signature
+verifySignature(message: Uint8Array, signature: Uint8Array): Promise<boolean>
+```
+
+---
+
+## Low-Level Transaction Builders
+
+```typescript
+import { coordinatorTransactions, systemTransactions } from '@ika.xyz/sdk';
+```
+
+All coordinator functions follow: `(ikaConfig, coordinatorObjectRef, ...params, tx)`.
+
+Key functions (50+):
+
+```typescript
+// DKG
+registerSessionIdentifier(config, coordRef, sessionBytes, tx)
+requestDWalletDKGWithPublicUserSecretKeyShare(config, coordRef, ...params, tx)
+requestDWalletDKG(config, coordRef, ...params, tx)
+
+// Presign
+requestGlobalPresign(config, coordRef, ...params, tx)
+requestPresign(config, coordRef, ...params, tx)
+
+// Sign
+requestSignAndReturnId(config, coordRef, ...params, tx)
+requestSignWithImportedKey(config, coordRef, ...params, tx)
+
+// Future Sign
+requestFutureSignAndReturnId(config, coordRef, ...params, tx)
+futureSign(config, coordRef, ...params, tx)
+
+// Approval
+approveMessage(config, coordRef, ...params, tx)
+approveImportedKeyMessage(config, coordRef, ...params, tx)
+
+// Verification
+verifyPresignCap(config, coordRef, ...params, tx)
+
+// Encryption
+registerEncryptionKey(config, coordRef, ...params, tx)
+getActiveEncryptionKey(config, coordRef, address, tx)
+
+// Transfer
+requestReEncryptUserShareFor(config, coordRef, ...params, tx)
+acceptEncryptedUserShare(config, coordRef, ...params, tx)
+
+// Convert
+makeDWalletUserSecretKeySharesPublic(config, coordRef, ...params, tx)
+
+// Import
+requestImportedKeyDWalletVerification(config, coordRef, ...params, tx)
+```
+
+---
+
+## PollingOptions
+
+All `*InParticularState` methods accept:
+
+```typescript
+{
+    timeout?: number,          // default: 30000ms
+    interval?: number,         // default: 1000ms (initial)
+    maxInterval?: number,      // default: 5000ms (max with backoff)
+    backoffMultiplier?: number, // default: 1.5
+    signal?: AbortSignal,      // for cancellation
+}
+```
+
+## Error Classes
+
+```typescript
+IkaClientError              // Base error class
+├── ObjectNotFoundError     // Object not found on chain
+├── InvalidObjectError      // Object parsing/validation failed
+├── NetworkError            // Network operation failure
+└── CacheError              // Caching operation failure
+```

--- a/skills/ika-sdk/references/flows.md
+++ b/skills/ika-sdk/references/flows.md
@@ -1,0 +1,397 @@
+# End-to-End Flows
+
+Complete flows for every dWallet operation type.
+
+## Prerequisites (All Flows)
+
+```typescript
+import { getNetworkConfig, IkaClient, IkaTransaction, UserShareEncryptionKeys,
+    Curve, SignatureAlgorithm, Hash, prepareDKGAsync, createRandomSessionIdentifier,
+    createUserSignMessageWithPublicOutput, publicKeyFromDWalletOutput,
+    parseSignatureFromSignOutput, prepareImportedKeyDWalletVerification,
+} from '@ika.xyz/sdk';
+import { getJsonRpcFullnodeUrl, SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+import { Transaction } from '@mysten/sui/transactions';
+
+const suiClient = new SuiJsonRpcClient({
+    url: getJsonRpcFullnodeUrl('testnet'), network: 'testnet',
+});
+const ikaClient = new IkaClient({
+    suiClient, config: getNetworkConfig('testnet'), cache: true,
+});
+await ikaClient.initialize();
+const networkKey = await ikaClient.getLatestNetworkEncryptionKey();
+```
+
+---
+
+## Flow 1: Shared dWallet (Full Lifecycle)
+
+Most common flow. Network signs autonomously - no user participation at sign time.
+
+### Step 1: Create Encryption Keys
+
+```typescript
+const keys = await UserShareEncryptionKeys.fromRootSeedKey(
+    new TextEncoder().encode('your-deterministic-seed'),
+    Curve.SECP256K1,
+);
+```
+
+### Step 2: Register Encryption Key
+
+```typescript
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+await ikaTx.registerEncryptionKey({ curve: Curve.SECP256K1 });
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+```
+
+### Step 3: DKG (Create dWallet with Public Share)
+
+```typescript
+const sessionIdBytes = createRandomSessionIdentifier();
+const dkgData = await prepareDKGAsync(ikaClient, Curve.SECP256K1, keys, sessionIdBytes, senderAddress);
+
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+const sessionId = ikaTx.registerSessionIdentifier(sessionIdBytes);
+const [dwalletCap, signId] = await ikaTx.requestDWalletDKGWithPublicUserShare({
+    publicKeyShareAndProof: dkgData.userDKGMessage,
+    publicUserSecretKeyShare: dkgData.userSecretKeyShare,
+    userPublicOutput: dkgData.userPublicOutput,
+    ikaCoin: tx.splitCoins(tx.object(ikaCoinId), [1_000_000]),
+    suiCoin: tx.splitCoins(tx.gas, [1_000_000]),
+    sessionIdentifier: sessionId,
+    dwalletNetworkEncryptionKeyId: networkKey.id,
+    curve: Curve.SECP256K1,
+});
+const result = await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+// Extract dwalletId from result events
+```
+
+### Step 4: Wait for DKG Completion & Get Public Key
+
+```typescript
+const dWallet = await ikaClient.getDWalletInParticularState(dwalletId, 'Active');
+const publicKey = await publicKeyFromDWalletOutput(
+    Curve.SECP256K1, Uint8Array.from(dWallet.state.Active.public_output),
+);
+// publicKey → derive ETH/BTC address
+```
+
+### Step 5: Request Presign
+
+```typescript
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx });
+const presignRef = ikaTx.requestGlobalPresign({
+    dwalletNetworkEncryptionKeyId: networkKey.id,
+    curve: Curve.SECP256K1,
+    signatureAlgorithm: SignatureAlgorithm.ECDSASecp256k1,
+    ikaCoin: tx.splitCoins(tx.object(ikaCoinId), [1_000_000]),
+    suiCoin: tx.splitCoins(tx.gas, [1_000_000]),
+});
+const result = await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+// Extract presignId from result events
+```
+
+### Step 6: Create User Signature & Request Sign
+
+```typescript
+const presign = await ikaClient.getPresignInParticularState(presignId, 'Completed');
+const pp = await ikaClient.getProtocolPublicParameters(dWallet);
+
+const msgSig = await createUserSignMessageWithPublicOutput(
+    pp, Uint8Array.from(dWallet.state.Active.public_output),
+    Uint8Array.from(dWallet.public_user_secret_key_share),
+    Uint8Array.from(presign.state.Completed.presign),
+    message, Hash.KECCAK256, SignatureAlgorithm.ECDSASecp256k1, Curve.SECP256K1,
+);
+
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+const signRef = await ikaTx.requestSign({
+    dWallet,
+    messageApproval: ikaTx.approveMessage({
+        dWalletCap, curve: Curve.SECP256K1,
+        signatureAlgorithm: SignatureAlgorithm.ECDSASecp256k1,
+        hashScheme: Hash.KECCAK256, message,
+    }),
+    hashScheme: Hash.KECCAK256,
+    verifiedPresignCap: ikaTx.verifyPresignCap({ presign }),
+    presign, message,
+    signatureScheme: SignatureAlgorithm.ECDSASecp256k1,
+    ikaCoin: tx.splitCoins(tx.object(ikaCoinId), [1_000_000]),
+    suiCoin: tx.splitCoins(tx.gas, [1_000_000]),
+});
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+```
+
+### Step 7: Retrieve Final Signature
+
+```typescript
+const sign = await ikaClient.getSignInParticularState(
+    signId, Curve.SECP256K1, SignatureAlgorithm.ECDSASecp256k1, 'Completed',
+);
+// sign.state.Completed.signature is already parsed, ready for broadcast
+```
+
+---
+
+## Flow 2: Zero-Trust dWallet
+
+User must participate in every signing operation. Maximum security.
+
+### DKG (uses requestDWalletDKG instead of WithPublicUserShare)
+
+```typescript
+const [dwalletCap, signId] = await ikaTx.requestDWalletDKG({
+    dkgRequestInput: dkgData,
+    ikaCoin: tx.splitCoins(tx.object(ikaCoinId), [1_000_000]),
+    suiCoin: tx.splitCoins(tx.gas, [1_000_000]),
+    sessionIdentifier: sessionId,
+    dwalletNetworkEncryptionKeyId: networkKey.id,
+    curve: Curve.SECP256K1,
+});
+```
+
+### Accept Encrypted Share (required for zero-trust)
+
+```typescript
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+await ikaTx.acceptEncryptedUserShare({
+    dWallet,
+    userPublicOutput: dkgData.userPublicOutput,
+    encryptedUserSecretKeyShareId: encShareId,
+});
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+```
+
+### Decrypt User Share (for signing)
+
+```typescript
+const encShare = await ikaClient.getEncryptedUserSecretKeyShareInParticularState(
+    encShareId, 'KeyHolderSigned',
+);
+const pp = await ikaClient.getProtocolPublicParameters(dWallet);
+const { secretShare, verifiedPublicOutput } = await keys.decryptUserShare(
+    dWallet, encShare, pp,
+);
+// Use secretShare in createUserSignMessageWithPublicOutput
+```
+
+### Sign (pass secretShare or encryptedUserSecretKeyShare)
+
+```typescript
+await ikaTx.requestSign({
+    dWallet,
+    messageApproval: ikaTx.approveMessage({ ... }),
+    hashScheme: Hash.KECCAK256,
+    verifiedPresignCap: ikaTx.verifyPresignCap({ presign }),
+    presign, message,
+    signatureScheme: SignatureAlgorithm.ECDSASecp256k1,
+    encryptedUserSecretKeyShare: encShare,  // OR secretShare: decryptedShare
+    ikaCoin: ..., suiCoin: ...,
+});
+```
+
+---
+
+## Flow 3: Imported Key dWallet
+
+Import an existing private key into the Ika network.
+
+### Prepare Import Data
+
+```typescript
+const sessionIdBytes = createRandomSessionIdentifier();
+const importData = await prepareImportedKeyDWalletVerification(
+    ikaClient, Curve.SECP256K1, sessionIdBytes, senderAddress, keys, privateKey,
+);
+// importData: { userPublicOutput, userMessage, encryptedUserShareAndProof }
+```
+
+### Request Import Verification
+
+```typescript
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+const sessionId = ikaTx.registerSessionIdentifier(sessionIdBytes);
+await ikaTx.requestImportedKeyDWalletVerification({
+    importDWalletVerificationRequestInput: importData,
+    ikaCoin: tx.splitCoins(tx.object(ikaCoinId), [1_000_000]),
+    suiCoin: tx.splitCoins(tx.gas, [1_000_000]),
+    sessionIdentifier: sessionId,
+    signerPublicKey: keys.getSigningPublicKeyBytes(),
+    curve: Curve.SECP256K1,
+});
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+```
+
+### Sign with Imported Key
+
+```typescript
+await ikaTx.requestSignWithImportedKey({
+    dWallet: importedKeyDWallet,
+    importedKeyMessageApproval: ikaTx.approveImportedKeyMessage({
+        dWalletCap: activeDWallet.dwallet_cap_id, curve: Curve.SECP256K1,
+        signatureAlgorithm: SignatureAlgorithm.ECDSASecp256k1,
+        hashScheme: Hash.KECCAK256, message,
+    }),
+    hashScheme: Hash.KECCAK256,
+    verifiedPresignCap: ikaTx.verifyPresignCap({ presign }),
+    presign, message,
+    signatureScheme: SignatureAlgorithm.ECDSASecp256k1,
+    ikaCoin: ..., suiCoin: ...,
+});
+```
+
+---
+
+## Flow 4: Transfer dWallet
+
+Re-encrypt user share for a different address.
+
+### Sender: Re-Encrypt Share
+
+```typescript
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: senderKeys });
+
+// With encrypted share (auto-decrypts internally)
+await ikaTx.requestReEncryptUserShareFor({
+    dWallet,
+    sourceEncryptedUserSecretKeyShare: encShare,
+    destinationEncryptionKeyAddress: recipientAddress,
+    ikaCoin: ..., suiCoin: ...,
+});
+
+// OR with decrypted secret share
+await ikaTx.requestReEncryptUserShareFor({
+    dWallet,
+    sourceSecretShare: decryptedSecretShare,
+    sourceEncryptedUserSecretKeyShare: encShare,
+    destinationEncryptionKeyAddress: recipientAddress,
+    ikaCoin: ..., suiCoin: ...,
+});
+
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+```
+
+### Recipient: Accept Transferred Share
+
+```typescript
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: recipientKeys });
+await ikaTx.acceptEncryptedUserShare({
+    dWallet,
+    sourceEncryptionKey: senderEncryptionKey,   // MUST be known out-of-band, not fetched
+    sourceEncryptedUserSecretKeyShare: sourceEncShare,
+    destinationEncryptedUserSecretKeyShare: destEncShare,
+});
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+```
+
+**Security**: `sourceEncryptionKey` must be known to the recipient beforehand (not fetched from network) to prevent MITM.
+
+---
+
+## Flow 5: Future Sign (Two-Phase Signing)
+
+Compute partial signature first, approve message later. Useful for DAOs/governance where approval is separate from computation.
+
+### Phase 1: Request Future Sign (off-chain computation)
+
+```typescript
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+const futureSignRef = await ikaTx.requestFutureSign({
+    dWallet,
+    hashScheme: Hash.SHA256,
+    verifiedPresignCap: ikaTx.verifyPresignCap({ presign }),
+    presign, message,
+    signatureScheme: SignatureAlgorithm.Taproot,
+    ikaCoin: tx.splitCoins(tx.object(ikaCoinId), [1_000_000]),
+    suiCoin: tx.splitCoins(tx.gas, [1_000_000]),
+});
+const result = await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+// Extract partialUserSignatureId from events
+```
+
+### Wait for Partial Signature
+
+```typescript
+const partialSig = await ikaClient.getPartialUserSignatureInParticularState(
+    partialUserSignatureId, 'NetworkVerificationCompleted',
+);
+```
+
+### Phase 2: Complete Sign (with approval)
+
+```typescript
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx });
+const signRef = ikaTx.futureSign({
+    partialUserSignatureCap: partialSig.cap_id,
+    messageApproval: ikaTx.approveMessage({
+        dWalletCap, curve: Curve.SECP256K1,
+        signatureAlgorithm: SignatureAlgorithm.Taproot,
+        hashScheme: Hash.SHA256, message,
+    }),
+    ikaCoin: ..., suiCoin: ...,
+});
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+```
+
+---
+
+## Flow 6: Convert Zero-Trust to Shared
+
+```typescript
+// Must have saved userSecretKeyShare from original DKG
+const tx = new Transaction();
+const ikaTx = new IkaTransaction({ ikaClient, transaction: tx, userShareEncryptionKeys: keys });
+ikaTx.makeDWalletUserSecretKeySharesPublic({
+    dWallet: zeroTrustDWallet,
+    secretShare: savedUserSecretKeyShare,
+    ikaCoin: tx.splitCoins(tx.object(ikaCoinId), [1_000_000]),
+    suiCoin: tx.splitCoins(tx.gas, [1_000_000]),
+});
+await suiClient.core.signAndExecuteTransaction({ transaction: tx, signer: keypair });
+```
+
+---
+
+## Chain-Specific Configurations
+
+| Target Chain | Curve | SignatureAlgorithm | Hash | Notes |
+|---|---|---|---|---|
+| Ethereum | SECP256K1 | ECDSASecp256k1 | KECCAK256 | Standard ECDSA |
+| Bitcoin Legacy | SECP256K1 | ECDSASecp256k1 | DoubleSHA256 | P2PKH/P2SH |
+| Bitcoin Taproot | SECP256K1 | Taproot | SHA256 | BIP-340 Schnorr |
+| Solana | ED25519 | EdDSA | SHA512 | Ed25519 signing |
+| WebAuthn/P-256 | SECP256R1 | ECDSASecp256r1 | SHA256 | Passkeys |
+| Substrate | RISTRETTO | SchnorrkelSubstrate | Merlin | Polkadot/Kusama |
+
+---
+
+## KeySpring Pattern
+
+Derive cross-chain wallet from any authentication source.
+
+```typescript
+// Any deterministic seed source works:
+// - Wallet signature: await wallet.signMessage('ika-keyspring-v1')
+// - WebAuthn PRF: prf.results.first (from navigator.credentials.get)
+// - KDF output: any 32+ byte deterministic secret
+
+const seed = await wallet.signMessage('ika-keyspring-v1');
+const keys = await UserShareEncryptionKeys.fromRootSeedKey(
+    new Uint8Array(seed), Curve.SECP256K1,
+);
+// Proceed with DKG → the resulting dWallet public key maps to an ETH address
+```
+
+Key insight: `fromRootSeedKey` is deterministic. Same seed always produces same keys. The dWallet's public key deterministically maps to addresses on target chains.

--- a/skills/ika-sdk/references/types-and-validation.md
+++ b/skills/ika-sdk/references/types-and-validation.md
@@ -1,0 +1,457 @@
+# Types and Validation
+
+Type system, enums, curve/signature/hash validation, and state narrowing.
+
+## Enums
+
+### Curve
+
+```typescript
+const Curve = {
+    SECP256K1: 'SECP256K1',    // Bitcoin, Ethereum (curveNumber: 0)
+    SECP256R1: 'SECP256R1',    // WebAuthn, P-256 (curveNumber: 1)
+    ED25519: 'ED25519',        // Solana, Substrate-Ed25519 (curveNumber: 2)
+    RISTRETTO: 'RISTRETTO',   // Schnorrkel/Substrate (curveNumber: 3)
+} as const;
+type Curve = (typeof Curve)[keyof typeof Curve];
+```
+
+### SignatureAlgorithm
+
+```typescript
+const SignatureAlgorithm = {
+    ECDSASecp256k1: 'ECDSASecp256k1',         // absoluteNumber: 0
+    Taproot: 'Taproot',                         // absoluteNumber: 1
+    ECDSASecp256r1: 'ECDSASecp256r1',          // absoluteNumber: 2
+    EdDSA: 'EdDSA',                             // absoluteNumber: 3
+    SchnorrkelSubstrate: 'SchnorrkelSubstrate', // absoluteNumber: 4
+} as const;
+type SignatureAlgorithm = (typeof SignatureAlgorithm)[keyof typeof SignatureAlgorithm];
+```
+
+### Hash
+
+```typescript
+const Hash = {
+    KECCAK256: 'KECCAK256',       // absoluteNumber: 0
+    SHA256: 'SHA256',             // absoluteNumber: 1
+    DoubleSHA256: 'DoubleSHA256', // absoluteNumber: 2
+    SHA512: 'SHA512',             // absoluteNumber: 3
+    Merlin: 'Merlin',            // absoluteNumber: 4
+} as const;
+type Hash = (typeof Hash)[keyof typeof Hash];
+```
+
+## Valid Combinations (Full Config)
+
+```
+SECP256K1 (curve=0):
+├── ECDSASecp256k1 (sigAlgo=0):
+│   ├── KECCAK256 (hash=0)  ← Ethereum
+│   ├── SHA256 (hash=1)
+│   └── DoubleSHA256 (hash=2)  ← Bitcoin Legacy
+└── Taproot (sigAlgo=1):
+    └── SHA256 (hash=0)  ← Bitcoin Taproot
+
+SECP256R1 (curve=1):
+└── ECDSASecp256r1 (sigAlgo=0):
+    └── SHA256 (hash=0)  ← WebAuthn
+
+ED25519 (curve=2):
+└── EdDSA (sigAlgo=0):
+    └── SHA512 (hash=0)  ← Solana
+
+RISTRETTO (curve=3):
+└── SchnorrkelSubstrate (sigAlgo=0):
+    └── Merlin (hash=0)  ← Substrate
+```
+
+**Important**: Signature algorithm numbers are relative to curve. Hash numbers are relative to curve+sigAlgo. Absolute numbers are global.
+
+## Compile-Time Type Safety
+
+### ValidSignatureAlgorithmForCurve
+
+```typescript
+type ValidSignatureAlgorithmForCurve<C extends Curve> =
+    C extends 'SECP256K1' ? 'ECDSASecp256k1' | 'Taproot' :
+    C extends 'SECP256R1' ? 'ECDSASecp256r1' :
+    C extends 'ED25519' ? 'EdDSA' :
+    C extends 'RISTRETTO' ? 'SchnorrkelSubstrate' :
+    never;
+```
+
+### ValidHashForSignature
+
+```typescript
+type ValidHashForSignature<S extends SignatureAlgorithm> =
+    S extends 'ECDSASecp256k1' ? 'KECCAK256' | 'SHA256' | 'DoubleSHA256' :
+    S extends 'Taproot' ? 'SHA256' :
+    S extends 'ECDSASecp256r1' ? 'SHA256' :
+    S extends 'EdDSA' ? 'SHA512' :
+    S extends 'SchnorrkelSubstrate' ? 'Merlin' :
+    never;
+```
+
+### ValidatedSigningParams
+
+```typescript
+type ValidatedSigningParams<S extends SignatureAlgorithm> = {
+    hashScheme: ValidHashForSignature<S>;
+    signatureAlgorithm: S;
+};
+
+// Creates compile-time + runtime validated params
+createValidatedSigningParams(Hash.SHA256, SignatureAlgorithm.ECDSASecp256k1); // OK
+createValidatedSigningParams(Hash.SHA512, SignatureAlgorithm.ECDSASecp256k1); // Compile error
+```
+
+## Runtime Validation Functions
+
+### Validators (throw on invalid)
+
+```typescript
+validateHashSignatureCombination(hash: Hash, signatureAlgorithm: SignatureAlgorithm): void
+validateCurveSignatureAlgorithm(curve: Curve, signatureAlgorithm: SignatureAlgorithm): void
+```
+
+### Type Guards (return boolean)
+
+```typescript
+isValidHashForSignature<S>(hash: Hash, signatureAlgorithm: S): hash is ValidHashForSignature<S>
+isValidSignatureAlgorithmForCurve(curve: Curve, signatureAlgorithm: SignatureAlgorithm): boolean
+isValidHashForCurveAndSignature(curve: Curve, signatureAlgorithm: SignatureAlgorithm, hash: Hash): boolean
+```
+
+### Query Functions
+
+```typescript
+getValidSignatureAlgorithmsForCurve(curve: Curve): SignatureAlgorithm[]
+getValidHashesForCurveAndSignature(curve: Curve, signatureAlgorithm: SignatureAlgorithm): Hash[]
+getValidHashesForSignatureAlgorithm(signatureAlgorithm: SignatureAlgorithm): string[]
+```
+
+### Display Names
+
+```typescript
+getCurveName(curve: Curve): string                              // e.g., 'secp256k1'
+getSignatureAlgorithmName(signatureAlgorithm: SignatureAlgorithm): string
+getHashName(hash: Hash): string                                  // e.g., 'KECCAK256 (SHA3)'
+```
+
+## Number Conversion
+
+Two numbering schemes:
+- **Relative**: Numbers within their parent (sigAlgo relative to curve, hash relative to curve+sigAlgo)
+- **Absolute**: Global unique numbers
+
+### Enum → Number
+
+```typescript
+fromCurveToNumber(curve: Curve): number
+fromSignatureAlgorithmToNumber(curve: Curve, signatureAlgorithm: SignatureAlgorithm): number  // relative
+fromHashToNumber(curve: Curve, signatureAlgorithm: SignatureAlgorithm, hash: Hash): number    // relative
+fromSignatureAlgorithmToAbsoluteNumber(signatureAlgorithm: SignatureAlgorithm): number
+fromHashToAbsoluteNumber(hash: Hash): number
+
+// Batch conversions
+fromCurveAndSignatureAlgorithmToNumbers(curve, sigAlgo): { curveNumber, signatureAlgorithmNumber }
+fromCurveAndSignatureAlgorithmAndHashToNumbers(curve, sigAlgo, hash): { curveNumber, signatureAlgorithmNumber, hashNumber }
+```
+
+### Number → Enum
+
+```typescript
+fromNumberToCurve(curveNumber: number): Curve
+fromNumberToSignatureAlgorithm(curve: Curve, signatureAlgorithmNumber: number): SignatureAlgorithm  // relative
+fromNumberToHash(curve: Curve, signatureAlgorithm: SignatureAlgorithm, hashNumber: number): Hash    // relative
+fromAbsoluteNumberToSignatureAlgorithm(absoluteNumber: number): SignatureAlgorithm
+fromAbsoluteNumberToHash(absoluteNumber: number): Hash
+
+// Batch conversions
+fromNumbersToCurveAndSignatureAlgorithm(curveNum, sigAlgoNum): { curve, signatureAlgorithm }
+fromNumbersToCurveAndSignatureAlgorithmAndHash(curveNum, sigAlgoNum, hashNum): { curve, signatureAlgorithm, hash }
+```
+
+---
+
+## DWallet Types
+
+### DWalletKind
+
+```typescript
+const DWalletKind = {
+    ZeroTrust: 'zero-trust',
+    ImportedKey: 'imported-key',
+    ImportedKeyShared: 'imported-key-shared',
+    Shared: 'shared',
+} as const;
+type DWalletKind = (typeof DWalletKind)[keyof typeof DWalletKind];
+```
+
+### DWallet Discriminated Union
+
+```typescript
+type DWallet = ZeroTrustDWallet | ImportedKeyDWallet | ImportedSharedDWallet | SharedDWallet;
+
+type ZeroTrustDWallet = DWalletInternal & { kind: 'zero-trust' };
+type SharedDWallet = DWalletInternal & { kind: 'shared' };
+type ImportedKeyDWallet = DWalletInternal & { kind: 'imported-key' };
+type ImportedSharedDWallet = DWalletInternal & { kind: 'imported-key-shared' };
+```
+
+Kind is determined by:
+- Has `public_user_secret_key_share`? → shared or imported-key-shared
+- Has imported key markers? → imported-key or imported-key-shared
+- Otherwise → zero-trust
+
+### DWalletInternal Key Fields
+
+```typescript
+interface DWalletInternal {
+    id: string;
+    created_at_epoch: string;                         // bigint as string
+    curve: number;                                    // Use fromNumberToCurve()
+    public_user_secret_key_share: number[] | null;    // null for zero-trust
+    dwallet_cap_id: string;
+    dwallet_network_encryption_key_id: string;
+    is_imported_key_dwallet: boolean;
+    state: DWalletState;                              // Discriminated union
+    // public_output is inside state (Active or AwaitingKeyHolderSignature)
+    // Access as: dWallet.state.Active.public_output
+}
+```
+
+## State Types
+
+### DWalletState
+
+```typescript
+type DWalletState =
+    | 'DKGRequested'                              // DKG first round requested
+    | 'NetworkRejectedDKGRequest'                  // Network rejected DKG first round
+    | 'AwaitingUserDKGVerificationInitiation'      // DKG first round done, has first_round_output
+    | 'AwaitingNetworkDKGVerification'             // DKG second round requested
+    | 'NetworkRejectedDKGVerification'             // Network rejected DKG second round
+    | 'AwaitingNetworkImportedKeyVerification'     // Imported key verification requested
+    | 'NetworkRejectedImportedKeyVerification'     // Network rejected imported key
+    | 'AwaitingKeyHolderSignature'                 // DKG/import done, has public_output
+    | 'Active';                                    // Fully operational, has public_output
+```
+
+States with data:
+- `AwaitingUserDKGVerificationInitiation`: `{ first_round_output: number[] }`
+- `AwaitingKeyHolderSignature`: `{ public_output: number[] }`
+- `Active`: `{ public_output: number[] }`
+
+**`$kind` discriminator**: State objects use a `$kind` string field to identify which variant is active. Use `dWallet.state.$kind` to check the current state (e.g., `dWallet.state.$kind === 'Active'`). This applies to all state types (`DWalletState`, `PresignState`, `SignState`, `PartialUserSignatureState`, `EncryptedUserSecretKeyShareState`).
+
+### PresignState
+
+```typescript
+type PresignState =
+    | 'Requested'       // Presign requested, awaiting network
+    | 'NetworkRejected' // Network rejected the request
+    | 'Completed';      // Ready for signing, has presign data
+```
+
+States with data:
+- `Completed`: `{ presign: number[] }`
+
+### SignState
+
+```typescript
+type SignState =
+    | 'Requested'       // Sign requested, awaiting network
+    | 'NetworkRejected' // Network rejected the request
+    | 'Completed';      // Signature available
+```
+
+States with data:
+- `Completed`: `{ signature: number[] }`
+
+### PartialUserSignatureState
+
+```typescript
+type PartialUserSignatureState =
+    | 'AwaitingNetworkVerification'       // Awaiting network verification
+    | 'NetworkVerificationCompleted'      // Network verified successfully
+    | 'NetworkVerificationRejected';      // Network rejected verification
+```
+
+### EncryptedUserSecretKeyShareState
+
+```typescript
+type EncryptedUserSecretKeyShareState =
+    | 'AwaitingNetworkVerification'       // Awaiting network verification
+    | 'NetworkVerificationCompleted'      // Network verified successfully
+    | 'NetworkVerificationRejected'       // Network rejected verification
+    | 'KeyHolderSigned';                  // Key holder signed and accepted
+```
+
+States with data:
+- `KeyHolderSigned`: `{ user_output_signature: number[] }`
+
+## State Narrowing Generics
+
+```typescript
+// Narrow any object type to a specific state
+type DWalletWithState<S extends DWalletState>
+type PresignWithState<S extends PresignState>
+type SignWithState<S extends SignState>
+type PartialUserSignatureWithState<S extends PartialUserSignatureState>
+type EncryptedUserSecretKeyShareWithState<S extends EncryptedUserSecretKeyShareState>
+```
+
+Example:
+
+```typescript
+// Typed as DWalletWithState<'Active'> - guaranteed to have Active state
+const dWallet = await ikaClient.getDWalletInParticularState(id, 'Active');
+// dWallet.state.Active.public_output is type-safe accessible
+
+// Typed as PresignWithState<'Completed'>
+const presign = await ikaClient.getPresignInParticularState(id, 'Completed');
+// presign.state.Completed.presign is type-safe accessible
+```
+
+---
+
+## Config Types
+
+### IkaConfig
+
+```typescript
+interface IkaConfig {
+    packages: IkaPackageConfig;
+    objects: IkaObjectsConfig;
+}
+
+interface IkaPackageConfig {
+    ikaPackage: string;
+    ikaCommonPackage: string;
+    ikaSystemOriginalPackage: string;
+    ikaDwallet2pcMpcOriginalPackage: string;
+    ikaDwallet2pcMpcPackage: string;
+    ikaSystemPackage: string;
+}
+
+interface IkaObjectsConfig {
+    ikaSystemObject: { objectID: string; initialSharedVersion: number; };
+    ikaDWalletCoordinator: { objectID: string; initialSharedVersion: number; };
+}
+```
+
+### IkaClientOptions
+
+```typescript
+interface IkaClientOptions {
+    config: IkaConfig;
+    suiClient: ClientWithCoreApi;      // @mysten/sui client
+    timeout?: number;
+    cache?: boolean;                    // default: true
+    encryptionKeyOptions?: EncryptionKeyOptions;
+}
+```
+
+### EncryptionKeyOptions
+
+```typescript
+interface EncryptionKeyOptions {
+    encryptionKeyID?: string;   // Use specific key
+    autoDetect?: boolean;       // Auto-detect from dWallet (default: true)
+}
+```
+
+### NetworkEncryptionKey
+
+```typescript
+interface NetworkEncryptionKey {
+    id: string;
+    epoch: number;
+    networkDKGOutputID: string;
+    reconfigurationOutputID: string | undefined;
+}
+```
+
+### UserSignatureInputs
+
+```typescript
+type UserSignatureInputs = {
+    activeDWallet?: DWallet;
+    publicOutput?: Uint8Array;
+    secretShare?: Uint8Array;
+    encryptedUserSecretKeyShare?: EncryptedUserSecretKeyShare;
+    presign: Presign;
+    message: Uint8Array;
+    hash: Hash;
+    signatureScheme: SignatureAlgorithm;
+    curve: Curve;
+    createWithCentralizedOutput?: boolean;
+};
+```
+
+---
+
+## Import Summary
+
+```typescript
+// Core
+import { IkaClient, IkaTransaction, getNetworkConfig } from '@ika.xyz/sdk';
+
+// Keys
+import { UserShareEncryptionKeys } from '@ika.xyz/sdk';
+
+// Enums
+import { Curve, SignatureAlgorithm, Hash } from '@ika.xyz/sdk';
+
+// Crypto functions
+import {
+    prepareDKGAsync, prepareDKG,
+    createRandomSessionIdentifier, sessionIdentifierDigest,
+    createUserSignMessageWithPublicOutput, createUserSignMessageWithCentralizedOutput,
+    publicKeyFromDWalletOutput, publicKeyFromCentralizedDKGOutput,
+    parseSignatureFromSignOutput,
+    prepareImportedKeyDWalletVerification,
+    verifyUserShare, verifySecpSignature, userAndNetworkDKGOutputMatch,
+    createClassGroupsKeypair, encryptSecretShare,
+} from '@ika.xyz/sdk';
+
+// Types
+import type {
+    DWallet, ZeroTrustDWallet, SharedDWallet, ImportedKeyDWallet, ImportedSharedDWallet,
+    DWalletCap, DWalletInternal, DWalletKind, DWalletState, DWalletWithState,
+    Presign, PresignState, PresignWithState,
+    Sign, SignState, SignWithState,
+    EncryptedUserSecretKeyShare, EncryptedUserSecretKeyShareState, EncryptedUserSecretKeyShareWithState,
+    PartialUserSignature, PartialUserSignatureState, PartialUserSignatureWithState,
+    EncryptionKey, NetworkEncryptionKey, EncryptionKeyOptions,
+    IkaConfig, IkaClientOptions, IkaPackageConfig, IkaObjectsConfig,
+    UserSignatureInputs,
+} from '@ika.xyz/sdk';
+
+// Validation
+import {
+    validateHashSignatureCombination, validateCurveSignatureAlgorithm,
+    isValidHashForSignature, isValidSignatureAlgorithmForCurve, isValidHashForCurveAndSignature,
+    getValidSignatureAlgorithmsForCurve, getValidHashesForCurveAndSignature,
+    createValidatedSigningParams,
+    fromCurveToNumber, fromSignatureAlgorithmToNumber, fromHashToNumber,
+    fromNumberToCurve, fromNumberToSignatureAlgorithm, fromNumberToHash,
+    fromSignatureAlgorithmToAbsoluteNumber, fromAbsoluteNumberToSignatureAlgorithm,
+    fromHashToAbsoluteNumber, fromAbsoluteNumberToHash,
+    fromCurveAndSignatureAlgorithmToNumbers, fromCurveAndSignatureAlgorithmAndHashToNumbers,
+    fromNumbersToCurveAndSignatureAlgorithm, fromNumbersToCurveAndSignatureAlgorithmAndHash,
+} from '@ika.xyz/sdk';
+import type {
+    ValidSignatureAlgorithmForCurve, ValidHashForSignature, ValidatedSigningParams,
+} from '@ika.xyz/sdk';
+
+// Low-level
+import { coordinatorTransactions, systemTransactions } from '@ika.xyz/sdk';
+
+// Errors
+import {
+    IkaClientError, ObjectNotFoundError, InvalidObjectError, NetworkError, CacheError,
+} from '@ika.xyz/sdk';
+```


### PR DESCRIPTION
## Summary

This PR adds a new **AI Skills** documentation section and fixes outdated Sui transaction execution examples.

## Changes

- add a new `skills` section to the docs navigation
- add a landing page for AI Skills under `docs/content/docs/skills`
- add repository skill assets for:
  - `ika-sdk`
  - `ika-move`
  - `ika-operator`
- document installation and usage patterns for Ika agent skills
- update Move integration examples to use `suiClient.core.signAndExecuteTransaction(...)`