### PR TITLE
fix(sui-executor): notifier gas-handling and advance_epoch robustness under load

### DIFF
--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -879,6 +879,14 @@ where
                 // the cached gas ref survives the failure and every retry
                 // rebuilds the identical stale tx until the one-hour panic,
                 // wedging checkpoint submission.
+                //
+                // Match the variant payload — do NOT pass `err.to_string()`
+                // and especially not clippy's `unnecessary_to_owned`
+                // "simplification" of it, `err.as_ref()`: `IkaError` derives
+                // strum's `AsRefStr`, so `as_ref()` returns only the variant
+                // name ("SuiClientTxFailureGeneric"), which never contains
+                // the rejection markers — it compiles fine and silently
+                // disables this recovery.
                 if let IkaError::SuiClientTxFailureGeneric(_, message) = &err {
                     state.handle_possible_stale_gas_rejection(message);
                 }

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -41,7 +41,7 @@ use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_json_rpc_types::{SuiExecutionStatus, SuiTransactionBlockResponse};
 use sui_macros::fail_point_async;
 use sui_types::MOVE_STDLIB_PACKAGE_ID;
-use sui_types::base_types::{ObjectID, TransactionDigest};
+use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{Argument, CallArg, Transaction};
 use tokio::sync::watch;
@@ -57,6 +57,24 @@ pub enum StopReason {
 
 const ONE_HOUR_IN_SECONDS: u64 = 60 * 60;
 
+/// Serialized submission state for the notifier's single Sui address.
+///
+/// `last_tx_digest` gates submission ordering (wait for the previous tx
+/// to be observed before sending the next). `gas_coins` caches the gas
+/// `ObjectRef` carried by the previous tx's effects so the next tx is
+/// built against the *authoritative* post-tx gas version rather than the
+/// notifier fullnode's `get_gas_objects` view, which lags the validators
+/// by hundreds of versions under checkpoint-heavy load and otherwise
+/// produces "transaction needs to be rebuilt (stale object version)"
+/// rejections that stall epoch advance. Submission is serial (the lock is
+/// held across each `submit_tx_to_sui`), so the cached ref is always the
+/// exact current version when the next tx is built.
+#[derive(Default)]
+struct NotifierSubmitState {
+    last_tx_digest: Option<TransactionDigest>,
+    gas_coins: Option<Vec<ObjectRef>>,
+}
+
 pub struct SuiExecutor<C> {
     system_object_sender: Sender<Option<(System, SystemInner)>>,
     dwallet_coordinator_object_sender:
@@ -66,7 +84,7 @@ pub struct SuiExecutor<C> {
     sui_notifier: Option<SuiNotifier>,
     sui_client: Arc<SuiClient<C>>,
     metrics: Arc<SuiConnectorMetrics>,
-    notifier_tx_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
+    notifier_tx_lock: Arc<tokio::sync::Mutex<NotifierSubmitState>>,
 }
 
 struct EpochSwitchState {
@@ -100,7 +118,7 @@ where
             sui_notifier,
             sui_client,
             metrics,
-            notifier_tx_lock: Arc::new(tokio::sync::Mutex::new(None)),
+            notifier_tx_lock: Arc::new(tokio::sync::Mutex::new(NotifierSubmitState::default())),
         }
     }
 
@@ -603,9 +621,10 @@ where
         ika_dwallet_2pc_mpc_package_id: ObjectID,
         network_encryption_key_ids: Vec<ObjectID>,
         sui_notifier: &SuiNotifier,
-        notifier_tx_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
+        notifier_tx_lock: Arc<tokio::sync::Mutex<NotifierSubmitState>>,
     ) -> anyhow::Result<SuiTransactionBlockResponse> {
-        let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
+        let gas_coins =
+            Self::next_gas_coins(&notifier_tx_lock, sui_client, sui_notifier.sui_address).await;
         // let gas_coin = gas_coins
         //     .first()
         //     .ok_or_else(|| IkaError::SuiConnectorInternalError("no gas coin found".to_string()))?;
@@ -644,10 +663,11 @@ where
         sui_client: &Arc<SuiClient<C>>,
         ika_dwallet_2pc_mpc_package_id: ObjectID,
         sui_notifier: &SuiNotifier,
-        notifier_tx_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
+        notifier_tx_lock: Arc<tokio::sync::Mutex<NotifierSubmitState>>,
         default_pricing_keys: &[PricingInfoKey],
     ) -> anyhow::Result<SuiTransactionBlockResponse> {
-        let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
+        let gas_coins =
+            Self::next_gas_coins(&notifier_tx_lock, sui_client, sui_notifier.sui_address).await;
         // let gas_coin = gas_coins
         //     .first()
         //     .ok_or_else(|| IkaError::SuiConnectorInternalError("no gas coin found".to_string()))?;
@@ -695,13 +715,33 @@ where
         Ok(Self::submit_tx_to_sui(notifier_tx_lock, transaction, sui_client).await?)
     }
 
