### PR TITLE
fix(dwallet-mpc): deterministic internal-presign session identifiers across validators

### DIFF
--- a/crates/dwallet-mpc-types/src/mpc_protocol_configuration.rs
+++ b/crates/dwallet-mpc-types/src/mpc_protocol_configuration.rs
@@ -7,7 +7,7 @@ use crate::dwallet_mpc::{DWalletCurve, DWalletSignatureAlgorithm, DwalletNetwork
 use group::HashScheme;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Protocol flags for DKG and signing operations
 #[repr(u32)]
@@ -41,8 +41,17 @@ pub const DWALLET_DKG_PROTOCOL_FLAG: u32 = 9;
 pub const DWALLET_DKG_WITH_SIGN_PROTOCOL_FLAG: u32 = 10;
 
 lazy_static! {
-    /// Supported curves to signature algorithms to hash schemes
-    pub static ref SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES: HashMap<u32, HashMap<u32, Vec<u32>>> = {
+    /// Supported curves to signature algorithms to hash schemes.
+    ///
+    /// MUST be an ordered map (`BTreeMap`), at both nesting levels. Validators
+    /// iterate this map to instantiate internal presign sessions, assigning each
+    /// session a sequence number from a single shared counter in iteration order;
+    /// the sequence number is bound into the session identifier transcript. With
+    /// `HashMap`'s per-process random iteration order, each validator derived
+    /// *different* session identifiers for the same (curve, algorithm) work, so
+    /// those sessions could never reach quorum and the presign pools starved for
+    /// the whole epoch (wedging epoch advance once a user presign request locked).
+    pub static ref SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES: BTreeMap<u32, BTreeMap<u32, Vec<u32>>> = {
         vec![
             (
                 0, // Curve: Secp256k1

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -44,7 +44,7 @@ use ika_types::messages_dwallet_mpc::{
 use ika_types::noa_checkpoint::CounterpartyChainKind;
 use mpc::{MajorityVote, WeightedThresholdAccessStructure};
 use std::collections::hash_map::Entry;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use sui_types::base_types::ObjectID;
 use tokio::sync::mpsc::Sender;
@@ -805,7 +805,14 @@ impl DWalletMPCManager {
                 None => return,
             };
 
-        let agreed_key_ids: Vec<_> = self.agreed_network_key_data.keys().copied().collect();
+        // Ordered (`BTreeSet`) on purpose: the loop below assigns internal presign
+        // session sequence numbers from a single shared counter in iteration order,
+        // and the sequence number is bound into the session identifier. Every
+        // validator must iterate keys (and curves/algorithms — see
+        // `SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES`) in the same
+        // order, or they derive different session identifiers for the same work
+        // and the sessions never reach quorum.
+        let agreed_key_ids: BTreeSet<_> = self.agreed_network_key_data.keys().copied().collect();
         for key_id in agreed_key_ids {
             for (curve, signature_algorithms) in supported_curve_to_signature_algorithms() {
                 for signature_algorithm in signature_algorithms {


### PR DESCRIPTION
## The bug

Internal presign sessions draw their sequence number from a single shared counter, assigned in iteration order over (network key id) × (curve) × (signature algorithm) — and that sequence number is bound into the session identifier transcript. Both iteration sources were unordered:

- `SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES` was a `HashMap<u32, HashMap<u32, Vec<u32>>>` — iteration order is random per process (`RandomState`), so each validator walked curves/algorithms in a different order;
- the agreed network key ids were iterated straight off a `HashMap`.

Each validator therefore derived **different session identifiers for the same (curve, algorithm) work**. Those sessions can never reach quorum, never complete, and the instantiated≠completed gate then blocks epoch advance.

## The fix

Make both iterations deterministic (`BTreeMap` / sorted ids) so every validator assigns the same sequence numbers to the same work, producing identical session identifiers.

Cherry-picked from `feat/ika-upgrade-test` (29e8a097d1), where the cross-binary churn and v1.1.8 upgrade rehearsals run green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
