### PR TITLE
fix(dwallet-mpc): network-key adoption gates — no committee-unapproved parameter set may go live

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
@@ -8,6 +8,7 @@ mod message_before_event;
 mod missing_network_key;
 mod network_dkg;
 mod network_dkg_bwd_compat;
+mod network_key_adoption;
 mod network_owned_address_sign;
 mod noa_checkpoint;
 mod presign_consensus;

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -1,0 +1,231 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Regression tests for the network-key adoption/instantiation
+//! determinism gates.
+//!
+//! Live-incident background (2026-06-12 localnet, run 3): at an epoch
+//! boundary one validator adopted overlay key data whose
+//! reconfiguration output didn't match what its peers instantiated,
+//! installed a parameter set the committee never agreed to run that
+//! epoch, and then honestly computed internal-presign outputs that
+//! byte-diverged from its peers'. The output-quorum byte-equality
+//! tally convicted it as malicious, its consensus messages were
+//! dropped, and the committee silently ran threshold-3-of-4 with zero
+//! redundancy. The session's *message subsets* were ruled out as the
+//! divergence source (the guaranteed-output-delivery layer pins the
+//! advance subset to the first consensus round at which the threshold
+//! holds, identically on every validator); the divergent input was the
+//! session public input — the protocol public parameters derived from
+//! the locally installed network key.
+//!
+//! The gates under test:
+//! - `adopt_cert_verified_keys` must NOT adopt an overlay entry with
+//!   an empty reconfiguration output for a key whose prior-epoch
+//!   handoff cert pins a reconfiguration digest (a DKG-only
+//!   instantiation derives parameters the committee never agreed on).
+//! - `instantiate_adopted_network_keys` must NOT spawn an
+//!   instantiation for adopted data whose `current_epoch` metadata
+//!   doesn't match the manager's epoch (previously the mismatch was
+//!   only rejected ~10s later, after the parameter derivation had
+//!   already been burnt on the rayon pool).
+
+use crate::dwallet_mpc::integration_tests::utils;
+use ika_network::mpc_artifacts::mpc_data_blob_hash;
+use ika_types::handoff::{CertifiedHandoffAttestation, HandoffAttestation, HandoffItemKey};
+use ika_types::messages_dwallet_mpc::{
+    DWalletNetworkEncryptionKeyData, DWalletNetworkEncryptionKeyState,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use sui_types::base_types::ObjectID;
+
+fn network_key_data(
+    key_id: ObjectID,
+    current_epoch: u64,
+    network_dkg_public_output: Vec<u8>,
+    current_reconfiguration_public_output: Vec<u8>,
+) -> DWalletNetworkEncryptionKeyData {
+    DWalletNetworkEncryptionKeyData {
+        id: key_id,
+        current_epoch,
+        dkg_at_epoch: 0,
+        network_dkg_public_output,
+        current_reconfiguration_public_output,
+        state: DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted,
+    }
+}
+
+/// An overlay entry whose reconfiguration output is (transiently) empty
+/// must not be adopted through the initial-DKG branch when the prior
+/// epoch's handoff cert pins a reconfiguration digest for the key — and
+/// must be adopted once the overlay carries the cert-pinned bytes.
+#[tokio::test]
+async fn empty_reconfiguration_overlay_is_not_adopted_when_cert_pins_reconfiguration() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (
+        mut dwallet_mpc_services,
+        _sui_data_senders,
+        _sent_consensus_messages_collectors,
+        epoch_stores,
+        _notify_services,
+        _network_owned_address_sign_request_senders,
+        _network_owned_address_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services(1);
+    let service = dwallet_mpc_services.first_mut().unwrap();
+    let epoch_id = service.epoch;
+    let prior_epoch = epoch_id - 1;
+
+    let key_id = ObjectID::random();
+    let dkg_output = b"test network dkg public output".to_vec();
+    let reconfiguration_output = b"test network reconfiguration public output".to_vec();
+
+    // The prior epoch's cert pins BOTH the stable DKG digest and the
+    // epoch-specific reconfiguration digest for this key. Items must be
+    // sorted by key (`HandoffItemKey`'s derived `Ord`: DKG < reconfiguration).
+    let attestation = HandoffAttestation {
+        epoch: prior_epoch,
+        next_committee_pubkey_set_hash: [0u8; 32],
+        items: vec![
+            (
+                HandoffItemKey::NetworkDkgOutput { key_id },
+                mpc_data_blob_hash(&dkg_output),
+            ),
+            (
+                HandoffItemKey::NetworkReconfigurationOutput { key_id },
+                mpc_data_blob_hash(&reconfiguration_output),
+            ),
+        ],
+    };
+    epoch_stores
+        .first()
+        .unwrap()
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(
+            prior_epoch,
+            CertifiedHandoffAttestation {
+                attestation,
+                signatures: vec![],
+            },
+        );
+
+    // Overlay with an EMPTY reconfiguration output: pre-fix this slipped
+    // through the initial-DKG branch (DKG-digest check only) and
+    // instantiated DKG-derived parameters.
+    let empty_reconfiguration_overlay = Arc::new(HashMap::from([(
+        key_id,
+        network_key_data(key_id, epoch_id, dkg_output.clone(), vec![]),
+    )]));
+    let manager = service.dwallet_mpc_manager_mut();
+    manager.adopt_cert_verified_keys(&empty_reconfiguration_overlay);
+    assert!(
+        !manager.agreed_network_key_data.contains_key(&key_id),
+        "an empty-reconfiguration overlay entry must not be adopted while the prior \
+         epoch's cert pins a reconfiguration digest for the key"
+    );
+
+    // A non-empty reconfiguration output that MISMATCHES the cert must
+    // also stay unadopted (pre-existing behavior, asserted as a guard).
+    let mismatching_overlay = Arc::new(HashMap::from([(
+        key_id,
+        network_key_data(
+            key_id,
+            epoch_id,
+            dkg_output.clone(),
+            b"some other reconfiguration bytes".to_vec(),
+        ),
+    )]));
+    manager.adopt_cert_verified_keys(&mismatching_overlay);
+    assert!(
+        !manager.agreed_network_key_data.contains_key(&key_id),
+        "a cert-mismatching reconfiguration output must not be adopted"
+    );
+
+    // Once the overlay carries the cert-pinned bytes, adoption proceeds.
+    let matching_overlay = Arc::new(HashMap::from([(
+        key_id,
+        network_key_data(
+            key_id,
+            epoch_id,
+            dkg_output.clone(),
+            reconfiguration_output.clone(),
+        ),
+    )]));
+    manager.adopt_cert_verified_keys(&matching_overlay);
+    let adopted = manager
+        .agreed_network_key_data
+        .get(&key_id)
+        .expect("the cert-matching overlay entry must be adopted");
+    assert_eq!(
+        adopted.current_reconfiguration_public_output, reconfiguration_output,
+        "the adopted data must carry the cert-pinned reconfiguration bytes"
+    );
+}
+
+/// Adopted key data whose `current_epoch` metadata doesn't match the
+/// manager's epoch must be rejected BEFORE spawning the expensive
+/// instantiation — not ~10s later by the post-instantiation poll.
+#[tokio::test]
+async fn stale_epoch_network_key_data_is_not_spawned() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (
+        mut dwallet_mpc_services,
+        _sui_data_senders,
+        _sent_consensus_messages_collectors,
+        _epoch_stores,
+        _notify_services,
+        _network_owned_address_sign_request_senders,
+        _network_owned_address_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services(1);
+    let service = dwallet_mpc_services.first_mut().unwrap();
+    let epoch_id = service.epoch;
+    let manager = service.dwallet_mpc_manager_mut();
+
+    // Stale snapshot: the syncer fetched the chain object before the
+    // chain rolled over to the manager's epoch.
+    let stale_key_id = ObjectID::random();
+    manager.agreed_network_key_data.insert(
+        stale_key_id,
+        network_key_data(
+            stale_key_id,
+            epoch_id - 1,
+            b"dkg bytes".to_vec(),
+            b"reconfiguration bytes".to_vec(),
+        ),
+    );
+    manager.instantiate_adopted_network_keys();
+    assert!(
+        !manager
+            .pending_network_key_instantiations
+            .contains_key(&stale_key_id),
+        "key data with a stale epoch must not spawn an instantiation"
+    );
+
+    // Current-epoch data for the same key spawns normally (the gate
+    // discriminates on the epoch, not on the key).
+    let current_key_id = ObjectID::random();
+    manager.agreed_network_key_data.insert(
+        current_key_id,
+        network_key_data(
+            current_key_id,
+            epoch_id,
+            b"dkg bytes".to_vec(),
+            b"reconfiguration bytes".to_vec(),
+        ),
+    );
+    manager.instantiate_adopted_network_keys();
+    assert!(
+        !manager
+            .pending_network_key_instantiations
+            .contains_key(&stale_key_id),
+        "the stale-epoch key must still not spawn"
+    );
+    assert!(
+        manager
+            .pending_network_key_instantiations
+            .contains_key(&current_key_id),
+        "current-epoch key data must spawn an instantiation"
+    );
+}

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -15,6 +15,7 @@ use ika_protocol_config::ProtocolConfig;
 use ika_types::committee::Committee;
 use ika_types::crypto::AuthorityName;
 use ika_types::error::IkaResult;
+use ika_types::handoff::CertifiedHandoffAttestation;
 use ika_types::message::DWalletCheckpointMessageKind;
 use ika_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
 use ika_types::messages_dwallet_checkpoint::DWalletCheckpointSignatureMessage;
@@ -71,6 +72,11 @@ pub(crate) struct TestingAuthorityPerEpochStore {
     /// Assigned presigns keyed by (signature_algorithm, session_identifier, blending_index).
     pub(crate) assigned_presigns:
         Arc<Mutex<HashMap<(DWalletSignatureAlgorithm, SessionIdentifier, u16), AssignedPresign>>>,
+    /// Configurable certified handoff attestations, keyed by epoch.
+    /// Empty by default (the cert-gated adoption path then behaves as
+    /// "cert absent"); tests for the cert-digest gate insert one here.
+    pub(crate) certified_handoff_attestations:
+        Arc<Mutex<HashMap<EpochId, CertifiedHandoffAttestation>>>,
 }
 
 pub(crate) struct IntegrationTestState {
@@ -135,6 +141,7 @@ impl TestingAuthorityPerEpochStore {
             presign_pools: Arc::new(Mutex::new(Default::default())),
             used_presigns: Arc::new(Mutex::new(HashMap::new())),
             assigned_presigns: Arc::new(Mutex::new(HashMap::new())),
+            certified_handoff_attestations: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -436,12 +443,17 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
 
     fn get_certified_handoff_attestation(
         &self,
-        _epoch: sui_types::base_types::EpochId,
+        epoch: sui_types::base_types::EpochId,
     ) -> IkaResult<Option<ika_types::handoff::CertifiedHandoffAttestation>> {
-        // Testing impl: no persisted certs; the cert-verified
-        // instantiation path is a no-op and tests exercise the
-        // consensus-voted path.
-        Ok(None)
+        // Testing impl: serves the configurable in-memory map (empty by
+        // default, in which case the cert-verified adoption path behaves
+        // as "cert absent" and tests exercise the consensus-voted path).
+        Ok(self
+            .certified_handoff_attestations
+            .lock()
+            .unwrap()
+            .get(&epoch)
+            .cloned())
     }
 
     fn is_mpc_data_frozen(&self) -> IkaResult<bool> {

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -18,7 +18,7 @@ use crate::dwallet_mpc::{
     generate_access_structure_from_committee, get_validator_mpc_keys_by_party_id,
     party_id_to_authority_name,
 };
-use crate::dwallet_session_request::DWalletSessionRequest;
+use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionRequestMetricData};
 use dwallet_classgroups_types::ClassGroupsKeyPairAndProof;
 use dwallet_mpc_types::dwallet_mpc::{
     DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm, NetworkEncryptionKeyPublicData,
@@ -209,7 +209,8 @@ pub(crate) struct DWalletMPCManager {
     /// an expensive, long-running computation; awaiting it inline froze
     /// the whole MPC service loop — every session on the validator —
     /// for its full duration at each epoch boundary.
-    pending_network_key_instantiations: HashMap<ObjectID, PendingNetworkKeyInstantiation>,
+    pub(crate) pending_network_key_instantiations:
+        HashMap<ObjectID, PendingNetworkKeyInstantiation>,
 
     /// Last time the handoff-cert read-error warn in
     /// `adopt_cert_verified_keys` was emitted. The adoption pass runs
@@ -225,6 +226,13 @@ pub(crate) struct DWalletMPCManager {
     /// would re-warn per republish; warn once per distinct local digest,
     /// debug thereafter.
     warned_cert_digest_mismatches: HashSet<(ObjectID, [u8; 32])>,
+
+    /// Sessions whose protocol-cryptographic-data generation already
+    /// failed and was logged. The generation re-runs every 20ms service
+    /// iteration, so a stuck session would otherwise emit ~50 identical
+    /// errors/second; log once per session (the skip-and-retry behavior
+    /// itself is unthrottled).
+    warned_cryptographic_data_generation_failures: HashSet<SessionIdentifier>,
 
     // The sequence number of the next internal presign session.
     // Starts from 1 in every epoch, and increases as they are spawned.
@@ -276,7 +284,7 @@ pub(crate) struct DWalletMPCManager {
 /// An in-flight network-key instantiation: the input bytes that were
 /// attempted (retained for the failure record, which suppresses retries
 /// on identical bytes) and the receiver its result arrives on.
-struct PendingNetworkKeyInstantiation {
+pub(crate) struct PendingNetworkKeyInstantiation {
     attempted: DWalletNetworkEncryptionKeyData,
     receiver: oneshot::Receiver<DwalletMPCResult<NetworkEncryptionKeyPublicData>>,
 }
@@ -383,6 +391,7 @@ impl DWalletMPCManager {
             pending_network_key_instantiations: HashMap::new(),
             last_cert_read_warn: None,
             warned_cert_digest_mismatches: HashSet::new(),
+            warned_cryptographic_data_generation_failures: HashSet::new(),
             last_failed_network_key_data: HashMap::new(),
             next_internal_presign_sequence_number: 1,
             instantiated_internal_presign_sessions: HashMap::new(),
@@ -802,6 +811,46 @@ impl DWalletMPCManager {
             }
             let local_dkg_digest = mpc_data_blob_hash(&data.network_dkg_public_output);
             if data.current_reconfiguration_public_output.is_empty() {
+                // A cert that pins a reconfiguration digest for this key means
+                // the committee agreed this epoch runs on parameters derived
+                // from THAT reconfiguration output. An overlay entry whose
+                // reconfiguration output is (transiently) empty must therefore
+                // never be adopted through this initial-DKG branch: it would
+                // instantiate DKG-derived parameters — a set the committee
+                // never agreed to use this epoch — and every MPC output this
+                // validator computes with them byte-diverges from its peers',
+                // which the output-quorum byte-equality tally then convicts
+                // as malicious. Skip and retry: the overlay re-merges every
+                // sync tick and the prepare-then-start barrier installs the
+                // cert-pinned blob by digest at the boundary, so the bytes
+                // become locally resolvable. Warn once per cert digest
+                // (deduped), debug on repeats — same pattern as the
+                // mismatch skips below.
+                if off_chain_on
+                    && let Some(cert_reconfiguration_digest) = reconfiguration_digests.get(key_id)
+                {
+                    if self
+                        .warned_cert_digest_mismatches
+                        .insert((*key_id, *cert_reconfiguration_digest))
+                    {
+                        warn!(
+                            ?key_id,
+                            ?cert_reconfiguration_digest,
+                            "prior epoch's handoff cert pins a reconfiguration output for \
+                             this key but the overlay's reconfiguration output is empty — \
+                             skipping adoption until the blob resolves locally (a DKG-only \
+                             instantiation would diverge from the committee-agreed \
+                             parameters)"
+                        );
+                    } else {
+                        debug!(
+                            ?key_id,
+                            "overlay reconfiguration output still empty for a \
+                             cert-reconfigured key — skipping adoption"
+                        );
+                    }
+                    continue;
+                }
                 // Initial-DKG state: adopt the deterministic local DKG
                 // output. Require the match only if a cert pins it.
                 if let Some(cert_dkg) = dkg_digests.get(key_id)
@@ -1784,6 +1833,12 @@ impl DWalletMPCManager {
 
         let number_of_ready_to_advance_sessions = ready_to_advance_sessions.len();
 
+        // Collected inside the immutable-borrow iteration below, logged
+        // (deduped per session) after it ends — a generation failure
+        // recurs every 20ms service tick for a stuck session, and the
+        // skip used to be silent, which blinded post-mortems.
+        let mut failed_cryptographic_data_generations = Vec::new();
+
         let computation_requests: Vec<_> = ready_to_advance_sessions
             .into_iter()
             .flat_map(|(session, _)| {
@@ -1802,15 +1857,28 @@ impl DWalletMPCManager {
                     return None;
                 };
 
-                self.generate_protocol_cryptographic_data(
+                let protocol_cryptographic_data = match self.generate_protocol_cryptographic_data(
                     &session.computation_type,
                     &request.protocol_data,
                     last_read_consensus_round,
                     public_input.clone(),
                     &self.protocol_config,
-                )
-                .ok()?
-                .map(|protocol_cryptographic_data| {
+                ) {
+                    Ok(protocol_cryptographic_data) => protocol_cryptographic_data,
+                    Err(e) => {
+                        // The skip is correct (the session simply isn't
+                        // advanceable this tick); the silence was the bug.
+                        failed_cryptographic_data_generations.push((
+                            session.session_identifier,
+                            DWalletSessionRequestMetricData::from(&request.protocol_data),
+                            e,
+                        ));
+
+                        return None;
+                    }
+                };
+
+                protocol_cryptographic_data.map(|protocol_cryptographic_data| {
                     let attempt_number = protocol_cryptographic_data.get_attempt_number();
                     let mpc_round = protocol_cryptographic_data.get_mpc_round();
 
@@ -1833,6 +1901,24 @@ impl DWalletMPCManager {
                 })
             })
             .collect();
+
+        for (session_identifier, protocol_data, error) in failed_cryptographic_data_generations {
+            // Once per session: the failure recurs every tick while the
+            // session is stuck, and the first occurrence carries all the
+            // signal.
+            if self
+                .warned_cryptographic_data_generation_failures
+                .insert(session_identifier)
+            {
+                error!(
+                    ?session_identifier,
+                    mpc_protocol = %protocol_data,
+                    error = ?error,
+                    "failed to generate protocol cryptographic data — session skipped \
+                     this tick (will retry every service iteration)"
+                );
+            }
+        }
 
         let completed_computation_results = self
             .cryptographic_computations_orchestrator
@@ -2079,6 +2165,26 @@ impl DWalletMPCManager {
                 // meantime, the snapshot comparison below re-fires once
                 // the in-flight one completes.
                 if self.pending_network_key_instantiations.contains_key(key_id) {
+                    return false;
+                }
+                // The adopted snapshot can carry a stale chain epoch — the
+                // syncer fetched it before the chain rolled over (or after,
+                // for a manager about to be torn down). The post-instantiation
+                // poll already rejects such a key (`key.epoch() != self.epoch_id`),
+                // but only after ~10s of parameter derivation burnt on the
+                // rayon pool — and while that doomed instantiation is in
+                // flight, the correct same-key data cannot spawn. Reject the
+                // metadata mismatch before spawning instead; the syncer
+                // re-fetches and the adoption pass delivers the current
+                // epoch's data within a few ticks.
+                if key_data.current_epoch != self.epoch_id {
+                    debug!(
+                        ?key_id,
+                        key_data_epoch = key_data.current_epoch,
+                        current_epoch = self.epoch_id,
+                        "adopted network-key data carries a different epoch — not \
+                         spawning instantiation; awaiting the current epoch's overlay"
+                    );
                     return false;
                 }
                 // Filter to: first instantiation OR the *content*

--- a/specs/handoff.md
+++ b/specs/handoff.md
@@ -126,6 +126,24 @@ next epoch inherits.
    compatibility, but the certificate-gated off-chain copy is the only
    sanctioned read path.
 
+   Two adoption guards keep the installed parameter set identical
+   across the committee (a validator that installs anything else
+   honestly computes byte-divergent MPC outputs and is convicted
+   malicious by the output-quorum byte-equality tally — silently
+   reducing the committee's fault tolerance):
+   - An overlay entry whose reconfiguration output is (transiently)
+     EMPTY must not be adopted through the initial-DKG branch while
+     the certificate pins a reconfiguration digest for the key:
+     DKG-derived parameters are a set the committee never agreed to
+     run this epoch. Skip and retry; the overlay re-merges every sync
+     tick and the barrier installs the pinned blob by digest.
+   - Adopted data whose `current_epoch` metadata differs from the
+     manager's epoch is rejected BEFORE the (expensive, ~10s)
+     instantiation spawns — a stale chain snapshot at the boundary
+     otherwise burns the instantiation and blocks the same key's
+     correct data behind the in-flight entry, widening the
+     epoch-entry key gap during which sessions park.
+
 ## Key invariants
 
 1. One handoff per epoch, attested at EndOfPublish, verified against


### PR DESCRIPTION
## Summary

Fixes the **false-malicious conviction** failure mode surfaced during the epoch-close wedge investigation (see PR #1721's "known issue" note): a validator that installs a different network-key parameter set than its peers honestly computes byte-divergent MPC outputs, and the output-quorum byte-equality tally convicts it as malicious — observed live, including the node logging `node recognized itself as malicious`. One conviction silently converts a 4-validator committee into zero-redundancy 3-of-4; the network keeps running degraded with no error-level signal until any further loss freezes MPC.

Root context: at every epoch-N entry, early-starting validators transiently see stale/incomplete overlay data (the epoch-entry stale-mpc_data race). Two adoption holes let that transient state become an installed parameter set:

1. **Empty-reconfiguration-output adoption** — an overlay entry whose reconfiguration output is transiently empty slipped through the initial-DKG adoption branch even when the prior epoch's handoff cert pins a reconfiguration digest for the key, instantiating DKG-derived parameters the committee never agreed to run this epoch. Now skipped (warn once per cert digest, deduped) and retried until the cert-pinned bytes resolve locally — the overlay re-merges every sync tick and the prepare-then-start barrier installs the pinned blob by digest.
2. **Stale-epoch pre-spawn rejection** — adopted data whose `current_epoch` metadata mismatches the manager's epoch was only rejected ~10s *after* the parameter derivation burnt on the rayon pool, and the doomed in-flight instantiation blocked the same key's correct data behind it, widening the entry key gap during which sessions park. Now rejected before spawning.

Plus an observability fix that blinded two post-mortems: a session whose protocol-cryptographic-data generation fails was silently skipped every 20ms service tick (`.ok()?`). The skip semantics stay; it now logs once per session (deduped).

## Tests

- New `network_key_adoption.rs`: both gates with positive controls — the cert-pinned empty/mismatching/matching overlay progression (self-validating: if the cert weren't consumed, the mismatch assertion would fail via the blind-adopt path), and stale-vs-current epoch spawn discrimination.
- Regression battery green: `beyond_lock_target` 2/2, `computation_results_batch` 1/1, `missing_network_key` 1/1; clippy clean on touched code.
- Spec updated: `specs/handoff.md` certificate-consumption section documents both guards and why divergence ends in conviction.

## What this does NOT fix (tracked separately)

The residual epoch-entry race (validators still fetch the prior epoch's overlay at entry) and the CI-only "parked sessions never compute after the key installs" link — see the tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)