### PR TITLE
Add ika-solana-signer crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6784,6 +6784,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ika-solana-signer"
+version = "1.1.9"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bcs",
+ "dwallet-mpc-centralized-party",
+ "dwallet-mpc-types",
+ "fastcrypto",
+ "hex",
+ "ika-config",
+ "ika-sui-client",
+ "ika-types",
+ "rand 0.9.0",
+ "sui-json-rpc-types",
+ "sui-rpc-api",
+ "sui-sdk",
+ "sui-types",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "ika-sui-client"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/ika-move-contracts",
     "crates/ika-network",
     "crates/ika-archival",
+    "crates/ika-solana-signer",
 ]
 [workspace.package]
 # This version string will be inherited by ika-core, ika-node, ika-tools, ika-sdk, and ika crates.

--- a/crates/ika-solana-signer/Cargo.toml
+++ b/crates/ika-solana-signer/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "ika-solana-signer"
+version.workspace = true
+authors = ["dWallet Labs, Ltd. <dev@dwalletlabs.com>"]
+license = "BSD-3-Clause-Clear"
+publish = false
+edition = "2024"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+bcs.workspace = true
+hex.workspace = true
+rand.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+
+fastcrypto.workspace = true
+
+dwallet-mpc-centralized-party.workspace = true
+dwallet-mpc-types.workspace = true
+ika-config.workspace = true
+ika-sui-client.workspace = true
+ika-types.workspace = true
+
+sui-json-rpc-types.workspace = true
+sui-rpc-api.workspace = true
+sui-sdk.workspace = true
+sui-types.workspace = true

--- a/crates/ika-solana-signer/src/config.rs
+++ b/crates/ika-solana-signer/src/config.rs
@@ -1,0 +1,80 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+use std::time::Duration;
+
+use ika_types::messages_dwallet_mpc::IkaNetworkConfig;
+use sui_types::{base_types::ObjectID, crypto::SuiKeyPair};
+
+/// How [`crate::IkaSigner`] obtains the user's secret key share for the dWallet.
+#[derive(Clone)]
+pub enum SecretShareSource {
+    /// Raw bytes already on hand (e.g. read from disk by the caller).
+    Bytes(Vec<u8>),
+
+    /// The signer should fetch the encrypted share from chain and decrypt it
+    /// using the supplied class-groups decryption key. Pair this with the
+    /// `derive_encryption_keys` helper from `ika-sui-client::dwallet_signer`
+    /// applied to the user's seed.
+    OnChainEncrypted {
+        /// Class-groups decryption key derived from the user's seed.
+        decryption_key: Vec<u8>,
+        /// `encryption_key_address` (Ed25519 signing keypair public key, as
+        /// `SuiAddress`) used to find the matching encrypted share on chain.
+        encryption_key_address: sui_types::base_types::SuiAddress,
+    },
+}
+
+/// Presign strategy.
+#[derive(Clone)]
+pub enum PresignMode {
+    /// Each [`crate::IkaSigner::sign_message`] call internally requests a fresh
+    /// global presign, polls until completion, auto-verifies, and uses it once.
+    /// Stateless but adds an extra MPC round-trip per signature.
+    PerSignGlobal,
+
+    /// Use a pre-verified presign cap. Single-shot — once consumed, subsequent
+    /// `sign_message` calls return [`crate::IkaSignerError::PresignCapConsumed`].
+    /// Reconstruct the signer with a fresh cap to sign again.
+    SingleProvided(ObjectID),
+}
+
+/// Configuration for [`crate::IkaSigner::create`].
+pub struct IkaSignerConfig {
+    /// Full Sui JSON-RPC URL the signer will talk to.
+    pub sui_rpc_url: String,
+
+    /// On-chain locations of the Ika packages and shared objects.
+    pub ika_network_config: IkaNetworkConfig,
+
+    /// Keypair that pays Sui gas and IKA fees, and signs the on-chain
+    /// `request_sign` / `request_global_presign` transactions.
+    pub payer: SuiKeyPair,
+
+    /// dWallet object ID. Must be ed25519 and in `Active` state.
+    pub dwallet_id: ObjectID,
+
+    /// dWallet capability object the user owns (passed to `request_sign`).
+    pub dwallet_cap_id: ObjectID,
+
+    /// How to source the user secret key share for centralized signing.
+    pub share_source: SecretShareSource,
+
+    pub presign_mode: PresignMode,
+
+    /// IKA payment coin object. Must exist before signing — the CLI's
+    /// "auto-create zero IKA coin" path is not done here.
+    pub ika_coin_id: ObjectID,
+
+    /// Optional explicit SUI coin to pay with. `None` uses the gas coin
+    /// (matches the TS SDK's `transaction.gas` pattern).
+    pub sui_coin_id: Option<ObjectID>,
+
+    pub gas_budget: u64,
+
+    /// Sign-session poll timeout. Defaults to 300s if `None`.
+    pub poll_timeout: Option<Duration>,
+
+    /// Sign-session poll interval. Defaults to 3s if `None`.
+    pub poll_interval: Option<Duration>,
+}

--- a/crates/ika-solana-signer/src/error.rs
+++ b/crates/ika-solana-signer/src/error.rs
@@ -1,0 +1,35 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+use thiserror::Error;
+
+/// Errors surfaced by [`crate::IkaSigner`].
+#[derive(Debug, Error)]
+pub enum IkaSignerError {
+    #[error("dWallet {0} is not in Active state; cannot sign yet")]
+    DWalletNotActive(String),
+
+    #[error("dWallet {dwallet_id} curve is {actual} (expected ed25519/{expected})")]
+    UnsupportedCurve {
+        dwallet_id: String,
+        actual: u32,
+        expected: u32,
+    },
+
+    #[error("Could not extract Ed25519 public key from dWallet {0}'s public_output")]
+    InvalidPublicOutput(String),
+
+    #[error("Sign session was rejected by the network")]
+    SignRejected,
+
+    #[error(
+        "Provided presign cap has already been consumed; reconstruct IkaSigner with a fresh cap or PresignMode::PerSignGlobal"
+    )]
+    PresignCapConsumed,
+
+    #[error("MPC centralized signing failed: {0}")]
+    Crypto(String),
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}

--- a/crates/ika-solana-signer/src/flow.rs
+++ b/crates/ika-solana-signer/src/flow.rs
@@ -23,6 +23,21 @@ use crate::config::{IkaSignerConfig, PresignMode, SecretShareSource};
 use crate::error::IkaSignerError;
 use crate::pubkey::ed25519_curve_id;
 
+/// Package ID to address Move calls at.
+///
+/// The dWallet coordinator object carries a `version` field that must match
+/// the `VERSION` constant of whichever package it's called through. When the
+/// network has upgraded the coordinator (e.g. to V2 on testnet), V1 calls
+/// abort with `EWrongInnerVersion` inside `coordinator::inner_mut`. Always
+/// use V2 if the network config exposes it; fall back to V1 only when the
+/// network hasn't been upgraded.
+fn dwallet_package_id(cfg: &IkaSignerConfig) -> ObjectID {
+    cfg.ika_network_config
+        .packages
+        .ika_dwallet_2pc_mpc_package_id_v2
+        .unwrap_or(cfg.ika_network_config.packages.ika_dwallet_2pc_mpc_package_id)
+}
+
 /// Solana-specific algorithm identifiers used in every sign call.
 const EDDSA_SIG_ALGORITHM: u32 = 0;
 const SHA512_HASH_SCHEME: u32 = 0;
@@ -69,14 +84,13 @@ pub(crate) async fn sign_with_presign(
         sui_coin_id: cfg.sui_coin_id,
     };
 
