### PR TITLE
docs: remove out-of-context references (apply #1745 rule)

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations.rs
@@ -1208,7 +1208,7 @@ impl ProtocolCryptographicData {
                         private_output,
                     } => {
                         // Wrap the public output with its version. Main
-                        // Reconfig writes V3 (post-PR-#1707 shape); the
+                        // Reconfig writes V3; the
                         // bwd-compat path in `advance_network_reconfiguration_bwd_compat`
                         // writes V2.
                         let public_output_value = bcs::to_bytes(

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -73,7 +73,8 @@ impl ReconfigurationPartyPublicInputGenerator for ReconfigurationParty {
             crate::dwallet_mpc::get_validator_mpc_keys_by_party_id(&upcoming_committee)?;
 
         // At main Reconfig (callable only from `_version == 3`) every upcoming
-        // committee member MUST publish the post-PR-#1707 bundle shape. The
+        // committee member MUST publish the version-3 bundle shape
+        // (class-groups + per-curve PVSS HPKE keys). The
         // shape-tolerant decoder accepts old-shape submissions silently, so a
         // not-yet-migrated validator in the upcoming committee would land here
         // with empty PVSS entries while their class-groups entry is present.
@@ -98,7 +99,8 @@ impl ReconfigurationPartyPublicInputGenerator for ReconfigurationParty {
         {
             return Err(DwalletMPCError::InvalidMPCPartyType(format!(
                 "at reconfiguration_message_version == 3 every upcoming committee \
-                 member must publish the post-PR-#1707 bundle shape, but only \
+                 member must publish the version-3 bundle shape (class-groups + \
+                 per-curve PVSS HPKE keys), but only \
                  {class_groups_count}/{expected} class-groups, \
                  {secp256k1_pvss_count}/{expected} secp256k1 PVSS, \
                  {secp256r1_pvss_count}/{expected} secp256r1 PVSS, \

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/protocol_cryptographic_data.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/protocol_cryptographic_data.rs
@@ -88,7 +88,7 @@ pub(crate) enum ProtocolCryptographicData {
         advance_request: AdvanceRequest<<bwd_compat_dkg::Party as mpc::Party>::Message>,
         class_groups_decryption_key: ClassGroupsDecryptionKey,
     },
-    /// Network DKG running the post-PR-#1707 main Party
+    /// Network DKG running the version-3 main Party
     /// (`twopc_mpc::decentralized_party::dkg::Party`). Selected when
     /// `ProtocolConfig::is_network_encryption_key_version_v3()` is `true`.
     NetworkEncryptionKeyDkg {

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -2159,7 +2159,7 @@ impl DWalletMPCService {
                         }
                         Ok(dwallet_mpc_types::dwallet_mpc::VersionedNetworkDkgOutput::V2(_))
                         | Ok(dwallet_mpc_types::dwallet_mpc::VersionedNetworkDkgOutput::V3(_)) => {
-                            // V2 (bwd-compat) and V3 (post-PR-#1707 main) both support all curves.
+                            // V2 (bwd-compat) and V3 (current main) both support all curves.
                             vec![
                                 DWalletCurve::Secp256k1 as u32,
                                 DWalletCurve::Secp256r1 as u32,
@@ -2227,7 +2227,7 @@ impl DWalletMPCService {
                         }
                         Ok(dwallet_mpc_types::dwallet_mpc::VersionedDecryptionKeyReconfigurationOutput::V2(_))
                         | Ok(dwallet_mpc_types::dwallet_mpc::VersionedDecryptionKeyReconfigurationOutput::V3(_)) => {
-                            // V2 (bwd-compat) and V3 (post-PR-#1707 main) both support all curves.
+                            // V2 (bwd-compat) and V3 (current main) both support all curves.
                             vec![
                                 DWalletCurve::Secp256k1 as u32,
                                 DWalletCurve::Secp256r1 as u32,

--- a/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
@@ -181,10 +181,10 @@ pub(crate) fn session_input_from_request(
             // protocol_version. At `_version == 2` (mainnet-v1.1.8 era) peers
             // publish bare `ClassGroupsEncryptionKeyAndProof` and the
             // bwd-compat DKG `PublicInput::new` takes only the class-groups
-            // CRT map. At `_version == 3` (post-PR-#1707) we have per-curve
+            // CRT map. At `_version == 3` we have per-curve
             // PVSS HPKE keys too and call the main DKG `PublicInput::new`.
             let dkg_public_input = if protocol_config.is_network_encryption_key_version_v3() {
-                // At `_version == 3` every committee member MUST publish the post-PR-#1707
+                // At `_version == 3` every committee member MUST publish the version-3
                 // bundle shape (class-groups + per-curve PVSS HPKE). The shape-tolerant
                 // decoder accepts old-shape submissions silently, so a validator that
                 // hasn't migrated would land here with empty PVSS entries while their
@@ -202,7 +202,8 @@ pub(crate) fn session_input_from_request(
                 {
                     return Err(DwalletMPCError::InvalidMPCPartyType(format!(
                         "at network_encryption_key_version == 3 every committee member \
-                         must publish the post-PR-#1707 bundle shape, but only \
+                         must publish the version-3 bundle shape (class-groups + per-curve \
+                         PVSS HPKE keys), but only \
                          {class_groups_count}/{expected} class-groups, \
                          {secp256k1_pvss_count}/{expected} secp256k1 PVSS, \
                          {secp256r1_pvss_count}/{expected} secp256r1 PVSS, \

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -661,7 +661,7 @@ where
             .map_err(DwalletMPCError::IkaError)?;
 
         // Shape-tolerant decode per validator. PVSS HashMaps gain an entry only
-        // when the validator published the post-PR-#1707 bundle shape;
+        // when the validator published the version-3 bundle shape;
         // mainnet-v1.1.8-shape validators contribute only their class-groups key.
         let decoded_per_validator: Vec<_> = committee
             .iter()
@@ -673,7 +673,7 @@ where
                 if decoded.is_none() {
                     warn!(
                         authority = ?name,
-                        "Failed to decode validator encryption keys (neither mainnet-v1.1.8 nor post-PR-#1707 shape)"
+                        "Failed to decode validator encryption keys (neither mainnet-v1.1.8 nor version-3 shape)"
                     );
                 }
                 decoded.map(|d| (*name, d))

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -282,7 +282,7 @@ pub fn reevaluate_buffered_joiner_announcements(
 /// paths hashing this output produce the same digest.
 ///
 /// At `network_encryption_key_version == 3` (the v4 protocol shape)
-/// the inner bytes are the post-PR-#1707 `ValidatorEncryptionKeysAndProofs`
+/// the inner bytes are the `ValidatorEncryptionKeysAndProofs`
 /// bundle — class-groups + per-curve PVSS HPKE keys + proofs.
 /// `decode_validator_encryption_keys` accepts either shape (new or
 /// mainnet-v1.1.8 class-groups-only); using the new shape here is
@@ -811,7 +811,7 @@ pub fn default_handoff_items_builders(
 /// off-chain. `class_groups` is required for every authority in the
 /// working set (the strict gate). The three PVSS halves are
 /// opportunistic per-validator: present only when the validator
-/// published under the post-PR-#1707 shape
+/// published under the version-3 shape
 /// (`network_encryption_key_version == 3`).
 ///
 /// Under v4 the off-chain producer (`derive_mpc_data_blob`) always

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -25,8 +25,8 @@ const MAX_PROTOCOL_VERSION: u64 = 4;
 // Version 2: network_encryption_key_version = 2.
 // Version 3: reconfiguration_message_version = 2 (mainnet-v1.1.8).
 // Version 4: off_chain_validator_metadata pipeline on; internal_presign_sessions on;
-//            consensus_skip_gced_blocks_in_direct_finalization on; post-PR-#1707 crypto
-//            (network_encryption_key_version = 3, reconfiguration_message_version = 3) —
+//            consensus_skip_gced_blocks_in_direct_finalization on; version-3 crypto
+//            (network_encryption_key_version = 3, reconfiguration_message_version = 3; #1707) —
 //            validators publish `ValidatorEncryptionKeysAndProofs` (class-groups + per-curve
 //            PVSS HPKE) and DKG/Reconfiguration use `twopc_mpc::decentralized_party::*`.
 // Version 5: noa_checkpoints on.
@@ -390,8 +390,8 @@ impl ProtocolConfig {
         self.feature_flags.internal_presign_sessions
     }
 
-    /// True iff this protocol_version uses the post-PR-#1707 network DKG /
-    /// validator-key-publication shape — `ValidatorEncryptionKeysAndProofs`
+    /// True iff this protocol_version uses the version-3 network DKG /
+    /// validator-key-publication shape (#1707) — `ValidatorEncryptionKeysAndProofs`
     /// (class-groups + per-curve PVSS HPKE) and
     /// `twopc_mpc::decentralized_party::dkg::Party`. False at protocol_version
     /// <= 3 (mainnet-v1.1.8), where the publication is bare
@@ -401,8 +401,8 @@ impl ProtocolConfig {
         self.network_encryption_key_version.is_some_and(|v| v == 3)
     }
 
-    /// True iff this protocol_version uses the post-PR-#1707 reconfiguration
-    /// shape — `twopc_mpc::decentralized_party::reconfiguration::Party` with
+    /// True iff this protocol_version uses the version-3 reconfiguration
+    /// shape (#1707) — `twopc_mpc::decentralized_party::reconfiguration::Party` with
     /// per-curve PVSS HPKE keys in `PublicInput`. False at protocol_version
     /// <= 3, where reconfiguration runs against
     /// `twopc_mpc::decentralized_party_backward_compatible::reconfiguration::Party`.

--- a/crates/ika-test-cluster/tests/joiner.rs
+++ b/crates/ika-test-cluster/tests/joiner.rs
@@ -55,7 +55,7 @@ async fn test_joiner_added_at_epoch_2() {
     wait_for_node_epoch(&joiner.node_handle, 2).await;
 }
 
-/// F4-1 explicit check: a joiner that registers mid-epoch must land
+/// Churn-tolerance check: a joiner that registers mid-epoch must land
 /// in the *frozen* mpc_data input set, and therefore in the next
 /// committee's off-chain-assembled `class_groups_public_keys_and_proofs`
 /// map. The ready-signal emit gate (`decide_ready_to_finalize`) delays
@@ -64,11 +64,11 @@ async fn test_joiner_added_at_epoch_2() {
 /// is precisely what lets a joiner — who can only announce after
 /// `V_{e+1}` is published — be captured by the freeze.
 ///
-/// This test caught a real F4-1 deadlock — the joiner watcher + freeze
-/// emit-gate both keyed off the *assembled* committee, which can't
-/// include a joiner until after the freeze excludes it. Fixed by the
-/// chain next-epoch-committee channel, after which the joiner fans its
-/// mpc_data out (it never did before).
+/// This test caught a real mid-epoch-joiner deadlock — the joiner
+/// watcher + freeze emit-gate both keyed off the *assembled* committee,
+/// which can't include a joiner until after the freeze excludes it.
+/// Fixed by the chain next-epoch-committee channel, after which the
+/// joiner fans its mpc_data out (it never did before).
 ///
 /// The integration path (observe the chain committee → fan out → relay
 /// accept once the relayer's JoinerPubkeyProvider refreshes → consensus
@@ -141,7 +141,7 @@ async fn test_joiner_lands_in_next_committee_class_groups() {
     assert!(
         in_class_groups,
         "joiner {joiner_name:?} must appear in epoch-2 committee \
-         class_groups_public_keys_and_proofs (F4-1: freeze must capture \
+         class_groups_public_keys_and_proofs (freeze must capture \
          the mid-epoch joiner)"
     );
 }

--- a/crates/ika-types/src/committee.rs
+++ b/crates/ika-types/src/committee.rs
@@ -593,14 +593,15 @@ pub struct ValidatorEncryptionKeysAndProofs {
 /// Result of shape-tolerant decoding of the Move-side validator encryption-key
 /// bytes. The class-groups CRT key is always present (both shapes carry it);
 /// the three PVSS halves are present only when the validator published the
-/// post-PR-#1707 bundle shape ([`ValidatorEncryptionKeysAndProofs`]).
+/// version-3 bundle shape ([`ValidatorEncryptionKeysAndProofs`]).
 ///
 /// Validators that published under the mainnet-v1.1.8 shape (bare
 /// `ClassGroupsEncryptionKeyAndProof`) come back here with PVSS halves as
 /// `None`; downstream DKG / Reconfiguration dispatch picks the
 /// `decentralized_party_backward_compatible` Party (which needs no PVSS keys).
 ///
-/// TEMPORARY: only exists for the mainnet-v1.1.8 → post-PR-#1707 transition window.
+/// TEMPORARY: only exists for the transition from the mainnet-v1.1.8
+/// bare-class-groups key shape to the version-3 bundle (#1707).
 /// Once every validator has republished under the new shape and the network has
 /// settled at `network_encryption_key_version == 3`, delete this struct and have
 /// the decode sites read [`ValidatorEncryptionKeysAndProofs`] directly.
@@ -615,7 +616,7 @@ pub struct DecodedValidatorEncryptionKeys {
 /// Decode the bytes from `MPCDataV1::class_groups_public_key_and_proof()`
 /// accepting either publication shape:
 ///
-/// - [`ValidatorEncryptionKeysAndProofs`] — post-PR-#1707 bundle (class-groups
+/// - [`ValidatorEncryptionKeysAndProofs`] — version-3 bundle (class-groups
 ///   CRT key + 3 per-curve PVSS HPKE keys). Validators publish this at
 ///   `ProtocolConfig::network_encryption_key_version() == 3` (protocol_version
 ///   `>= 5`).
@@ -629,7 +630,8 @@ pub struct DecodedValidatorEncryptionKeys {
 /// shape: the old-shape parse path consumes the leading class-groups array and
 /// errors on the trailing PVSS section, then the new-shape arm succeeds.
 ///
-/// TEMPORARY: only exists for the mainnet-v1.1.8 → post-PR-#1707 transition window.
+/// TEMPORARY: only exists for the transition from the mainnet-v1.1.8
+/// bare-class-groups key shape to the version-3 bundle (#1707).
 /// Delete this function (and the old-shape fallback) once the network has settled
 /// at `network_encryption_key_version == 3` and every validator publishes
 /// [`ValidatorEncryptionKeysAndProofs`]; decode sites can then call

--- a/crates/ika-types/src/sui/epoch_start_system.rs
+++ b/crates/ika-types/src/sui/epoch_start_system.rs
@@ -141,7 +141,7 @@ impl EpochStartSystemTrait for EpochStartSystemV1 {
             .iter()
             .map(|validator| {
                 // Shape-tolerant decode: accepts both the mainnet-v1.1.8
-                // bare-class-groups payload and the post-PR-#1707 bundle. PVSS
+                // bare-class-groups payload and the version-3 bundle. PVSS
                 // halves come back as `None` for validators publishing the old
                 // shape; downstream DKG/Reconfig dispatch picks the bwd-compat
                 // Party in that case.
@@ -194,7 +194,7 @@ impl EpochStartSystemTrait for EpochStartSystemV1 {
         // Shape-tolerant decode per validator. Mainnet-v1.1.8-shape payloads
         // (bare class-groups) populate only the class-groups HashMap; PVSS
         // HashMaps gain an entry only when the validator published the
-        // post-PR-#1707 bundle shape.
+        // version-3 bundle shape.
         let decoded_per_validator: Vec<_> = self
             .active_validators
             .iter()
@@ -206,7 +206,7 @@ impl EpochStartSystemTrait for EpochStartSystemV1 {
                 if decoded.is_none() {
                     error!(
                         authority = ?validator.authority_name(),
-                        "Failed to decode validator encryption keys (neither mainnet-v1.1.8 nor post-PR-#1707 shape)"
+                        "Failed to decode validator encryption keys (neither mainnet-v1.1.8 nor version-3 shape)"
                     );
                 }
                 decoded.map(|d| (validator.authority_name(), d))

--- a/crates/ika/src/validator_commands.rs
+++ b/crates/ika/src/validator_commands.rs
@@ -72,9 +72,11 @@ pub enum IkaValidatorCommand {
         /// can interop with mainnet-v1.1.8 peers. See the same flag on
         /// `set-next-epoch-mpc-data`.
         ///
-        /// TEMPORARY: only exists for the mainnet-v1.1.8 → post-PR-#1707
-        /// transition. Delete this flag (and the legacy publication branch in
-        /// the command implementation) once the network has settled at
+        /// TEMPORARY: only exists for the transition from the mainnet-v1.1.8
+        /// bare-class-groups key shape to the version-3 bundle
+        /// (`ValidatorEncryptionKeysAndProofs`, added in #1707). Delete this
+        /// flag (and the legacy publication branch in the command
+        /// implementation) once the network has settled at
         /// `network_encryption_key_version == 3`.
         #[clap(long)]
         legacy_class_groups_only: bool,
@@ -328,8 +330,8 @@ pub enum IkaValidatorCommand {
         ika_sui_config: Option<PathBuf>,
         /// Publish the mainnet-v1.1.8-shape MPC data (bare
         /// `ClassGroupsEncryptionKeyAndProof`, no per-curve PVSS HPKE keys)
-        /// instead of the default post-PR-#1707 bundle
-        /// (`ValidatorEncryptionKeysAndProofs`).
+        /// instead of the default version-3 bundle
+        /// (`ValidatorEncryptionKeysAndProofs`, added in #1707).
         ///
         /// Set this flag while the network is still at `protocol_version <= 3`
         /// so mainnet-v1.1.8 peers can decode this validator's published bytes.
@@ -337,9 +339,11 @@ pub enum IkaValidatorCommand {
         /// — at that point all validators run the new binary and consume the
         /// new shape.
         ///
-        /// TEMPORARY: only exists for the mainnet-v1.1.8 → post-PR-#1707
-        /// transition. Delete this flag (and the legacy publication branch in
-        /// the command implementation) once the network has settled at
+        /// TEMPORARY: only exists for the transition from the mainnet-v1.1.8
+        /// bare-class-groups key shape to the version-3 bundle
+        /// (`ValidatorEncryptionKeysAndProofs`, added in #1707). Delete this
+        /// flag (and the legacy publication branch in the command
+        /// implementation) once the network has settled at
         /// `network_encryption_key_version == 3`.
         #[clap(long)]
         legacy_class_groups_only: bool,

--- a/dev-docs/specs/validator-mpc-data-announcements.md
+++ b/dev-docs/specs/validator-mpc-data-announcements.md
@@ -84,7 +84,8 @@ which bytes* deterministic in consensus order.
   set: the reconfiguration proceeds without them. The certificate
   cannot backfill an announcement that missed the freeze — convergence
   of announcement propagation BEFORE the freeze is the only mechanism
-  (this is the F4-1 churn property).
+  (this is the property that lets reconfiguration tolerate committee
+  churn: late or churning members are simply excluded, never block it).
 
 ## Next-committee assembly
 


### PR DESCRIPTION
Applies the "write for a reader without the originating context" rule added to `CLAUDE.md` in #1745: internal labels (ticket shorthands, test/property IDs, plan/phase tags) are meaningless to anyone outside the moment they were coined and rot once that context is gone. This PR spells out the mechanism in plain terms while preserving every piece of technical content. Comment/string-only — no code logic changed.

## Categories spelled out

**`post-PR-#1707` (24 occurrences)** — used as the name of a concept: the validator encryption-key publication shape introduced at `network_encryption_key_version == 3` (`ValidatorEncryptionKeysAndProofs`: class-groups CRT key + 3 per-curve PVSS HPKE keys), as opposed to the older bare-class-groups-only shape. Replaced with "version-3" / "version-3 bundle shape", keeping `#1707` as a pointer where it still adds value (e.g. the protocol-version history comment and the `is_*_version_v3` doc-comments). Operator-facing log/error strings now read "version-3 shape" instead of the bare PR label. Files:
- `crates/ika/src/validator_commands.rs`
- `crates/ika-protocol-config/src/lib.rs`
- `crates/ika-core/src/validator_metadata.rs`
- `crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs`
- `crates/ika-core/src/dwallet_mpc/mpc_session/input.rs`
- `crates/ika-core/src/dwallet_mpc/crytographic_computation/protocol_cryptographic_data.rs`
- `crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations.rs`
- `crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs`
- `crates/ika-core/src/sui_connector/sui_syncer.rs`
- `crates/ika-types/src/committee.rs`
- `crates/ika-types/src/sui/epoch_start_system.rs`

**`F4-1` (4 occurrences)** — bare property ID. Spelled out as the reconfiguration-churn / mid-epoch-joiner-capture property (late or churning committee members are excluded by the freeze, never block reconfiguration). Files:
- `dev-docs/specs/validator-mpc-data-announcements.md`
- `crates/ika-test-cluster/tests/joiner.rs`

## Deliberately left untouched

- The `Phase 1/2/3` labels inside `dwallet_mpc/integration_tests/**` — these are self-defining temporal sequences within each test (the comment defines what each phase does locally), not external plan/phase tags.
- Plain cross-reference pointers like `(issue #1736)`, `(#575, pin de3cddd+)` in the playbooks — the concept is named in English; the `#NNNN` is just a tracking pointer.
- The `mainnet-v1.1.8` version anchor (a real ika release that names the old key shape) and the Sui `mainnet-v1.70.2` pins.
- The `"Phase 4f"` example in `dev-docs/plans/README.md` and `CLAUDE.md` — those use it deliberately as an illustration of the rule.

## Verification

`cargo fmt --all`; `cargo check --release` clean on every touched crate (ika-core, ika-protocol-config, ika-types, ika) and the `joiner` test target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)