### PR TITLE
fix(presign): key presign storage and single-use by (session_id, blending_index)

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -281,7 +281,7 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, Vec<u8>)>>;
+    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>>;
 
     /// Returns the next idle status updates after the given consensus round.
     fn next_idle_status_update(
@@ -314,10 +314,18 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
     ) -> IkaResult<Option<(Round, Vec<ConsensusNOAObservation>)>>;
 
     /// Marks a presign as used so it cannot be reused.
-    fn mark_presign_as_used(&self, presign_session_id: SessionIdentifier) -> IkaResult<()>;
+    fn mark_presign_as_used(
+        &self,
+        presign_session_id: SessionIdentifier,
+        presign_blending_index: u16,
+    ) -> IkaResult<()>;
 
     /// Checks if a presign has already been used.
-    fn is_presign_used(&self, presign_session_id: SessionIdentifier) -> IkaResult<bool>;
+    fn is_presign_used(
+        &self,
+        presign_session_id: SessionIdentifier,
+        presign_blending_index: u16,
+    ) -> IkaResult<bool>;
 
     /// Assigns a presign to a user by moving it from the internal pool to the assigned pool.
     /// This is used for external presign requests.
@@ -328,13 +336,14 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
         user_verification_key: Option<Vec<u8>>,
         dwallet_id: Option<ObjectID>,
         current_epoch: u64,
-    ) -> IkaResult<Option<SessionIdentifier>>;
+    ) -> IkaResult<Option<(SessionIdentifier, u16)>>;
 
-    /// Retrieves an assigned presign by session identifier and signature algorithm.
+    /// Retrieves an assigned presign by session identifier, blending index, and signature algorithm.
     fn get_assigned_presign(
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         session_identifier: SessionIdentifier,
+        blending_index: u16,
     ) -> IkaResult<Option<AssignedPresign>>;
 
     /// Pops an assigned presign from the pool. Used when the presign is consumed for signing.
@@ -342,6 +351,7 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         session_identifier: SessionIdentifier,
+        blending_index: u16,
     ) -> IkaResult<Option<AssignedPresign>>;
 }
 
@@ -472,7 +482,7 @@ impl AuthorityPerEpochStoreTrait for AuthorityPerEpochStore {
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, Vec<u8>)>> {
+    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
         let tables = self.tables()?;
         tables.pop_presign(signature_algorithm, dwallet_network_encryption_key_id)
     }
@@ -552,14 +562,22 @@ impl AuthorityPerEpochStoreTrait for AuthorityPerEpochStore {
         }
     }
 
