### PR TITLE
sdk: fix getLatestNetworkEncryptionKey hang under gRPC

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -8,7 +8,7 @@
 		"directory": "sdk/typescript"
 	},
 	"homepage": "https://docs.ika.xyz/sdk",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"license": "BSD-3-Clause-Clear",
 	"sideEffects": false,
 	"files": [

--- a/sdk/typescript/src/client/ika-client.ts
+++ b/sdk/typescript/src/client/ika-client.ts
@@ -1102,27 +1102,31 @@ export class IkaClient {
 					keyParsed.reconfiguration_public_outputs.id,
 				);
 
-				const lastReconfigOutput = (
-					await Promise.all(
-						reconfigOutputsDFs.map(async (df) => {
-							const name = bcs.u32().parse(df.name.bcs);
-							const reconfigObject = await this.client.core.getObject({
-								objectId: df.fieldId,
-								include: { content: true },
-							});
-
-							const parsedValue = DynamicField(TableVec).parse(objResToBcs(reconfigObject));
-
-							return {
-								name,
-								parsedValue,
-							};
-						}),
-					)
-				)
+				// We only need one reconfiguration output (the second-to-last by
+				// epoch, since the last one may not have completed yet). Sort
+				// the dynamic-field metadata by name first, then fetch the
+				// single object we care about. Fetching every entry's object
+				// trips public-endpoint rate limits on networks with long
+				// reconfiguration histories.
+				const targetReconfigDF = reconfigOutputsDFs
+					.map((df) => ({ df, name: bcs.u32().parse(df.name.bcs) }))
 					.sort((a, b) => Number(a.name) - Number(b.name))
 					// The last reconfiguration has not necessarily been completed, so we take the second to last
 					.at(-2);
+
+				const lastReconfigOutput = targetReconfigDF
+					? {
+							name: targetReconfigDF.name,
+							parsedValue: DynamicField(TableVec).parse(
+								objResToBcs(
+									await this.client.core.getObject({
+										objectId: targetReconfigDF.df.fieldId,
+										include: { content: true },
+									}),
+								),
+							),
+						}
+					: undefined;
 
 				const encryptionKey: NetworkEncryptionKey = {
 					id: keyName,

--- a/sdk/typescript/src/client/utils.ts
+++ b/sdk/typescript/src/client/utils.ts
@@ -42,7 +42,7 @@ export async function fetchAllDynamicFields(
 	suiClient: ClientWithCoreApi,
 	parentId: string,
 ): Promise<SuiClientTypes.DynamicFieldEntry[]> {
-	const allFields: any[] = [];
+	const allFields: SuiClientTypes.DynamicFieldEntry[] = [];
 	let cursor: string | null = null;
 
 	while (true) {
@@ -53,7 +53,12 @@ export async function fetchAllDynamicFields(
 
 		allFields.push(...response.dynamicFields);
 
-		if (response.cursor === cursor) {
+		// Use `hasNextPage` as the authoritative stop condition. The
+		// previous cursor-equality check was incorrect: when the final
+		// page returns `cursor: null` after a non-null prior cursor, the
+		// inequality drove the loop back to a null cursor (i.e., page 1)
+		// and looped forever.
+		if (!response.hasNextPage) {
 			break;
 		}
 


### PR DESCRIPTION
## Summary

Two bugs in `@ika.xyz/sdk` that surface together when `IkaClient` is initialised against `SuiGrpcClient` on networks with non-trivial reconfiguration history (testnet currently has **284** reconfiguration outputs on the active encryption key). Together they make `getLatestNetworkEncryptionKey()` (and therefore `getProtocolPublicParameters(undefined, ...)`, `quoteSign`, etc.) hang forever under gRPC.

Existing JSON-RPC consumers (recovery, the SDK's own `createTestSuiClient`, the in-tree examples) were unaffected and still are after this change.

### Bug 1 — `fetchAllDynamicFields` infinite-loops under gRPC

```ts
// before
while (true) {
  const response = await suiClient.core.listDynamicFields({ parentId, cursor });
  allFields.push(...response.dynamicFields);
  if (response.cursor === cursor) break;
  cursor = response.cursor;
}
```

The stop condition is wrong. Under **JSON-RPC** the terminal page echoes the request cursor, so `response.cursor === cursor` is `true` and the loop exits. Under **gRPC** the terminal page returns `cursor: null` (which differs from the prior page's non-null cursor), so the loop assigns `cursor = null` and re-fetches page 1, forever.

Fix: use the documented `hasNextPage` signal — both transports honor it per `SuiClientTypes.ListDynamicFieldsResponse`.

### Bug 2 — `#fetchEncryptionKeysFromNetwork` blasts the validator

```ts
// before
const reconfigOutputsDFs = await fetchAllDynamicFields(this.client, keyParsed.reconfiguration_public_outputs.id);
const lastReconfigOutput = (await Promise.all(
  reconfigOutputsDFs.map(async (df) => {
    const reconfigObject = await this.client.core.getObject({ objectId: df.fieldId, ... });
    return { name: bcs.u32().parse(df.name.bcs), parsedValue: DynamicField(TableVec).parse(objResToBcs(reconfigObject)) };
  })
)).sort((a, b) => Number(a.name) - Number(b.name)).at(-2);
```

This issues **one `getObject` per reconfiguration output** — on testnet today that's 284 concurrent reads — only to discard 282 of them after sorting and taking `.at(-2)`. Mysten's public testnet endpoint rejects this with `RESOURCE_EXHAUSTED` ("Too Many Requests"), and there's no backoff in the SDK so the call never recovers.

Fix: sort the dynamic-field metadata first (cheap, paginated; we already had the data), then `getObject` **only the entry we actually need**. The selected entry is byte-identical to before.

## Repro

Against testnet via `SuiGrpcClient`, on `main` (`@ika.xyz/sdk` 0.4.0):

```
[+0.00s] step 1: ikaClient.initialize()
[+1.62s]   initialize() ok in 1609ms
[+1.62s] step 2: getLatestNetworkEncryptionKey()
[probe] STILL HUNG after 240s
```

With this PR:

```
[+0.00s] step 1: ikaClient.initialize()
[+2.29s]   initialize() ok in 2281ms
[+2.29s] step 2: getLatestNetworkEncryptionKey()
[+5.95s]   key id=0xe7c7...37cc epoch=1 in 3663ms
[+5.95s] step 3: getProtocolPublicParameters(undefined, SECP256K1)
[+16.68s]   bytes len=44642756 in 10729ms
[+16.68s] step 4: simulateTransaction(current_pricing)
[+17.14s]   $kind=Transaction cmdResults=1 in 462ms
[+17.14s]   pricing entries: 49
[+17.15s] ALL OK
```

## Backwards compatibility

No public API changes. `lastReconfigOutput`'s shape and the resulting `NetworkEncryptionKey.reconfigurationOutputID` are identical pre/post for any input that previously returned (i.e. JSON-RPC). For gRPC inputs that previously hung, the call now returns the value it always should have.

Bumps `@ika.xyz/sdk` 0.4.0 → 0.4.1.

## Test plan

- [x] SDK unit tests: same pass/fail as `main` (one pre-existing `objResToBcs` mock failure on `main` and on this branch — unrelated to the diff).
- [x] Manual: against `https://fullnode.testnet.sui.io:443` via `SuiGrpcClient` — `initialize` + `getLatestNetworkEncryptionKey` + `getProtocolPublicParameters(curve)` for all 4 curves, plus `simulateTransaction(current_pricing)`. All return correct values.
- [x] Manual: returned `NetworkEncryptionKey` matches recovery's existing JSON-RPC consumers' usage (same fields, same byte content for the second-to-last reconfig output).