### PR TITLE
Add Solana Integration docs + homepage update

### DIFF
--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -4,6 +4,13 @@ import Link from 'next/link';
 
 const features = [
 	{
+		title: 'Solana Integration',
+		description: 'Build Solana programs that control dWallets for cross-chain signing. Pinocchio, Anchor, and Native frameworks supported.',
+		href: 'https://solana-pre-alpha.ika.xyz',
+		icon: Globe,
+		gradient: 'from-[#9945FF] to-[#14F195]',
+	},
+	{
 		title: 'SDK',
 		description: 'TypeScript SDK for building applications with dWallets',
 		href: '/docs/sdk',
@@ -66,13 +73,17 @@ export default function HomePage() {
 						</p>
 
 						{/* Solana callout */}
-						<div className="mt-6 inline-flex items-center gap-2.5 rounded-full bg-gradient-to-r from-purple-500/10 to-fuchsia-500/10 dark:from-purple-500/20 dark:to-fuchsia-500/20 border border-purple-200/60 dark:border-purple-700/40 px-5 py-2">
+						<Link
+							href="https://solana-pre-alpha.ika.xyz"
+							target="_blank"
+							className="mt-6 inline-flex items-center gap-2.5 rounded-full bg-gradient-to-r from-[#9945FF]/10 to-[#14F195]/10 dark:from-[#9945FF]/20 dark:to-[#14F195]/20 border border-[#9945FF]/40 dark:border-[#9945FF]/30 px-5 py-2 transition-all hover:scale-105 hover:shadow-lg hover:shadow-[#9945FF]/10"
+						>
 							<Image src="/solana-logo.svg" alt="Solana" width={16} height={16} className="dark:brightness-0 dark:invert" />
-							<span className="text-sm font-medium text-purple-700 dark:text-purple-300">
-								Solana support coming soon
+							<span className="text-sm font-medium text-[#9945FF] dark:text-[#14F195]">
+								Solana Pre-Alpha is live — Build dWallet programs now
 							</span>
-							<span className="h-1.5 w-1.5 rounded-full bg-purple-500 animate-pulse" />
-						</div>
+							<span className="h-1.5 w-1.5 rounded-full bg-[#14F195] animate-pulse" />
+						</Link>
 
 						{/* CTA Buttons */}
 						<div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -1,4 +1,4 @@
 {
 	"title": "Documentation",
-	"pages": ["sdk", "cli", "move-integration", "core-concepts", "skills"]
+	"pages": ["solana-integration", "sdk", "cli", "move-integration", "core-concepts", "skills"]
 }

--- a/docs/content/docs/solana-integration/index.mdx
+++ b/docs/content/docs/solana-integration/index.mdx
@@ -5,83 +5,20 @@ icon: Globe
 ---
 
 import { Cards, Card } from 'fumadocs-ui/components/card';
-import { Callout } from 'fumadocs-ui/components/callout';
 
 # Solana Integration
 
-Build Solana programs that control dWallets — enabling cross-chain signing directly from your Solana smart contracts. Create multisigs, governance systems, or any program logic that authorizes signing on Bitcoin, Ethereum, and other chains.
-
-<Callout type="info" title="Pre-Alpha Available">
-  The Solana dWallet SDK is available as a pre-alpha release. Start building today with Pinocchio, Anchor, or Native Solana programs. Full documentation, examples, and a local mock environment are included.
-</Callout>
-
-## What You Can Build
-
-- **Governance-controlled signing** — DAO votes trigger cross-chain transactions
-- **Multisig wallets** — M-of-N threshold signing across any chain
-- **Programmable custody** — Smart contract logic controls when and how dWallets sign
-- **Cross-chain DeFi** — Solana programs that execute trades on Ethereum, Bitcoin, etc.
-
-## Supported Frameworks
-
-| Framework | Description |
-|-----------|-------------|
-| **Pinocchio** | Lightweight, no-std CPI wrapper for maximum performance |
-| **Anchor** | High-level Anchor framework integration with account macros |
-| **Native** | Standard `solana-program` integration |
-
-## How It Works
-
-1. **Create a dWallet** via gRPC — the Ika network generates a distributed key pair
-2. **Transfer authority** to your program's CPI PDA — your program now controls signing
-3. **Approve messages** from your program logic — when conditions are met (votes, approvals, etc.), your program CPI-calls `approve_message`
-4. **Sign via gRPC** — submit the approval proof to get the actual cross-chain signature
-
-## Get Started
-
-The full Solana pre-alpha documentation — including installation guides, tutorials, examples, API reference, and a local development environment — is available at:
+Build Solana programs that control dWallets for cross-chain signing. The Solana dWallet SDK is available as a pre-alpha release with full documentation, examples, and a local development environment.
 
 <Cards>
   <Card
-    title="Solana Pre-Alpha Docs"
-    description="Complete SDK documentation with tutorials, examples, and API reference"
+    title="Solana Pre-Alpha Docs →"
+    description="Installation, tutorials, API reference, and examples"
     href="https://solana-pre-alpha.ika.xyz"
   />
   <Card
-    title="GitHub Repository"
-    description="Source code, examples, and developer SDK"
+    title="GitHub Repository →"
+    description="Source code and developer SDK"
     href="https://github.com/dwallet-labs/ika-pre-alpha"
   />
 </Cards>
-
-## Examples
-
-The pre-alpha ships with two complete examples:
-
-### Voting dWallet
-Open governance where anyone can vote. When quorum is reached, the program automatically signs the approved message. Demonstrates the full CPI authority pattern.
-
-### Multisig dWallet
-M-of-N multisig with fixed members, on-chain transaction data, approve/reject flow, and future sign support. Includes a React frontend.
-
-Both examples include Pinocchio, Anchor, and Native implementations with Mollusk unit tests and TypeScript end-to-end tests.
-
-## Quick Start
-
-```bash
-# Clone the SDK
-git clone https://github.com/dwallet-labs/ika-pre-alpha.git
-cd ika-pre-alpha
-
-# Build example programs
-just build-sbf
-
-# Run unit tests
-just test-examples-mollusk
-
-# Install TypeScript dependencies
-just install-ts
-
-# Run e2e tests (requires local validator + mock)
-just e2e-voting <DWALLET_ID> <VOTING_ID>
-```

--- a/docs/content/docs/solana-integration/index.mdx
+++ b/docs/content/docs/solana-integration/index.mdx
@@ -1,0 +1,87 @@
+---
+title: Solana Integration
+description: Build Solana programs that control dWallets for cross-chain signing
+icon: Globe
+---
+
+import { Cards, Card } from 'fumadocs-ui/components/card';
+import { Callout } from 'fumadocs-ui/components/callout';
+
+# Solana Integration
+
+Build Solana programs that control dWallets — enabling cross-chain signing directly from your Solana smart contracts. Create multisigs, governance systems, or any program logic that authorizes signing on Bitcoin, Ethereum, and other chains.
+
+<Callout type="info" title="Pre-Alpha Available">
+  The Solana dWallet SDK is available as a pre-alpha release. Start building today with Pinocchio, Anchor, or Native Solana programs. Full documentation, examples, and a local mock environment are included.
+</Callout>
+
+## What You Can Build
+
+- **Governance-controlled signing** — DAO votes trigger cross-chain transactions
+- **Multisig wallets** — M-of-N threshold signing across any chain
+- **Programmable custody** — Smart contract logic controls when and how dWallets sign
+- **Cross-chain DeFi** — Solana programs that execute trades on Ethereum, Bitcoin, etc.
+
+## Supported Frameworks
+
+| Framework | Description |
+|-----------|-------------|
+| **Pinocchio** | Lightweight, no-std CPI wrapper for maximum performance |
+| **Anchor** | High-level Anchor framework integration with account macros |
+| **Native** | Standard `solana-program` integration |
+
+## How It Works
+
+1. **Create a dWallet** via gRPC — the Ika network generates a distributed key pair
+2. **Transfer authority** to your program's CPI PDA — your program now controls signing
+3. **Approve messages** from your program logic — when conditions are met (votes, approvals, etc.), your program CPI-calls `approve_message`
+4. **Sign via gRPC** — submit the approval proof to get the actual cross-chain signature
+
+## Get Started
+
+The full Solana pre-alpha documentation — including installation guides, tutorials, examples, API reference, and a local development environment — is available at:
+
+<Cards>
+  <Card
+    title="Solana Pre-Alpha Docs"
+    description="Complete SDK documentation with tutorials, examples, and API reference"
+    href="https://solana-pre-alpha.ika.xyz"
+  />
+  <Card
+    title="GitHub Repository"
+    description="Source code, examples, and developer SDK"
+    href="https://github.com/dwallet-labs/ika-pre-alpha"
+  />
+</Cards>
+
+## Examples
+
+The pre-alpha ships with two complete examples:
+
+### Voting dWallet
+Open governance where anyone can vote. When quorum is reached, the program automatically signs the approved message. Demonstrates the full CPI authority pattern.
+
+### Multisig dWallet
+M-of-N multisig with fixed members, on-chain transaction data, approve/reject flow, and future sign support. Includes a React frontend.
+
+Both examples include Pinocchio, Anchor, and Native implementations with Mollusk unit tests and TypeScript end-to-end tests.
+
+## Quick Start
+
+```bash
+# Clone the SDK
+git clone https://github.com/dwallet-labs/ika-pre-alpha.git
+cd ika-pre-alpha
+
+# Build example programs
+just build-sbf
+
+# Run unit tests
+just test-examples-mollusk
+
+# Install TypeScript dependencies
+just install-ts
+
+# Run e2e tests (requires local validator + mock)
+just e2e-voting <DWALLET_ID> <VOTING_ID>
+```


### PR DESCRIPTION
## Summary

- Update homepage: Solana badge changed from "coming soon" to "**Solana Pre-Alpha is live**" with link to `solana-pre-alpha.ika.xyz`
- Add Solana Integration card to features grid (first position, Solana gradient colors)
- Add new `solana-integration` docs section at `/docs/solana-integration` explaining:
  - What you can build (governance, multisig, custody, cross-chain DeFi)
  - Supported frameworks (Pinocchio, Anchor, Native)
  - How it works (DKG → CPI authority → approve message → sign)
  - Links to pre-alpha docs and GitHub repo
  - Quick start commands
  - Example overviews (voting + multisig)

## Context

The Solana pre-alpha SDK is published at `dwallet-labs/ika-pre-alpha` with full docs deployed to `solana-pre-alpha.ika.xyz`. This PR links the main docs site to it.