-    fn mark_presign_as_used(&self, presign_session_id: SessionIdentifier) -> IkaResult<()> {
+    fn mark_presign_as_used(
+        &self,
+        presign_session_id: SessionIdentifier,
+        presign_blending_index: u16,
+    ) -> IkaResult<()> {
         let tables = self.tables()?;
-        tables.mark_presign_as_used(presign_session_id)
+        tables.mark_presign_as_used(presign_session_id, presign_blending_index)
     }
 
-    fn is_presign_used(&self, presign_session_id: SessionIdentifier) -> IkaResult<bool> {
+    fn is_presign_used(
+        &self,
+        presign_session_id: SessionIdentifier,
+        presign_blending_index: u16,
+    ) -> IkaResult<bool> {
         let tables = self.tables()?;
-        tables.is_presign_used(presign_session_id)
+        tables.is_presign_used(presign_session_id, presign_blending_index)
     }
 
     fn assign_presign(
@@ -569,7 +587,7 @@ impl AuthorityPerEpochStoreTrait for AuthorityPerEpochStore {
         user_verification_key: Option<Vec<u8>>,
         dwallet_id: Option<ObjectID>,
         current_epoch: u64,
-    ) -> IkaResult<Option<SessionIdentifier>> {
+    ) -> IkaResult<Option<(SessionIdentifier, u16)>> {
         let tables = self.tables()?;
         tables.assign_presign(
             signature_algorithm,
@@ -584,18 +602,20 @@ impl AuthorityPerEpochStoreTrait for AuthorityPerEpochStore {
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         session_identifier: SessionIdentifier,
+        blending_index: u16,
     ) -> IkaResult<Option<AssignedPresign>> {
         let tables = self.tables()?;
-        tables.get_assigned_presign(signature_algorithm, session_identifier)
+        tables.get_assigned_presign(signature_algorithm, session_identifier, blending_index)
     }
 
     fn pop_assigned_presign(
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         session_identifier: SessionIdentifier,
+        blending_index: u16,
     ) -> IkaResult<Option<AssignedPresign>> {
         let tables = self.tables()?;
-        tables.pop_assigned_presign(signature_algorithm, session_identifier)
+        tables.pop_assigned_presign(signature_algorithm, session_identifier, blending_index)
     }
 }
 
@@ -667,8 +687,10 @@ pub enum ReconfigCertStatus {
 
 /// Presign pool DB table type.
 /// Key: (network_encryption_key_id, session_sequence_number).
-/// Value: (session_identifier, list of serialized presign bytes).
-type PresignPoolTable = DBMap<(ObjectID, u64), (SessionIdentifier, Vec<Vec<u8>>)>;
+/// Value: (session_identifier, list of (blending_index, serialized presign bytes)).
+/// The blending index is the presign's position in the originally-inserted vector;
+/// together with the session identifier it uniquely identifies a single presign.
+type PresignPoolTable = DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>;
 
 /// AuthorityEpochTables contains tables that contain data that is only valid within an epoch.
 #[derive(DBMapUtils)]
@@ -759,20 +781,21 @@ pub struct AuthorityEpochTables {
     /// Internal presign pools, keyed by (network_encryption_key_id, session_sequence_number).
     /// Each entry contains presigns generated by that session, along with the session identifier.
     /// Presigns are consumed in order (lowest session sequence number first) within a given key ID.
-    /// Value is (SessionIdentifier, Vec<presign_bytes>) - the session ID and list of presigns.
+    /// Value is (SessionIdentifier, Vec<(blending_index, presign_bytes)>) - the session ID and
+    /// list of presigns, each tagged with its blending index (position in the inserted vector).
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
     internal_presign_pool_ecdsa_secp256k1:
-        DBMap<(ObjectID, u64), (SessionIdentifier, Vec<Vec<u8>>)>,
+        DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
     internal_presign_pool_ecdsa_secp256r1:
-        DBMap<(ObjectID, u64), (SessionIdentifier, Vec<Vec<u8>>)>,
+        DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
-    internal_presign_pool_eddsa: DBMap<(ObjectID, u64), (SessionIdentifier, Vec<Vec<u8>>)>,
+    internal_presign_pool_eddsa: DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
-    internal_presign_pool_taproot: DBMap<(ObjectID, u64), (SessionIdentifier, Vec<Vec<u8>>)>,
+    internal_presign_pool_taproot: DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
     internal_presign_pool_schnorrkel_substrate:
-        DBMap<(ObjectID, u64), (SessionIdentifier, Vec<Vec<u8>>)>,
+        DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
 
     /// Tracks the total count of presigns in each pool by (signature algorithm, network encryption key ID).
     /// Value is the count.
@@ -799,25 +822,26 @@ pub struct AuthorityEpochTables {
     noa_observations: DBMap<Round, Vec<ConsensusNOAObservation>>,
 
     /// Tracks presigns that have been consumed for signing.
-    /// Key: SessionIdentifier - the session ID of the presign session that created the presign
+    /// Key: (SessionIdentifier, blending_index) - uniquely identifies a single presign within
+    /// the blended vector produced by the presign session that created it.
     /// Value: () - just marks it as used
     /// Once a presign is used, it should never be used again.
-    used_presigns: DBMap<SessionIdentifier, ()>,
+    used_presigns: DBMap<(SessionIdentifier, u16), ()>,
 
     /// Assigned presigns pools for external presigns.
-    /// Key: SessionIdentifier - the session ID that uniquely identifies this assigned presign
+    /// Key: (SessionIdentifier, blending_index) - uniquely identifies this assigned presign
     /// Value: AssignedPresign - contains presign data, user verification key, dwallet_id (for non-global), and epoch
     /// These expire at the end of the epoch and are used for external sign requests.
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
-    assigned_presigns_ecdsa_secp256k1: DBMap<SessionIdentifier, AssignedPresign>,
+    assigned_presigns_ecdsa_secp256k1: DBMap<(SessionIdentifier, u16), AssignedPresign>,
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
-    assigned_presigns_ecdsa_secp256r1: DBMap<SessionIdentifier, AssignedPresign>,
+    assigned_presigns_ecdsa_secp256r1: DBMap<(SessionIdentifier, u16), AssignedPresign>,
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
-    assigned_presigns_eddsa: DBMap<SessionIdentifier, AssignedPresign>,
+    assigned_presigns_eddsa: DBMap<(SessionIdentifier, u16), AssignedPresign>,
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
-    assigned_presigns_taproot: DBMap<SessionIdentifier, AssignedPresign>,
+    assigned_presigns_taproot: DBMap<(SessionIdentifier, u16), AssignedPresign>,
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
-    assigned_presigns_schnorrkel_substrate: DBMap<SessionIdentifier, AssignedPresign>,
+    assigned_presigns_schnorrkel_substrate: DBMap<(SessionIdentifier, u16), AssignedPresign>,
 }
 
 fn pending_consensus_transactions_table_default_config() -> DBOptions {
@@ -956,6 +980,13 @@ impl AuthorityEpochTables {
         let table = self.presign_pool_table(signature_algorithm);
         let key = (dwallet_network_encryption_key_id, session_sequence_number);
 
+        // Tag each presign with its blending index (its position in the inserted vector).
+        let blended_presigns: Vec<(u16, Vec<u8>)> = presigns
+            .into_iter()
+            .enumerate()
+            .map(|(blending_index, presign)| (blending_index as u16, presign))
+            .collect();
+
         let size_key = (signature_algorithm, dwallet_network_encryption_key_id);
         let current_size = self
             .internal_presign_pool_sizes
@@ -964,7 +995,7 @@ impl AuthorityEpochTables {
 
         // Batch both writes atomically to prevent size counter drift.
         let mut batch = table.batch();
-        batch.insert_batch(table, [(&key, &(session_identifier, presigns))])?;
+        batch.insert_batch(table, [(&key, &(session_identifier, blended_presigns))])?;
         batch.insert_batch(
             &self.internal_presign_pool_sizes,
             [(&size_key, &(current_size + num_presigns))],
@@ -989,20 +1020,21 @@ impl AuthorityEpochTables {
     }
 
     /// Pops a single presign from the pool for the given signature algorithm and network
-    /// encryption key. Returns the session identifier and presign bytes, or None if the pool
-    /// is empty. Presigns are consumed in order of session sequence number (lowest first).
+    /// encryption key. Returns the session identifier, the presign's blending index, and presign
+    /// bytes, or None if the pool is empty. Presigns are consumed in order of session sequence
+    /// number (lowest first).
     pub fn pop_presign(
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, Vec<u8>)>> {
-        let Some((batch, session_identifier, presign)) =
+    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
+        let Some((batch, session_identifier, blending_index, presign)) =
             self.prepare_pop_presign(signature_algorithm, dwallet_network_encryption_key_id)?
         else {
             return Ok(None);
         };
         batch.write()?;
-        Ok(Some((session_identifier, presign)))
+        Ok(Some((session_identifier, blending_index, presign)))
     }
 
     /// Prepares a presign pop without committing, returning the uncommitted batch.
@@ -1012,7 +1044,7 @@ impl AuthorityEpochTables {
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(DBBatch, SessionIdentifier, Vec<u8>)>> {
+    ) -> IkaResult<Option<(DBBatch, SessionIdentifier, u16, Vec<u8>)>> {
         let table = self.presign_pool_table(signature_algorithm);
 
         // Get the first entry for this network encryption key ID.
@@ -1056,8 +1088,8 @@ impl AuthorityEpochTables {
             return Ok(None);
         }
 
-        // Remove the first presign from the vec
-        let presign = presigns.remove(0);
+        // Remove the first presign from the vec, along with its blending index.
+        let (blending_index, presign) = presigns.remove(0);
 
         // Read size counter before batch
         let size_key = (signature_algorithm, dwallet_network_encryption_key_id);
@@ -1086,25 +1118,36 @@ impl AuthorityEpochTables {
             [(&size_key, &(current_size.saturating_sub(1)))],
         )?;
 
-        Ok(Some((batch, session_identifier, presign)))
+        Ok(Some((batch, session_identifier, blending_index, presign)))
     }
 
     /// Marks a presign as used so it cannot be reused.
-    pub fn mark_presign_as_used(&self, presign_session_id: SessionIdentifier) -> IkaResult<()> {
-        self.used_presigns.insert(&presign_session_id, &())?;
+    pub fn mark_presign_as_used(
+        &self,
+        presign_session_id: SessionIdentifier,
+        presign_blending_index: u16,
+    ) -> IkaResult<()> {
+        self.used_presigns
+            .insert(&(presign_session_id, presign_blending_index), &())?;
         Ok(())
     }
 
     /// Checks if a presign has already been used.
-    pub fn is_presign_used(&self, presign_session_id: SessionIdentifier) -> IkaResult<bool> {
-        Ok(self.used_presigns.contains_key(&presign_session_id)?)
+    pub fn is_presign_used(
+        &self,
+        presign_session_id: SessionIdentifier,
+        presign_blending_index: u16,
+    ) -> IkaResult<bool> {
+        Ok(self
+            .used_presigns
+            .contains_key(&(presign_session_id, presign_blending_index))?)
     }
 
     /// Returns a reference to the assigned presign pool table for the given signature algorithm.
     fn assigned_presign_pool_table(
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
-    ) -> &DBMap<SessionIdentifier, AssignedPresign> {
+    ) -> &DBMap<(SessionIdentifier, u16), AssignedPresign> {
         match signature_algorithm {
             DWalletSignatureAlgorithm::ECDSASecp256k1 => &self.assigned_presigns_ecdsa_secp256k1,
             DWalletSignatureAlgorithm::ECDSASecp256r1 => &self.assigned_presigns_ecdsa_secp256r1,
@@ -1125,8 +1168,8 @@ impl AuthorityEpochTables {
         user_verification_key: Option<Vec<u8>>,
         dwallet_id: Option<ObjectID>,
         current_epoch: u64,
-    ) -> IkaResult<Option<SessionIdentifier>> {
-        let Some((mut batch, session_identifier, presign)) =
+    ) -> IkaResult<Option<(SessionIdentifier, u16)>> {
+        let Some((mut batch, session_identifier, blending_index, presign)) =
             self.prepare_pop_presign(signature_algorithm, dwallet_network_encryption_key_id)?
         else {
             return Ok(None);
@@ -1134,6 +1177,7 @@ impl AuthorityEpochTables {
 
         let assigned_presign = AssignedPresign {
             session_identifier,
+            blending_index,
             presign,
             user_verification_key,
             dwallet_id,
@@ -1142,20 +1186,24 @@ impl AuthorityEpochTables {
 
         // Extend the pop batch with the assigned pool insert, then commit atomically.
         let assigned_table = self.assigned_presign_pool_table(signature_algorithm);
-        batch.insert_batch(assigned_table, [(&session_identifier, &assigned_presign)])?;
+        batch.insert_batch(
+            assigned_table,
+            [(&(session_identifier, blending_index), &assigned_presign)],
+        )?;
         batch.write()?;
 
-        Ok(Some(session_identifier))
+        Ok(Some((session_identifier, blending_index)))
     }
 
-    /// Retrieves an assigned presign by session identifier and signature algorithm.
+    /// Retrieves an assigned presign by session identifier, blending index, and signature algorithm.
     pub fn get_assigned_presign(
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         session_identifier: SessionIdentifier,
+        blending_index: u16,
     ) -> IkaResult<Option<AssignedPresign>> {
         let table = self.assigned_presign_pool_table(signature_algorithm);
-        Ok(table.get(&session_identifier)?)
+        Ok(table.get(&(session_identifier, blending_index))?)
     }
 
     /// Pops an assigned presign from the pool. Used when the presign is consumed for signing.
@@ -1163,11 +1211,12 @@ impl AuthorityEpochTables {
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         session_identifier: SessionIdentifier,
+        blending_index: u16,
     ) -> IkaResult<Option<AssignedPresign>> {
         let table = self.assigned_presign_pool_table(signature_algorithm);
-        let assigned_presign = table.get(&session_identifier)?;
+        let assigned_presign = table.get(&(session_identifier, blending_index))?;
         if assigned_presign.is_some() {
-            table.remove(&session_identifier)?;
+            table.remove(&(session_identifier, blending_index))?;
         }
         Ok(assigned_presign)
     }
@@ -2859,13 +2908,16 @@ mod tests {
 
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 2);
 
-        let (popped_session, first_presign) =
+        let (popped_session, first_blending_index, first_presign) =
             tables.pop_presign(algorithm, key_id).unwrap().unwrap();
         assert_eq!(popped_session, session_id);
+        assert_eq!(first_blending_index, 0);
         assert_eq!(first_presign, vec![1u8, 2, 3]);
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 1);
 
-        let (_, second_presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, second_blending_index, second_presign) =
+            tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        assert_eq!(second_blending_index, 1);
         assert_eq!(second_presign, vec![4u8, 5, 6]);
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 0);
 
@@ -2893,13 +2945,15 @@ mod tests {
         assert_eq!(tables.presign_pool_size(algorithm, key_id_a).unwrap(), 2);
         assert_eq!(tables.presign_pool_size(algorithm, key_id_b).unwrap(), 3);
 
-        let (popped_session, presign) = tables.pop_presign(algorithm, key_id_a).unwrap().unwrap();
+        let (popped_session, _, presign) =
+            tables.pop_presign(algorithm, key_id_a).unwrap().unwrap();
         assert_eq!(popped_session, session_id_a);
         assert_eq!(presign, vec![10u8]);
         assert_eq!(tables.presign_pool_size(algorithm, key_id_a).unwrap(), 1);
         assert_eq!(tables.presign_pool_size(algorithm, key_id_b).unwrap(), 3);
 
-        let (popped_session, presign) = tables.pop_presign(algorithm, key_id_b).unwrap().unwrap();
+        let (popped_session, _, presign) =
+            tables.pop_presign(algorithm, key_id_b).unwrap().unwrap();
         assert_eq!(popped_session, session_id_b);
         assert_eq!(presign, vec![20u8]);
 
@@ -2910,7 +2964,7 @@ mod tests {
 
         // key_id_b still has presigns
         assert_eq!(tables.presign_pool_size(algorithm, key_id_b).unwrap(), 2);
-        let (_, presign) = tables.pop_presign(algorithm, key_id_b).unwrap().unwrap();
+        let (_, _, presign) = tables.pop_presign(algorithm, key_id_b).unwrap().unwrap();
         assert_eq!(presign, vec![21u8]);
     }
 
@@ -2952,13 +3006,13 @@ mod tests {
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 3);
 
         // Should pop in ascending session_sequence_number order
-        let (_, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
         assert_eq!(presign, vec![5u8]);
 
-        let (_, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
         assert_eq!(presign, vec![10u8]);
 
-        let (_, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
         assert_eq!(presign, vec![20u8]);
 
         assert!(tables.pop_presign(algorithm, key_id).unwrap().is_none());
@@ -2988,15 +3042,15 @@ mod tests {
 
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 3);
 
-        let (_, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
         assert_eq!(presign, vec![1u8]);
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 2);
 
-        let (_, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
         assert_eq!(presign, vec![2u8]);
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 1);
 
-        let (_, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
         assert_eq!(presign, vec![3u8]);
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 0);
 
@@ -3022,13 +3076,13 @@ mod tests {
         assert_eq!(tables.presign_pool_size(ecdsa, key_id).unwrap(), 1);
         assert_eq!(tables.presign_pool_size(eddsa, key_id).unwrap(), 1);
 
-        let (_, presign) = tables.pop_presign(ecdsa, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables.pop_presign(ecdsa, key_id).unwrap().unwrap();
         assert_eq!(presign, vec![100u8]);
         assert_eq!(tables.presign_pool_size(ecdsa, key_id).unwrap(), 0);
 
         // EdDSA pool unaffected
         assert_eq!(tables.presign_pool_size(eddsa, key_id).unwrap(), 1);
-        let (_, presign) = tables.pop_presign(eddsa, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables.pop_presign(eddsa, key_id).unwrap().unwrap();
         assert_eq!(presign, vec![200u8]);
     }
 }

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -1249,7 +1249,7 @@ impl DWalletMPCService {
                         request.signature_algorithm,
                         request.dwallet_network_encryption_key_id,
                     ) {
-                        Ok(Some((_presign_session_id, presign))) => {
+                        Ok(Some((_presign_session_id, _presign_blending_index, presign))) => {
                             match bcs::to_bytes(&VersionedPresignOutput::V2(presign)) {
                                 Ok(presign) => {
                                     info!(

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
@@ -116,12 +116,16 @@ async fn network_owned_address_sign_flow(
         pool_size_before > 0,
         "pool should have at least one presign"
     );
-    let presign_session_identifiers_before: HashSet<SessionIdentifier> = test_state.epoch_stores[0]
+    let presigns_before: HashSet<(SessionIdentifier, u16)> = test_state.epoch_stores[0]
         .presign_pools
         .lock()
         .unwrap()
         .get(&(signature_algorithm, network_key_id))
-        .map(|pool| pool.iter().map(|(id, _)| *id).collect())
+        .map(|pool| {
+            pool.iter()
+                .map(|(id, blending_index, _)| (*id, *blending_index))
+                .collect()
+        })
         .unwrap_or_default();
 
     // Send a NetworkOwnedAddressSignRequest to all validators via the channel.
@@ -181,13 +185,9 @@ async fn network_owned_address_sign_flow(
         .lock()
         .unwrap()
         .clone();
-    let consumed_from_snapshot: HashSet<_> = presign_session_identifiers_before
+    let consumed_from_snapshot: HashSet<_> = presigns_before
         .iter()
-        .filter(|id| {
-            used_presigns
-                .get(id)
-                .is_some_and(|(used_count, _)| *used_count > 0)
-        })
+        .filter(|presign_key| used_presigns.contains_key(presign_key))
         .collect();
     info!(
         used_presigns_count = used_presigns.len(),

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -33,9 +33,11 @@ use sui_types::messages_consensus::Round;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tracing::info;
 
-/// Test presign pool: maps (algorithm, key_id) to a list of (session_id, presign_bytes).
-type TestPresignPool =
-    Arc<Mutex<HashMap<(DWalletSignatureAlgorithm, ObjectID), Vec<(SessionIdentifier, Vec<u8>)>>>>;
+/// Test presign pool: maps (algorithm, key_id) to a list of (session_id, blending_index,
+/// presign_bytes). The blending index is the presign's position in its inserted vector.
+type TestPresignPool = Arc<
+    Mutex<HashMap<(DWalletSignatureAlgorithm, ObjectID), Vec<(SessionIdentifier, u16, Vec<u8>)>>>,
+>;
 
 /// A testing implementation of the `AuthorityPerEpochStoreTrait`.
 /// Records all received data for testing purposes.
@@ -64,14 +66,13 @@ pub(crate) struct TestingAuthorityPerEpochStore {
     /// Presign pool keyed by (signature algorithm, dwallet_network_encryption_key_id)
     /// Each entry contains a vector of (SessionIdentifier, presign_bytes)
     pub(crate) presign_pools: TestPresignPool,
-    /// Tracks presign session usage counts.
-    /// Maps session ID → (used_count, total_inserted_count).
-    /// A presign is considered fully used only when all presigns from that session
-    /// have been consumed (used_count >= total_count).
-    pub(crate) used_presigns: Arc<Mutex<HashMap<SessionIdentifier, (u64, u64)>>>,
-    /// Assigned presigns keyed by (signature_algorithm, session_identifier).
+    /// Tracks which individual presigns have been consumed for signing.
+    /// Keyed by (session_identifier, blending_index) to uniquely identify a single presign
+    /// within the blended vector produced by a presign session.
+    pub(crate) used_presigns: Arc<Mutex<HashMap<(SessionIdentifier, u16), ()>>>,
+    /// Assigned presigns keyed by (signature_algorithm, session_identifier, blending_index).
     pub(crate) assigned_presigns:
-        Arc<Mutex<HashMap<(DWalletSignatureAlgorithm, SessionIdentifier), AssignedPresign>>>,
+        Arc<Mutex<HashMap<(DWalletSignatureAlgorithm, SessionIdentifier, u16), AssignedPresign>>>,
 }
 
 pub(crate) struct IntegrationTestState {
@@ -248,20 +249,20 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
         // Deduplicate by session_identifier: production code overwrites on the same
         // (key_id, session_sequence_number) key, so only one copy of each session's
         // presigns should exist in the pool. Skip if already present.
-        let already_exists = pool.iter().any(|(sid, _)| *sid == session_identifier);
+        let already_exists = pool.iter().any(|(sid, _, _)| *sid == session_identifier);
         if already_exists {
             return Ok(());
         }
 
-        let count = presigns.len() as u64;
-        for presign in presigns {
-            pool.push((session_identifier, presign));
-        }
-
-        // Track inserted count for is_presign_used checks.
-        let mut used = self.used_presigns.lock().unwrap();
-        let entry = used.entry(session_identifier).or_insert((0, 0));
-        entry.1 += count;
+        // Tag each presign with its blending index (its position in the inserted vector).
+        pool.extend(
+            presigns
+                .into_iter()
+                .enumerate()
+                .map(|(blending_index, presign)| {
+                    (session_identifier, blending_index as u16, presign)
+                }),
+        );
 
         Ok(())
     }
@@ -280,28 +281,34 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, Vec<u8>)>> {
+    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
         let mut pools = self.presign_pools.lock().unwrap();
         let key = (signature_algorithm, dwallet_network_encryption_key_id);
         Ok(pools.get_mut(&key).and_then(|pool| pool.pop()))
     }
 
-    fn mark_presign_as_used(&self, presign_session_id: SessionIdentifier) -> IkaResult<()> {
-        let mut used = self.used_presigns.lock().unwrap();
-        let entry = used.entry(presign_session_id).or_insert((0, 0));
-        entry.0 += 1;
+    fn mark_presign_as_used(
+        &self,
+        presign_session_id: SessionIdentifier,
+        presign_blending_index: u16,
+    ) -> IkaResult<()> {
+        self.used_presigns
+            .lock()
+            .unwrap()
+            .insert((presign_session_id, presign_blending_index), ());
         Ok(())
     }
 
-    fn is_presign_used(&self, presign_session_id: SessionIdentifier) -> IkaResult<bool> {
-        let used = self.used_presigns.lock().unwrap();
-        match used.get(&presign_session_id) {
-            // A session is "used" if:
-            // - It was marked without prior insert (total=0, used>0): external use
-            // - All batch presigns have been consumed (used >= total, total > 0)
-            Some((used_count, total_count)) => Ok(*used_count > 0 && *used_count >= *total_count),
-            None => Ok(false),
-        }
+    fn is_presign_used(
+        &self,
+        presign_session_id: SessionIdentifier,
+        presign_blending_index: u16,
+    ) -> IkaResult<bool> {
+        Ok(self
+            .used_presigns
+            .lock()
+            .unwrap()
+            .contains_key(&(presign_session_id, presign_blending_index)))
     }
 
     fn next_idle_status_update(
@@ -373,12 +380,13 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
         user_verification_key: Option<Vec<u8>>,
         dwallet_id: Option<ObjectID>,
         current_epoch: u64,
-    ) -> IkaResult<Option<SessionIdentifier>> {
+    ) -> IkaResult<Option<(SessionIdentifier, u16)>> {
         let popped = self.pop_presign(signature_algorithm, dwallet_network_encryption_key_id)?;
         match popped {
-            Some((session_id, presign_bytes)) => {
+            Some((session_id, blending_index, presign_bytes)) => {
                 let assigned = AssignedPresign {
                     session_identifier: session_id,
+                    blending_index,
                     presign: presign_bytes,
                     user_verification_key,
                     dwallet_id,
@@ -387,8 +395,8 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
                 self.assigned_presigns
                     .lock()
                     .unwrap()
-                    .insert((signature_algorithm, session_id), assigned);
-                Ok(Some(session_id))
+                    .insert((signature_algorithm, session_id, blending_index), assigned);
+                Ok(Some((session_id, blending_index)))
             }
             None => Ok(None),
         }
@@ -398,12 +406,13 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         session_identifier: SessionIdentifier,
+        blending_index: u16,
     ) -> IkaResult<Option<AssignedPresign>> {
         Ok(self
             .assigned_presigns
             .lock()
             .unwrap()
-            .get(&(signature_algorithm, session_identifier))
+            .get(&(signature_algorithm, session_identifier, blending_index))
             .cloned())
     }
 
@@ -411,12 +420,13 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         session_identifier: SessionIdentifier,
+        blending_index: u16,
     ) -> IkaResult<Option<AssignedPresign>> {
-        Ok(self
-            .assigned_presigns
-            .lock()
-            .unwrap()
-            .remove(&(signature_algorithm, session_identifier)))
+        Ok(self.assigned_presigns.lock().unwrap().remove(&(
+            signature_algorithm,
+            session_identifier,
+            blending_index,
+        )))
     }
 }
 

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/validator_restart.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/validator_restart.rs
@@ -463,20 +463,22 @@ async fn test_epoch_store_presign_pool_operations() {
         "pop from empty pool should return None"
     );
 
-    // Verify mark_presign_as_used / is_presign_used tracks consumed presigns.
+    // Verify mark_presign_as_used / is_presign_used tracks consumed presigns,
+    // keyed by (session_identifier, blending_index).
     let used_session_id = SessionIdentifier::new(SessionType::InternalPresign, [99u8; 32]);
+    let used_blending_index = 0u16;
     assert!(
         !test_epoch_store
-            .is_presign_used(used_session_id)
+            .is_presign_used(used_session_id, used_blending_index)
             .expect("is_presign_used should not error"),
         "is_presign_used should return false before marking"
     );
     test_epoch_store
-        .mark_presign_as_used(used_session_id)
+        .mark_presign_as_used(used_session_id, used_blending_index)
         .expect("mark_presign_as_used should not error");
     assert!(
         test_epoch_store
-            .is_presign_used(used_session_id)
+            .is_presign_used(used_session_id, used_blending_index)
             .expect("is_presign_used should not error"),
         "is_presign_used should return true after marking"
     );
@@ -498,7 +500,7 @@ async fn test_epoch_store_presign_pool_operations() {
         .expect("failed to insert presign for assign roundtrip");
 
     // assign_presign pops one presign from the internal pool and places it in the assigned pool
-    let assigned_session_id = test_epoch_store
+    let (assigned_session_id, assigned_blending_index) = test_epoch_store
         .assign_presign(
             DWalletSignatureAlgorithm::ECDSASecp256k1,
             assign_key_id,
@@ -523,6 +525,7 @@ async fn test_epoch_store_presign_pool_operations() {
         .get_assigned_presign(
             DWalletSignatureAlgorithm::ECDSASecp256k1,
             assigned_session_id,
+            assigned_blending_index,
         )
         .expect("get_assigned_presign should not error")
         .expect("assigned presign should exist after assign");
@@ -541,6 +544,7 @@ async fn test_epoch_store_presign_pool_operations() {
         .get_assigned_presign(
             DWalletSignatureAlgorithm::ECDSASecp256k1,
             assigned_session_id,
+            assigned_blending_index,
         )
         .expect("second get_assigned_presign should not error");
     assert!(
@@ -553,6 +557,7 @@ async fn test_epoch_store_presign_pool_operations() {
         .pop_assigned_presign(
             DWalletSignatureAlgorithm::ECDSASecp256k1,
             assigned_session_id,
+            assigned_blending_index,
         )
         .expect("pop_assigned_presign should not error")
         .expect("pop should return the assigned presign");
@@ -567,6 +572,7 @@ async fn test_epoch_store_presign_pool_operations() {
         .get_assigned_presign(
             DWalletSignatureAlgorithm::ECDSASecp256k1,
             assigned_session_id,
+            assigned_blending_index,
         )
         .expect("get after pop should not error");
     assert!(

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -993,11 +993,11 @@ impl DWalletMPCManager {
         };
 
         // Try to get a presign from the internal presign pool
-        let (presign_session_id, presign) = match self
+        let (presign_session_id, presign_blending_index, presign) = match self
             .epoch_store
             .pop_presign(signature_algorithm, dwallet_network_encryption_key_id)
         {
-            Ok(Some(pair)) => pair,
+            Ok(Some(triple)) => triple,
             Ok(None) => {
                 error!(
                     ?signature_algorithm,
@@ -1021,11 +1021,12 @@ impl DWalletMPCManager {
         // Check if this presign has already been used (safety check)
         if self
             .epoch_store
-            .is_presign_used(presign_session_id)
+            .is_presign_used(presign_session_id, presign_blending_index)
             .unwrap_or(false)
         {
             error!(
                 ?presign_session_id,
+                ?presign_blending_index,
                 should_never_happen = true,
                 "Presign has already been used — this should not happen"
             );
@@ -1033,9 +1034,13 @@ impl DWalletMPCManager {
         }
 
         // Mark the presign as used to prevent double-spending
-        if let Err(e) = self.epoch_store.mark_presign_as_used(presign_session_id) {
+        if let Err(e) = self
+            .epoch_store
+            .mark_presign_as_used(presign_session_id, presign_blending_index)
+        {
             error!(
                 ?presign_session_id,
+                ?presign_blending_index,
                 error = ?e,
                 should_never_happen = true,
                 "Failed to mark presign as used"

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -213,6 +213,9 @@ impl ConsensusNOAObservation {
 pub struct AssignedPresign {
     /// The session identifier of the presign session that created this presign.
     pub session_identifier: SessionIdentifier,
+    /// The blending index: the presign's position in the blended vector produced by the presign
+    /// session. Together with the session identifier it uniquely identifies a single presign.
+    pub blending_index: u16,
     /// The actual presign data.
     pub presign: Vec<u8>,
     /// The user verification key associated with the dWallet (if applicable).


### PR DESCRIPTION
## Problem

A *blended* presign session produces N presigns that all share one `SessionIdentifier`. Three storage mechanisms keyed presigns by `SessionIdentifier` alone, which is unsafe/incorrect once N > 1:

- **Assigned-presign pool** — keyed by `SessionIdentifier`, so a second assign from the same blended session *overwrote* the first.
- **`used_presigns`** (the nonce-reuse guard) — `mark/is_presign_used(session_id)` marked the *whole session* used, unable to distinguish individual blended presigns.
- **Internal pool** — only the session id was returned from `pop()`, so the per-presign identity was lost.

Nonce reuse in schnorr/ECDSA leaks the private key, so per-presign identity must be exact.

## Fix

Make the blending index (a presign's position in the blended vector) first-class identity: **`(SessionIdentifier, blending_index: u16)`** everywhere.

- Internal pool value `Vec<Vec<u8>>` → `Vec<(u16, Vec<u8>)>`; `insert_presigns` tags each presign with its position; `pop_presign` returns `(session_id, blending_index, bytes)`.
- `used_presigns` keyed by `(SessionIdentifier, u16)`; `mark_presign_as_used`/`is_presign_used` take the index.
- Assigned-presign pool keyed by `(SessionIdentifier, u16)`; `AssignedPresign` carries `blending_index`; `assign_presign` returns `(SessionIdentifier, u16)`.
- NOA sign path threads the popped blending index into the single-use guard.

No migration concern — these are validator-local per-epoch tables. Tests updated; the mock store now tracks single-use per `(session, index)`.

Prerequisite for the Fast Schnorr (VSS) sign work, which additionally persists a per-blending-index private nonce output and will key it by the same identity.

## Test

`cargo build --release -p ika-core --all-targets` clean; `cargo test --release -p ika-core -- presign` → 14 passed (storage unit tests + assigned-pool roundtrip + NOA single-use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)