### PR TITLE
fix(dwallet-mpc): gate post-v1.1.8 consensus-output streams (write + read) for cross-binary replay

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -2756,8 +2756,21 @@ impl ConsensusCommitOutput {
     ) -> IkaResult {
         let tables = epoch_store.tables()?;
 
-        // Write all the dWallet MPC related messages from this consensus round to the local DB.
-        // The [`DWalletMPCService`] constantly reads and process those messages.
+        // Streams added after mainnet-v1.1.8 are persisted only once the protocol
+        // feature that introduced them is live, gated on the same flag the
+        // `DWalletMPCService` replay reads gate on. This keeps the on-disk
+        // consensus-output schema at a given protocol version identical to what an
+        // older binary writes: without it, a newer binary replaying an older
+        // binary's history (a rolling mainnet-v1.1.8 -> dev binary swap) finds
+        // these tables sparse where the dense per-round driver
+        // (`dwallet_mpc_messages`) expects them aligned, and the replay
+        // round-equality check trips.
+        let internal_presign = epoch_store
+            .protocol_config()
+            .internal_presign_sessions_enabled();
+        let noa = epoch_store.protocol_config().noa_checkpoints();
+
+        // Written by every binary including mainnet-v1.1.8 — dense, one per round.
         batch.insert_batch(
             &tables.dwallet_mpc_messages,
             [(self.consensus_round, self.dwallet_mpc_round_messages)],
@@ -2767,46 +2780,60 @@ impl ConsensusCommitOutput {
             [(self.consensus_round, self.dwallet_mpc_round_outputs)],
         )?;
         batch.insert_batch(
-            &tables.dwallet_internal_mpc_outputs,
-            [(
-                self.consensus_round,
-                self.dwallet_internal_mpc_round_outputs,
-            )],
-        )?;
-        batch.insert_batch(
-            &tables.idle_status_updates,
-            [(self.consensus_round, self.idle_status_updates)],
-        )?;
-        batch.insert_batch(
-            &tables.sui_chain_observation_updates,
-            [(self.consensus_round, self.sui_chain_observation_updates)],
-        )?;
-        batch.insert_batch(
-            &tables.global_presign_requests,
-            [(self.consensus_round, self.global_presign_requests)],
-        )?;
-        batch.insert_batch(
-            &tables.network_key_data_messages,
-            [(self.consensus_round, self.network_key_data)],
-        )?;
-        batch.insert_batch(
-            &tables.noa_observations,
-            [(self.consensus_round, self.noa_observations)],
-        )?;
-        batch.insert_batch(
             &tables.verified_dwallet_checkpoint_messages,
             [(
                 self.consensus_round,
                 self.verified_dwallet_checkpoint_messages,
             )],
         )?;
+        // `network_key_data_messages` is also a post-v1.1.8 stream, but the
+        // off-chain-metadata line that supersedes this on dev removes it
+        // entirely, so it is intentionally left ungated here rather than tied to
+        // a throwaway flag.
         batch.insert_batch(
-            &tables.verified_system_checkpoint_messages,
-            [(
-                self.consensus_round,
-                self.verified_system_checkpoint_messages,
-            )],
+            &tables.network_key_data_messages,
+            [(self.consensus_round, self.network_key_data)],
         )?;
+
+        // Internal presign & sign sessions (#1623): internal MPC outputs, global
+        // presign requests, and idle-status (presign-pool) updates.
+        if internal_presign {
+            batch.insert_batch(
+                &tables.dwallet_internal_mpc_outputs,
+                [(
+                    self.consensus_round,
+                    self.dwallet_internal_mpc_round_outputs,
+                )],
+            )?;
+            batch.insert_batch(
+                &tables.global_presign_requests,
+                [(self.consensus_round, self.global_presign_requests)],
+            )?;
+            batch.insert_batch(
+                &tables.idle_status_updates,
+                [(self.consensus_round, self.idle_status_updates)],
+            )?;
+        }
+
+        // NOA signed-checkpoint cluster (#1664/#1672): system-checkpoint messages,
+        // NOA observations, and the Sui-chain-observation context they consume.
+        if noa {
+            batch.insert_batch(
+                &tables.verified_system_checkpoint_messages,
+                [(
+                    self.consensus_round,
+                    self.verified_system_checkpoint_messages,
+                )],
+            )?;
+            batch.insert_batch(
+                &tables.noa_observations,
+                [(self.consensus_round, self.noa_observations)],
+            )?;
+            batch.insert_batch(
+                &tables.sui_chain_observation_updates,
+                [(self.consensus_round, self.sui_chain_observation_updates)],
+            )?;
+        }
 
         batch.insert_batch(
             &tables.consensus_message_processed,

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -887,36 +887,55 @@ impl DWalletMPCService {
                 }
             };
 
-            let mpc_outputs = self
-                .epoch_store
-                .next_dwallet_internal_mpc_output(self.last_read_consensus_round);
+            // Internal presign sessions are a v4 feature
+            // (`internal_presign_sessions_enabled`), and only a binary with the
+            // feature live ever writes `dwallet_internal_mpc_outputs` records.
+            // The round assertion below assumes a *dense* stream — one record
+            // per processed consensus round — which holds only when every round
+            // in the replayed history was produced by such a binary. While the
+            // feature is disabled the stream is empty; worse, when replaying a
+            // history whose earlier rounds were produced by a binary that never
+            // wrote internal outputs (a pre-v4 node, e.g. during a rolling
+            // protocol/binary upgrade) the stream is *sparse*:
+            // `next_dwallet_internal_mpc_output` returns the next future record,
+            // whose round is ahead of the round being processed, and the
+            // dense-stream assertion trips. Gate the read on the same feature
+            // flag that gates instantiation so a node ignores the internal-output
+            // stream until internal presign is actually live.
+            let internal_mpc_outputs = if self.protocol_config.internal_presign_sessions_enabled() {
+                let mpc_outputs = self
+                    .epoch_store
+                    .next_dwallet_internal_mpc_output(self.last_read_consensus_round);
 
-            let internal_mpc_outputs = match mpc_outputs {
-                Ok(Some((round, outputs))) => {
-                    // Validate round matches
-                    if round != mpc_messages_consensus_round {
-                        error!(
-                            ?mpc_messages_consensus_round,
-                            ?round,
-                            "consensus round mismatch for internal MPC outputs"
-                        );
-                        panic!("consensus round mismatch for internal MPC outputs");
+                match mpc_outputs {
+                    Ok(Some((round, outputs))) => {
+                        // Validate round matches
+                        if round != mpc_messages_consensus_round {
+                            error!(
+                                ?mpc_messages_consensus_round,
+                                ?round,
+                                "consensus round mismatch for internal MPC outputs"
+                            );
+                            panic!("consensus round mismatch for internal MPC outputs");
+                        }
+                        outputs
                     }
-                    outputs
+                    Ok(None) => {
+                        // No internal MPC outputs for this round - use empty list.
+                        // This can happen during initialization or when no internal outputs are generated.
+                        Vec::new()
+                    }
+                    Err(e) => {
+                        error!(
+                            error=?e,
+                            last_read_consensus_round=self.last_read_consensus_round,
+                            "failed to load internal DWallet MPC outputs from the local DB"
+                        );
+                        panic!("failed to load DWallet MPC outputs from the local DB");
+                    }
                 }
-                Ok(None) => {
-                    // No internal MPC outputs for this round - use empty list.
-                    // This can happen during initialization or when no internal outputs are generated.
-                    Vec::new()
-                }
-                Err(e) => {
-                    error!(
-                        error=?e,
-                        last_read_consensus_round=self.last_read_consensus_round,
-                        "failed to load internal DWallet MPC outputs from the local DB"
-                    );
-                    panic!("failed to load DWallet MPC outputs from the local DB");
-                }
+            } else {
+                Vec::new()
             };
 
             let verified_dwallet_checkpoint_messages = self

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -970,100 +970,139 @@ impl DWalletMPCService {
                 }
             };
 
-            let verified_system_checkpoint_messages = self
-                .epoch_store
-                .next_verified_system_checkpoint_message(self.last_read_consensus_round);
-            let verified_system_checkpoint_messages = match verified_system_checkpoint_messages {
-                Ok(Some((round, messages))) => {
-                    if round != mpc_messages_consensus_round {
-                        error!(
-                            ?mpc_messages_consensus_round,
-                            ?round,
-                            "consensus round mismatch for verified system checkpoint messages"
-                        );
-                        panic!("consensus round mismatch for verified system checkpoint messages");
+            // System-checkpoint messages back NOA (Network-Owned-Address) signing,
+            // introduced with the NOA signed-checkpoint infrastructure. Gate the
+            // read on the same `noa_checkpoints` flag that gates writing this
+            // stream, so a node whose history was produced before the feature was
+            // live (e.g. a mainnet-v1.1.8 -> dev rolling swap replaying v1.1.8's
+            // rounds) skips the stream the older binary never wrote, instead of
+            // tripping the dense-per-round alignment check below.
+            let verified_system_checkpoint_messages = if self.protocol_config.noa_checkpoints() {
+                let verified_system_checkpoint_messages = self
+                    .epoch_store
+                    .next_verified_system_checkpoint_message(self.last_read_consensus_round);
+                match verified_system_checkpoint_messages {
+                    Ok(Some((round, messages))) => {
+                        if round != mpc_messages_consensus_round {
+                            error!(
+                                ?mpc_messages_consensus_round,
+                                ?round,
+                                "consensus round mismatch for verified system checkpoint messages"
+                            );
+                            panic!(
+                                "consensus round mismatch for verified system checkpoint messages"
+                            );
+                        }
+                        messages
                     }
-                    messages
-                }
-                Ok(None) => Vec::new(),
-                Err(e) => {
-                    error!(
-                        error=?e,
-                        last_read_consensus_round=self.last_read_consensus_round,
-                        "failed to load verified system checkpoint messages from the local DB"
-                    );
-                    panic!("failed to load verified system checkpoint messages from the local DB");
-                }
-            };
-
-            let idle_status_updates = match self
-                .epoch_store
-                .next_idle_status_update(self.last_read_consensus_round)
-            {
-                Ok(Some((round, updates))) => {
-                    if round != mpc_messages_consensus_round {
+                    Ok(None) => Vec::new(),
+                    Err(e) => {
                         error!(
-                            ?round,
-                            ?mpc_messages_consensus_round,
-                            "idle status updates consensus round does not match MPC messages consensus round"
+                            error=?e,
+                            last_read_consensus_round=self.last_read_consensus_round,
+                            "failed to load verified system checkpoint messages from the local DB"
                         );
                         panic!(
-                            "idle status updates consensus round does not match MPC messages consensus round"
+                            "failed to load verified system checkpoint messages from the local DB"
                         );
                     }
-                    updates
                 }
-                Ok(None) => Vec::new(),
-                Err(e) => {
-                    error!(error=?e, "failed to load idle status updates from the local DB");
-                    panic!("failed to load idle status updates from the local DB");
-                }
+            } else {
+                Vec::new()
             };
 
-            let sui_chain_observation_updates = match self
-                .epoch_store
-                .next_sui_chain_observation_update(self.last_read_consensus_round)
-            {
-                Ok(Some((round, updates))) => {
-                    if round != mpc_messages_consensus_round {
-                        error!(
-                            ?round,
-                            ?mpc_messages_consensus_round,
-                            "sui chain observation updates consensus round does not match MPC messages consensus round"
-                        );
-                        panic!(
-                            "sui chain observation updates consensus round does not match MPC messages consensus round"
-                        );
+            // Idle-status updates drive the internal presign pool (idle-fill),
+            // introduced with internal presign & sign sessions. Gate on the same
+            // flag that gates writing them so pre-feature history (v1.1.8 rounds)
+            // is skipped rather than tripping the alignment check.
+            let idle_status_updates = if self.protocol_config.internal_presign_sessions_enabled() {
+                match self
+                    .epoch_store
+                    .next_idle_status_update(self.last_read_consensus_round)
+                {
+                    Ok(Some((round, updates))) => {
+                        if round != mpc_messages_consensus_round {
+                            error!(
+                                ?round,
+                                ?mpc_messages_consensus_round,
+                                "idle status updates consensus round does not match MPC messages consensus round"
+                            );
+                            panic!(
+                                "idle status updates consensus round does not match MPC messages consensus round"
+                            );
+                        }
+                        updates
                     }
-                    updates
+                    Ok(None) => Vec::new(),
+                    Err(e) => {
+                        error!(error=?e, "failed to load idle status updates from the local DB");
+                        panic!("failed to load idle status updates from the local DB");
+                    }
                 }
-                Ok(None) => Vec::new(),
-                Err(e) => {
-                    error!(error=?e, "failed to load sui chain observation updates from the local DB");
-                    panic!("failed to load sui chain observation updates from the local DB");
-                }
+            } else {
+                Vec::new()
             };
 
-            let presign_request_messages = match self
-                .epoch_store
-                .next_global_presign_request(self.last_read_consensus_round)
-            {
-                Ok(Some((round, msgs))) => {
-                    if round != mpc_messages_consensus_round {
-                        error!(
-                            ?round,
-                            ?mpc_messages_consensus_round,
-                            "presign requests consensus round mismatch"
-                        );
-                        panic!("presign requests consensus round mismatch");
+            // Sui-chain observations supply the agreed chain context the NOA
+            // system-checkpoint handler consumes, so they belong to the NOA
+            // cluster — gate on `noa_checkpoints` like the system-checkpoint read.
+            let sui_chain_observation_updates = if self.protocol_config.noa_checkpoints() {
+                match self
+                    .epoch_store
+                    .next_sui_chain_observation_update(self.last_read_consensus_round)
+                {
+                    Ok(Some((round, updates))) => {
+                        if round != mpc_messages_consensus_round {
+                            error!(
+                                ?round,
+                                ?mpc_messages_consensus_round,
+                                "sui chain observation updates consensus round does not match MPC messages consensus round"
+                            );
+                            panic!(
+                                "sui chain observation updates consensus round does not match MPC messages consensus round"
+                            );
+                        }
+                        updates
                     }
-                    msgs
+                    Ok(None) => Vec::new(),
+                    Err(e) => {
+                        error!(error=?e, "failed to load sui chain observation updates from the local DB");
+                        panic!("failed to load sui chain observation updates from the local DB");
+                    }
                 }
-                Ok(None) => Vec::new(),
-                Err(e) => {
-                    error!(error=?e, "failed to load global presign requests from the local DB");
-                    panic!("failed to load global presign requests from the local DB");
+            } else {
+                Vec::new()
+            };
+
+            // Global presign requests were introduced with internal presign &
+            // sign sessions — gate on the same flag that gates writing them.
+            let presign_request_messages = if self
+                .protocol_config
+                .internal_presign_sessions_enabled()
+            {
+                match self
+                    .epoch_store
+                    .next_global_presign_request(self.last_read_consensus_round)
+                {
+                    Ok(Some((round, msgs))) => {
+                        if round != mpc_messages_consensus_round {
+                            error!(
+                                ?round,
+                                ?mpc_messages_consensus_round,
+                                "presign requests consensus round mismatch"
+                            );
+                            panic!("presign requests consensus round mismatch");
+                        }
+                        msgs
+                    }
+                    Ok(None) => Vec::new(),
+                    Err(e) => {
+                        error!(error=?e, "failed to load global presign requests from the local DB");
+                        panic!("failed to load global presign requests from the local DB");
+                    }
                 }
+            } else {
+                Vec::new()
             };
 
             let network_key_data_messages = match self
@@ -1088,26 +1127,31 @@ impl DWalletMPCService {
                 }
             };
 
-            let noa_observation_messages = match self
-                .epoch_store
-                .next_noa_observation(self.last_read_consensus_round)
-            {
-                Ok(Some((round, msgs))) => {
-                    if round != mpc_messages_consensus_round {
-                        error!(
-                            ?round,
-                            ?mpc_messages_consensus_round,
-                            "NOA observations consensus round mismatch"
-                        );
-                        panic!("NOA observations consensus round mismatch");
+            // NOA observations belong to the NOA cluster — gate on `noa_checkpoints`.
+            let noa_observation_messages = if self.protocol_config.noa_checkpoints() {
+                match self
+                    .epoch_store
+                    .next_noa_observation(self.last_read_consensus_round)
+                {
+                    Ok(Some((round, msgs))) => {
+                        if round != mpc_messages_consensus_round {
+                            error!(
+                                ?round,
+                                ?mpc_messages_consensus_round,
+                                "NOA observations consensus round mismatch"
+                            );
+                            panic!("NOA observations consensus round mismatch");
+                        }
+                        msgs
                     }
-                    msgs
+                    Ok(None) => Vec::new(),
+                    Err(e) => {
+                        error!(error=?e, "failed to load NOA observations from the local DB");
+                        panic!("failed to load NOA observations from the local DB");
+                    }
                 }
-                Ok(None) => Vec::new(),
-                Err(e) => {
-                    error!(error=?e, "failed to load NOA observations from the local DB");
-                    panic!("failed to load NOA observations from the local DB");
-                }
+            } else {
+                Vec::new()
             };
 
             if mpc_messages_consensus_round != external_mpc_outputs_consensus_round {


### PR DESCRIPTION
## Problem

The consensus-output replay loop in `DWalletMPCService` reads several per-round
tables and asserts each record's round equals the round being processed
(`round == mpc_messages_consensus_round`). That assertion assumes a **dense**
stream — one record per consensus round — which only holds when every round in
the replayed history was produced by a binary that writes that table.

On a rolling **mainnet-v1.1.8 → dev** binary swap, dev restarts on v1.1.8's
RocksDB and replays it. v1.1.8 writes only `dwallet_mpc_messages`,
`dwallet_mpc_outputs`, and `verified_dwallet_checkpoint_messages`; every other
consensus-output table was added after v1.1.8. The dense driver
(`dwallet_mpc_messages`) advances normally, but the post-v1.1.8 tables are
sparse/absent for the v1.1.8 rounds, so `next_*` returns a far-future,
dev-written record and the round-equality assert panics, crashing the node mid
rolling-upgrade.

## Fix

Gate **both the write (`write_to_batch`) and the replay read** of each
post-v1.1.8 stream on the protocol feature that introduced it, so a node only
persists/replays it once the feature is live. This keeps the on-disk
consensus-output schema at a given protocol version identical to what an older
binary writes at that version — dev-at-v3 behaves exactly like v1.1.8-at-v3.

| Stream | Gate |
|---|---|
| `dwallet_internal_mpc_outputs` | `internal_presign_sessions` |
| `global_presign_requests` | `internal_presign_sessions` |
| `idle_status_updates` (presign-pool idle-fill) | `internal_presign_sessions` |
| `verified_system_checkpoint_messages` | `noa_checkpoints` |
| `noa_observations` | `noa_checkpoints` |
| `sui_chain_observation_updates` | `noa_checkpoints` |

`dwallet_mpc_messages`, `dwallet_mpc_outputs`, `verified_dwallet_checkpoint_messages`
are written by v1.1.8 too (dense) and stay ungated.

`network_key_data_messages` is also post-v1.1.8, but the off-chain-metadata work
that supersedes this on `dev` removes that stream entirely, so it is
intentionally left ungated here rather than tied to a throwaway flag.

> Originally this PR gated only the `dwallet_internal_mpc_outputs` **read**; that
> fixed the first of these identical assertions. Expanded to cover the write side
> and all six affected streams after the cross-binary harness reached the next
> assertion (`verified_system_checkpoint_messages`).

## Validation

Validated end to end by the out-of-process cross-binary upgrade harness (on the
off-chain-metadata branch, where the harness lives): a real
**mainnet-v1.1.8 → dev** 4-validator rolling swap boots, survives the post-swap
replay, and the capability vote advances protocol **v3 → v4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)