### PR TITLE
test(cluster): widen mid-epoch-joiner freeze window to fix flaky exclusion

### DIFF
--- a/crates/ika-test-cluster/tests/joiner.rs
+++ b/crates/ika-test-cluster/tests/joiner.rs
@@ -90,16 +90,29 @@ async fn test_joiner_lands_in_next_committee_class_groups() {
     //      keygen (a fixed, multi-second cost) and land `add_validator`
     //      on-chain so it's selected into `V_{e+1}`. This is gated by
     //      crypto/tx time, NOT by poll cadence, so it needs absolute
-    //      wall-clock — a 60s epoch (30s window) is too tight.
+    //      wall-clock.
     //   2. Freeze `[epoch/2 → 3·epoch/4]`: fan out → relay → fetch →
-    //      decode-validate → re-emit, so the freeze captures its
-    //      mpc_data. `epoch_scaled_poll_interval` shrinks this path's
-    //      cadences to fit the window.
-    // 120s gives a 60s registration window and a 30s freeze window —
-    // both comfortable.
+    //      decode-validate → re-emit, so a stake quorum's ready signals
+    //      cover the joiner before the `3·epoch/4` deadline forces the
+    //      freeze without it. `epoch_scaled_poll_interval` shrinks this
+    //      path's cadences to fit the window, but the per-peer
+    //      class-groups decode-validate is a fixed crypto cost that does
+    //      NOT compress with the epoch.
+    //
+    // This is a deliberately time-compressed epoch (production epochs are
+    // hours, where these windows are minutes and a joiner never misses).
+    // At 120s the freeze window is only `epoch/4` = 30s, and under the
+    // Test Cluster suite's 4-way parallelism — four full Sui+ika swarms
+    // contending for CPU — the quorum decode-validate of the joiner's blob
+    // intermittently overran 30s, so the deadline froze the input set
+    // without the joiner and this assertion flaked. 240s doubles the
+    // freeze window to 60s (and keeps the registration window at a roomy
+    // 120s) — comfortable margin over the contended propagation floor,
+    // while staying well under the epoch length at which the network-key
+    // DKG starts to stall.
     let mut cluster = IkaTestClusterBuilder::new()
         .with_num_validators(4)
-        .with_epoch_duration_ms(120_000)
+        .with_epoch_duration_ms(240_000)
         .with_protocol_version(ProtocolVersion::new(4))
         .build()
         .await

--- a/dev-docs/learnings/pitfalls.md
+++ b/dev-docs/learnings/pitfalls.md
@@ -106,6 +106,22 @@ rule, not the instance.
   → Rule: budgets guard against "never", not "slow" — set them
   generously and keep the budget hierarchy ordered (per-call < per-case
   < per-job) so the failure surfaces with the most specific error.
+- **Time-compressed epoch tests: a protocol WINDOW that is a fraction of
+  the epoch races a crypto cost that does NOT compress.** Cluster tests
+  shrink the epoch (e.g. 120s) to run fast, but the mid-epoch-joiner
+  freeze window is `epoch/4`, while the per-peer class-groups
+  decode-validate the joiner must clear inside it is a fixed multi-second
+  cost. Under 4-way suite parallelism the 30s window fell below the
+  contended propagation floor, the `3·epoch/4` deadline froze the input
+  set without the joiner, and `test_joiner_lands_in_next_committee_class_groups`
+  flaked (joiner missing from `class_groups_public_keys_and_proofs`). The
+  production behavior is correct — at hour-long epochs the window is
+  minutes; a joiner that truly can't propagate is excluded by design.
+  → Rule: when a test compresses the epoch, size it so every
+  epoch-FRACTION window still exceeds the ABSOLUTE (non-compressing) work
+  inside it WITH margin for CI contention; don't tune to "passes alone".
+  (`epoch_scaled_poll_interval` compresses poll cadences but cannot
+  compress the crypto.)
 - **Test-harness state that production syncs from chain must be set
   explicitly.** The in-process harness never syncs the epoch-close lock
   target, so it stays 0 and (correctly) gates everything; tests set it


### PR DESCRIPTION
## Summary

Fixes the intermittent failure of `test_joiner_lands_in_next_committee_class_groups` (the assertion that flaked the Test Cluster suite): the mid-epoch joiner reached epoch 2 but its `class_groups_public_keys_and_proofs` entry was missing from the epoch-2 committee.

## Root cause — a test time-compression artifact, not a production bug

A mid-epoch joiner is captured only if its mpc_data is decode-validated by a **stake quorum** inside the freeze window `[epoch/2 (V_{e+1} published) → 3·epoch/4 (ready-signal deadline)]` = `epoch/4`. Inside that window the path is: fan out → relay → peer fetch → **class-groups decode-validate** → re-emit ready signals (`mpc_data_announcement_sender::decide_ready_to_finalize`; freeze in `authority_per_epoch_store.rs`). `epoch_scaled_poll_interval` compresses the *poll cadences* with the epoch, but the per-peer **decode-validate is a fixed multi-second crypto cost that does not compress**.

At a 120s test epoch that window is **30s**. Under the Test Cluster suite's 4-way parallelism — four full Sui+ika swarms contending for CPU — the quorum decode-validate intermittently overran 30s, so the `3·epoch/4` deadline forced the ready signals (and the freeze) **without** the joiner. That exclusion is **correct by design**: reconfiguration never blocks waiting on a joiner (the liveness rule hardened in #1741), and at production epoch lengths the window is *minutes*, so this never happens in production.

## Fix

Double the test epoch to **240s** (freeze window → 60s, registration window → a roomy 120s), staying well under the epoch length at which the network-key DKG starts to stall. This deterministically gives the propagation enough wall-clock — it is **not** a retry band-aid. Also adds a `dev-docs/learnings/pitfalls.md` entry: in time-compressed epoch tests, every epoch-*fraction* window must exceed the *absolute* (non-compressing) crypto cost inside it, with margin for CI contention.

No production code changes; the reconfiguration mechanism is untouched.

## Verification
- `cargo check -p ika-test-cluster --tests` → clean.
- Passes locally at 240s (394s, joiner captured).
- Flake resolution to be confirmed across **repeated** Test Cluster CI runs (a single pass can't prove a flake fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