+    /// Returns the gas coins to fund the next notifier tx. Prefers the
+    /// cached `ObjectRef` carried by the previous tx's effects (the
+    /// authoritative post-tx version); falls back to a fresh
+    /// `get_gas_objects` fetch only when nothing is cached yet (first tx
+    /// of the process). See [`NotifierSubmitState`] for why the fullnode
+    /// fetch is avoided on the steady-state path.
+    async fn next_gas_coins(
+        notifier_tx_lock: &Arc<tokio::sync::Mutex<NotifierSubmitState>>,
+        sui_client: &Arc<SuiClient<C>>,
+        address: SuiAddress,
+    ) -> Vec<ObjectRef> {
+        {
+            let state = notifier_tx_lock.lock().await;
+            if let Some(gas) = &state.gas_coins {
+                return gas.clone();
+            }
+        }
+        sui_client.get_gas_objects(address).await
+    }
+
     async fn submit_tx_to_sui(
-        notifier_tx_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
+        notifier_tx_lock: Arc<tokio::sync::Mutex<NotifierSubmitState>>,
         transaction: Transaction,
         sui_client: &Arc<SuiClient<C>>,
     ) -> DwalletMPCResult<SuiTransactionBlockResponse> {
-        let mut last_submitted_tx_digest = notifier_tx_lock.lock().await;
-        if let Some(prev_digest) = *last_submitted_tx_digest {
+        let mut state = notifier_tx_lock.lock().await;
+        if let Some(prev_digest) = state.last_tx_digest {
             while sui_client
                 .get_events_by_tx_digest(prev_digest)
                 .await
@@ -746,6 +786,13 @@ where
             .into());
         };
 
+        // The tx executed (effects are present), so the gas coin advanced
+        // to a new version regardless of move success/abort. Cache that
+        // authoritative ref for the next tx instead of re-reading the
+        // notifier fullnode, which lags under load and yields stale gas
+        // versions that get rejected and stall epoch advance.
+        state.gas_coins = Some(vec![tx_effects.gas_object().reference.to_object_ref()]);
+
         if let SuiExecutionStatus::Failure { error } = tx_effects.status() {
             return Err(IkaError::SuiClientTxFailureGeneric(
                 tx_response.digest,
@@ -756,7 +803,7 @@ where
             .into());
         };
 
-        *last_submitted_tx_digest = Some(tx_response.digest);
+        state.last_tx_digest = Some(tx_response.digest);
         Ok(tx_response)
     }
 
@@ -765,10 +812,11 @@ where
         ika_dwallet_2pc_mpc_package_id: ObjectID,
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
-        notifier_tx_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
+        notifier_tx_lock: Arc<tokio::sync::Mutex<NotifierSubmitState>>,
     ) -> IkaResult<SuiTransactionBlockResponse> {
         info!("Running `process_mid_epoch()`");
-        let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
+        let gas_coins =
+            Self::next_gas_coins(&notifier_tx_lock, sui_client, sui_notifier.sui_address).await;
         // let gas_coin = gas_coins
         //     .first()
         //     .ok_or_else(|| IkaError::SuiConnectorInternalError("no gas coin found".to_string()))?;
@@ -838,10 +886,11 @@ where
         ika_dwallet_2pc_mpc_package_id: ObjectID,
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
-        notifier_tx_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
+        notifier_tx_lock: Arc<tokio::sync::Mutex<NotifierSubmitState>>,
     ) -> IkaResult<SuiTransactionBlockResponse> {
         info!("Process `lock_last_active_session_sequence_number()`");
-        let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
+        let gas_coins =
+            Self::next_gas_coins(&notifier_tx_lock, sui_client, sui_notifier.sui_address).await;
         // let gas_coin = gas_coins
         //     .first()
         //     .ok_or_else(|| IkaError::SuiConnectorInternalError("no gas coin found".to_string()))?;
@@ -904,10 +953,11 @@ where
         ika_dwallet_2pc_mpc_package_id: ObjectID,
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
-        notifier_tx_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
+        notifier_tx_lock: Arc<tokio::sync::Mutex<NotifierSubmitState>>,
     ) -> IkaResult<SuiTransactionBlockResponse> {
         info!("Running `process_request_advance_epoch()`");
-        let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
+        let gas_coins =
+            Self::next_gas_coins(&notifier_tx_lock, sui_client, sui_notifier.sui_address).await;
         // let gas_coin = gas_coins
         //     .first()
         //     .ok_or_else(|| IkaError::SuiConnectorInternalError("no gas coin found".to_string()))?;
@@ -981,11 +1031,12 @@ where
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
         metrics: &Arc<SuiConnectorMetrics>,
-        notifier_tx_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
+        notifier_tx_lock: Arc<tokio::sync::Mutex<NotifierSubmitState>>,
     ) -> IkaResult<SuiTransactionBlockResponse> {
         let mut ptb = ProgrammableTransactionBuilder::new();
 
-        let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
+        let gas_coins =
+            Self::next_gas_coins(&notifier_tx_lock, sui_client, sui_notifier.sui_address).await;
         //merge_gas_coins(&mut ptb, &gas_coins)?;
         // let gas_coin = gas_coins
         //     .first()
@@ -1067,11 +1118,12 @@ where
         sui_notifier: &SuiNotifier,
         sui_client: &Arc<SuiClient<C>>,
         metrics: &Arc<SuiConnectorMetrics>,
-        notifier_tx_lock: Arc<tokio::sync::Mutex<Option<TransactionDigest>>>,
+        notifier_tx_lock: Arc<tokio::sync::Mutex<NotifierSubmitState>>,
     ) -> IkaResult<()> {
         let mut ptb = ProgrammableTransactionBuilder::new();
 
-        let gas_coins = sui_client.get_gas_objects(sui_notifier.sui_address).await;
+        let gas_coins =
+            Self::next_gas_coins(&notifier_tx_lock, sui_client, sui_notifier.sui_address).await;
         // merge_gas_coins(&mut ptb, &gas_coins)?;
         // let gas_coin = gas_coins
         //     .first()

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -87,6 +87,25 @@ struct NotifierSubmitState {
     min_gas_version: Option<SequenceNumber>,
 }
 
+impl NotifierSubmitState {
+    /// Inspect a submission failure and, if it is a stale-gas rejection,
+    /// drop the cached gas ref and record the rejected version as the
+    /// re-fetch floor. Only a stale-gas rejection means the cached gas ref
+    /// is bad; any other error leaves the cache intact — the gas was fine,
+    /// the tx failed for an unrelated reason, and clearing it would force
+    /// an unnecessary (and possibly stale) fullnode re-fetch.
+    fn handle_possible_stale_gas_rejection(&mut self, error_message: &str) {
+        let is_stale_gas = error_message.contains("unavailable for consumption")
+            || error_message.contains("needs to be rebuilt");
+        if is_stale_gas {
+            if let Some(used) = &self.last_used_gas {
+                self.min_gas_version = used.iter().map(|gas_ref| gas_ref.1).max();
+            }
+            self.gas_coins = None;
+        }
+    }
+}
+
 /// Cap on how long `next_gas_coins` waits for the fullnode to catch up past a
 /// rejected gas version before giving up and using whatever it returns (the
 /// outer `retry_with_max_elapsed_time!` re-attempts). 60 × 500ms = 30s.
@@ -845,29 +864,36 @@ where
             "Submitting a transaction to Sui"
         );
 
