### PR TITLE
test(test-cluster): gradual protocol-version upgrade (v3 → v4) across epochs

### DIFF
--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -678,6 +678,12 @@ impl IkaNode {
         self.state.current_epoch_for_testing()
     }
 
+    /// Protocol version of the validator's current epoch store. Useful for
+    /// asserting on protocol-version transitions across reconfigurations.
+    pub fn current_protocol_version_for_testing(&self) -> ika_protocol_config::ProtocolVersion {
+        self.state.epoch_store_for_testing().protocol_version()
+    }
+
     pub fn db_checkpoint_path(&self) -> PathBuf {
         self.config.db_checkpoint_path()
     }

--- a/crates/ika-test-cluster/src/lib.rs
+++ b/crates/ika-test-cluster/src/lib.rs
@@ -7,6 +7,7 @@
 
 use anyhow::Result;
 use ika_config::initiation::InitiationParameters;
+use ika_protocol_config::ProtocolVersion;
 use ika_swarm::memory::{Swarm, SwarmBuilder};
 use ika_swarm_config::network_config::NetworkConfig;
 use ika_swarm_config::node_config_builder::{FullnodeConfigBuilder, ValidatorConfigBuilder};
@@ -14,6 +15,7 @@ use ika_swarm_config::sui_client::{ContractPaths, initialize_ika_system, publish
 use ika_swarm_config::validator_initialization_config::{
     ValidatorInitializationConfig, ValidatorInitializationConfigBuilder,
 };
+use ika_types::supported_protocol_versions::SupportedProtocolVersions;
 use rand::rngs::OsRng;
 use sui_keys::keystore::AccountKeystore;
 use sui_sdk::SuiClientBuilder;
@@ -37,6 +39,13 @@ const VALIDATOR_FUNDING_MIST: u64 = 100_000_000_000;
 pub struct IkaTestCluster {
     pub test_cluster: TestCluster,
     pub swarm: Swarm,
+    /// Validator protocol public keys in the configured order. The i-th name
+    /// is the authority name of the validator built from
+    /// `validator_initialization_configs[i]`. Used by index-based test helpers
+    /// (e.g. `upgrade_validator_supported_protocol_versions`) because the
+    /// swarm stores nodes in a HashMap and `validator_nodes()` order is
+    /// otherwise unspecified.
+    pub validator_names: Vec<ika_types::crypto::AuthorityName>,
 }
 
 impl IkaTestCluster {
@@ -62,11 +71,59 @@ impl IkaTestCluster {
             tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         }
     }
+
+    /// Current ika protocol version, read from the first validator's in-memory
+    /// epoch store. Updated when the network reconfigures into a new epoch.
+    pub fn current_protocol_version(&self) -> ProtocolVersion {
+        let handle = self
+            .swarm
+            .validator_node_handles()
+            .into_iter()
+            .next()
+            .expect("swarm must have at least one validator node");
+        handle.with(|node| node.current_protocol_version_for_testing())
+    }
+
+    /// Simulate an in-place validator upgrade: stop the validator, mutate its
+    /// `NodeConfig.supported_protocol_versions`, and restart it. The next
+    /// `AuthorityCapabilitiesV1` notification (sent at the start of the next
+    /// epoch the validator observes) carries the new range, which the
+    /// end-of-epoch quorum vote uses to pick the next protocol version.
+    ///
+    /// Index is into `validator_names` (insertion order at build time).
+    pub async fn upgrade_validator_supported_protocol_versions(
+        &self,
+        validator_index: usize,
+        new_versions: SupportedProtocolVersions,
+    ) -> Result<()> {
+        let name = *self
+            .validator_names
+            .get(validator_index)
+            .expect("validator_index out of range");
+        let node = self
+            .swarm
+            .node(&name)
+            .expect("validator node exists for the configured name");
+        tracing::info!(
+            ?validator_index,
+            ?new_versions,
+            "upgrading validator: stop -> mutate config -> start",
+        );
+        node.stop();
+        node.config().supported_protocol_versions = Some(new_versions);
+        node.start().await?;
+        Ok(())
+    }
 }
 
 pub struct IkaTestClusterBuilder {
     num_validators: usize,
     epoch_duration_ms: Option<u64>,
+    protocol_version: Option<ProtocolVersion>,
+    /// Per-validator `SupportedProtocolVersions` overrides (indexed). When
+    /// `None`, every validator uses `SupportedProtocolVersions::SYSTEM_DEFAULT`.
+    /// `Some(v)` must have length `num_validators`.
+    per_validator_supported_protocol_versions: Option<Vec<SupportedProtocolVersions>>,
 }
 
 impl IkaTestClusterBuilder {
@@ -74,6 +131,8 @@ impl IkaTestClusterBuilder {
         Self {
             num_validators: DEFAULT_NUM_VALIDATORS,
             epoch_duration_ms: None,
+            protocol_version: None,
+            per_validator_supported_protocol_versions: None,
         }
     }
 
@@ -84,6 +143,27 @@ impl IkaTestClusterBuilder {
 
     pub fn with_epoch_duration_ms(mut self, epoch_duration_ms: u64) -> Self {
         self.epoch_duration_ms = Some(epoch_duration_ms);
+        self
+    }
+
+    /// Genesis protocol version. Defaults to `ProtocolVersion::MAX`. Use this
+    /// to boot the cluster at an older version (e.g. v3) so an epoch
+    /// transition will exercise the capability vote and advance to a newer
+    /// version (e.g. v4) supported by `SupportedProtocolVersions::SYSTEM_DEFAULT`.
+    pub fn with_protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
+        self.protocol_version = Some(protocol_version);
+        self
+    }
+
+    /// Per-validator `SupportedProtocolVersions` overrides — vector length must
+    /// equal `num_validators`. Use this to model a gradual upgrade scenario
+    /// where some validators support a newer max than others. When unset,
+    /// every validator gets `SupportedProtocolVersions::SYSTEM_DEFAULT`.
+    pub fn with_per_validator_supported_protocol_versions(
+        mut self,
+        per_validator_versions: Vec<SupportedProtocolVersions>,
+    ) -> Self {
+        self.per_validator_supported_protocol_versions = Some(per_validator_versions);
         self
     }
 
@@ -154,6 +234,9 @@ impl IkaTestClusterBuilder {
         if let Some(epoch_duration_ms) = self.epoch_duration_ms {
             initiation_parameters.epoch_duration_ms = epoch_duration_ms;
         }
+        if let Some(protocol_version) = self.protocol_version {
+            initiation_parameters.protocol_version = protocol_version.as_u64();
+        }
 
         let system = initialize_ika_system(
             test_cluster.wallet_mut(),
@@ -170,20 +253,49 @@ impl IkaTestClusterBuilder {
         // dir; restore cwd so the caller's process state isn't mutated.
         std::env::set_current_dir(&cwd)?;
 
-        let validator_configs = validator_initialization_configs
+        // Validators must declare which protocol versions they support so they
+        // send `AuthorityCapabilitiesV1` notifications — that's what the
+        // end-of-epoch quorum vote reads to pick the next protocol version.
+        // Without an override every validator gets `SYSTEM_DEFAULT`
+        // (`ProtocolVersion::MIN..=MAX`); the per-validator override lets
+        // tests model heterogeneous / gradual upgrade scenarios.
+        if let Some(per_validator) = self.per_validator_supported_protocol_versions.as_ref() {
+            anyhow::ensure!(
+                per_validator.len() == validator_initialization_configs.len(),
+                "per_validator_supported_protocol_versions has {} entries but cluster has {} validators",
+                per_validator.len(),
+                validator_initialization_configs.len(),
+            );
+        }
+        let validator_configs: Vec<_> = validator_initialization_configs
             .iter()
-            .map(|v| {
-                ValidatorConfigBuilder::new().build(
-                    v,
-                    sui_rpc_url.clone(),
-                    packages.ika_package_id,
-                    packages.ika_common_package_id,
-                    packages.ika_dwallet_2pc_mpc_package_id,
-                    packages.ika_system_package_id,
-                    system.ika_system_object_id,
-                    system.ika_dwallet_coordinator_object_id,
-                )
+            .enumerate()
+            .map(|(i, v)| {
+                let supported_versions = self
+                    .per_validator_supported_protocol_versions
+                    .as_ref()
+                    .map(|per_validator| per_validator[i])
+                    .unwrap_or(SupportedProtocolVersions::SYSTEM_DEFAULT);
+                ValidatorConfigBuilder::new()
+                    .with_supported_protocol_versions(supported_versions)
+                    .build(
+                        v,
+                        sui_rpc_url.clone(),
+                        packages.ika_package_id,
+                        packages.ika_common_package_id,
+                        packages.ika_dwallet_2pc_mpc_package_id,
+                        packages.ika_system_package_id,
+                        system.ika_system_object_id,
+                        system.ika_dwallet_coordinator_object_id,
+                    )
             })
+            .collect();
+        // Record the validators' protocol public keys in their configured
+        // order so test helpers (e.g. `upgrade_validator_supported_protocol_versions`)
+        // can address a specific validator by index.
+        let validator_names: Vec<_> = validator_configs
+            .iter()
+            .map(|c| c.protocol_public_key())
             .collect();
         // The ika epoch only advances when a Notifier node submits the
         // `process_mid_epoch` / `request_advance_epoch` transactions to Sui (the
@@ -232,6 +344,7 @@ impl IkaTestClusterBuilder {
         Ok(IkaTestCluster {
             test_cluster,
             swarm,
+            validator_names,
         })
     }
 }

--- a/crates/ika-test-cluster/tests/protocol_version_transition.rs
+++ b/crates/ika-test-cluster/tests/protocol_version_transition.rs
@@ -1,0 +1,138 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Gradual protocol-version transition (v3 → v4) across multiple epochs.
+//!
+//! Models a real rolling upgrade: the network boots at `ProtocolVersion::MIN`
+//! (currently 3) with one validator supporting `MIN..=MAX` and the other three
+//! pinned at `MIN..=MIN`. The end-of-epoch capability quorum vote
+//! (`choose_highest_protocol_version_and_move_contracts_upgrades_v1`) needs
+//! `2f+1 = 3` of `n=4` validators to support a higher version before
+//! `SetNextConfigVersion` fires.
+//!
+//! Effective threshold note: ika inherits Sui's
+//! `buffer_stake_for_protocol_upgrade_bps` (default 5000). For `n=4` (f=1,
+//! quorum=3) the effective threshold is `quorum + ceil(f * 5000/10000) = 4`,
+//! so a protocol upgrade requires **all 4** validators to support the new
+//! version. The test follows that natural threshold rather than overriding
+//! the buffer.
+//!
+//! The expected progression for `n=4`:
+//!
+//! | After epoch | v4 supporters | Vote outcome           | Next epoch starts at |
+//! |-------------|---------------|------------------------|----------------------|
+//! | 0           | 1 / 4         | threshold not met      | v3                   |
+//! | 1           | 2 / 4         | threshold not met      | v3                   |
+//! | 2           | 4 / 4         | **threshold met**      | **v4**               |
+//! | 3           | 4 / 4         | already at MAX         | v4                   |
+//!
+//! Between epochs we "upgrade" another validator (or pair of validators) in
+//! place — stop the node, mutate its `NodeConfig.supported_protocol_versions`,
+//! restart — so the capability notification at the start of the next epoch
+//! carries the new max. This is what
+//! `IkaTestCluster::upgrade_validator_supported_protocol_versions` does.
+//!
+//! Waiting for epoch 4 (one full reconfiguration past the version transition)
+//! is what confirms the network operates correctly at *both* versions: epoch
+//! 2 → 3's reconfiguration runs entirely at v3, and epoch 3 → 4's runs
+//! entirely at v4 (different `network_encryption_key_version`,
+//! `reconfiguration_message_version`, plus the new feature flags).
+//!
+//! `#[tokio::test(flavor = "multi_thread")]` per CLAUDE.md "Picking a test
+//! type": we exercise coordination + real parallel cryptography, not the kind
+//! of scheduling determinism that justifies `#[sim_test]`.
+
+use ika_protocol_config::ProtocolVersion;
+use ika_test_cluster::IkaTestClusterBuilder;
+use ika_types::supported_protocol_versions::SupportedProtocolVersions;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_protocol_version_gradual_upgrade_v3_to_v4() {
+    telemetry_subscribers::init_for_testing();
+
+    let min_only = SupportedProtocolVersions::new_for_testing(
+        ProtocolVersion::MIN.as_u64(),
+        ProtocolVersion::MIN.as_u64(),
+    );
+    let min_to_max = SupportedProtocolVersions::SYSTEM_DEFAULT; // MIN..=MAX
+
+    // validator[0] supports v4 from genesis; the other three are pinned at v3.
+    let cluster = IkaTestClusterBuilder::new()
+        .with_num_validators(4)
+        .with_epoch_duration_ms(10_000)
+        .with_protocol_version(ProtocolVersion::MIN)
+        .with_per_validator_supported_protocol_versions(vec![
+            min_to_max, // validator[0]: supports v3 and v4
+            min_only,   // validator[1]: v3 only
+            min_only,   // validator[2]: v3 only
+            min_only,   // validator[3]: v3 only
+        ])
+        .build()
+        .await
+        .expect("ika test cluster failed to boot");
+
+    assert_eq!(
+        cluster.current_protocol_version(),
+        ProtocolVersion::MIN,
+        "cluster should boot at ProtocolVersion::MIN",
+    );
+
+    // Drive epoch 0 -> 1. The capability vote sees 1/4 supporting v4 — well
+    // below the 4/4 effective threshold — so epoch 1 starts at v3.
+    cluster.test_cluster.trigger_reconfiguration().await;
+    cluster.wait_for_epoch(1).await;
+    assert_eq!(
+        cluster.current_protocol_version(),
+        ProtocolVersion::MIN,
+        "with only 1/4 supporting v4, epoch 1 should remain at v3",
+    );
+
+    // Upgrade validator[1] to support v4. With the stop-mutate-start helper
+    // it picks up the new range on restart and sends an updated capability
+    // notification at the start of the next epoch it observes.
+    cluster
+        .upgrade_validator_supported_protocol_versions(1, min_to_max)
+        .await
+        .expect("upgrading validator[1] failed");
+
+    // Drive epoch 1 -> 2. Capability vote: 2/4 — still below the threshold — v3.
+    cluster.wait_for_epoch(2).await;
+    assert_eq!(
+        cluster.current_protocol_version(),
+        ProtocolVersion::MIN,
+        "with 2/4 supporting v4, epoch 2 should remain at v3",
+    );
+
+    // Upgrade validators[2] and [3] together. Now 4/4 support v4 — the full
+    // effective threshold (`quorum + ceil(f * 5000/10000) = 4` for n=4) is
+    // met. Upgrade them sequentially; the network keeps a 3-of-4 active
+    // quorum while either is briefly restarting.
+    cluster
+        .upgrade_validator_supported_protocol_versions(2, min_to_max)
+        .await
+        .expect("upgrading validator[2] failed");
+    cluster
+        .upgrade_validator_supported_protocol_versions(3, min_to_max)
+        .await
+        .expect("upgrading validator[3] failed");
+
+    // Drive epoch 2 -> 3. Capability vote: 4/4 — threshold met — v4.
+    cluster.wait_for_epoch(3).await;
+    assert_eq!(
+        cluster.current_protocol_version(),
+        ProtocolVersion::MAX,
+        "with 4/4 supporting v4 at end-of-epoch-2, epoch 3 should advance to v4",
+    );
+
+    // Drive epoch 3 -> 4. This is the first reconfiguration that runs
+    // entirely under v4's rules — confirming the network operates correctly
+    // at the new version (and not just that it can vote into it). v4 is the
+    // current MAX, so no further version change is possible.
+    cluster.wait_for_epoch(4).await;
+    assert_eq!(
+        cluster.current_protocol_version(),
+        ProtocolVersion::MAX,
+        "epoch 4 should stay at v4 (the network just completed a full \
+         reconfiguration under v4's rules)",
+    );
+}


### PR DESCRIPTION
## What

A `#[tokio::test(flavor = "multi_thread")]` that drives a **gradual rolling upgrade** — capability votes spread across multiple epochs — and asserts the network operates correctly at both protocol versions.

Effective threshold note: ika inherits Sui's `buffer_stake_for_protocol_upgrade_bps` (default 5000). For `n=4` (f=1, quorum=3) the effective threshold is `quorum + ceil(f * 5000/10000) = 4`, so a protocol upgrade requires **all 4** validators to support the new version. The test follows that natural threshold (no production-code override of the buffer).

| End-of-epoch | v4 supporters | Vote outcome      | Next epoch starts at |
|--------------|---------------|-------------------|----------------------|
| 0            | 1 / 4         | threshold not met | v3                   |
| 1            | 2 / 4         | threshold not met | v3                   |
| 2            | **4 / 4**     | **threshold met** | **v4**               |
| 3            | 4 / 4         | (already at MAX)  | v4                   |

Boots at `ProtocolVersion::MIN` (currently 3) with one validator declaring `MIN..=MAX` and three pinned at `MIN..=MIN`. Between epochs the test "upgrades" the next validator(s) in place: stops the node, mutates `NodeConfig.supported_protocol_versions`, restarts. The capability notification (`AuthorityCapabilitiesV1`) sent at the start of the next epoch the validator observes carries the new range, which the end-of-epoch quorum vote (`choose_highest_protocol_version_and_move_contracts_upgrades_v1`) reads. To clear the 4-of-4 effective threshold the third step upgrades **two** validators (indices 2 and 3) together.

**Waiting for epoch 4** — one full reconfiguration past the version transition — is what confirms v4 actually works. Epoch 2 → 3's reconfiguration runs entirely at v3 (the vote at end-of-epoch-2 sets v4 for epoch 3); it's epoch 3 → 4 that runs an entire reconfiguration under v4's new rules: `network_encryption_key_version` 2→3, `reconfiguration_message_version` 2→3, plus the new feature flags (`internal_presign_sessions`, `bls_checkpoints`, `noa_checkpoints`).

## API additions on `ika-test-cluster`

| New | What it does |
|---|---|
| `IkaTestClusterBuilder::with_protocol_version(ProtocolVersion)` | Set the genesis on-chain ika protocol version (`initiation_parameters.protocol_version`). Default unchanged (`MAX`). |
| `IkaTestClusterBuilder::with_per_validator_supported_protocol_versions(Vec<SupportedProtocolVersions>)` | Per-validator overrides for capability voting; length must match `num_validators`. Default: every validator gets `SYSTEM_DEFAULT` (`MIN..=MAX`) so they participate in voting. |
| `IkaTestCluster::validator_names: Vec<AuthorityName>` | Validators' protocol public keys in configured order — the underlying swarm stores nodes in a `HashMap`, so this is the only stable index-based addressing. |
| `IkaTestCluster::current_protocol_version()` | Read the in-memory protocol version from the first validator's epoch store. |
| `IkaTestCluster::upgrade_validator_supported_protocol_versions(i, new)` | Stop the node, mutate config under its existing `Mutex<NodeConfig>`, restart. Other validators stay up; 3-of-4 active quorum holds during the brief restart. |
| `IkaNode::current_protocol_version_for_testing()` | Sibling of the existing `current_epoch_for_testing` accessor. |

## Verified

End-to-end **passes in ~15.6 min wall time** (4 reconfigurations × real class-groups crypto):

```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 936.27s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)