### PR TITLE
fix(dwallet-mpc): serve global presigns below internal_presign_sessions activation (network-wedge deadlock)

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -535,8 +535,22 @@ impl DWalletMPCManager {
             return None;
         }
 
-        if let Some((presign_id, curve, signature_algorithm, dwallet_network_encryption_key_id)) =
-            request.protocol_data.is_global_presign()
+        // Global presigns are served from the internal presign pool — but the
+        // pool only exists once `internal_presign_sessions` activates (the
+        // whole request/fulfill pipeline is gated on that flag, see
+        // `next_global_presign_request` in the service). Before activation —
+        // i.e. while running at the previous protocol version right after an
+        // upgrade, with the on-chain `GlobalPresignConfig` already routing
+        // presigns to global — diverting the request here would strand it:
+        // no pool to serve it, no MPC session spawned, and the session is
+        // locked into its epoch (`all_current_epoch_sessions_completed`
+        // blocks `advance_epoch`), wedging the network below the version
+        // that could serve it. So pre-activation, fall through and run the
+        // request as a user-requested MPC session — the pre-pool serving
+        // behavior (the dwallet-output-less presign computation path).
+        if self.protocol_config.internal_presign_sessions_enabled()
+            && let Some((presign_id, curve, signature_algorithm, dwallet_network_encryption_key_id)) =
+                request.protocol_data.is_global_presign()
         {
             if request.session_sequence_number.is_none() {
                 error!(


### PR DESCRIPTION
## The bug

`handle_mpc_request` unconditionally diverts every `is_global_presign()` request into `global_presign_requests` (internal-pool fulfillment) and returns without creating an MPC session. But the pool's entire request/fulfill pipeline is gated on `internal_presign_sessions_enabled()` — a **protocol v4** feature flag. Below v4 the diverted request is unservable: no pool to serve it, no session spawned.

That is not a stall — it is a **permanent network wedge**:

1. The session is locked into its epoch.
2. `advance_epoch` requires `all_current_epoch_sessions_completed` (sessions_manager.move).
3. The epoch can never end ⇒ the capability vote can never activate v4 ⇒ the only protocol version that could serve the request is unreachable.

Mainnet upgrades into exactly this window: `GlobalPresignConfig` is already populated on-chain (verified at epoch 315 — all 3130 live presign sessions are global, `dwallet_id: None`), so validators restart on the new binary at protocol v3 with global presign requests in flight. **One in-flight presign at restart wedges the network permanently.**

Caught by the literal-mainnet-v1.1.8 upgrade rehearsal on `feat/ika-upgrade-test`: a workload launched in the post-swap/pre-activation window deadlocked the epoch for 23+ minutes until timeout; with this fix the same rehearsal is green end-to-end (v3 fallback serving + v4 pool serving both exercised).

## The fix

Gate the diversion on the same flag that gates the pool pipeline. Pre-activation, the request falls through to a user-requested MPC session — byte-identical to v1.1.8's serving path:

- input built via `try_new_v2(None)` (the dwallet-output-less presign computation),
- output emitted as `RespondDWalletPresign` with `dwallet_id: None`,
- self-wrapped `VersionedPresignOutput::V2` — the same chain-facing bytes the pool path produces.

One condition; no new code paths. Once v4 activates, behavior is unchanged (pool serving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