-        let tx_response = sui_client
+        let tx_response = match sui_client
             .execute_transaction_block_with_effects(transaction)
-            .await?;
+            .await
+        {
+            Ok(tx_response) => tx_response,
+            Err(err) => {
+                // The fullnode can also reject the tx at submission with a
+                // JSON-RPC error instead of returning a response carrying
+                // `errors` — input-object check failures ("needs to be
+                // rebuilt" / "unavailable for consumption") surface this
+                // way, wrapped in `SuiClientTxFailureGeneric`. Apply the same
+                // stale-gas recovery as the `errors` branch below; otherwise
+                // the cached gas ref survives the failure and every retry
+                // rebuilds the identical stale tx until the one-hour panic,
+                // wedging checkpoint submission.
+                if let IkaError::SuiClientTxFailureGeneric(_, message) = &err {
+                    state.handle_possible_stale_gas_rejection(message);
+                }
+                return Err(err.into());
+            }
+        };
 
         if !tx_response.errors.is_empty() {
             let errors = format!("{:?}", tx_response.errors);
-            // Distinguish a stale-gas rejection from any other pre-execution
-            // error. Only the former means the cached gas ref is stale, so only
-            // then drop it AND record the rejected version as a floor — so the
-            // caller's `retry_with_max_elapsed_time!` re-fetch waits for the
-            // notifier fullnode to advance past it instead of re-serving the
-            // same stale version in a tight loop (which wedged epoch advance).
-            // Other errors leave the gas cache intact: the gas was fine, the tx
-            // failed for an unrelated reason, and clearing it would force an
-            // unnecessary (and possibly stale) fullnode re-fetch.
-            let is_stale_gas = errors.contains("unavailable for consumption")
-                || errors.contains("needs to be rebuilt");
-            if is_stale_gas {
-                if let Some(used) = &state.last_used_gas {
-                    state.min_gas_version = used.iter().map(|gas_ref| gas_ref.1).max();
-                }
-                state.gas_coins = None;
-            }
+            // A stale-gas rejection drops the cached gas ref AND records the
+            // rejected version as a floor — so the caller's
+            // `retry_with_max_elapsed_time!` re-fetch waits for the notifier
+            // fullnode to advance past it instead of re-serving the same
+            // stale version in a tight loop (which wedged epoch advance).
+            state.handle_possible_stale_gas_rejection(&errors);
             return Err(IkaError::SuiClientTxFailureGeneric(tx_response.digest, errors).into());
         }
 

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -771,6 +771,15 @@ where
             .await?;
 
         if !tx_response.errors.is_empty() {
+            // The tx was rejected before execution (e.g. a stale gas-coin
+            // version: the cached ref lagged the coin's on-chain version under
+            // fullnode lag or a lost race). The cached `gas_coins` that built
+            // it is therefore stale — drop it so the caller's
+            // `retry_with_max_elapsed_time!` re-fetches a fresh ref from the
+            // fullnode on the next attempt. Without this the retry resubmits
+            // the same stale version every time and spins for the full retry
+            // budget (an hour), wedging epoch advance.
+            state.gas_coins = None;
             return Err(IkaError::SuiClientTxFailureGeneric(
                 tx_response.digest,
                 format!("{:?}", tx_response.errors),
@@ -779,6 +788,10 @@ where
         }
 
         let Some(tx_effects) = tx_response.effects.clone() else {
+            // No effects to derive the post-tx gas version from; treat the
+            // cached ref as unreliable and re-fetch on retry (same rationale
+            // as the rejection path above).
+            state.gas_coins = None;
             return Err(IkaError::SuiClientTxFailureGeneric(
                 tx_response.digest,
                 "Transaction effects are missing".to_string(),

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -41,7 +41,7 @@ use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_json_rpc_types::{SuiExecutionStatus, SuiTransactionBlockResponse};
 use sui_macros::fail_point_async;
 use sui_types::MOVE_STDLIB_PACKAGE_ID;
-use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest};
+use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{Argument, CallArg, Transaction};
 use tokio::sync::watch;
@@ -73,7 +73,24 @@ const ONE_HOUR_IN_SECONDS: u64 = 60 * 60;
 struct NotifierSubmitState {
     last_tx_digest: Option<TransactionDigest>,
     gas_coins: Option<Vec<ObjectRef>>,
+    /// The gas ref(s) handed to the most recent submission, so a failure can
+    /// learn which version was rejected without threading it back through the
+    /// callers. Submission is serial, so this is unambiguous.
+    last_used_gas: Option<Vec<ObjectRef>>,
+    /// When a tx is rejected for a stale gas version, the rejected version is
+    /// recorded here as a floor: the next `get_gas_objects` re-fetch must
+    /// return a version strictly greater before it is trusted. This stops the
+    /// re-fetch from reusing the same stale version the lagging notifier
+    /// fullnode keeps serving (e.g. after another holder of this address — in
+    /// the in-process test cluster, the shared publisher coin — advanced it),
+    /// which would otherwise re-reject in a tight loop and wedge epoch advance.
+    min_gas_version: Option<SequenceNumber>,
 }
+
+/// Cap on how long `next_gas_coins` waits for the fullnode to catch up past a
+/// rejected gas version before giving up and using whatever it returns (the
+/// outer `retry_with_max_elapsed_time!` re-attempts). 60 × 500ms = 30s.
+const MAX_GAS_REFETCH_ATTEMPTS: u32 = 60;
 
 pub struct SuiExecutor<C> {
     system_object_sender: Sender<Option<(System, SystemInner)>>,
@@ -726,13 +743,38 @@ where
         sui_client: &Arc<SuiClient<C>>,
         address: SuiAddress,
     ) -> Vec<ObjectRef> {
+        // Fast path: the authoritative ref carried by the prior tx's effects.
         {
-            let state = notifier_tx_lock.lock().await;
-            if let Some(gas) = &state.gas_coins {
-                return gas.clone();
+            let mut state = notifier_tx_lock.lock().await;
+            if let Some(gas) = state.gas_coins.clone() {
+                state.last_used_gas = Some(gas.clone());
+                return gas;
             }
         }
-        sui_client.get_gas_objects(address).await
+        // Slow path (first tx of the process, or after a stale-gas rejection
+        // cleared the cache): re-fetch from the fullnode. If a prior rejection
+        // recorded a `min_gas_version` floor, wait for the fullnode to catch up
+        // past it before trusting the result — the notifier fullnode lags the
+        // validators, so an immediate re-fetch keeps serving the same stale
+        // version that was just rejected.
+        let mut attempts = 0u32;
+        loop {
+            let gas = sui_client.get_gas_objects(address).await;
+            let mut state = notifier_tx_lock.lock().await;
+            let highest = gas.iter().map(|gas_ref| gas_ref.1).max();
+            let acceptable = match state.min_gas_version {
+                Some(floor) => highest.is_some_and(|version| version > floor),
+                None => true,
+            };
+            if acceptable || attempts >= MAX_GAS_REFETCH_ATTEMPTS {
+                state.min_gas_version = None;
+                state.last_used_gas = Some(gas.clone());
+                return gas;
+            }
+            drop(state);
+            attempts += 1;
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
     }
 
     async fn submit_tx_to_sui(
@@ -771,26 +813,30 @@ where
             .await?;
 
         if !tx_response.errors.is_empty() {
-            // The tx was rejected before execution (e.g. a stale gas-coin
-            // version: the cached ref lagged the coin's on-chain version under
-            // fullnode lag or a lost race). The cached `gas_coins` that built
-            // it is therefore stale — drop it so the caller's
-            // `retry_with_max_elapsed_time!` re-fetches a fresh ref from the
-            // fullnode on the next attempt. Without this the retry resubmits
-            // the same stale version every time and spins for the full retry
-            // budget (an hour), wedging epoch advance.
-            state.gas_coins = None;
-            return Err(IkaError::SuiClientTxFailureGeneric(
-                tx_response.digest,
-                format!("{:?}", tx_response.errors),
-            )
-            .into());
+            let errors = format!("{:?}", tx_response.errors);
+            // Distinguish a stale-gas rejection from any other pre-execution
+            // error. Only the former means the cached gas ref is stale, so only
+            // then drop it AND record the rejected version as a floor — so the
+            // caller's `retry_with_max_elapsed_time!` re-fetch waits for the
+            // notifier fullnode to advance past it instead of re-serving the
+            // same stale version in a tight loop (which wedged epoch advance).
+            // Other errors leave the gas cache intact: the gas was fine, the tx
+            // failed for an unrelated reason, and clearing it would force an
+            // unnecessary (and possibly stale) fullnode re-fetch.
+            let is_stale_gas = errors.contains("unavailable for consumption")
+                || errors.contains("needs to be rebuilt");
+            if is_stale_gas {
+                if let Some(used) = &state.last_used_gas {
+                    state.min_gas_version = used.iter().map(|gas_ref| gas_ref.1).max();
+                }
+                state.gas_coins = None;
+            }
+            return Err(IkaError::SuiClientTxFailureGeneric(tx_response.digest, errors).into());
         }
 
         let Some(tx_effects) = tx_response.effects.clone() else {
             // No effects to derive the post-tx gas version from; treat the
-            // cached ref as unreliable and re-fetch on retry (same rationale
-            // as the rejection path above).
+            // cached ref as unreliable and re-fetch on retry.
             state.gas_coins = None;
             return Err(IkaError::SuiClientTxFailureGeneric(
                 tx_response.digest,
@@ -805,6 +851,9 @@ where
         // notifier fullnode, which lags under load and yields stale gas
         // versions that get rejected and stall epoch advance.
         state.gas_coins = Some(vec![tx_effects.gas_object().reference.to_object_ref()]);
+        // The cached ref is now authoritative again; drop any stale-version
+        // floor a prior rejection left so a future re-fetch isn't over-gated.
+        state.min_gas_version = None;
 
         if let SuiExecutionStatus::Failure { error } = tx_effects.status() {
             return Err(IkaError::SuiClientTxFailureGeneric(

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -47,7 +47,7 @@ use sui_types::transaction::{Argument, CallArg, Transaction};
 use tokio::sync::watch;
 use tokio::sync::watch::Sender;
 use tokio::time::{self, Duration};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum StopReason {
@@ -337,10 +337,26 @@ where
             epoch_switch_state.ran_lock_last_session = true;
             info!("Successfully locked last session in current epoch");
         }
-        if coordinator_inner.received_end_of_publish
+        // Mirror the on-chain `all_current_epoch_sessions_completed` assertion in
+        // `sessions_manager::advance_epoch`: the locked user-session batch must be
+        // fully completed AND every system session (network-key DKG/reconfiguration)
+        // must have finished. `received_end_of_publish` is set from a quorum snapshot
+        // and can momentarily precede a freshly-initiated system session (a
+        // `respond_*` on a network-key session chains a new `initiate_system_session`),
+        // so we re-check against the just-synced coordinator state before submitting.
+        // Submitting `advance_epoch` while this is false MoveAborts with
+        // `ENotAllCurrentEpochSessionsCompleted` (code 6); the outer hour-long retry
+        // would then burn out and `panic!` the validator over a transient,
+        // self-clearing condition — dropping the committee below quorum mid-transition
+        // and risking a network-wide wedge. Gating the submission keeps the panic for
+        // genuinely fatal submission failures only.
+        let sessions_manager = &coordinator_inner.sessions_manager;
+        let all_current_epoch_sessions_completed =
+            sessions_manager.all_current_epoch_sessions_completed();
+        let advance_gate_open = coordinator_inner.received_end_of_publish
             && system_inner_v1.received_end_of_publish
-            && !epoch_switch_state.ran_request_advance_epoch
-        {
+            && !epoch_switch_state.ran_request_advance_epoch;
+        if advance_gate_open && all_current_epoch_sessions_completed {
             info!("Calling `process_request_advance_epoch()`");
             let response = retry_with_max_elapsed_time!(
                 Self::process_request_advance_epoch(
@@ -360,6 +376,27 @@ where
             }
             info!("Successfully requested advance epoch");
             epoch_switch_state.ran_request_advance_epoch = true;
+        } else if advance_gate_open {
+            // End-of-publish is in, but sessions are still draining. Hold this
+            // tick (do NOT submit a doomed `advance_epoch`); re-check next tick.
+            debug!(
+                epoch = coordinator_inner.current_epoch,
+                locked = sessions_manager
+                    .locked_last_user_initiated_session_to_complete_in_current_epoch,
+                user_completed = sessions_manager
+                    .user_sessions_keeper
+                    .completed_sessions_count,
+                user_target =
+                    sessions_manager.last_user_initiated_session_to_complete_in_current_epoch,
+                system_started = sessions_manager
+                    .system_sessions_keeper
+                    .started_sessions_count,
+                system_completed = sessions_manager
+                    .system_sessions_keeper
+                    .completed_sessions_count,
+                "end-of-publish received but current-epoch sessions are still completing; \
+                 holding advance_epoch this tick",
+            );
         }
     }
 

--- a/crates/ika-types/src/sui/system_inner_v1.rs
+++ b/crates/ika-types/src/sui/system_inner_v1.rs
@@ -127,6 +127,24 @@ pub struct SessionsManager {
     pub max_active_sessions_buffer: u64,
 }
 
+impl SessionsManager {
+    /// Rust mirror of the on-chain `sessions_manager::all_current_epoch_sessions_completed`
+    /// assertion gating `advance_epoch`: the user-completion target must be locked,
+    /// the locked batch of user sessions must be fully completed, and every system
+    /// session (network-key DKG/reconfiguration) must have finished. The notifier
+    /// checks this against the just-synced state before submitting `advance_epoch`,
+    /// so a transient "still draining" window never becomes a doomed transaction.
+    pub fn all_current_epoch_sessions_completed(&self) -> bool {
+        let user_sessions_completed = self.user_sessions_keeper.completed_sessions_count
+            == self.last_user_initiated_session_to_complete_in_current_epoch;
+        let system_sessions_completed = self.system_sessions_keeper.started_sessions_count
+            == self.system_sessions_keeper.completed_sessions_count;
+        self.locked_last_user_initiated_session_to_complete_in_current_epoch
+            && user_sessions_completed
+            && system_sessions_completed
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct SupportConfig {
     pub supported_curves_to_signature_algorithms_to_hash_schemes:
@@ -279,4 +297,55 @@ pub struct ValidatorCapV1 {
 pub struct ValidatorOperationCapV1 {
     pub id: ObjectID,
     pub validator_id: ObjectID,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keeper(started: u64, completed: u64) -> SessionsKeeper {
+        SessionsKeeper {
+            sessions: Table::default(),
+            session_events: Bag::default(),
+            started_sessions_count: started,
+            completed_sessions_count: completed,
+            next_session_sequence_number: started,
+        }
+    }
+
+    fn sessions_manager(
+        locked: bool,
+        user_completed: u64,
+        user_target: u64,
+        system_started: u64,
+        system_completed: u64,
+    ) -> SessionsManager {
+        SessionsManager {
+            registered_user_session_identifiers: Table::default(),
+            user_sessions_keeper: keeper(user_target, user_completed),
+            system_sessions_keeper: keeper(system_started, system_completed),
+            last_user_initiated_session_to_complete_in_current_epoch: user_target,
+            locked_last_user_initiated_session_to_complete_in_current_epoch: locked,
+            max_active_sessions_buffer: 100,
+        }
+    }
+
+    #[test]
+    fn all_current_epoch_sessions_completed_truth_table() {
+        // Locked, all user + system sessions completed → ready to advance.
+        assert!(sessions_manager(true, 10, 10, 3, 3).all_current_epoch_sessions_completed());
+
+        // Not locked → never ready, even if every count lines up.
+        assert!(!sessions_manager(false, 10, 10, 3, 3).all_current_epoch_sessions_completed());
+
+        // A user session in the locked batch is still pending.
+        assert!(!sessions_manager(true, 9, 10, 3, 3).all_current_epoch_sessions_completed());
+
+        // A system session started after end-of-publish but not yet completed:
+        // exactly the transient that made `advance_epoch` MoveAbort with code 6.
+        assert!(!sessions_manager(true, 10, 10, 4, 3).all_current_epoch_sessions_completed());
+
+        // No sessions at all in a freshly-locked epoch → trivially ready.
+        assert!(sessions_manager(true, 0, 0, 0, 0).all_current_epoch_sessions_completed());
+    }
 }


### PR DESCRIPTION
Six commits, cherry-picked in their original order from `feat/ika-upgrade-test`, making the notifier's Sui-submission path robust under load. They chain on `sui_executor.rs`, so they ship as one PR; each commit message carries its full story. The distinct fixes:

1. **Track the gas coin from tx effects** (`593aef39`): the executor rebuilt every checkpoint/epoch-advance tx with gas fetched from the notifier's fullnode, which lags the validators by hundreds of object versions under checkpoint-heavy load — stale gas version, rejection, retry against the same lagging view, stalled epoch advance. Cache the gas `ObjectRef` from each tx's effects (the authoritative post-tx version) and build the next tx against it.
2. **Drop the cached gas ref on submission failure** (`34f70b99`): on a rejection the cache wasn't cleared, so `retry_with_max_elapsed_time!` spun on the identical stale ref for the full retry budget (an hour). Clear it on both failure paths.
3. **Stale-gas rejection robustness** (`7cae3fee`): recover when the notifier's gas coin is advanced by another holder of the key — re-fetch floored at the rejected version instead of spinning.
4. **Gate `request_advance_epoch` on session completion** (`caa2cde4`): the notifier submitted `request_advance_epoch` as soon as a quorum's checkpoint arrived; if just-synced state showed sessions still pending, the Move call aborted and the notifier died in a panic loop. Re-check the on-chain completion predicate before submitting. (Touches `system_inner_v1.rs` for the predicate read.)
5. **Apply stale-gas recovery to RPC-level submission rejections** (`01600b82`): the recovery only triggered on effects-level failures; RPC-level rejections (the common shape for stale gas) bypassed it. Factor the recovery into one path covering both.
6. **Document the `err.as_ref()` clippy trap** (`59b0db3e`): clippy's `unnecessary_to_owned` suggestion silently changes which error variant the stale-gas matcher sees; the comment prevents a "cleanup" from reintroducing the spin.

Validated on `feat/ika-upgrade-test`: the full dwallet-creation integration suite (8/8) passes with `sui_tx_err=0`, where the pre-fix binary stalled at epoch 5 with 100+ gas-version rejections; the cross-binary churn and literal v1.1.8 upgrade rehearsals are green on top of these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
