### PR TITLE
feat(ika_system): expose `is_in_committees(System, ID): bool`

### DIFF
--- a/contracts/ika_system/sources/system.move
+++ b/contracts/ika_system/sources/system.move
@@ -507,6 +507,21 @@ public fun next_epoch_active_committee(self: &System): Option<BlsCommittee> {
     self.inner().next_epoch_active_committee()
 }
 
+/// Returns true if `validator_id` is in the current active committee or
+/// the next epoch's active committee. Equivalent to
+/// `active_committee().contains(&id) || next_epoch_active_committee().map(|c|
+/// c.contains(&id)).unwrap_or(false)` but returns just the boolean rather
+/// than copying the full `BlsCommittee` structures.
+///
+/// Useful for integrations that need to detect when a validator has
+/// rotated out of both committees and select the correct withdrawal path
+/// (the one-step inactive-validator branch in
+/// `validator::withdraw_stake`) instead of the two-epoch cooldown that
+/// would otherwise abort with `EWithdrawDirectly`.
+public fun is_in_committees(self: &System, validator_id: ID): bool {
+    self.inner().is_in_committees(validator_id)
+}
+
 /// Locks the committee of the next epoch to allow starting the reconfiguration process.
 public fun initiate_mid_epoch_reconfiguration(self: &mut System, clock: &Clock) {
     self.inner_mut().initiate_mid_epoch_reconfiguration(clock);

--- a/contracts/ika_system/sources/system/system_inner.move
+++ b/contracts/ika_system/sources/system/system_inner.move
@@ -743,6 +743,10 @@ public(package) fun next_epoch_active_committee(self: &SystemInner): Option<BlsC
     self.validator_set.next_epoch_active_committee()
 }
 
+public(package) fun is_in_committees(self: &SystemInner, validator_id: ID): bool {
+    self.validator_set.is_in_committees(validator_id)
+}
+
 public(package) fun verify_validator_cap(
     self: &SystemInner,
     cap: &ValidatorCap,

--- a/contracts/ika_system/sources/system/validator_set.move
+++ b/contracts/ika_system/sources/system/validator_set.move
@@ -752,6 +752,22 @@ public(package) fun is_active_validator(self: &ValidatorSet, validator_id: ID): 
     self.active_committee.contains(&validator_id)
 }
 
+/// Returns true if `validator_id` is in either the current active committee
+/// or the next epoch's active committee. Mirrors the `is_current_committee
+/// || is_next_committee` predicate used internally by
+/// `request_withdraw_stake` / `withdraw_stake` to branch between the
+/// two-epoch-cooldown path and the inactive-direct-withdraw path.
+///
+/// Exposed so external callers (liquid staking pools, custody integrations)
+/// can route around the `EWithdrawDirectly` abort in
+/// `validator::request_withdraw_stake` when a validator they hold positions
+/// on has rotated out of both committees, without copying the full
+/// `BlsCommittee` to do the same check externally.
+public(package) fun is_in_committees(self: &ValidatorSet, validator_id: ID): bool {
+    self.active_committee.contains(&validator_id)
+        || self.next_epoch_active_committee.is_some_and!(|c| c.contains(&validator_id))
+}
+
 /// Returns all the validators who are currently reporting `validator_id`
 public(package) fun get_reporters_of(self: &ValidatorSet, validator_id: ID): VecSet<ID> {
     if (self.validator_report_records.contains(&validator_id)) {


### PR DESCRIPTION
Adds a public read predicate to `ika_system::system::System` that returns true when a validator is in the current active committee or the next epoch's active committee. Mirrors the internal `is_current_committee || is_next_committee` test already used by `validator_set::request_withdraw_stake` and
`validator_set::withdraw_stake` to branch between the two-epoch cooldown path and the inactive-direct-withdraw path.

Why

External integrations (liquid staking pools, custody integrations, anything wrapping `StakedIka`) need to know when a validator has rotated out of both committees, because `request_withdraw_stake` aborts with `EWithdrawDirectly` in that case. The intended flow per `validator::withdraw_stake` (validator.move:373-388) is to bypass `request_withdraw_stake` and call `system::withdraw_stake` directly on the still-Staked position — but the caller has no clean way to detect when to take that branch.

Without this predicate, integrators have three poor options:
1. Speculatively call `request_withdraw_stake` and let it abort — Move has no try/catch, so this kills the whole transaction.
2. Call the existing public `active_committee()` and `next_epoch_active_committee()` accessors and run `.contains()` externally. Works, but copies the full `BlsCommittee` value (BLS pubkeys + voting power per member) on every read just to compute one bool.
3. Add an admin-gated rescue function with elevated trust to call `system::withdraw_stake` directly — expands the trust surface and breaks multisig/timelock-only governance designs.

The predicate is observability of state the system already tracks. No behaviour change.

Wiring

Threads through the same three layers as the existing `active_committee()` getter:
- `validator_set::is_in_committees(&ValidatorSet, ID): bool` (public(package))
- `system_inner::is_in_committees(&SystemInner, ID): bool` (public(package))
- `system::is_in_committees(&System, ID): bool` (public)

Implementation is two reads on the existing `active_committee` and `next_epoch_active_committee` fields plus `bls_committee::contains` (already public). Zero new state, zero new dependencies.

Build status

Local `sui move build` on ika_system blocked by a pre-existing upstream stdlib mismatch:
`ika_common/sources/bls_committee.move:149` calls
`n_members.div_ceil(8)` which isn't on `std::u64` in sui 1.72.1. Same error reproduces on plain `origin/main` without this change — unrelated to this PR. The patch compiles cleanly against the sui version `ika_common` was authored on.

Context

Originating use case is liquid-staking pool recovery from validator rotation. Spec writeup including the validator.move line references and the alternatives we considered:
https://github.com/inkwell-finance/ika-liquid-staking-spec (drafted 2026-05-12; happy to share the markdown if helpful for review).

Happy to add a test once the `div_ceil` stdlib drift is resolved upstream, or to split that into a separate prep PR if you'd like.

## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
