### PR TITLE
[TEMP] Skip pre-flight dry-run + gas estimation in construct_unsigned_txn

### DIFF
--- a/crates/ika-sui-client/src/ika_validator_transactions.rs
+++ b/crates/ika-sui-client/src/ika_validator_transactions.rs
@@ -35,7 +35,6 @@ use move_core_types::identifier::IdentStr;
 use move_core_types::language_storage::{StructTag, TypeTag};
 use serde::Serialize;
 use shared_crypto::intent::Intent;
-use sui::client_commands::{SuiClientCommandResult, execute_dry_run};
 use sui::fire_drill::get_gas_obj_ref;
 use sui_json_rpc_types::{
     SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse,
@@ -44,7 +43,6 @@ use sui_keys::keystore::AccountKeystore;
 use sui_sdk::wallet_context::WalletContext;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::collection_types::Entry;
-use sui_types::effects::TransactionEffectsAPI;
 use sui_types::object::Owner;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{Argument, CallArg, ObjectArg, Transaction, TransactionKind};
@@ -723,35 +721,11 @@ pub(crate) async fn construct_unsigned_txn(
     let tx = ptb.finish();
     let tx_kind = TransactionKind::ProgrammableTransaction(tx.clone());
 
-    let dry_run = execute_dry_run(
-        context,
-        sender,
-        tx_kind.clone(),
-        None,
-        gas_price,
-        vec![],
-        None,
-    )
-    .await
-    .map_err(|e| IkaError::DryRunFailed(e.to_string()))?;
-    if let SuiClientCommandResult::DryRun(dry_run) = dry_run
-        && dry_run.transaction.effects.status().is_err()
-    {
-        let err_msg = format!("{:?}", dry_run.transaction.effects.status());
-        tracing::debug!(?dry_run.transaction.effects, "Dry run failed");
-        return Err(IkaError::DryRunFailed(err_msg));
-    };
-
-    let gas_budget = sui::client_commands::estimate_gas_budget(
-        context,
-        sender,
-        tx_kind,
-        gas_price,
-        vec![],
-        None,
-    )
-    .await
-    .unwrap_or(gas_budget);
+    // [TEMP] Pre-flight dry-run + gas estimation disabled while testnet runs a
+    // newer Sui gRPC schema than the SDK pin in this workspace; both calls
+    // fail to decode `SimulateTransactionResponse`. The real submit still
+    // surfaces tx errors via effects, just without the early signal.
+    let _ = (gas_price, &tx_kind);
 
     let rgp = sui_client
         .get_reference_gas_price()


### PR DESCRIPTION
## Summary
- Disables the `execute_dry_run` + `estimate_gas_budget` calls inside `construct_unsigned_txn` while testnet runs a newer Sui gRPC schema than what the workspace pin (`testnet-v1.67.1`) decodes
- Unblocks local CLI usage against testnet (e.g. `ika dwallet create` was failing with `DryRunFailed("Dry run failed")`); the real submit still surfaces tx errors via effects, just without the dry-run early signal
- Drops two now-dead imports (`SuiClientCommandResult`, `execute_dry_run`, `TransactionEffectsAPI`) so clippy stays clean

## Why this is `[TEMP]`
Public testnet fullnodes report `sui-node/1.71.0`; this workspace pins Sui at `testnet-v1.67.1`. Their `SimulateTransactionResponse` gRPC schemas have diverged enough that the SDK in this workspace fails to decode the response. The dry-run path is the only place this hits today.

## Why this isn't the proper fix
The proper fix is to bump every `tag = "testnet-v1.67.1"` in the workspace `Cargo.toml` to `testnet-v1.71.0` (the tag that matches what testnet fullnodes serve). I prototyped that — it's a non-trivial refactor:

- Sui's 4-minor jump cascades multiple lockfile bumps (`tower ^0.5 → ^0.5.3`, `chrono ^0.4 → ^0.4.44`, `rustls-webpki`, …). Surgical `cargo update -p X` fails because cargo re-validates the whole graph each time.
- A blanket relock (`cargo generate-lockfile`) drifts the RustCrypto prerelease line: `elliptic-curve` jumps from `0.14.0-rc.16` to `rc.32`, which `ecdsa 0.17.0-rc.7` (required transitively via the `inkrypto` git dep) cannot compile against — `try_from_rng` and friends were renamed in that rc range.
- Doing it cleanly needs explicit `[patch.crates-io]` pins for `elliptic-curve` and the rest of the RustCrypto prerelease line, and someone who knows what the `inkrypto` rev `abd7f010` was originally built against.

Tracking that as separate follow-up work; this PR is the unblocker until it lands.

## Test plan
- [x] `cargo build --release -p ika-sui-client` — unchanged crate compiles clean (already verified locally; clippy clean, no `unused_imports` warnings)
- [x] `cargo build --release -p ika` — CLI still builds
- [x] `ika dwallet create --curve ed25519` against testnet completes (used during integration testing of the new TS signer in `solana-foundation/solana-keychain`)
- [ ] Revisit and revert this commit once the proper Sui bump lands