+    let package_id = dwallet_package_id(cfg);
     let response = if state.metadata.is_imported_key_dwallet {
         tx::request_imported_key_sign_tx_with_signer(
             rpc,
             keypair,
             sender,
-            cfg.ika_network_config
-                .packages
-                .ika_dwallet_2pc_mpc_package_id,
+            package_id,
             cfg.ika_network_config
                 .objects
                 .ika_dwallet_coordinator_object_id,
@@ -97,9 +111,7 @@ pub(crate) async fn sign_with_presign(
             rpc,
             keypair,
             sender,
-            cfg.ika_network_config
-                .packages
-                .ika_dwallet_2pc_mpc_package_id,
+            package_id,
             cfg.ika_network_config
                 .objects
                 .ika_dwallet_coordinator_object_id,
@@ -209,9 +221,7 @@ pub(crate) async fn fresh_global_presign(
         rpc,
         keypair,
         sender,
-        cfg.ika_network_config
-            .packages
-            .ika_dwallet_2pc_mpc_package_id,
+        dwallet_package_id(cfg),
         cfg.ika_network_config
             .objects
             .ika_dwallet_coordinator_object_id,

--- a/crates/ika-solana-signer/src/flow.rs
+++ b/crates/ika-solana-signer/src/flow.rs
@@ -1,0 +1,301 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Sign-flow orchestration: presign → centralized sign → submit → poll.
+
+use std::time::Duration;
+
+use anyhow::Context;
+use dwallet_mpc_centralized_party::advance_centralized_sign_party;
+use ika_sui_client::dwallet_signer::{
+    DWalletMetadata, SignSessionResult, fetch_encrypted_share_for_dwallet, fetch_presign_output,
+    find_sign_session_id, is_presign_cap_verified, poll_sign_session, tx,
+};
+use ika_sui_client::ika_dwallet_transactions::PaymentCoinArgs;
+use rand::RngCore;
+use sui_rpc_api::Client as RpcClient;
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    crypto::SuiKeyPair,
+};
+
+use crate::config::{IkaSignerConfig, PresignMode, SecretShareSource};
+use crate::error::IkaSignerError;
+use crate::pubkey::ed25519_curve_id;
+
+/// Solana-specific algorithm identifiers used in every sign call.
+const EDDSA_SIG_ALGORITHM: u32 = 0;
+const SHA512_HASH_SCHEME: u32 = 0;
+
+/// Cached state captured from the dWallet at signer construction time.
+pub(crate) struct DWalletState {
+    pub metadata: DWalletMetadata,
+    pub dkg_output: Vec<u8>,
+    pub protocol_pp: Vec<u8>,
+    pub network_encryption_key_id: ObjectID,
+}
+
+/// Run the centralized sign step against an explicit presign output + cap.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn sign_with_presign(
+    rpc: &mut RpcClient,
+    sui_client: &sui_sdk::SuiClient,
+    keypair: &SuiKeyPair,
+    sender: SuiAddress,
+    cfg: &IkaSignerConfig,
+    state: &DWalletState,
+    secret_share: &[u8],
+    presign_cap_id: ObjectID,
+    presign_output: Vec<u8>,
+    needs_verification: bool,
+    message: Vec<u8>,
+) -> Result<[u8; 64], IkaSignerError> {
+    let centralized_signature = advance_centralized_sign_party(
+        state.protocol_pp.clone(),
+        state.dkg_output.clone(),
+        secret_share.to_vec(),
+        presign_output,
+        message.clone(),
+        ed25519_curve_id(),
+        EDDSA_SIG_ALGORITHM,
+        SHA512_HASH_SCHEME,
+    )
+    .map_err(|e| IkaSignerError::Crypto(format!("{e}")))?;
+
+    let session_identifier_bytes = random_bytes().to_vec();
+
+    let coins = PaymentCoinArgs {
+        ika_coin_id: cfg.ika_coin_id,
+        sui_coin_id: cfg.sui_coin_id,
+    };
+
+    let response = if state.metadata.is_imported_key_dwallet {
+        tx::request_imported_key_sign_tx_with_signer(
+            rpc,
+            keypair,
+            sender,
+            cfg.ika_network_config
+                .packages
+                .ika_dwallet_2pc_mpc_package_id,
+            cfg.ika_network_config
+                .objects
+                .ika_dwallet_coordinator_object_id,
+            cfg.dwallet_cap_id,
+            EDDSA_SIG_ALGORITHM,
+            SHA512_HASH_SCHEME,
+            message,
+            centralized_signature,
+            presign_cap_id,
+            session_identifier_bytes,
+            coins,
+            cfg.gas_budget,
+            needs_verification,
+        )
+        .await?
+    } else {
+        tx::request_sign_tx_with_signer(
+            rpc,
+            keypair,
+            sender,
+            cfg.ika_network_config
+                .packages
+                .ika_dwallet_2pc_mpc_package_id,
+            cfg.ika_network_config
+                .objects
+                .ika_dwallet_coordinator_object_id,
+            cfg.dwallet_cap_id,
+            EDDSA_SIG_ALGORITHM,
+            SHA512_HASH_SCHEME,
+            message,
+            centralized_signature,
+            presign_cap_id,
+            session_identifier_bytes,
+            coins,
+            cfg.gas_budget,
+            needs_verification,
+        )
+        .await?
+    };
+
+    let digest = response
+        .effects
+        .as_ref()
+        .map(|e| {
+            use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
+            e.transaction_digest().to_string()
+        })
+        .ok_or_else(|| anyhow::anyhow!("sign tx returned no effects"))?;
+
+    let session_id_str = find_sign_session_id(sui_client, &digest)
+        .await
+        .ok_or_else(|| anyhow::anyhow!("could not locate sign session id from tx events"))?;
+    let session_id: ObjectID = session_id_str.parse().context("invalid sign session id")?;
+
+    let result = poll_sign_session(
+        sui_client,
+        session_id,
+        cfg.poll_interval,
+        cfg.poll_timeout.or(Some(Duration::from_secs(300))),
+    )
+    .await?;
+
+    let sig_hex = match result {
+        SignSessionResult::Completed { signature } => signature,
+        SignSessionResult::Rejected => return Err(IkaSignerError::SignRejected),
+    };
+
+    let sig_bytes = hex::decode(&sig_hex)
+        .map_err(|e| anyhow::anyhow!("invalid signature hex from sign session: {e}"))?;
+    if sig_bytes.len() != 64 {
+        return Err(anyhow::anyhow!(
+            "expected 64-byte ed25519 signature, got {} bytes",
+            sig_bytes.len()
+        )
+        .into());
+    }
+    let mut out = [0u8; 64];
+    out.copy_from_slice(&sig_bytes);
+    Ok(out)
+}
+
+/// Resolve the secret share source into raw bytes (decrypting from chain if needed).
+pub(crate) async fn resolve_secret_share(
+    sui_client: &sui_sdk::SuiClient,
+    cfg: &IkaSignerConfig,
+    state: &DWalletState,
+) -> Result<Vec<u8>, IkaSignerError> {
+    match &cfg.share_source {
+        SecretShareSource::Bytes(b) => Ok(b.clone()),
+        SecretShareSource::OnChainEncrypted {
+            decryption_key,
+            encryption_key_address,
+        } => {
+            let encrypted = fetch_encrypted_share_for_dwallet(
+                sui_client,
+                cfg.dwallet_id,
+                *encryption_key_address,
+            )
+            .await?;
+            let decrypted = dwallet_mpc_centralized_party::decrypt_user_share_v2(
+                ed25519_curve_id(),
+                decryption_key.clone(),
+                state.dkg_output.clone(),
+                encrypted,
+                state.protocol_pp.clone(),
+            )
+            .map_err(|e| IkaSignerError::Crypto(format!("decrypt failed: {e}")))?;
+            Ok(decrypted)
+        }
+    }
+}
+
+/// Issue a fresh global presign and wait for it to complete.
+/// Returns `(presign_cap_id, presign_output_bytes, needs_verification = true)`.
+pub(crate) async fn fresh_global_presign(
+    rpc: &mut RpcClient,
+    sui_client: &sui_sdk::SuiClient,
+    keypair: &SuiKeyPair,
+    sender: SuiAddress,
+    cfg: &IkaSignerConfig,
+    state: &DWalletState,
+) -> Result<(ObjectID, Vec<u8>, bool), IkaSignerError> {
+    let session_identifier_bytes = random_bytes().to_vec();
+    let coins = PaymentCoinArgs {
+        ika_coin_id: cfg.ika_coin_id,
+        sui_coin_id: cfg.sui_coin_id,
+    };
+
+    let response = tx::request_global_presign_tx_with_signer(
+        rpc,
+        keypair,
+        sender,
+        cfg.ika_network_config
+            .packages
+            .ika_dwallet_2pc_mpc_package_id,
+        cfg.ika_network_config
+            .objects
+            .ika_dwallet_coordinator_object_id,
+        state.network_encryption_key_id,
+        ed25519_curve_id(),
+        EDDSA_SIG_ALGORITHM,
+        session_identifier_bytes,
+        coins,
+        cfg.gas_budget,
+    )
+    .await?;
+
+    let presign_cap_id = extract_presign_cap_from_response(&response)
+        .ok_or_else(|| anyhow::anyhow!("could not locate presign cap in tx events"))?;
+
+    // Poll the presign session for completion via `fetch_presign_output` retries.
+    let timeout = cfg.poll_timeout.unwrap_or(Duration::from_secs(300));
+    let interval = cfg.poll_interval.unwrap_or(Duration::from_secs(3));
+    let start = std::time::Instant::now();
+    let presign_output = loop {
+        if start.elapsed() > timeout {
+            return Err(anyhow::anyhow!(
+                "timeout waiting for presign {presign_cap_id} to complete"
+            )
+            .into());
+        }
+        match fetch_presign_output(sui_client, presign_cap_id).await {
+            Ok(bytes) => break bytes,
+            Err(_) => tokio::time::sleep(interval).await,
+        }
+    };
+
+    Ok((presign_cap_id, presign_output, true))
+}
+
+/// Resolve a caller-provided presign cap into `(cap_id, presign_output, needs_verification)`.
+pub(crate) async fn use_provided_presign(
+    sui_client: &sui_sdk::SuiClient,
+    presign_cap_id: ObjectID,
+) -> Result<(ObjectID, Vec<u8>, bool), IkaSignerError> {
+    let already_verified = is_presign_cap_verified(sui_client, presign_cap_id).await?;
+    let presign_output = fetch_presign_output(sui_client, presign_cap_id).await?;
+    Ok((presign_cap_id, presign_output, !already_verified))
+}
+
+fn extract_presign_cap_from_response(
+    response: &sui_json_rpc_types::SuiTransactionBlockResponse,
+) -> Option<ObjectID> {
+    use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
+    let effects = response.effects.as_ref()?;
+    // The PTB transfers the new presign cap to the sender. Find the first
+    // created object owned by an address.
+    effects
+        .created()
+        .iter()
+        .find(|c| matches!(c.owner, sui_types::object::Owner::AddressOwner(_)))
+        .map(|c| c.reference.object_id)
+}
+
+/// Determine the presign source for this `sign_message` call.
+pub(crate) async fn resolve_presign(
+    rpc: &mut RpcClient,
+    sui_client: &sui_sdk::SuiClient,
+    keypair: &SuiKeyPair,
+    sender: SuiAddress,
+    cfg: &IkaSignerConfig,
+    state: &DWalletState,
+    consumed_provided_cap: bool,
+) -> Result<(ObjectID, Vec<u8>, bool), IkaSignerError> {
+    match &cfg.presign_mode {
+        PresignMode::PerSignGlobal => {
+            fresh_global_presign(rpc, sui_client, keypair, sender, cfg, state).await
+        }
+        PresignMode::SingleProvided(cap_id) => {
+            if consumed_provided_cap {
+                return Err(IkaSignerError::PresignCapConsumed);
+            }
+            use_provided_presign(sui_client, *cap_id).await
+        }
+    }
+}
+
+fn random_bytes() -> [u8; 32] {
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    bytes
+}

--- a/crates/ika-solana-signer/src/lib.rs
+++ b/crates/ika-solana-signer/src/lib.rs
@@ -1,0 +1,36 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Solana Ed25519 signer backed by an Ika dWallet.
+//!
+//! Wraps a pre-provisioned ed25519 dWallet on the Ika network and exposes
+//! `sign_message` returning a 64-byte Ed25519 signature. Intended to be
+//! adapted into [`solana-keychain`](https://github.com/solana-foundation/solana-keychain)'s
+//! `SolanaSigner` trait by a thin downstream crate.
+//!
+//! # API shape
+//!
+//! - [`IkaSigner::create`] takes a pre-built [`IkaSignerConfig`] (Sui RPC URL,
+//!   keypair to pay Sui gas + IKA fees, dWallet ID, secret share source) and
+//!   fetches the dWallet's metadata + Ed25519 public key once.
+//! - [`IkaSigner::pubkey`] returns the 32-byte Ed25519 public key (Solana address).
+//! - [`IkaSigner::sign_message`] runs the MPC sign flow against Sui and returns
+//!   the 64-byte Ed25519 signature.
+//! - [`IkaSigner::is_available`] does a lightweight check that the Sui RPC is
+//!   reachable and the dWallet is in `Active` state.
+//!
+//! # Provisioning
+//!
+//! dWallet creation, key import, and presign provisioning are out of scope —
+//! use the `ika` CLI or the TypeScript `IkaTransaction` API. This crate only
+//! signs with an existing ed25519 dWallet.
+
+mod config;
+mod error;
+mod flow;
+mod pubkey;
+mod signer;
+
+pub use config::{IkaSignerConfig, PresignMode, SecretShareSource};
+pub use error::IkaSignerError;
+pub use signer::IkaSigner;

--- a/crates/ika-solana-signer/src/pubkey.rs
+++ b/crates/ika-solana-signer/src/pubkey.rs
@@ -1,0 +1,32 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Extract the 32-byte Ed25519 public key from a dWallet's `public_output`.
+
+use dwallet_mpc_centralized_party::public_key_from_dwallet_output_by_curve;
+
+use crate::error::IkaSignerError;
+
+const ED25519_CURVE_ID: u32 = 2;
+
+/// Decode the dWallet's BCS-encoded `public_output` into a Solana-compatible
+/// 32-byte Ed25519 public key.
+pub fn extract_ed25519_pubkey(
+    dwallet_id: &str,
+    public_output: &[u8],
+) -> Result<[u8; 32], IkaSignerError> {
+    let curve = dwallet_mpc_types::dwallet_mpc::DWalletCurve::Curve25519;
+    let bytes = public_key_from_dwallet_output_by_curve(curve, public_output)
+        .map_err(|_| IkaSignerError::InvalidPublicOutput(dwallet_id.to_string()))?;
+    if bytes.len() != 32 {
+        return Err(IkaSignerError::InvalidPublicOutput(dwallet_id.to_string()));
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+/// The numeric curve ID for Ed25519/Curve25519 dWallets in the on-chain encoding.
+pub const fn ed25519_curve_id() -> u32 {
+    ED25519_CURVE_ID
+}

--- a/crates/ika-solana-signer/src/signer.rs
+++ b/crates/ika-solana-signer/src/signer.rs
@@ -1,0 +1,162 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+use std::sync::Arc;
+
+use ika_sui_client::SuiConnectorClient;
+use ika_sui_client::dwallet_signer::{fetch_dwallet_metadata, get_network_key_info_for};
+use ika_sui_client::metrics::SuiClientMetrics;
+use sui_rpc_api::Client as RpcClient;
+use sui_sdk::SuiClientBuilder;
+use sui_types::base_types::SuiAddress;
+use tokio::sync::Mutex;
+
+use crate::config::{IkaSignerConfig, PresignMode};
+use crate::error::IkaSignerError;
+use crate::flow::{DWalletState, resolve_presign, resolve_secret_share, sign_with_presign};
+use crate::pubkey::{ed25519_curve_id, extract_ed25519_pubkey};
+
+/// Signer for Solana Ed25519 messages backed by an Ika dWallet.
+///
+/// Construct with [`IkaSigner::create`]. Sign with [`IkaSigner::sign_message`].
+pub struct IkaSigner {
+    cfg: IkaSignerConfig,
+    sender: SuiAddress,
+    pubkey: [u8; 32],
+    state: DWalletState,
+    /// Cached resolved secret share. Resolved once at construction time so that
+    /// hot-path signing doesn't re-decrypt on every call.
+    secret_share: Vec<u8>,
+    /// Persistent SDK client (read-only RPC).
+    sui_client: sui_sdk::SuiClient,
+    /// Persistent gRPC client (used for object refs and tx execution).
+    /// Mutable because `sui_rpc_api::Client::get_object` takes `&mut self`.
+    rpc: Arc<Mutex<RpcClient>>,
+    /// Tracks whether a `SingleProvided` presign cap has already been consumed.
+    consumed_provided_cap: Arc<Mutex<bool>>,
+}
+
+impl IkaSigner {
+    /// Build a signer against an existing ed25519 dWallet.
+    ///
+    /// Validates that the dWallet is in `Active` state and uses the ed25519 curve,
+    /// fetches the network key parameters needed for centralized signing, resolves
+    /// the secret share, and caches everything for fast `sign_message`.
+    pub async fn create(cfg: IkaSignerConfig) -> Result<Self, IkaSignerError> {
+        let sui_client = SuiClientBuilder::default()
+            .build(&cfg.sui_rpc_url)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to build Sui SDK client: {e}"))?;
+
+        let metadata = fetch_dwallet_metadata(&sui_client, cfg.dwallet_id).await?;
+
+        if metadata.curve != ed25519_curve_id() {
+            return Err(IkaSignerError::UnsupportedCurve {
+                dwallet_id: cfg.dwallet_id.to_string(),
+                actual: metadata.curve,
+                expected: ed25519_curve_id(),
+            });
+        }
+
+        let dkg_output = metadata
+            .dkg_output
+            .clone()
+            .ok_or_else(|| IkaSignerError::DWalletNotActive(cfg.dwallet_id.to_string()))?;
+
+        let network_encryption_key_id = metadata
+            .network_encryption_key_id
+            .ok_or_else(|| IkaSignerError::DWalletNotActive(cfg.dwallet_id.to_string()))?;
+
+        let connector = SuiConnectorClient::new(
+            &cfg.sui_rpc_url,
+            SuiClientMetrics::new_for_testing(),
+            cfg.ika_network_config.clone(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to build SuiConnectorClient: {e}"))?;
+
+        let net_key = get_network_key_info_for(
+            &connector,
+            Some(network_encryption_key_id),
+            ed25519_curve_id(),
+        )
+        .await?;
+
+        let state = DWalletState {
+            metadata,
+            dkg_output,
+            protocol_pp: net_key.protocol_public_parameters,
+            network_encryption_key_id,
+        };
+
+        let pubkey = extract_ed25519_pubkey(&cfg.dwallet_id.to_string(), &state.dkg_output)?;
+
+        let secret_share = resolve_secret_share(&sui_client, &cfg, &state).await?;
+
+        let sender: SuiAddress = (&cfg.payer.public()).into();
+        let rpc = RpcClient::new(&cfg.sui_rpc_url)
+            .map_err(|e| anyhow::anyhow!("failed to build Sui gRPC client: {e}"))?;
+
+        Ok(Self {
+            cfg,
+            sender,
+            pubkey,
+            state,
+            secret_share,
+            sui_client,
+            rpc: Arc::new(Mutex::new(rpc)),
+            consumed_provided_cap: Arc::new(Mutex::new(false)),
+        })
+    }
+
+    /// 32-byte Ed25519 public key (Solana address).
+    pub fn pubkey(&self) -> [u8; 32] {
+        self.pubkey
+    }
+
+    /// Run the MPC sign flow against the Ika network and return a 64-byte
+    /// Ed25519 signature.
+    pub async fn sign_message(&self, message: &[u8]) -> Result<[u8; 64], IkaSignerError> {
+        let mut rpc = self.rpc.lock().await;
+        let mut consumed = self.consumed_provided_cap.lock().await;
+
+        let (presign_cap_id, presign_output, needs_verification) = resolve_presign(
+            &mut rpc,
+            &self.sui_client,
+            &self.cfg.payer,
+            self.sender,
+            &self.cfg,
+            &self.state,
+            *consumed,
+        )
+        .await?;
+
+        if matches!(self.cfg.presign_mode, PresignMode::SingleProvided(_)) {
+            *consumed = true;
+        }
+
+        sign_with_presign(
+            &mut rpc,
+            &self.sui_client,
+            &self.cfg.payer,
+            self.sender,
+            &self.cfg,
+            &self.state,
+            &self.secret_share,
+            presign_cap_id,
+            presign_output,
+            needs_verification,
+            message.to_vec(),
+        )
+        .await
+    }
+
+    /// Lightweight reachability check: confirms the Sui RPC is up and the
+    /// dWallet is still in `Active` state.
+    pub async fn is_available(&self) -> bool {
+        match fetch_dwallet_metadata(&self.sui_client, self.cfg.dwallet_id).await {
+            Ok(m) => m.dkg_output.is_some(),
+            Err(_) => false,
+        }
+    }
+}

--- a/crates/ika-solana-signer/tests/testnet_integration.rs
+++ b/crates/ika-solana-signer/tests/testnet_integration.rs
@@ -1,0 +1,126 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Live integration test against Sui testnet + Ika testnet.
+//!
+//! Skipped at runtime when `IKA_DWALLET_ID` is unset, so `cargo test --release`
+//! stays green for contributors without a provisioned dWallet.
+//!
+//! Required env vars (mirrors the TS `@solana/keychain-ika` integration test
+//! setup so the same provisioned dWallet works for both):
+//!
+//! - `SUI_RPC_URL` — Sui fullnode URL (testnet).
+//! - `SUI_KEYPAIR` — Bech32 `suiprivkey1…` (output of `sui keytool export
+//!   <addr> --json`). The address must own the dWallet cap and have IKA + SUI.
+//! - `IKA_DWALLET_ID` — Active ed25519 dWallet object ID.
+//! - `IKA_DWALLET_CAP_ID` — `DWalletCap` object ID owned by the keypair.
+//! - `IKA_SECRET_SHARE_HEX` — Hex-encoded user secret share (raw bytes — same
+//!   format `ika dwallet create --output-secret hex` emits).
+//! - `IKA_IKA_COIN_ID` — IKA `Coin<IKA>` object ID owned by the keypair with
+//!   enough balance to pay presign + sign fees.
+
+use std::str::FromStr;
+
+use fastcrypto::ed25519::{Ed25519PublicKey, Ed25519Signature};
+use fastcrypto::traits::{ToFromBytes, VerifyingKey};
+use ika_solana_signer::{IkaSigner, IkaSignerConfig, PresignMode, SecretShareSource};
+use ika_types::messages_dwallet_mpc::IkaNetworkConfig;
+use sui_types::base_types::ObjectID;
+use sui_types::crypto::SuiKeyPair;
+
+fn testnet_network_config() -> IkaNetworkConfig {
+    // Verbatim from `deployed_contracts/testnet/address.yaml`. Hardcoded so the
+    // test is self-contained and doesn't have to reach into the workspace
+    // layout at runtime.
+    IkaNetworkConfig::new(
+        ObjectID::from_str("0x1f26bb2f711ff82dcda4d02c77d5123089cb7f8418751474b9fb744ce031526a")
+            .unwrap(),
+        ObjectID::from_str("0x96fc75633b6665cf84690587d1879858ff76f88c10c945e299f90bf4e0985eb0")
+            .unwrap(),
+        ObjectID::from_str("0xf02f5960c94fce1899a3795b5d11fd076bc70a8d0e20a2b19923d990ed490730")
+            .unwrap(),
+        Some(
+            ObjectID::from_str("0x6573a6c13daf26a64eb8a37d3c7a4391b353031e223072ca45b1ff9366f59293")
+                .unwrap(),
+        ),
+        ObjectID::from_str("0xae71e386fd4cff3a080001c4b74a9e485cd6a209fa98fb272ab922be68869148")
+            .unwrap(),
+        ObjectID::from_str("0x2172c6483ccd24930834e30102e33548b201d0607fb1fdc336ba3267d910dec6")
+            .unwrap(),
+        ObjectID::from_str("0x4d157b7415a298c56ec2cb1dcab449525fa74aec17ddba376a83a7600f2062fc")
+            .unwrap(),
+    )
+}
+
+fn env_or_skip(key: &str) -> Option<String> {
+    match std::env::var(key) {
+        Ok(v) if !v.is_empty() => Some(v),
+        _ => {
+            eprintln!("[skip] env var {key} unset; skipping live testnet integration test");
+            None
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn signs_message_against_testnet() {
+    // Gate on the dWallet ID being set so the test is skipped on machines
+    // without a provisioned dWallet rather than failing.
+    let Some(dwallet_id) = env_or_skip("IKA_DWALLET_ID") else {
+        return;
+    };
+    let dwallet_id = ObjectID::from_str(&dwallet_id).expect("IKA_DWALLET_ID is not a valid ObjectID");
+
+    let sui_rpc_url = std::env::var("SUI_RPC_URL").expect("SUI_RPC_URL required");
+    let sui_keypair_bech32 = std::env::var("SUI_KEYPAIR").expect("SUI_KEYPAIR required");
+    let dwallet_cap_id = ObjectID::from_str(
+        &std::env::var("IKA_DWALLET_CAP_ID").expect("IKA_DWALLET_CAP_ID required"),
+    )
+    .expect("IKA_DWALLET_CAP_ID is not a valid ObjectID");
+    let secret_share_hex =
+        std::env::var("IKA_SECRET_SHARE_HEX").expect("IKA_SECRET_SHARE_HEX required");
+    let ika_coin_id = ObjectID::from_str(
+        &std::env::var("IKA_IKA_COIN_ID").expect("IKA_IKA_COIN_ID required"),
+    )
+    .expect("IKA_IKA_COIN_ID is not a valid ObjectID");
+
+    let payer = SuiKeyPair::decode(&sui_keypair_bech32)
+        .expect("SUI_KEYPAIR must be a Bech32 `suiprivkey1…` string");
+    let secret_share = hex::decode(secret_share_hex.trim_start_matches("0x"))
+        .expect("IKA_SECRET_SHARE_HEX is not valid hex");
+
+    let cfg = IkaSignerConfig {
+        sui_rpc_url,
+        ika_network_config: testnet_network_config(),
+        payer,
+        dwallet_id,
+        dwallet_cap_id,
+        share_source: SecretShareSource::Bytes(secret_share),
+        presign_mode: PresignMode::PerSignGlobal,
+        ika_coin_id,
+        sui_coin_id: None,
+        gas_budget: 1_000_000_000,
+        poll_timeout: None,
+        poll_interval: None,
+    };
+
+    let signer = IkaSigner::create(cfg).await.expect("IkaSigner::create failed");
+    assert!(signer.is_available().await, "is_available should be true for an Active dWallet");
+
+    let pubkey_bytes = signer.pubkey();
+    let pubkey = Ed25519PublicKey::from_bytes(&pubkey_bytes)
+        .expect("dWallet pubkey is not a valid Ed25519 point");
+
+    let message = b"hello from ika-solana-signer integration test";
+    let signature_bytes = signer
+        .sign_message(message)
+        .await
+        .expect("sign_message failed against testnet");
+
+    let signature = Ed25519Signature::from_bytes(&signature_bytes)
+        .expect("returned signature is not a valid Ed25519 signature");
+
+    pubkey
+        .verify(message, &signature)
+        .expect("ed25519 signature did not verify under the dWallet pubkey");
+}

--- a/crates/ika-sui-client/src/dwallet_signer/mod.rs
+++ b/crates/ika-sui-client/src/dwallet_signer/mod.rs
@@ -14,6 +14,7 @@ pub mod metadata;
 pub mod network_key;
 pub mod presign;
 pub mod sign_session;
+pub mod tx;
 
 pub use coin::find_ika_coin;
 pub use common::{

--- a/crates/ika-sui-client/src/dwallet_signer/sign_session.rs
+++ b/crates/ika-sui-client/src/dwallet_signer/sign_session.rs
@@ -17,11 +17,18 @@ pub enum SignSessionResult {
 }
 
 /// Extract the sign session object ID from a sign transaction's events.
+///
+/// `SignRequestEvent` is wrapped in `DWalletSessionEvent`, which has a top-level
+/// `session_object_id` referring to a transient SessionManager record. The
+/// actual `SignSession` object — the one that flips to `Completed` /
+/// `NetworkRejected` — is `event_data.sign_id`. Polling
+/// `session_object_id` instead times out at 300s because it gets cleaned up
+/// almost immediately after dispatch.
 pub async fn find_sign_session_id(sdk_client: &sui_sdk::SuiClient, digest: &str) -> Option<String> {
     fetch_tx_events(sdk_client, digest)
         .await
         .as_deref()
-        .and_then(|evts| extract_event_field(evts, "SignRequestEvent", "session_object_id"))
+        .and_then(|evts| extract_event_field(evts, "SignRequestEvent", "sign_id"))
 }
 
 /// Poll a sign session until it reaches `Completed` or `NetworkRejected`.
@@ -48,24 +55,25 @@ pub async fn poll_sign_session(
         match fetch_object_fields(sdk_client, sign_session_id).await {
             Ok(fields) => {
                 if let Some(state) = fields.get("state") {
-                    let variant = state.get("variant").and_then(|v| v.as_str()).unwrap_or("");
-                    match variant {
-                        "Completed" => {
-                            let sig_bytes = state
-                                .get("fields")
-                                .and_then(|f| f.get("signature"))
-                                .and_then(extract_bytes_from_json)
-                                .unwrap_or_default();
-                            return Ok(SignSessionResult::Completed {
-                                signature: hex::encode(sig_bytes),
-                            });
-                        }
-                        "NetworkRejected" => {
-                            return Ok(SignSessionResult::Rejected);
-                        }
-                        _ => {
-                            // Still "Requested", keep polling
-                        }
+                    // Sui's parsedJson represents Move enums as
+                    // `{ "type": "<EnumStructTag>", "fields": { ...inner fields of the active variant... } }`
+                    // — there's no `variant` tag, the active variant is
+                    // inferred from which inner fields are present. For
+                    // SignState: `Completed` carries `signature`, while
+                    // `Requested` and `NetworkRejected` both have empty fields.
+                    //
+                    // We can detect Completed unambiguously via `signature`.
+                    // Distinguishing Requested from NetworkRejected requires
+                    // another signal; we treat both empty-field cases as
+                    // "still pending" until the polling timeout. (TODO: detect
+                    // NetworkRejected via the rejection event emitted by
+                    // validators rather than via the SignSession object.)
+                    let inner = state.get("fields");
+                    if let Some(sig_value) = inner.and_then(|f| f.get("signature")) {
+                        let sig_bytes = extract_bytes_from_json(sig_value).unwrap_or_default();
+                        return Ok(SignSessionResult::Completed {
+                            signature: hex::encode(sig_bytes),
+                        });
                     }
                 } else if start.elapsed().as_secs() == 30 {
                     let keys: Vec<&str> = fields

--- a/crates/ika-sui-client/src/dwallet_signer/tx.rs
+++ b/crates/ika-sui-client/src/dwallet_signer/tx.rs
@@ -1,0 +1,430 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! WalletContext-free transaction submission for the dWallet sign flow.
+//!
+//! Mirrors the PTB construction in [`crate::ika_dwallet_transactions`] for the
+//! sign / global-presign / imported-key sign paths, but takes an `RpcClient` +
+//! `SuiKeyPair` instead of a `WalletContext` so embedded signers don't need a
+//! Sui CLI wallet config.
+
+use anyhow::{Context, Result};
+use ika_types::sui::{
+    APPROVE_IMPORTED_KEY_MESSAGE_FUNCTION_NAME, APPROVE_MESSAGE_FUNCTION_NAME,
+    DWALLET_2PC_MPC_COORDINATOR_MODULE_NAME, REGISTER_SESSION_IDENTIFIER_FUNCTION_NAME,
+    REQUEST_GLOBAL_PRESIGN_FUNCTION_NAME, REQUEST_IMPORTED_KEY_SIGN_AND_RETURN_ID_FUNCTION_NAME,
+    REQUEST_SIGN_AND_RETURN_ID_FUNCTION_NAME, VERIFY_PRESIGN_CAP_FUNCTION_NAME,
+};
+use shared_crypto::intent::{Intent, IntentMessage};
+use sui::fire_drill::get_gas_obj_ref;
+use sui_json_rpc_types::{
+    SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse,
+};
+use sui_rpc_api::Client as RpcClient;
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    crypto::{Signature, SuiKeyPair},
+    object::Owner,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    transaction::{
+        Argument, CallArg, ObjectArg, SharedObjectMutability, Transaction, TransactionData,
+    },
+};
+
+use crate::ika_dwallet_transactions::PaymentCoinArgs;
+
+/// Resolve the dWallet 2PC-MPC coordinator as a shared `CallArg` without a `WalletContext`.
+pub async fn coordinator_call_arg(
+    rpc: &mut RpcClient,
+    coordinator_object_id: ObjectID,
+) -> Result<CallArg> {
+    let owner = rpc
+        .get_object(coordinator_object_id)
+        .await
+        .with_context(|| format!("failed to get coordinator object {coordinator_object_id}"))?
+        .owner()
+        .clone();
+    let initial_shared_version = match owner {
+        Owner::Shared {
+            initial_shared_version,
+        } => initial_shared_version,
+        _ => anyhow::bail!("Coordinator object {coordinator_object_id} is not a shared object"),
+    };
+    Ok(CallArg::Object(ObjectArg::SharedObject {
+        id: coordinator_object_id,
+        initial_shared_version,
+        mutability: SharedObjectMutability::Mutable,
+    }))
+}
+
+/// Resolve [`PaymentCoinArgs`] into PTB inputs using only an [`RpcClient`].
+pub async fn resolve_payment_coins(
+    coins: &PaymentCoinArgs,
+    ptb: &mut ProgrammableTransactionBuilder,
+    rpc: &RpcClient,
+) -> Result<(Argument, Argument)> {
+    let ika_coin_ref = rpc
+        .transaction_builder()
+        .get_object_ref(coins.ika_coin_id)
+        .await?;
+    let ika = ptb.input(CallArg::Object(ObjectArg::ImmOrOwnedObject(ika_coin_ref)))?;
+    let sui = match coins.sui_coin_id {
+        Some(id) => {
+            let r = rpc.transaction_builder().get_object_ref(id).await?;
+            ptb.input(CallArg::Object(ObjectArg::ImmOrOwnedObject(r)))?
+        }
+        None => Argument::GasCoin,
+    };
+    Ok((ika, sui))
+}
+
+/// Build an unsigned transaction without WalletContext (no dry-run; pass an explicit gas budget).
+pub async fn build_tx_data(
+    rpc: &RpcClient,
+    sender: SuiAddress,
+    ptb: ProgrammableTransactionBuilder,
+    gas_budget: u64,
+) -> Result<TransactionData> {
+    let tx = ptb.finish();
+    let rgp = rpc.get_reference_gas_price().await?;
+    let gas_obj_ref = get_gas_obj_ref(sender, rpc, gas_budget).await?;
+    Ok(TransactionData::new_programmable(
+        sender,
+        vec![gas_obj_ref],
+        tx,
+        gas_budget,
+        rgp,
+    ))
+}
+
+/// Sign a `TransactionData` with a `SuiKeyPair` and execute via the RPC client.
+pub async fn sign_and_execute(
+    keypair: &SuiKeyPair,
+    rpc: &RpcClient,
+    tx_data: TransactionData,
+) -> Result<SuiTransactionBlockResponse> {
+    let intent_msg = IntentMessage::new(Intent::sui_transaction(), tx_data.clone());
+    let signature = Signature::new_secure(&intent_msg, keypair);
+    let tx = Transaction::from_data(tx_data, vec![signature]);
+    let executed = rpc.execute_transaction_and_wait_for_checkpoint(&tx).await?;
+    let effects: SuiTransactionBlockEffects = executed
+        .effects
+        .try_into()
+        .map_err(|e| anyhow::anyhow!("failed to convert effects: {e}"))?;
+    Ok(SuiTransactionBlockResponse {
+        digest: *effects.transaction_digest(),
+        effects: Some(effects),
+        ..Default::default()
+    })
+}
+
+// -----------------------------------------------------------------------------
+// PTB helpers — duplicated from ika_dwallet_transactions because that module's
+// helpers are pure (`&mut ptb`) but live alongside WalletContext code; importing
+// them here keeps the call sites readable. If those helpers ever take rpc/context
+// they should be re-pointed here.
+// -----------------------------------------------------------------------------
+
+fn register_session_identifier(
+    ptb: &mut ProgrammableTransactionBuilder,
+    coordinator: Argument,
+    user_bytes: &[u8],
+    package_id: ObjectID,
+) -> Result<Argument> {
+    let user_bytes_arg = ptb.input(CallArg::Pure(bcs::to_bytes(&user_bytes.to_vec())?))?;
+    Ok(ptb.programmable_move_call(
+        package_id,
+        DWALLET_2PC_MPC_COORDINATOR_MODULE_NAME.into(),
+        REGISTER_SESSION_IDENTIFIER_FUNCTION_NAME.to_owned(),
+        vec![],
+        vec![coordinator, user_bytes_arg],
+    ))
+}
+
+fn approve_message(
+    ptb: &mut ProgrammableTransactionBuilder,
+    coordinator: Argument,
+    dwallet_cap: Argument,
+    signature_algorithm: u32,
+    hash_scheme: u32,
+    message: &[u8],
+    package_id: ObjectID,
+) -> Result<Argument> {
+    let sig_algo_arg = ptb.input(CallArg::Pure(bcs::to_bytes(&signature_algorithm)?))?;
+    let hash_scheme_arg = ptb.input(CallArg::Pure(bcs::to_bytes(&hash_scheme)?))?;
+    let message_arg = ptb.input(CallArg::Pure(bcs::to_bytes(&message.to_vec())?))?;
+    Ok(ptb.programmable_move_call(
+        package_id,
+        DWALLET_2PC_MPC_COORDINATOR_MODULE_NAME.into(),
+        APPROVE_MESSAGE_FUNCTION_NAME.to_owned(),
+        vec![],
+        vec![
+            coordinator,
+            dwallet_cap,
+            sig_algo_arg,
+            hash_scheme_arg,
+            message_arg,
+        ],
+    ))
+}
+
+fn approve_imported_key_message(
+    ptb: &mut ProgrammableTransactionBuilder,
+    coordinator: Argument,
+    imported_key_dwallet_cap: Argument,
+    signature_algorithm: u32,
+    hash_scheme: u32,
+    message: &[u8],
+    package_id: ObjectID,
+) -> Result<Argument> {
+    let sig_algo_arg = ptb.input(CallArg::Pure(bcs::to_bytes(&signature_algorithm)?))?;
+    let hash_scheme_arg = ptb.input(CallArg::Pure(bcs::to_bytes(&hash_scheme)?))?;
+    let message_arg = ptb.input(CallArg::Pure(bcs::to_bytes(&message.to_vec())?))?;
+    Ok(ptb.programmable_move_call(
+        package_id,
+        DWALLET_2PC_MPC_COORDINATOR_MODULE_NAME.into(),
+        APPROVE_IMPORTED_KEY_MESSAGE_FUNCTION_NAME.to_owned(),
+        vec![],
+        vec![
+            coordinator,
+            imported_key_dwallet_cap,
+            sig_algo_arg,
+            hash_scheme_arg,
+            message_arg,
+        ],
+    ))
+}
+
+// -----------------------------------------------------------------------------
+// Sign / presign tx builders — each takes (rpc, sui_keypair, sender, …).
+// -----------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+pub async fn request_sign_tx_with_signer(
+    rpc: &mut RpcClient,
+    keypair: &SuiKeyPair,
+    sender: SuiAddress,
+    package_id: ObjectID,
+    coordinator_object_id: ObjectID,
+    dwallet_cap_id: ObjectID,
+    signature_algorithm: u32,
+    hash_scheme: u32,
+    message: Vec<u8>,
+    message_centralized_signature: Vec<u8>,
+    verified_presign_cap_id: ObjectID,
+    session_identifier_bytes: Vec<u8>,
+    coins: PaymentCoinArgs,
+    gas_budget: u64,
+    verify_presign: bool,
+) -> Result<SuiTransactionBlockResponse> {
+    let mut ptb = ProgrammableTransactionBuilder::new();
+
+    let coordinator_arg = coordinator_call_arg(rpc, coordinator_object_id).await?;
+    let coordinator = ptb.input(coordinator_arg)?;
+
+    let session_id =
+        register_session_identifier(&mut ptb, coordinator, &session_identifier_bytes, package_id)?;
+
+    let dwallet_cap_ref = rpc
+        .transaction_builder()
+        .get_object_ref(dwallet_cap_id)
+        .await?;
+    let dwallet_cap_arg = ptb.input(CallArg::Object(ObjectArg::ImmOrOwnedObject(
+        dwallet_cap_ref,
+    )))?;
+
+    let message_approval = approve_message(
+        &mut ptb,
+        coordinator,
+        dwallet_cap_arg,
+        signature_algorithm,
+        hash_scheme,
+        &message,
+        package_id,
+    )?;
+
+    let presign_cap_ref = rpc
+        .transaction_builder()
+        .get_object_ref(verified_presign_cap_id)
+        .await?;
+    let presign_cap_input = ptb.input(CallArg::Object(ObjectArg::ImmOrOwnedObject(
+        presign_cap_ref,
+    )))?;
+    let presign_cap_arg = if verify_presign {
+        ptb.programmable_move_call(
+            package_id,
+            DWALLET_2PC_MPC_COORDINATOR_MODULE_NAME.into(),
+            VERIFY_PRESIGN_CAP_FUNCTION_NAME.to_owned(),
+            vec![],
+            vec![coordinator, presign_cap_input],
+        )
+    } else {
+        presign_cap_input
+    };
+
+    let centralized_sig_arg = ptb.input(CallArg::Pure(bcs::to_bytes(
+        &message_centralized_signature,
+    )?))?;
+
+    let (ika_coin_arg, sui_coin_arg) = resolve_payment_coins(&coins, &mut ptb, rpc).await?;
+
+    ptb.programmable_move_call(
+        package_id,
+        DWALLET_2PC_MPC_COORDINATOR_MODULE_NAME.into(),
+        REQUEST_SIGN_AND_RETURN_ID_FUNCTION_NAME.to_owned(),
+        vec![],
+        vec![
+            coordinator,
+            presign_cap_arg,
+            message_approval,
+            centralized_sig_arg,
+            session_id,
+            ika_coin_arg,
+            sui_coin_arg,
+        ],
+    );
+
+    let tx_data = build_tx_data(rpc, sender, ptb, gas_budget).await?;
+    sign_and_execute(keypair, rpc, tx_data).await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn request_imported_key_sign_tx_with_signer(
+    rpc: &mut RpcClient,
+    keypair: &SuiKeyPair,
+    sender: SuiAddress,
+    package_id: ObjectID,
+    coordinator_object_id: ObjectID,
+    dwallet_cap_id: ObjectID,
+    signature_algorithm: u32,
+    hash_scheme: u32,
+    message: Vec<u8>,
+    message_centralized_signature: Vec<u8>,
+    verified_presign_cap_id: ObjectID,
+    session_identifier_bytes: Vec<u8>,
+    coins: PaymentCoinArgs,
+    gas_budget: u64,
+    verify_presign: bool,
+) -> Result<SuiTransactionBlockResponse> {
+    let mut ptb = ProgrammableTransactionBuilder::new();
+
+    let coordinator_arg = coordinator_call_arg(rpc, coordinator_object_id).await?;
+    let coordinator = ptb.input(coordinator_arg)?;
+
+    let session_id =
+        register_session_identifier(&mut ptb, coordinator, &session_identifier_bytes, package_id)?;
+
+    let dwallet_cap_ref = rpc
+        .transaction_builder()
+        .get_object_ref(dwallet_cap_id)
+        .await?;
+    let dwallet_cap_arg = ptb.input(CallArg::Object(ObjectArg::ImmOrOwnedObject(
+        dwallet_cap_ref,
+    )))?;
+
+    let message_approval = approve_imported_key_message(
+        &mut ptb,
+        coordinator,
+        dwallet_cap_arg,
+        signature_algorithm,
+        hash_scheme,
+        &message,
+        package_id,
+    )?;
+
+    let presign_cap_ref = rpc
+        .transaction_builder()
+        .get_object_ref(verified_presign_cap_id)
+        .await?;
+    let presign_cap_input = ptb.input(CallArg::Object(ObjectArg::ImmOrOwnedObject(
+        presign_cap_ref,
+    )))?;
+    let presign_cap_arg = if verify_presign {
+        ptb.programmable_move_call(
+            package_id,
+            DWALLET_2PC_MPC_COORDINATOR_MODULE_NAME.into(),
+            VERIFY_PRESIGN_CAP_FUNCTION_NAME.to_owned(),
+            vec![],
+            vec![coordinator, presign_cap_input],
+        )
+    } else {
+        presign_cap_input
+    };
+
+    let centralized_sig_arg = ptb.input(CallArg::Pure(bcs::to_bytes(
+        &message_centralized_signature,
+    )?))?;
+
+    let (ika_coin_arg, sui_coin_arg) = resolve_payment_coins(&coins, &mut ptb, rpc).await?;
+
+    ptb.programmable_move_call(
+        package_id,
+        DWALLET_2PC_MPC_COORDINATOR_MODULE_NAME.into(),
+        REQUEST_IMPORTED_KEY_SIGN_AND_RETURN_ID_FUNCTION_NAME.to_owned(),
+        vec![],
+        vec![
+            coordinator,
+            presign_cap_arg,
+            message_approval,
+            centralized_sig_arg,
+            session_id,
+            ika_coin_arg,
+            sui_coin_arg,
+        ],
+    );
+
+    let tx_data = build_tx_data(rpc, sender, ptb, gas_budget).await?;
+    sign_and_execute(keypair, rpc, tx_data).await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn request_global_presign_tx_with_signer(
+    rpc: &mut RpcClient,
+    keypair: &SuiKeyPair,
+    sender: SuiAddress,
+    package_id: ObjectID,
+    coordinator_object_id: ObjectID,
+    dwallet_network_encryption_key_id: ObjectID,
+    curve: u32,
+    signature_algorithm: u32,
+    session_identifier_bytes: Vec<u8>,
+    coins: PaymentCoinArgs,
+    gas_budget: u64,
+) -> Result<SuiTransactionBlockResponse> {
+    let mut ptb = ProgrammableTransactionBuilder::new();
+
+    let coordinator_arg = coordinator_call_arg(rpc, coordinator_object_id).await?;
+    let coordinator = ptb.input(coordinator_arg)?;
+
+    let session_id =
+        register_session_identifier(&mut ptb, coordinator, &session_identifier_bytes, package_id)?;
+
+    let encryption_key_id_arg = ptb.input(CallArg::Pure(bcs::to_bytes(
+        &dwallet_network_encryption_key_id,
+    )?))?;
+    let curve_arg = ptb.input(CallArg::Pure(bcs::to_bytes(&curve)?))?;
+    let sig_algo_arg = ptb.input(CallArg::Pure(bcs::to_bytes(&signature_algorithm)?))?;
+
+    let (ika_coin_arg, sui_coin_arg) = resolve_payment_coins(&coins, &mut ptb, rpc).await?;
+
+    let presign_cap = ptb.programmable_move_call(
+        package_id,
+        DWALLET_2PC_MPC_COORDINATOR_MODULE_NAME.into(),
+        REQUEST_GLOBAL_PRESIGN_FUNCTION_NAME.to_owned(),
+        vec![],
+        vec![
+            coordinator,
+            encryption_key_id_arg,
+            curve_arg,
+            sig_algo_arg,
+            session_id,
+            ika_coin_arg,
+            sui_coin_arg,
+        ],
+    );
+
+    ptb.transfer_arg(sender, presign_cap);
+
+    let tx_data = build_tx_data(rpc, sender, ptb, gas_budget).await?;
+    sign_and_execute(keypair, rpc, tx_data).await
+}


### PR DESCRIPTION
> Stacked on #1700 — review/merge that first.

## Summary

New `crates/ika-solana-signer` crate exposing `IkaSigner`, a Solana Ed25519 signer backed by an Ika dWallet. Wraps a pre-provisioned ed25519 dWallet and runs the full MPC sign flow against Sui — presign (or caller-supplied verified cap) → centralized sign step → submit `request_sign_tx` → poll sign session → return the 64-byte Ed25519 signature.

## Public API

\`\`\`rust
let signer = IkaSigner::create(IkaSignerConfig {
    sui_rpc_url, ika_network_config, payer, dwallet_id, dwallet_cap_id,
    share_source: SecretShareSource::Bytes(secret_share_bytes),
    presign_mode: PresignMode::PerSignGlobal,
    ika_coin_id, sui_coin_id: None,
    gas_budget: 200_000_000,
    poll_timeout: None, poll_interval: None,
}).await?;

let pubkey: [u8; 32] = signer.pubkey();
let signature: [u8; 64] = signer.sign_message(b"hello solana").await?;
\`\`\`

`pubkey` is parsed from the dWallet's BCS-encoded `public_output` via `dwallet_mpc_centralized_party::public_key_from_dwallet_output_by_curve` — not a guessed byte slice.

## Presign modes

- `PerSignGlobal` — each \`sign_message\` requests a fresh global presign, polls until complete, auto-verifies in the sign tx, uses it once. Stateless. Extra MPC round-trip per signature.
- `SingleProvided(ObjectID)` — caller provides a verified or unverified presign cap. Single-shot — subsequent calls return \`PresignCapConsumed\`. Reconstruct the signer with a fresh cap to sign again. Lets advanced users manage their own pool.

No internal background pool in v1.

## What's also new in `ika-sui-client`

`dwallet_signer::tx` — WalletContext-free sign / global-presign / imported-key-sign tx builders that take \`(RpcClient, SuiKeyPair, sender, …)\`, sign via \`Signature::new_secure\` against an \`IntentMessage\`, and execute through \`execute_transaction_and_wait_for_checkpoint\`. The CLI's existing \`request_sign_tx\` / \`request_global_presign_tx\` are untouched — this is a parallel write path the embedded signer uses.

The PTB-construction helpers (\`register_session_identifier\`, \`approve_message\`, \`approve_imported_key_message\`) are duplicated locally rather than re-pointed; they're 15-line pure functions and re-pointing across modules adds dependency churn for negligible gain. Worth revisiting if/when the CLI write path adopts the same shape.

## Out of scope

- DKG, key import, payment-coin auto-creation. Use the \`ika\` CLI or \`IkaTransaction\` to provision a dWallet, then hand its ID to \`IkaSigner\`.
- secp256k1 / secp256r1 / ristretto curves. Solana doesn't need them.
- \`solana-keychain\` \`SolanaSigner\` trait integration. Lands in a follow-up PR alongside end-to-end tests against \`ika-swarm\`.

## Test plan

- [x] \`cargo build --release -p ika-solana-signer -p ika-sui-client -p ika\` — clean
- [x] \`cargo clippy --release --workspace --all-targets\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] End-to-end: provision an ed25519 dWallet via \`ika dwallet create --curve ed25519\` against \`ika-swarm\`, then \`IkaSigner::create\` + \`sign_message\`, verify with \`ed25519-dalek\`. (PR 3.)
- [ ] Devnet / Solana smoke test via a tiny example binary. (PR 3.)

## Plan reference

\`~/.claude/plans/lets-do-it-calm-pebble.md\`. This PR delivers Track 2.