### PR TITLE
fix(test-infra): pre-allocate deterministic swarm ports to end the bind race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6969,6 +6969,7 @@ dependencies = [
  "sui-macros",
  "sui-sdk",
  "sui-simulator",
+ "sui-swarm-config",
  "sui-types",
  "telemetry-subscribers",
  "test-cluster",

--- a/crates/ika-config/src/local_ip_utils.rs
+++ b/crates/ika-config/src/local_ip_utils.rs
@@ -69,6 +69,33 @@ pub fn localhost_for_testing() -> String {
     "127.0.0.1".to_string()
 }
 
+/// Base port for this test process's deterministic port block.
+///
+/// `cargo nextest` runs each test in its own process and assigns every
+/// concurrently-running test a unique global slot (`NEXTEST_TEST_GLOBAL_SLOT`).
+/// Deriving a disjoint port block per slot lets parallel test processes
+/// pre-allocate non-overlapping, deterministic ports for their swarm nodes, so
+/// they never probe-then-bind the same port and collide with
+/// `Address already in use`. `ports_per_slot` must cover every port one test
+/// process allocates. The block stays below the Linux ephemeral range
+/// (32768+) so the OS never hands one of these ports to an unrelated socket.
+/// (Unset slot -> 0, the natural single-process/local default.)
+pub fn deterministic_port_base(ports_per_slot: u16) -> u16 {
+    const FIRST_BASE: u32 = 9000;
+    const CEILING: u32 = 32000;
+    let slot: u32 = std::env::var("NEXTEST_TEST_GLOBAL_SLOT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let base = FIRST_BASE + slot * ports_per_slot as u32;
+    assert!(
+        base + ports_per_slot as u32 <= CEILING,
+        "nextest global slot {slot} overflows the deterministic test-port range \
+         [{FIRST_BASE}, {CEILING}); lower the cluster suite's --test-threads"
+    );
+    base as u16
+}
+
 /// Returns an available port for the given host in simtest.
 /// We don't care about host because it's all managed by simulator. Just obtain a unique port.
 #[cfg(msim)]

--- a/crates/ika-test-cluster/Cargo.toml
+++ b/crates/ika-test-cluster/Cargo.toml
@@ -31,6 +31,7 @@ ika-types.workspace = true
 sui-json-rpc-types.workspace = true
 sui-keys.workspace = true
 sui-sdk.workspace = true
+sui-swarm-config.workspace = true
 sui-types.workspace = true
 test-cluster.workspace = true
 

--- a/crates/ika-test-cluster/src/lib.rs
+++ b/crates/ika-test-cluster/src/lib.rs
@@ -14,6 +14,7 @@ use fastcrypto::ed25519::{Ed25519KeyPair, Ed25519PrivateKey};
 use fastcrypto::hash::{HashFunction, Keccak256};
 use fastcrypto::traits::{KeyPair as _, Signer, ToFromBytes};
 use ika_config::initiation::InitiationParameters;
+use ika_config::local_ip_utils;
 use ika_node::IkaNodeHandle;
 use ika_protocol_config::ProtocolVersion;
 use ika_sui_client::SuiConnectorClient;
@@ -37,9 +38,12 @@ use ika_types::crypto::AuthorityPublicKeyBytes;
 use ika_types::messages_dwallet_mpc::{IkaNetworkConfig, SessionIdentifier, SessionType};
 use ika_types::supported_protocol_versions::SupportedProtocolVersions;
 use rand::rngs::OsRng;
+use std::sync::atomic::{AtomicU16, Ordering};
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_keys::key_derive::generate_new_key;
 use sui_sdk::SuiClientBuilder;
+use sui_swarm_config::genesis_config::ValidatorGenesisConfigBuilder;
+use sui_swarm_config::network_config_builder::ConfigBuilder;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::crypto::SignatureScheme;
 use test_cluster::{TestCluster, TestClusterBuilder};
@@ -58,6 +62,20 @@ const DEFAULT_NUM_VALIDATORS: usize = 4;
 /// orders of magnitude over what's needed; faucet calls fund similarly.
 const VALIDATOR_FUNDING_MIST: u64 = 100_000_000_000;
 
+/// Ports reserved per test process for deterministic swarm-node allocation.
+/// Generous headroom over one cluster's needs (Sui + ika validators, joiners,
+/// the notifier fullnode RPC).
+const PORTS_PER_TEST_SLOT: u16 = 1000;
+/// Ports each swarm node consumes; the validator builders lay out up to 7
+/// addresses per node, so 10 leaves headroom.
+const NODE_PORT_STRIDE: u16 = 10;
+/// Sui fullnode RPC port offset within a test's slot (past the Sui validator
+/// sub-block `[0, IKA_NODE_PORT_OFFSET)`).
+const SUI_FULLNODE_RPC_PORT_OFFSET: u16 = 280;
+/// Offset of the ika-node sub-block within a test's slot; Sui nodes occupy
+/// `[0, IKA_NODE_PORT_OFFSET)`, ika nodes the remainder up to PORTS_PER_TEST_SLOT.
+const IKA_NODE_PORT_OFFSET: u16 = 300;
+
 pub struct IkaTestCluster {
     pub test_cluster: TestCluster,
     pub swarm: Swarm,
@@ -75,6 +93,14 @@ pub struct IkaTestCluster {
     /// swarm stores nodes in a HashMap and `validator_nodes()` order is
     /// otherwise unspecified.
     pub validator_names: Vec<ika_types::crypto::AuthorityName>,
+    /// Base port of this process's ika-node port block. Joiners added after
+    /// build draw deterministic ports from here so they don't race a
+    /// concurrently-running test process (see
+    /// `local_ip_utils::deterministic_port_base`).
+    pub ika_node_port_base: u16,
+    /// Next deterministic ika-node port index. Initial validators take
+    /// `[0, num_validators)`; each joiner claims the next slot.
+    pub next_ika_node_index: AtomicU16,
 }
 
 /// Handle to a validator that joined the network after the initial
@@ -194,7 +220,13 @@ impl IkaTestCluster {
         let boot_lock = acquire_cluster_boot_lock().await;
 
         let mut rng = OsRng;
-        let mut joiner_init = ValidatorInitializationConfigBuilder::new().build(&mut rng);
+        // Deterministic ports from this process's ika-node block so the joiner
+        // doesn't race a concurrently-booting test process during its
+        // probe-to-bind window.
+        let joiner_index = self.next_ika_node_index.fetch_add(1, Ordering::SeqCst);
+        let mut joiner_init = ValidatorInitializationConfigBuilder::new()
+            .with_deterministic_ports(self.ika_node_port_base + joiner_index * NODE_PORT_STRIDE)
+            .build(&mut rng);
         joiner_init.name = Some(format!(
             "joiner-{}",
             self.swarm.validator_node_handles().len()
@@ -1051,8 +1083,33 @@ impl IkaTestClusterBuilder {
         #[cfg(not(msim))]
         let boot_lock = acquire_cluster_boot_lock().await;
 
+        // Pre-allocate a disjoint, per-test-process port block so that parallel
+        // `nextest` test processes never probe-then-bind the same port (the
+        // `Address already in use` swarm-boot flake). The Sui validators (via an
+        // injected NetworkConfig below) and the ika validators/joiners both draw
+        // deterministic ports from this block.
+        let port_base = local_ip_utils::deterministic_port_base(PORTS_PER_TEST_SLOT);
+        let ika_node_port_base = port_base + IKA_NODE_PORT_OFFSET;
+
+        // Build the Sui validators with deterministic ports and inject them as a
+        // NetworkConfig — `TestClusterBuilder::new().build()` would otherwise let
+        // the upstream Sui swarm probe its own (racy) ports, which we can't
+        // otherwise control. The default genesis still funds `get_address_0()`
+        // and the validators (ConfigBuilder uses `GenesisConfig::for_local_testing`).
+        let mut sui_validator_rng = OsRng;
+        let sui_validators = (0..self.num_validators)
+            .map(|i| {
+                ValidatorGenesisConfigBuilder::new()
+                    .with_deterministic_ports(port_base + i as u16 * NODE_PORT_STRIDE)
+                    .build(&mut sui_validator_rng)
+            })
+            .collect::<Vec<_>>();
+        let sui_network_config = ConfigBuilder::new_with_temp_dir()
+            .with_validators(sui_validators)
+            .build();
         let mut test_cluster = TestClusterBuilder::new()
-            .with_num_validators(self.num_validators)
+            .set_network_config(sui_network_config)
+            .with_fullnode_rpc_port(port_base + SUI_FULLNODE_RPC_PORT_OFFSET)
             .build()
             .await;
 
@@ -1063,7 +1120,9 @@ impl IkaTestClusterBuilder {
         let validator_initialization_configs: Vec<ValidatorInitializationConfig> = (0..self
             .num_validators)
             .map(|i| {
-                let mut cfg = ValidatorInitializationConfigBuilder::new().build(&mut rng);
+                let mut cfg = ValidatorInitializationConfigBuilder::new()
+                    .with_deterministic_ports(ika_node_port_base + i as u16 * NODE_PORT_STRIDE)
+                    .build(&mut rng);
                 cfg.name = Some(format!("validator-{i}"));
                 cfg
             })
@@ -1250,6 +1309,10 @@ impl IkaTestClusterBuilder {
             sui_rpc_url,
             publisher_address,
             validator_names,
+            ika_node_port_base,
+            // Initial validators consumed indices [0, num_validators); joiners
+            // claim the next deterministic slots.
+            next_ika_node_index: AtomicU16::new(self.num_validators as u16),
         })
     }
 }

--- a/dev-docs/learnings/pitfalls.md
+++ b/dev-docs/learnings/pitfalls.md
@@ -73,10 +73,25 @@ rule, not the instance.
 
 - **Probe-then-bind port allocation races across processes.** Two test
   processes probing for free ports then binding later collide
-  ("Address already in use") — and the window can be SECONDS when setup
-  work sits between probe and bind (the joiner spawn did several
-  on-chain txs in between). → Rule: hold a cross-process lock from probe
-  to bind, and audit every node-spawn path, not just the boot path.
+  ("Address already in use"). A cross-process *boot lock* is NOT enough:
+  it serializes boots, but other tests' swarm nodes stay alive (holding
+  their ports) while their bodies run unlocked, and the probe — `TcpListener`
+  on a port that a live node holds for *UDP* (anemo/QUIC binds UDP; TCP
+  free-ness says nothing about UDP, which has no TIME_WAIT) — hands out a
+  doomed port. This flaked the cluster suite in BOTH swarm layers:
+  `ika_node::IkaNode::create_p2p_network` and (via the injected base chain)
+  `sui_node::SuiNode::create_p2p_network`. → Rule: don't probe — PRE-ALLOCATE
+  a disjoint, deterministic port block per test PROCESS, keyed on
+  `NEXTEST_TEST_GLOBAL_SLOT` (unique among concurrently-running tests), so no
+  two tests ever share a port for the lifetime of their nodes. See
+  `crates/ika-config/src/local_ip_utils.rs::deterministic_port_base` and its
+  use in `ika-test-cluster` (ika validators/joiners via
+  `with_deterministic_ports`; the upstream Sui validators via a
+  `ConfigBuilder` `NetworkConfig` injected with `set_network_config`, since
+  Sui's swarm otherwise probes its own ports). Fullnodes ride along — they
+  reuse a validator's deterministic p2p port and only probe TCP admin/RPC
+  (reliable). Keep the deterministic block below the OS ephemeral range
+  (32768+) so it's never handed to an unrelated socket.
 - **`tokio::sync::watch` keeps only the last value.** Two sends in a row
   lose the first — test helpers sending event batches must send ONE
   batch. Symptom: the first event simply never happened.


### PR DESCRIPTION
## Summary

Eliminates the flaky `Address already in use (os error 98)` swarm-boot failures in the Test Cluster suite by **pre-allocating deterministic ports per test process** instead of probe-then-bind. The race existed in **two swarm layers** (ika's own, and the upstream Sui `test_cluster` that ika boots on top of), so both are addressed.

## Root cause

`cargo nextest` runs each test in its own process, many in parallel. Each swarm node probed a free port then bound it later — and a node's p2p/consensus bind is anemo **QUIC over UDP**, while the probe was a **TCP** listener. TCP free-ness (and its TIME_WAIT grace) says nothing about UDP, so a process could pick a port a *live* node from another running test already held for UDP. The existing cross-process boot lock only serialized boots; it can't help when other tests' nodes stay alive holding ports.

## Fix — deterministic, disjoint port blocks per process

- **`local_ip_utils::deterministic_port_base(ports_per_slot)`** derives a disjoint port block from `NEXTEST_TEST_GLOBAL_SLOT` (unique among concurrently-running tests), kept below the OS ephemeral range (32768+). Parallel test processes therefore never share a port for the lifetime of their nodes — no probing, no race.
- **ika validators + joiners**: `with_deterministic_ports(base + idx*10)`, with a joiner index counter on `IkaTestCluster`.
- **Sui validators**: built with deterministic ports and injected via `ConfigBuilder::new_with_temp_dir().with_validators(...)` + `TestClusterBuilder::set_network_config(...).with_fullnode_rpc_port(...)`. Sui's swarm otherwise probes its own (uncontrollable) ports. The default `GenesisConfig::for_local_testing` still funds `get_address_0()` and the validators.
- **Fullnodes / notifier**: no special handling needed — each reuses a validator's deterministic p2p port and only probes a TCP admin/RPC port (reliable; TCP has TIME_WAIT).

## Why pre-allocation over retries

A retry only re-rolls the dice; the user asked for the race gone at the source. Deterministic per-process blocks make a collision structurally impossible across parallel tests. (Trade-off: a deterministic port that's already occupied has no fallback — mitigated by a dedicated sub-range well below the ephemeral range, and slots are reused only after a test process exits and frees its ports.)

## Notes
- **No new runtime deps** (`sui-swarm-config` added to `ika-test-cluster` dev/build graph; already a workspace member).
- Per-process **ports** (not IPs): `127.0.0.0/8` is only fully routable on Linux, so an IP-partition scheme would break local macOS runs.

## Verification
- `cargo check -p ika-config -p ika-test-cluster --all-targets` → clean.
- `cluster_boots_with_four_validators` passes locally (93s) — confirms the injected `set_network_config` genesis still funds `get_address_0()`/RPC and both swarm layers boot.
- Test Cluster + Integration + TS suites dispatched on this commit (see checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
