### PR TITLE
fix(test-cluster): wire a Notifier so wait_for_epoch can actually advance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7047,6 +7047,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "sui-config",
+ "sui-keys",
  "sui-macros",
  "sui-protocol-config",
  "sui-sdk",

--- a/crates/ika-test-cluster/Cargo.toml
+++ b/crates/ika-test-cluster/Cargo.toml
@@ -25,6 +25,7 @@ ika-swarm-config.workspace = true
 ika-types.workspace = true
 
 sui-config.workspace = true
+sui-keys.workspace = true
 sui-sdk.workspace = true
 sui-test-transaction-builder.workspace = true
 sui-types.workspace = true

--- a/crates/ika-test-cluster/src/lib.rs
+++ b/crates/ika-test-cluster/src/lib.rs
@@ -9,12 +9,13 @@ use anyhow::Result;
 use ika_config::initiation::InitiationParameters;
 use ika_swarm::memory::{Swarm, SwarmBuilder};
 use ika_swarm_config::network_config::NetworkConfig;
-use ika_swarm_config::node_config_builder::ValidatorConfigBuilder;
+use ika_swarm_config::node_config_builder::{FullnodeConfigBuilder, ValidatorConfigBuilder};
 use ika_swarm_config::sui_client::{ContractPaths, initialize_ika_system, publish_ika_packages};
 use ika_swarm_config::validator_initialization_config::{
     ValidatorInitializationConfig, ValidatorInitializationConfigBuilder,
 };
 use rand::rngs::OsRng;
+use sui_keys::keystore::AccountKeystore;
 use sui_sdk::SuiClientBuilder;
 use sui_types::base_types::SuiAddress;
 use test_cluster::{TestCluster, TestClusterBuilder};
@@ -184,9 +185,35 @@ impl IkaTestClusterBuilder {
                 )
             })
             .collect();
+        // The ika epoch only advances when a Notifier node submits the
+        // `process_mid_epoch` / `request_advance_epoch` transactions to Sui (the
+        // validators never do — `run_epoch_switch` is gated on a notifier key).
+        // Without one the network is frozen at its genesis epoch, so any test that
+        // calls `wait_for_epoch` hangs. Run one notifier (a fullnode carrying the
+        // publisher's Sui key) so reconfiguration actually progresses.
+        let publisher_keypair = test_cluster
+            .wallet()
+            .config
+            .keystore
+            .export(&publisher_address)?
+            .copy();
+        let mut notifier_rng = OsRng;
+        let notifier_config = FullnodeConfigBuilder::new().build(
+            &mut notifier_rng,
+            &validator_initialization_configs,
+            sui_rpc_url.clone(),
+            packages.ika_package_id,
+            packages.ika_common_package_id,
+            packages.ika_dwallet_2pc_mpc_package_id,
+            packages.ika_system_package_id,
+            system.ika_system_object_id,
+            system.ika_dwallet_coordinator_object_id,
+            Some(publisher_keypair),
+        );
+
         let network_config = NetworkConfig {
             validator_configs,
-            fullnode_configs: vec![],
+            fullnode_configs: vec![notifier_config],
             validator_initialization_configs,
             ika_package_id: packages.ika_package_id,
             ika_common_package_id: packages.ika_common_package_id,


### PR DESCRIPTION
## Problem

`IkaTestClusterBuilder` launched only validator nodes (`fullnode_configs: vec![]`), so no node carried the **Notifier** role. `SuiExecutor::run_epoch_switch` is gated on `sui_notifier.is_some()` — without a notifier, `process_mid_epoch` / `request_advance_epoch` are never submitted to Sui and the ika epoch is **frozen at its genesis value forever**.

Any test that calls `wait_for_epoch(>genesis)` hangs:
- `test_swarm_reaches_epoch_2` (smoke) — directly affected.
- Any future test driving the cluster through a reconfiguration.

(The Sui Clock does advance on its own in a tokio test cluster; the missing notifier — not the clock — was the real blocker. Defense-in-depth instrumentation while diagnosing this confirmed `run_epoch_switch` fires **0** times before the fix and **160+** after, with the clock crossing `epoch_start + epoch_duration/2` in real time.)

## Fix

Wire one notifier fullnode into `IkaTestClusterBuilder::build` via `FullnodeConfigBuilder`, carrying the publisher's Sui key (exported from the Sui test-cluster keystore). Adds `sui-keys` workspace dep.

Notes:
- The notifier is a fullnode (no consensus_config) with `notifier_client_key_pair: Some(..)` — `NodeMode::detect_from_config` treats it as `Notifier`.
- It's excluded from `Swarm::validator_node_handles()` (filtered on `consensus_config.is_some()`), so any `validator_node_handles().len() == 4` assertion stays correct.

## Verified

- `cargo build --release -p ika-test-cluster` — clean.
- Independently observed end-to-end on `fast-schnorr`: a `#[tokio::test(flavor = "multi_thread")]` driving the cluster to epoch 2 walks the full `process_mid_epoch → calculate_protocols_pricing → lock_last_active_session → network encryption key mid-epoch reconfiguration → request_advance_epoch` sequence and reaches `Finished epoch=1` → `Starting run_epoch epoch=2` in ~9.8 min wall time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)