### PR TITLE
docs: point to the upstream Sui source as a reference for forked code + consensus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,14 @@ already validated, branch names, and in-flight CI run IDs/URLs.
 ## Gotchas
 
 - **Release mode required**: Crypto operations are extremely slow in debug mode
-- **Forked from Sui**: Much code structure mirrors Sui Network patterns
+- **Forked from Sui — read the upstream as a reference**: much code
+  structure mirrors Sui Network patterns, so when a forked subsystem is
+  unclear (and especially for consensus — Mysticeti is Sui's
+  `consensus/core`), read the pinned Sui source. It's checked out locally
+  under `~/.cargo/git/checkouts/sui-*/<rev>/` (the one with `consensus/`
+  at its root) and browsable at github.com/MystenLabs/sui at the pinned
+  tag. How to locate it + what to read for what:
+  `dev-docs/reference/sui-upstream.md`.
 - **Sui version is pinned in MULTIPLE places** (currently `mainnet-v1.70.2`;
   sometimes a `testnet-v*` tag): when bumping it, bump EVERYWHERE in one
   PR — root `Cargo.toml` (~90 tag pins), excluded wasm workspace locks,
@@ -244,5 +251,8 @@ already validated, branch names, and in-flight CI run IDs/URLs.
   `dev-docs/conventions/sui-version-bump.md`; enforced in CI by
   `scripts/check-sui-version-consistency.sh`.
 - **WASM excluded**: `sdk/ika-wasm` is excluded from workspace (separate build)
-- **Mysticeti consensus**: Uses Sui's Mysticeti for MPC message routing
+- **Mysticeti consensus**: Uses Sui's Mysticeti for MPC message routing —
+  the commit/round semantics ika's freeze and epoch-close logic rely on
+  (leader rounds, commit boundaries) live in Sui's `consensus/core`, not
+  in ika (see the upstream reference above)
 - **NOA checkpoints not live**: The NOA checkpoint system (`crates/ika-core/src/noa_checkpoints/`) is under active development and not yet deployed. No backward compatibility constraints on serialization formats or type names

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -63,6 +63,12 @@ them has a bug — determine which before changing either.
 - [`learnings/pitfalls.md`](learnings/pitfalls.md) — non-obvious failure
   classes found in this codebase, each with the general rule it taught.
 
+### reference/ — pointers to external sources worth consulting
+- [`reference/sui-upstream.md`](reference/sui-upstream.md) — ika is forked
+  from Sui; how to find the pinned Sui source (locally + on GitHub) and
+  what to read in it for forked subsystems and consensus (Mysticeti =
+  Sui's `consensus/core`).
+
 ### plans/ — implementation plans worth keeping in the repo
 Multi-PR / multi-session efforts with an explicit status lifecycle
 (`active → landed/superseded/abandoned`). Intent and sequencing live

--- a/dev-docs/reference/sui-upstream.md
+++ b/dev-docs/reference/sui-upstream.md
@@ -1,0 +1,57 @@
+# Sui upstream as a reference
+
+ika is forked from Sui Network. Much of the node, authority, checkpoint,
+epoch, and networking structure mirrors Sui's, and the consensus layer
+(Mysticeti) is consumed from Sui directly. When a forked subsystem is
+unclear, or you're reasoning about consensus behavior, **read the pinned
+Sui source** — it is the canonical reference for the patterns ika
+inherited.
+
+## Where the source is
+
+- **Pinned version:** the `mainnet-v1.70.2` tag of
+  `https://github.com/MystenLabs/sui` (sometimes a `testnet-v*` tag —
+  check the `tag = "..."` in the root `Cargo.toml`). Always read the
+  version ika actually pins; older/newer Sui differs.
+- **Browse online:** github.com/MystenLabs/sui at that tag — the stable
+  way to reference a specific file/line.
+- **Local checkout** (fetched by cargo for the git dependencies):
+  `~/.cargo/git/checkouts/sui-<hash>/<rev>/`. The `<rev>` is the commit
+  the tag resolves to; find the directory with
+  `ls -d ~/.cargo/git/checkouts/sui-*/*/` (the `sui-rust-sdk-*` checkout
+  is a different dependency — the one you want has `consensus/`,
+  `crates/`, `sui-execution/` at its root). If it's absent, a
+  `cargo fetch` / build populates it.
+
+## What to read for what
+
+- **Consensus (Mysticeti):** Sui's `consensus/core/` — block production,
+  commit rule, the DAG, leader schedule, the `CommitConsumer`. ika routes
+  MPC messages through this; the commit/round semantics the freeze and
+  epoch-close logic depend on (leader rounds advancing non-monotonically,
+  commit boundaries) are defined here, not in ika.
+- **Authority / epoch / checkpoint patterns:** ika's
+  `crates/ika-core/src/authority/`, `epoch/`, and checkpoint stores mirror
+  Sui's `crates/sui-core/`. When an ika type or flow looks like it has
+  unexplained machinery, diff it against the Sui original — the ika
+  version is often "Sui's file with the MPC-specific parts swapped in."
+- **Networking:** ika's P2P / anemo usage follows Sui's `crates/sui-network`
+  and the anemo patterns.
+
+## How to use it
+
+1. Find the ika file you're working on; identify the Sui crate it mirrors
+   (names usually match: `sui-core` → `ika-core`, etc.).
+2. Open the same-named file in the pinned Sui source and compare — the
+   delta is the ika-specific behavior; the shared part behaves like
+   upstream.
+3. For consensus questions, go straight to `consensus/core/` rather than
+   inferring behavior from ika's call sites.
+
+## Caveat
+
+It is a *reference*, not gospel for ika's current behavior: ika has
+renamed symbols, removed some flows, and added MPC-specific logic, and it
+is pinned to one Sui version. Use upstream to understand inherited
+mechanics and intent; confirm ika's actual behavior against ika's code at
+the pinned version.


### PR DESCRIPTION
ika is forked from Sui and consumes Mysticeti consensus from it, so the pinned Sui source is the best reference for understanding inherited patterns and consensus semantics. This makes that explicit and tells you where to find it.

## Changes
- **`dev-docs/reference/sui-upstream.md`** (new) — where the pinned Sui source lives (the local `~/.cargo/git/checkouts/sui-*/<rev>/` checkout and github.com/MystenLabs/sui at the `mainnet-v1.70.2` tag), and what to read for what:
  - **Consensus (Mysticeti):** Sui's `consensus/core/` — the commit/round semantics ika's freeze and epoch-close logic depend on (leader rounds advancing non-monotonically, commit boundaries) are defined there, not in ika.
  - **Authority / epoch / checkpoint:** `sui-core` is what `ika-core` mirrors — diff the same-named file to isolate the MPC-specific delta.
  - Plus the caveat that it's a reference, not gospel: ika has renamed/removed/added, and is pinned to one Sui version.
- **`CLAUDE.md`** — the "Forked from Sui" and "Mysticeti consensus" gotchas now point at the upstream source and the new doc (concise, since CLAUDE.md loads every session; detail lives in dev-docs).
- **`dev-docs/README.md`** — adds a `reference/` category to the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)