### PR TITLE
ci: nightly orchestrator to auto-dispatch heavy suites on main + dev

### DIFF
--- a/.github/workflows/scheduled-all-suites.yaml
+++ b/.github/workflows/scheduled-all-suites.yaml
@@ -1,0 +1,97 @@
+name: Scheduled — All Heavy Suites
+
+# Orchestrator that fans out the heavy, normally-manual test suites across
+# BOTH long-lived branches (`main` and `dev`) on a nightly cadence.
+#
+# What it does:
+#   For each (branch x suite) pair it calls `gh workflow run <suite>.yaml
+#   --ref <branch>` with that suite's sensible default inputs. It only
+#   DISPATCHES the suites — it does not wait for them and does not report
+#   their pass/fail. Each dispatched run shows up under its OWN workflow
+#   (Test Cluster / Integration Tests CI / TS Integration Tests / Simtest)
+#   on the targeted branch, with its own logs and artifacts. This job
+#   succeeds as long as the dispatch calls themselves succeed.
+#
+# Cadence:
+#   - schedule: nightly at 03:00 UTC (off-peak; well clear of typical
+#     working-hours merges into dev). Each suite is 35-60 min, so a
+#     per-push trigger on the frequently-merged `dev` branch would be
+#     wasteful — nightly + on-demand is the intended cadence.
+#   - workflow_dispatch: run on demand at any time.
+#
+# IMPORTANT — scheduled triggers only fire from the repository DEFAULT
+# branch. The default branch here is `main`. A `schedule:` defined on a
+# workflow that exists only on `dev` will NOT fire on cron until this file
+# also lands on `main` (or the default branch is changed). The
+# `workflow_dispatch` path works as soon as this file is merged to either
+# branch. See the PR body for the follow-up needed to activate the cron.
+
+on:
+  schedule:
+    # 03:00 UTC nightly. (cron is UTC; GitHub has no per-workflow tz.)
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+# Dispatching another workflow requires `actions: write`; nothing here
+# touches repo contents beyond reading the checked-out workflow list.
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: dispatch ${{ matrix.suite }} on ${{ matrix.branch }}
+    runs-on: ubuntu-latest
+    strategy:
+      # Never let one suite's dispatch failure cancel the rest of the fan-out.
+      fail-fast: false
+      matrix:
+        branch: [main, dev]
+        suite:
+          - integration-tests-ci.yaml
+          - test-cluster.yaml
+          - ts-integration-tests.yaml
+          - simtest.yaml
+    steps:
+      # The `gh` CLI is preinstalled on GitHub-hosted ubuntu-latest runners.
+      # `github.token` (a.k.a. secrets.GITHUB_TOKEN) carries the
+      # `actions: write` permission granted above, which is all `gh workflow
+      # run` needs to dispatch a sibling workflow.
+      - name: Dispatch ${{ matrix.suite }} against ${{ matrix.branch }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ matrix.branch }}
+          SUITE: ${{ matrix.suite }}
+        run: |
+          set -euo pipefail
+          # Per-suite default inputs mirror each suite's own documented
+          # defaults (see dev-docs/playbooks/ci-suites.md). Threads stay at
+          # the validated 4-way for the memory-bound suites.
+          case "$SUITE" in
+            integration-tests-ci.yaml)
+              gh workflow run "$SUITE" --ref "$BRANCH" \
+                -f scope=integration \
+                -f test_threads=4
+              ;;
+            test-cluster.yaml)
+              gh workflow run "$SUITE" --ref "$BRANCH" \
+                -f package=ika-test-cluster \
+                -f test_threads=4
+              ;;
+            ts-integration-tests.yaml)
+              gh workflow run "$SUITE" --ref "$BRANCH" \
+                -f epoch_duration_ms=900000
+              ;;
+            simtest.yaml)
+              gh workflow run "$SUITE" --ref "$BRANCH"
+              ;;
+            *)
+              echo "unknown suite: $SUITE" >&2
+              exit 1
+              ;;
+          esac
+          echo "dispatched $SUITE against $BRANCH"

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -5,6 +5,20 @@ self-hosted runners (80 vCPU; measured at full per-thread parity with an
 M3 Max). Prefer these over hours-long local runs — they parallelize,
 don't tie up a laptop, and upload logs as artifacts for post-mortem.
 
