### PR TITLE
ika-node: soften enforce-minimum-cpu assert to warning for localnet/dev

### DIFF
--- a/crates/ika-core/src/runtime.rs
+++ b/crates/ika-core/src/runtime.rs
@@ -51,11 +51,14 @@ impl IkaRuntimes {
         };
         let total_cores_available: usize = total_cores_available.into();
         if cfg!(feature = "enforce-minimum-cpu") {
-            assert!(
-                total_cores_available >= 16,
-                "Validator must have at least 16 CPU cores"
-            );
-            total_cores_available - TOKIO_ALLOCATED_CORES
+            if total_cores_available < 16 {
+                error!(
+                    "DEV PATCH: validator has only {} CPU cores (production minimum is 16). \
+                     Downgraded from panic to warning for localnet/dev use.",
+                    total_cores_available
+                );
+            }
+            total_cores_available.saturating_sub(TOKIO_ALLOCATED_CORES).max(1)
         } else {
             total_cores_available
         }


### PR DESCRIPTION
## Problem

`IkaRuntimes::calculate_num_of_computations_cores()` in `crates/ika-core/src/runtime.rs` contains `assert!(total_cores_available >= 16, ...)` gated on the `enforce-minimum-cpu` Cargo feature. Upstream `ika-node`'s `Cargo.toml` includes `enforce-minimum-cpu` in its **default** features, so the assert activates implicitly on every release build unless someone passes `--no-default-features`.

On any dev machine with fewer than 16 physical cores (we hit this on a 12-core dev box), `ika-node` panics on startup:

```
Validator must have at least 16 CPU cores
```

This kills the localnet ceremony before DKG can begin. There is no localnet-friendly flag upstream today, so anyone trying to bring up a local Ika network for development on common hardware has to hand-patch the source and rebuild.

## Proposed fix (this PR)

Replace `assert!` with `if + tracing::error!`. Startup continues, the operator sees a clear warning that they're running underpowered. Production validators are unaffected — they already meet the threshold so the warning never fires.

Also: replace `total_cores_available - TOKIO_ALLOCATED_CORES` with `.saturating_sub(TOKIO_ALLOCATED_CORES).max(1)` so the arithmetic doesn't underflow on machines with ≤4 cores (which would be a separate panic).

## Why not just `--no-default-features`?

That disables more than just the CPU gate — it removes the whole feature bundle. A localnet operator shouldn't have to opt out of unrelated production features just to run on a 12-core dev laptop.

## Acceptance evidence

We applied this patch on a 12-core dev box and ran a full dWallet creation ceremony end-to-end (DKG through `Active`) on self-hosted Ika localnet:

- dWallet ID: `0xfc2d0b3e56f3b936f8d97f9b0d2d40311315b4c95b4e5c790f67e627aebaa65e`
- State: `Active` at v4406
- Ceremony: native `ika dwallet create --curve secp256k1` (no SDK custom path)
- Cost: 0 IKA + ~0.002 SUI gas (localnet pricing)

## Alternate shapes (open to maintainer preference)

1. **This PR**: `assert!` → `if + tracing::error!` (same behavior, warning instead of panic)
2. **Stricter feature gate**: keep `assert!`, gate it behind a new `enforce-minimum-cpu-strict` feature; existing `enforce-minimum-cpu` becomes warning-only. Lets production validators opt into the strict panic explicitly.
3. **Default-feature removal**: keep the assert as-is, but move `enforce-minimum-cpu` out of `ika-node`'s default Cargo features. Forces production deployments to opt in; localnet works out of the box.

Happy to refactor to shape 2 or 3 if maintainers prefer — shape 1 was the minimum patch that unblocked us, but the others have different tradeoffs.