+## Nightly orchestrator
+
+`.github/workflows/scheduled-all-suites.yaml` runs every night at 03:00
+UTC (and on `workflow_dispatch`). It fans out over `branch: [main, dev]`
+× the four heavy suites below and dispatches each via `gh workflow run`
+with that suite's default inputs. It only *dispatches* — each run reports
+under its own workflow (Test Cluster / Integration Tests CI / TS
+Integration Tests / Simtest) on the targeted branch, with its own logs.
+
+Caveat: GitHub fires `schedule:` triggers only from the repository
+DEFAULT branch (`main`). Until this orchestrator also lands on `main`,
+the nightly cron does not run; `workflow_dispatch` works from any branch
+it exists on.
+
 ## Dispatch commands
 
 ```bash


### PR DESCRIPTION
## What

Adds one orchestrator workflow, `.github/workflows/scheduled-all-suites.yaml`, that automatically runs the four heavy, currently-manual test suites for **both** the `main` and `dev` branches. Today those suites are `workflow_dispatch`-only, so nothing runs them on a schedule.

The orchestrator **only dispatches** the existing suite workflows — it does not run the tests itself and does not wait for or report their results. Each dispatched run appears under its own workflow (Test Cluster / Integration Tests CI / TS Integration Tests / Simtest) on the targeted branch, with its own logs and artifacts.

`ci.yaml` (build/fmt/clippy, already push/PR-triggered) is untouched.

## Triggers / cadence

- `schedule:` — nightly cron `0 3 * * *` = **03:00 UTC** (off-peak, clear of working-hours merges into `dev`; each suite is 35–60 min, so a per-push trigger on the frequently-merged `dev` would be wasteful).
- `workflow_dispatch:` — run on demand at any time.

Deliberately **no** `push` trigger.

## Matrix (branches × suites), `fail-fast: false`

For each pair it runs `gh workflow run <suite> --ref <branch>` with that suite's default inputs:

| Suite workflow | Default inputs passed |
| --- | --- |
| `integration-tests-ci.yaml` | `scope=integration`, `test_threads=4` |
| `test-cluster.yaml` | `package=ika-test-cluster`, `test_threads=4` |
| `ts-integration-tests.yaml` | `epoch_duration_ms=900000` |
| `simtest.yaml` | (none — its own defaults: `test_filter=test_swarm_reaches_epoch_2`, `seed=1`, `test_num=1`) |

Branches: `[main, dev]`. `fail-fast: false` so one suite's dispatch failure can't cancel the rest of the fan-out. The `test_threads=4` default matches the validated, memory-bound ceiling (8-way OOMs the 96Gi pod).

All four target suites were confirmed to have `workflow_dispatch` (required for `gh workflow run` to target them).

## Authentication

`gh` is preinstalled on GitHub-hosted `ubuntu-latest` runners. The job sets `permissions: { actions: write, contents: read }` (minimal — `actions: write` is what dispatching a sibling workflow needs) and passes `GH_TOKEN: ${{ github.token }}` to the `gh` calls. This mirrors the repo's existing token usage and needs no extra secret.

## ⚠️ Caveat: scheduled triggers fire only from the DEFAULT branch

The repository default branch is **`main`** (`gh repo view --json defaultBranchRef` → `main`). GitHub evaluates `schedule:` triggers **only** from the version of a workflow on the default branch. Because this PR targets `dev`, the **nightly cron will not start firing until this workflow also reaches `main`** (a follow-up merge into `main`, or a default-branch change). Until then:

- **`workflow_dispatch` works immediately** once merged to either branch.
- **The nightly schedule activates only after the file lands on `main`.**

Note the matrix still dispatches against *both* `main` and `dev` regardless of which branch the orchestrator runs from — the default-branch rule only governs whether the *cron itself* fires, not which branches it targets.

## Changes

- `.github/workflows/scheduled-all-suites.yaml` — new orchestrator (YAML-only; validated with `yaml.safe_load`).
- `dev-docs/playbooks/ci-suites.md` — short "Nightly orchestrator" note documenting cadence + the default-branch caveat.

No existing suite workflow logic was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)