### PR TITLE
feat: Fast Schnorr (VSS) signing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3379,7 +3379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3388,7 +3388,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4710,6 +4710,7 @@ dependencies = [
  "dwallet-rng",
  "group 0.2.0",
  "ika-types",
+ "mpc",
  "serde",
  "twopc_mpc",
 ]
@@ -5079,7 +5080,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5343,7 +5344,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7293,7 +7294,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7909,7 +7910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11582,7 +11583,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.8",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12327,7 +12328,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12340,7 +12341,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12408,7 +12409,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13372,7 +13373,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16092,7 +16093,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -17954,7 +17955,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/dwallet-classgroups-types/Cargo.toml
+++ b/crates/dwallet-classgroups-types/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 dwallet-rng.workspace = true
 class_groups = { workspace = true }
 group.workspace = true
+mpc.workspace = true
 crypto-bigint.workspace = true
 serde.workspace = true
 ika-types.workspace = true

--- a/crates/dwallet-classgroups-types/src/lib.rs
+++ b/crates/dwallet-classgroups-types/src/lib.rs
@@ -20,12 +20,11 @@ use class_groups::{
 };
 use crypto_bigint::Uint;
 use dwallet_rng::RootSeed;
+use group::GroupElement as _;
 use ika_types::committee::{
-    ClassGroupsEncryptionKeyAndProof, ClassGroupsProof, RistrettoPvssEncryptionKeyAndProof,
-    Secp256k1PvssEncryptionKeyAndProof, Secp256r1PvssEncryptionKeyAndProof,
-    ValidatorEncryptionKeysAndProofs,
+    ClassGroupsEncryptionKeyAndProof, ClassGroupsProof, ValidatorEncryptionKeysAndProofs,
 };
-use serde::{Deserialize, Serialize};
+use mpc::secret_sharing::shamir::known_order::generate_and_uc_prove_encryption_keypair;
 
 pub type ClassGroupsDecryptionKey = [Uint<{ CRT_FUNDAMENTAL_DISCRIMINANT_LIMBS }>; MAX_PRIMES];
 type AsyncProtocol = twopc_mpc::secp256k1::class_groups::ECDSAProtocol;
@@ -51,28 +50,26 @@ pub type Secp256k1PvssDecryptionKey = Uint<{ SECP256K1_FUNDAMENTAL_DISCRIMINANT_
 pub type Secp256r1PvssDecryptionKey = Uint<{ SECP256R1_FUNDAMENTAL_DISCRIMINANT_LIMBS }>;
 pub type RistrettoPvssDecryptionKey = Uint<{ RISTRETTO_FUNDAMENTAL_DISCRIMINANT_LIMBS }>;
 
-/// Validator's class-groups CRT decryption-key + matching encryption-key + UC-secure
-/// proof bundle.
+/// SECRET. Validator's own class-groups CRT decryption key. Holds only secret
+/// material — the matching public encryption key + UC-secure proof is returned
+/// alongside as [`ClassGroupsEncryptionKeyAndProof`] by [`Self::from_seed`].
 ///
-/// Wire-format unchanged since pre-bump: callers that serialize or store this
-/// struct continue to interoperate with existing keys.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ClassGroupsKeyPairAndProof {
-    #[serde(with = "group::helpers::const_generic_array_serialization")]
-    decryption_key_per_crt_prime: ClassGroupsDecryptionKey,
-    #[serde(with = "group::helpers::const_generic_array_serialization")]
-    encryption_key_and_proof: ClassGroupsEncryptionKeyAndProof,
+/// Deliberately **NOT** `Serialize` / `Deserialize`: the decryption key must
+/// never be written out, persisted, or transmitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClassGroupsSecret {
+    /// Class-groups CRT decryption key.
+    pub decryption_key: ClassGroupsDecryptionKey,
 }
 
-impl ClassGroupsKeyPairAndProof {
-    /// Generates a [`ClassGroupsKeyPairAndProof`] from a root seed.
+impl ClassGroupsSecret {
+    /// Deterministically generate the class-groups CRT decryption key and the
+    /// matching encryption-key-and-proof from a root seed. Uses
+    /// `class_groups_decryption_key_rng` so the same seed always reproduces
+    /// the same pair.
     ///
-    /// Deterministically generates class-groups keys using ChaCha20Rng
-    /// seeded with the dedicated `class_groups_decryption_key_rng` child of the
-    /// provided root seed. The same seed will always produce the same key pair.
-    ///
-    /// The seed should be cryptographically secure and kept confidential.
-    pub fn from_seed(root_seed: &RootSeed) -> Self {
+    /// The seed must be cryptographically secure and kept confidential.
+    pub fn from_seed(root_seed: &RootSeed) -> (Self, ClassGroupsEncryptionKeyAndProof) {
         let setup_parameters_per_crt_prime =
             construct_setup_parameters_per_crt_prime(DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER)
                 .unwrap();
@@ -94,46 +91,50 @@ impl ClassGroupsKeyPairAndProof {
         )
         .unwrap();
 
-        ClassGroupsKeyPairAndProof {
-            decryption_key_per_crt_prime: decryption_key,
+        (
+            ClassGroupsSecret { decryption_key },
             encryption_key_and_proof,
-        }
-    }
-
-    pub fn encryption_key_and_proof(&self) -> ClassGroupsEncryptionKeyAndProof {
-        self.encryption_key_and_proof.clone()
-    }
-
-    pub fn decryption_key(&self) -> ClassGroupsDecryptionKey {
-        self.decryption_key_per_crt_prime
+        )
     }
 }
 
-/// Validator's complete MPC key material: the existing [`ClassGroupsKeyPairAndProof`]
-/// as a member PLUS the three per-curve PVSS HPKE keypairs (private decryption key +
-/// public encryption key + UC-secure proof) introduced at the `cryptography-private @
-/// 9d35fa76` bump for upstream's threshold-encryption-to-sharing sub-protocol.
+/// SECRET. This validator's own private MPC key material — the class-groups CRT
+/// decryption key, the three per-curve PVSS HPKE decryption keys, and the
+/// Fast Schnorr (VSS) HPKE curve25519 secret key. Belongs to this validator
+/// alone (never another validator's keys).
 ///
-/// Wrapping the historical [`ClassGroupsKeyPairAndProof`] preserves its wire format
-/// for any existing serialized keys; new consumers that need the published payload
-/// call [`Self::validator_encryption_keys_and_proofs`].
+/// Holds only secrets. The matching public encryption keys + UC-secure proofs
+/// — which depend on fresh randomness consumed during keypair generation and
+/// therefore can't be re-derived from the secrets alone — live in the separate
+/// [`ValidatorEncryptionKeysAndProofs`] type and are returned alongside this
+/// struct by [`Self::from_seed`]; callers that need to publish the public
+/// payload use the second tuple element directly.
 ///
-/// Generated deterministically from the validator's [`RootSeed`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ClassGroupsAndPvssKeyPairAndProof {
-    pub class_groups: ClassGroupsKeyPairAndProof,
+/// Deliberately **NOT** `Serialize` / `Deserialize`: the private keys must
+/// never be written out, persisted, or transmitted.
+///
+/// Generated deterministically from the validator's [`RootSeed`]; the seed must
+/// be cryptographically secure and kept confidential.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatorMPCSecrets {
+    /// Class-groups CRT decryption key. Secret-only — the matching encryption
+    /// key + UC-secure proof lives in the returned [`ValidatorEncryptionKeysAndProofs`].
+    pub class_groups: ClassGroupsSecret,
 
-    secp256k1_pvss_decryption_key: Secp256k1PvssDecryptionKey,
-    secp256k1_pvss_encryption_key_and_proof: Secp256k1PvssEncryptionKeyAndProof,
+    /// Per-curve PVSS HPKE secret decryption keys. Never publish or transmit;
+    /// used at sign time when this validator decrypts its share of the
+    /// threshold-encryption-to-sharing dealing.
+    pub secp256k1_pvss_decryption_key: Secp256k1PvssDecryptionKey,
+    pub secp256r1_pvss_decryption_key: Secp256r1PvssDecryptionKey,
+    pub ristretto_pvss_decryption_key: RistrettoPvssDecryptionKey,
 
-    secp256r1_pvss_decryption_key: Secp256r1PvssDecryptionKey,
-    secp256r1_pvss_encryption_key_and_proof: Secp256r1PvssEncryptionKeyAndProof,
-
-    ristretto_pvss_decryption_key: RistrettoPvssDecryptionKey,
-    ristretto_pvss_encryption_key_and_proof: RistrettoPvssEncryptionKeyAndProof,
+    /// Fast Schnorr (VSS) HPKE secret key — a single curve25519 scalar
+    /// (one keypair serves all VSS signing curves) used as the VSS presign
+    /// `PrivateInput` for threshold-encryption-to-sharing.
+    pub vss_hpke_secret_key: group::curve25519::Scalar,
 }
 
-impl ClassGroupsAndPvssKeyPairAndProof {
+impl ValidatorMPCSecrets {
     /// Deterministically generates the validator's class-groups CRT material
     /// plus the three per-curve PVSS HPKE keypairs from a single [`RootSeed`].
     ///
@@ -150,8 +151,14 @@ impl ClassGroupsAndPvssKeyPairAndProof {
     /// deterministic derivation from `RootSeed` is sound.
     ///
     /// The seed must be cryptographically secure and kept confidential.
-    pub fn from_seed(root_seed: &RootSeed) -> Self {
-        let class_groups = ClassGroupsKeyPairAndProof::from_seed(root_seed);
+    ///
+    /// Returns the secrets alongside the matching public
+    /// [`ValidatorEncryptionKeysAndProofs`] payload. The UC proofs use fresh
+    /// randomness during keypair generation, so the public payload must be
+    /// captured here — it can't be recomputed from the secrets alone.
+    pub fn from_seed(root_seed: &RootSeed) -> (Self, ValidatorEncryptionKeysAndProofs) {
+        let (class_groups, class_groups_encryption_key_and_proof) =
+            ClassGroupsSecret::from_seed(root_seed);
 
         let secp256k1_setup =
             Secp256k1SetupParameters::derive_from_plaintext_parameters::<group::secp256k1::Scalar>(
@@ -210,58 +217,43 @@ impl ClassGroupsAndPvssKeyPairAndProof {
             >(&ristretto_setup, &mut ristretto_rng)
             .unwrap();
 
-        ClassGroupsAndPvssKeyPairAndProof {
+        // Fast Schnorr (VSS) HPKE keypair: a single curve25519 keypair (not
+        // class groups, not per-curve) used as the known-order
+        // threshold-encryption-to-sharing transport for the VSS Schnorr
+        // presign. One curve25519 keypair serves all VSS signing curves.
+        let (vss_hpke_secret, vss_hpke_public, vss_hpke_proof) =
+            generate_and_uc_prove_encryption_keypair(&mut root_seed.vss_hpke_secret_key_rng())
+                .unwrap();
+
+        let publics = ValidatorEncryptionKeysAndProofs {
+            class_groups: class_groups_encryption_key_and_proof,
+            secp256k1_pvss: (secp256k1_enc, secp256k1_proof),
+            secp256r1_pvss: (secp256r1_enc, secp256r1_proof),
+            ristretto_pvss: (ristretto_enc, ristretto_proof),
+            vss_hpke_public_key_and_proof: (vss_hpke_public.value(), vss_hpke_proof),
+        };
+        let secrets = ValidatorMPCSecrets {
             class_groups,
             secp256k1_pvss_decryption_key: secp256k1_dec,
-            secp256k1_pvss_encryption_key_and_proof: (secp256k1_enc, secp256k1_proof),
             secp256r1_pvss_decryption_key: secp256r1_dec,
-            secp256r1_pvss_encryption_key_and_proof: (secp256r1_enc, secp256r1_proof),
             ristretto_pvss_decryption_key: ristretto_dec,
-            ristretto_pvss_encryption_key_and_proof: (ristretto_enc, ristretto_proof),
-        }
+            vss_hpke_secret_key: vss_hpke_secret,
+        };
+        (secrets, publics)
     }
 
-    pub fn secp256k1_pvss_encryption_key_and_proof(&self) -> Secp256k1PvssEncryptionKeyAndProof {
-        self.secp256k1_pvss_encryption_key_and_proof.clone()
-    }
-
-    pub fn secp256r1_pvss_encryption_key_and_proof(&self) -> Secp256r1PvssEncryptionKeyAndProof {
-        self.secp256r1_pvss_encryption_key_and_proof.clone()
-    }
-
-    pub fn ristretto_pvss_encryption_key_and_proof(&self) -> RistrettoPvssEncryptionKeyAndProof {
-        self.ristretto_pvss_encryption_key_and_proof.clone()
-    }
-
-    /// Validator-private PVSS HPKE secret decryption key, secp256k1 plaintext space.
-    /// NEVER publish or transmit; required at sign time when the validator decrypts
-    /// its share of the threshold-encryption-to-sharing dealing.
-    pub fn secp256k1_pvss_decryption_key(&self) -> Secp256k1PvssDecryptionKey {
-        self.secp256k1_pvss_decryption_key
-    }
-
-    pub fn secp256r1_pvss_decryption_key(&self) -> Secp256r1PvssDecryptionKey {
-        self.secp256r1_pvss_decryption_key
-    }
-
-    pub fn ristretto_pvss_decryption_key(&self) -> RistrettoPvssDecryptionKey {
-        self.ristretto_pvss_decryption_key
-    }
-
-    /// Combined public payload to publish in the validator's on-chain record.
-    ///
-    /// Bundles the existing class-groups encryption-key + proof plus the three
-    /// per-curve PVSS encryption-keys-and-proofs into the
-    /// [`ValidatorEncryptionKeysAndProofs`] struct that's BCS-serialized into the
-    /// Move-side `class_groups_public_key_and_proof` field. See the doc on
-    /// [`ValidatorEncryptionKeysAndProofs`] for the mainnet wire-incompat warning.
-    pub fn validator_encryption_keys_and_proofs(&self) -> ValidatorEncryptionKeysAndProofs {
-        ValidatorEncryptionKeysAndProofs {
-            class_groups: self.class_groups.encryption_key_and_proof(),
-            secp256k1_pvss: self.secp256k1_pvss_encryption_key_and_proof.clone(),
-            secp256r1_pvss: self.secp256r1_pvss_encryption_key_and_proof.clone(),
-            ristretto_pvss: self.ristretto_pvss_encryption_key_and_proof.clone(),
-        }
+    /// Thin helper: re-derive only the validator's VSS HPKE secret key from
+    /// its `RootSeed`, deterministically matching the public key returned by
+    /// [`Self::from_seed`]. Provided for the VSS presign hot path where
+    /// rebuilding the full secrets struct would needlessly regenerate the
+    /// expensive class-groups material; for everything else, hold onto the
+    /// `vss_hpke_secret_key` field on a `ValidatorMPCSecrets` from
+    /// [`Self::from_seed`].
+    pub fn vss_hpke_secret_key_from_seed(root_seed: &RootSeed) -> group::curve25519::Scalar {
+        let (secret, _public, _proof) =
+            generate_and_uc_prove_encryption_keypair(&mut root_seed.vss_hpke_secret_key_rng())
+                .unwrap();
+        secret
     }
 }
 
@@ -272,37 +264,29 @@ mod tests {
     #[test]
     fn class_groups_and_pvss_key_pair_from_seed_is_deterministic() {
         let seed = RootSeed::new([0xA5u8; 32]);
-        let first = ClassGroupsAndPvssKeyPairAndProof::from_seed(&seed);
-        let second = ClassGroupsAndPvssKeyPairAndProof::from_seed(&seed);
-        assert_eq!(
-            bcs::to_bytes(&first).unwrap(),
-            bcs::to_bytes(&second).unwrap()
-        );
+        let (first_secrets, first_publics) = ValidatorMPCSecrets::from_seed(&seed);
+        let (second_secrets, second_publics) = ValidatorMPCSecrets::from_seed(&seed);
+        assert_eq!(first_secrets, second_secrets);
+        assert_eq!(first_publics, second_publics);
     }
 
     #[test]
     fn validator_encryption_keys_and_proofs_round_trips_through_bcs() {
         let seed = RootSeed::new([0xA5u8; 32]);
-        let original = ClassGroupsAndPvssKeyPairAndProof::from_seed(&seed)
-            .validator_encryption_keys_and_proofs();
+        let (_secrets, original) = ValidatorMPCSecrets::from_seed(&seed);
         let bytes = bcs::to_bytes(&original).expect("BCS serialize");
         let decoded: ValidatorEncryptionKeysAndProofs =
             bcs::from_bytes(&bytes).expect("BCS deserialize");
         assert_eq!(original, decoded);
     }
 
-    /// Tests for `ika_types::committee::decode_validator_encryption_keys` —
-    /// colocated here so the test can use `ClassGroupsAndPvssKeyPairAndProof::from_seed`
-    /// without creating a circular `ika-types` ↔ `dwallet-classgroups-types`
-    /// dev-dependency.
     mod decode_validator_encryption_keys {
         use super::*;
         use ika_types::committee::decode_validator_encryption_keys;
 
         fn sample_bundle() -> ValidatorEncryptionKeysAndProofs {
             let seed = RootSeed::new([0xA5u8; 32]);
-            ClassGroupsAndPvssKeyPairAndProof::from_seed(&seed)
-                .validator_encryption_keys_and_proofs()
+            ValidatorMPCSecrets::from_seed(&seed).1
         }
 
         #[test]
@@ -314,6 +298,10 @@ mod tests {
             assert_eq!(decoded.secp256k1_pvss, Some(bundle.secp256k1_pvss));
             assert_eq!(decoded.secp256r1_pvss, Some(bundle.secp256r1_pvss));
             assert_eq!(decoded.ristretto_pvss, Some(bundle.ristretto_pvss));
+            assert_eq!(
+                decoded.vss_hpke_public_key_and_proof,
+                Some(bundle.vss_hpke_public_key_and_proof)
+            );
         }
 
         #[test]
@@ -325,6 +313,7 @@ mod tests {
             assert!(decoded.secp256k1_pvss.is_none());
             assert!(decoded.secp256r1_pvss.is_none());
             assert!(decoded.ristretto_pvss.is_none());
+            assert!(decoded.vss_hpke_public_key_and_proof.is_none());
         }
 
         #[test]

--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -52,6 +52,13 @@ type Secp256r1DKGProtocol = twopc_mpc::secp256r1::class_groups::DKGProtocol;
 type Curve25519DKGProtocol = twopc_mpc::curve25519::class_groups::DKGProtocol;
 type RistrettoDKGProtocol = twopc_mpc::ristretto::class_groups::DKGProtocol;
 
+// Fast Schnorr (VSS) sign protocols. The centralized party reuses the shared
+// sign implementation (same PrivateInput / OutgoingMessage / 5-tuple public
+// input); only the decentralized party differs. Module path is `<curve>::vss`.
+type Secp256k1TaprootVSSProtocol = twopc_mpc::secp256k1::vss::TaprootVSSProtocol;
+type Curve25519EdDSAVSSProtocol = twopc_mpc::curve25519::vss::EdDSAVSSProtocol;
+type RistrettoSchnorrkelVSSProtocol = twopc_mpc::ristretto::vss::SchnorrkelVSSProtocol;
+
 type DKGCentralizedParty =
     <Secp256k1DKGProtocol as twopc_mpc::dkg::Protocol>::DKGCentralizedPartyRound;
 type SignCentralizedPartyV1 =
@@ -525,7 +532,55 @@ pub fn advance_centralized_sign_party_with_centralized_party_dkg_output(
                         &protocol_pp,
                     )
                 }
+                // Fast Schnorr (VSS): centralized party identical to AHE sibling.
+                DWalletSignatureAlgorithm::TaprootVSS => {
+                    advance_sign_with_centralized_party_dkg_output::<
+                        Secp256k1TaprootVSSProtocol,
+                        Secp256k1DKGProtocol,
+                    >(
+                        &centralized_party_secret_key_share,
+                        &presign,
+                        message,
+                        hash_scheme,
+                        hash_context,
+                        &centralized_party_dkg_public_output,
+                        &protocol_pp,
+                    )
+                }
+                DWalletSignatureAlgorithm::EdDSAVSS => {
+                    advance_sign_with_centralized_party_dkg_output::<
+                        Curve25519EdDSAVSSProtocol,
+                        Curve25519DKGProtocol,
+                    >(
+                        &centralized_party_secret_key_share,
+                        &presign,
+                        message,
+                        hash_scheme,
+                        hash_context,
+                        &centralized_party_dkg_public_output,
+                        &protocol_pp,
+                    )
+                }
+                DWalletSignatureAlgorithm::SchnorrkelVSS => {
+                    advance_sign_with_centralized_party_dkg_output::<
+                        RistrettoSchnorrkelVSSProtocol,
+                        RistrettoDKGProtocol,
+                    >(
+                        &centralized_party_secret_key_share,
+                        &presign,
+                        message,
+                        hash_scheme,
+                        hash_context,
+                        &centralized_party_dkg_public_output,
+                        &protocol_pp,
+                    )
+                }
             }
+        }
+        VersionedPresignOutput::V3(_) => {
+            anyhow::bail!(
+                "Fast Schnorr (VSS) presigns (V3) are not consumable from the centralized party"
+            )
         }
     }
 }
@@ -668,7 +723,57 @@ pub fn advance_centralized_sign_party(
                         &protocol_pp,
                     )
                 }
+                // Fast Schnorr (VSS): the centralized party's sign step is identical
+                // to its AHE sibling on the same curve; only the decentralized party
+                // differs. Reuse the same generic helper with the per-curve DKG protocol.
+                DWalletSignatureAlgorithm::TaprootVSS => {
+                    advance_sign_with_decentralized_party_dkg_output::<
+                        Secp256k1TaprootVSSProtocol,
+                        Secp256k1DKGProtocol,
+                    >(
+                        &centralized_party_secret_key_share,
+                        &presign,
+                        message,
+                        hash_scheme,
+                        hash_context,
+                        &decentralized_party_dkg_public_output,
+                        &protocol_pp,
+                    )
+                }
+                DWalletSignatureAlgorithm::EdDSAVSS => {
+                    advance_sign_with_decentralized_party_dkg_output::<
+                        Curve25519EdDSAVSSProtocol,
+                        Curve25519DKGProtocol,
+                    >(
+                        &centralized_party_secret_key_share,
+                        &presign,
+                        message,
+                        hash_scheme,
+                        hash_context,
+                        &decentralized_party_dkg_public_output,
+                        &protocol_pp,
+                    )
+                }
+                DWalletSignatureAlgorithm::SchnorrkelVSS => {
+                    advance_sign_with_decentralized_party_dkg_output::<
+                        RistrettoSchnorrkelVSSProtocol,
+                        RistrettoDKGProtocol,
+                    >(
+                        &centralized_party_secret_key_share,
+                        &presign,
+                        message,
+                        hash_scheme,
+                        hash_context,
+                        &decentralized_party_dkg_public_output,
+                        &protocol_pp,
+                    )
+                }
             }
+        }
+        VersionedPresignOutput::V3(_) => {
+            anyhow::bail!(
+                "Fast Schnorr (VSS) presigns (V3) are not consumable from the centralized party"
+            )
         }
     }
 }
@@ -1439,11 +1544,13 @@ fn decrypt_user_share_inner<P: twopc_mpc::dkg::Protocol>(
         bcs::from_bytes(encrypted_user_share_and_proof)?;
     let dwallet_dkg_output = match bcs::from_bytes(dwallet_dkg_output)? {
         VersionedDwalletDKGPublicOutput::V1(output) => {
+            // return Err(anyhow::anyhow!("2.1"));
             let versioned_output: P::DecentralizedPartyDKGOutput =
                 bcs::from_bytes::<P::DecentralizedPartyTargetedDKGOutput>(&output)?.into();
             versioned_output
         }
         VersionedDwalletDKGPublicOutput::V2 { dkg_output, .. } => {
+            // return Err(anyhow::anyhow!("2.2"));
             bcs::from_bytes::<P::DecentralizedPartyDKGOutput>(&dkg_output)?
         }
     };
@@ -1487,6 +1594,20 @@ pub fn parse_signature_from_sign_output_inner(
         }
         DWalletSignatureAlgorithm::Taproot => {
             let signature: TaprootSignature = bcs::from_bytes(&signature_output)?;
+            Ok(signature.to_bytes().to_vec())
+        }
+        // Fast Schnorr (VSS) variants produce the same standard signature object as
+        // their AHE sibling on the same curve (VSS only changes how it's computed).
+        DWalletSignatureAlgorithm::TaprootVSS => {
+            let signature: TaprootSignature = bcs::from_bytes(&signature_output)?;
+            Ok(signature.to_bytes().to_vec())
+        }
+        DWalletSignatureAlgorithm::EdDSAVSS => {
+            let signature: EdDSASignature = bcs::from_bytes(&signature_output)?;
+            Ok(signature.to_bytes().to_vec())
+        }
+        DWalletSignatureAlgorithm::SchnorrkelVSS => {
+            let signature: SchnorrkelSignature = bcs::from_bytes(&signature_output)?;
             Ok(signature.to_bytes().to_vec())
         }
     }

--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -210,27 +210,48 @@ pub enum DWalletSignatureAlgorithm {
     EdDSA,
     #[strum(to_string = "Schnorrkel")]
     Schnorrkel,
+    /// Fast Schnorr (VSS) variant of Taproot on secp256k1. DKG-created keys only.
+    #[strum(to_string = "TaprootVSS")]
+    TaprootVSS,
+    /// Fast Schnorr (VSS) variant of EdDSA on curve25519. DKG-created keys only.
+    #[strum(to_string = "EdDSAVSS")]
+    EdDSAVSS,
+    /// Fast Schnorr (VSS) variant of Schnorrkel on ristretto. DKG-created keys only.
+    #[strum(to_string = "SchnorrkelVSS")]
+    SchnorrkelVSS,
 }
 
 impl DWalletSignatureAlgorithm {
-    /// Returns the [`HashContext`] that pairs with this algorithm under cryptography-private
-    /// PR 547's domain-separation matrix.
-    ///
-    /// TODO(domain-separation): Schnorrkel currently hard-codes `b"substrate"` as the
-    /// signing-context bytes. Once the per-chain plumbing lands (PR 547 Part 2 / ika-private
-    /// wiring), the context should be sourced from `SignRequestEvent` so each chain can
-    /// supply its own. The byte literal here is byte-identical to what the crypto crate
-    /// previously hard-coded inside the Schnorrkel sign path and matches the already-deployed
-    /// schnorrkel domain separator — do not change without a coordinated upgrade.
+    /// True for the Fast Schnorr (VSS) signature algorithms. These are gated by
+    /// the `fast_schnorr_supported` protocol feature flag, support DKG-created
+    /// keys only (never imported), and do not support the combined
+    /// DKG-and-sign fast path.
+    pub fn is_vss(&self) -> bool {
+        matches!(
+            self,
+            DWalletSignatureAlgorithm::TaprootVSS
+                | DWalletSignatureAlgorithm::EdDSAVSS
+                | DWalletSignatureAlgorithm::SchnorrkelVSS
+        )
+    }
+
+    /// The signature-scheme hash domain-separation context. A property of the
+    /// scheme (sr25519 needs the `b"substrate"` signing context; ECDSA / Taproot
+    /// / EdDSA need none), independent of whether the presign is AHE or VSS — so
+    /// each VSS variant takes the same context as its non-VSS counterpart.
     pub fn hash_context(&self) -> HashContext {
         match self {
-            DWalletSignatureAlgorithm::Schnorrkel => HashContext::Schnorrkel {
-                signing_context: b"substrate".to_vec(),
-            },
+            DWalletSignatureAlgorithm::Schnorrkel | DWalletSignatureAlgorithm::SchnorrkelVSS => {
+                HashContext::Schnorrkel {
+                    signing_context: b"substrate".to_vec(),
+                }
+            }
             DWalletSignatureAlgorithm::ECDSASecp256k1
             | DWalletSignatureAlgorithm::ECDSASecp256r1
             | DWalletSignatureAlgorithm::Taproot
-            | DWalletSignatureAlgorithm::EdDSA => HashContext::None,
+            | DWalletSignatureAlgorithm::EdDSA
+            | DWalletSignatureAlgorithm::TaprootVSS
+            | DWalletSignatureAlgorithm::EdDSAVSS => HashContext::None,
         }
     }
 }
@@ -326,7 +347,18 @@ pub enum DwalletNetworkMPCError {
     MissingProtocolPublicParametersForCurve(DWalletCurve),
 }
 
-pub type ClassGroupsPublicKeyAndProofBytes = Vec<u8>;
+/// Opaque BCS bytes of a validator's published MPC public-key payload.
+///
+/// Shape depends on the propagation path:
+/// - Chain reads (Move `MPCDataV1::mpc_data_bytes`) — bare
+///   `ClassGroupsEncryptionKeyAndProof` (mainnet-v1.1.8).
+/// - Off-chain pipeline (`derive_mpc_data_blob` → consensus + P2P) — the full
+///   5-field `ValidatorEncryptionKeysAndProofs` (class-groups + per-curve PVSS
+///   HPKE + Fast Schnorr VSS HPKE).
+///
+/// Each consumer decodes directly to its expected shape with
+/// `bcs::from_bytes::<T>` — no try-then-fallback.
+pub type MpcDataBytes = Vec<u8>;
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum VersionedEncryptionKeyValue {
@@ -351,6 +383,10 @@ pub enum VersionedDwalletDKGPublicOutput {
 pub enum VersionedPresignOutput {
     V1(MPCPublicOutput),
     V2(MPCPublicOutput),
+    /// Fast Schnorr (VSS) presign. Distinct shape from V2 — the inner bytes
+    /// decode to a curve-specific `schnorr::vss::Presign`, not the AHE
+    /// presign decoded by V2 consumers.
+    V3(MPCPublicOutput),
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -461,17 +497,17 @@ pub enum VersionedMPCData {
 
 #[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
 pub struct MPCDataV1 {
-    pub class_groups_public_key_and_proof: ClassGroupsPublicKeyAndProofBytes,
+    pub mpc_data_bytes: MpcDataBytes,
 }
 
 #[enum_dispatch]
 pub trait MPCDataTrait {
-    fn class_groups_public_key_and_proof(&self) -> ClassGroupsPublicKeyAndProofBytes;
+    fn mpc_data_bytes(&self) -> MpcDataBytes;
 }
 
 impl MPCDataTrait for MPCDataV1 {
-    fn class_groups_public_key_and_proof(&self) -> ClassGroupsPublicKeyAndProofBytes {
-        self.class_groups_public_key_and_proof.clone()
+    fn mpc_data_bytes(&self) -> MpcDataBytes {
+        self.mpc_data_bytes.clone()
     }
 }
 

--- a/crates/dwallet-mpc-types/src/mpc_protocol_configuration.rs
+++ b/crates/dwallet-mpc-types/src/mpc_protocol_configuration.rs
@@ -87,23 +87,27 @@ lazy_static! {
             ),
             (
                 2, // Curve: Curve25519
-                vec![(
-                    0, // Signature Algorithm: EdDSA
-                    vec![
-                        0, // Hash: SHA512
-                    ],
-                )]
-                    .into_iter()
-                    .collect(),
+                vec![
+                    (
+                        0, // Signature Algorithm: EdDSA
+                        vec![
+                            0, // Hash: SHA512
+                        ],
+                    ),
+                ]
+                .into_iter()
+                .collect(),
             ),
             (
                 3, // Curve: Ristretto
-                vec![(
-                    0, // Signature Algorithm: Schnorrkel
-                    vec![
-                        0, // Hash: Merlin
-                    ],
-                )]
+                vec![
+                    (
+                        0, // Signature Algorithm: Schnorrkel
+                        vec![
+                            0, // Hash: Merlin
+                        ],
+                    ),
+                ]
                 .into_iter()
                 .collect(),
             ),
@@ -112,7 +116,16 @@ lazy_static! {
         .collect()
     };
 
-    /// Global presign supported curves to signature algorithms for DKG
+    /// Global presign supported curves to signature algorithms for DKG.
+    ///
+    /// VSS (Fast Schnorr) variants are deliberately absent: a VSS presign is
+    /// bound to the network DKG/reconfiguration output that produced it and
+    /// therefore lives for a single epoch only — it cannot be guaranteed to
+    /// remain usable across reconfiguration, which contradicts the current
+    /// Move presign-object lifetime contract. dWallets will be allowed to use
+    /// Fast Schnorr later, once users talk to the network directly. Until
+    /// then, the network still pre-generates VSS presigns internally for
+    /// NOA sign — see `network_presign_pool_algorithms`.
     pub static ref GLOBAL_PRESIGN_SUPPORTED_CURVE_TO_SIGNATURE_ALGORITHMS_FOR_DKG: HashMap<u32, Vec<u32>> = {
         let mut config = HashMap::new();
         config.insert(0, vec![0, 1]); // Secp256k1: ECDSA, Taproot
@@ -122,7 +135,13 @@ lazy_static! {
         config
     };
 
-    /// Global presign supported curves to signature algorithms for imported keys
+    /// Global presign supported curves to signature algorithms for imported keys.
+    ///
+    /// Same single-epoch reason as the DKG map above: VSS (Fast Schnorr)
+    /// presigns are bound to the network key output that produced them and
+    /// cannot satisfy the current Move presign-object lifetime contract, so
+    /// they are absent here. (Will be revisited once users talk to the
+    /// network directly.)
     pub static ref GLOBAL_PRESIGN_SUPPORTED_CURVE_TO_SIGNATURE_ALGORITHMS_FOR_IMPORTED_KEY: HashMap<u32, Vec<u32>> = {
         let mut config = HashMap::new();
         config.insert(0, vec![1]); // Secp256k1: Taproot (ECDSA not supported for imported keys)
@@ -159,9 +178,7 @@ lazy_static! {
 /// Returns all supported (curve, signature_algorithms) pairs.
 ///
 /// This is the canonical source of truth, derived from
-/// [`SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES`] — an
-/// ordered map (see its docs), so the output order is identical on
-/// every validator.
+/// [`SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES`].
 pub fn supported_curve_to_signature_algorithms()
 -> Vec<(DWalletCurve, Vec<DWalletSignatureAlgorithm>)> {
     SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES
@@ -175,6 +192,55 @@ pub fn supported_curve_to_signature_algorithms()
             Some((curve, algorithms))
         })
         .collect()
+}
+
+/// Algorithms the network pre-generates internal presigns for. Used by the MPC
+/// manager to drive its internal presign pool (which feeds NOA sign).
+///
+/// This is the dedicated source for the internal pool iteration — deliberately
+/// independent of `SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES`,
+/// which is the externally-requestable list serialized into the on-chain
+/// `support_config`. Fast Schnorr (VSS) variants are included here when the
+/// feature is enabled at this protocol version, but are deliberately NOT in
+/// the externally-supported map — the on-chain `validate_curve_and_signature_algorithm`
+/// rejects external `request_sign` / `request_presign` for them, while the
+/// internal pool still fills so NOA VSS sign has presigns to consume.
+pub fn network_presign_pool_algorithms(
+    fast_schnorr_supported: bool,
+) -> Vec<(DWalletCurve, DWalletSignatureAlgorithm)> {
+    let mut algorithms = vec![
+        (
+            DWalletCurve::Secp256k1,
+            DWalletSignatureAlgorithm::ECDSASecp256k1,
+        ),
+        (DWalletCurve::Secp256k1, DWalletSignatureAlgorithm::Taproot),
+        (
+            DWalletCurve::Secp256r1,
+            DWalletSignatureAlgorithm::ECDSASecp256r1,
+        ),
+        (DWalletCurve::Curve25519, DWalletSignatureAlgorithm::EdDSA),
+        (
+            DWalletCurve::Ristretto,
+            DWalletSignatureAlgorithm::Schnorrkel,
+        ),
+    ];
+    if fast_schnorr_supported {
+        algorithms.extend([
+            (
+                DWalletCurve::Secp256k1,
+                DWalletSignatureAlgorithm::TaprootVSS,
+            ),
+            (
+                DWalletCurve::Curve25519,
+                DWalletSignatureAlgorithm::EdDSAVSS,
+            ),
+            (
+                DWalletCurve::Ristretto,
+                DWalletSignatureAlgorithm::SchnorrkelVSS,
+            ),
+        ]);
+    }
+    algorithms
 }
 
 /// Convert curve u32 to DWalletCurve enum
@@ -210,6 +276,7 @@ pub fn try_into_signature_algorithm(
                             // Secp256k1
                             0 => Some(DWalletSignatureAlgorithm::ECDSASecp256k1),
                             1 => Some(DWalletSignatureAlgorithm::Taproot),
+                            2 => Some(DWalletSignatureAlgorithm::TaprootVSS),
                             _ => None,
                         },
                         1 => match signature_algorithm {
@@ -220,11 +287,13 @@ pub fn try_into_signature_algorithm(
                         2 => match signature_algorithm {
                             // Curve25519
                             0 => Some(DWalletSignatureAlgorithm::EdDSA),
+                            1 => Some(DWalletSignatureAlgorithm::EdDSAVSS),
                             _ => None,
                         },
                         3 => match signature_algorithm {
                             // Ristretto
                             0 => Some(DWalletSignatureAlgorithm::Schnorrkel),
+                            1 => Some(DWalletSignatureAlgorithm::SchnorrkelVSS),
                             _ => None,
                         },
                         _ => None,
@@ -270,6 +339,13 @@ pub fn try_into_hash_scheme(
                                         _ => None,
                                     }
                                 }
+                                2 => {
+                                    // TaprootVSS (Fast Schnorr)
+                                    match hash_scheme {
+                                        0 => Some(HashScheme::SHA256),
+                                        _ => None,
+                                    }
+                                }
                                 _ => None,
                             },
                             1 => match signature_algorithm {
@@ -292,12 +368,26 @@ pub fn try_into_hash_scheme(
                                         _ => None,
                                     }
                                 }
+                                1 => {
+                                    // EdDSAVSS (Fast Schnorr)
+                                    match hash_scheme {
+                                        0 => Some(HashScheme::SHA512),
+                                        _ => None,
+                                    }
+                                }
                                 _ => None,
                             },
                             3 => match signature_algorithm {
                                 // Ristretto
                                 0 => {
                                     // Schnorrkel},
+                                    match hash_scheme {
+                                        0 => Some(HashScheme::Merlin),
+                                        _ => None,
+                                    }
+                                }
+                                1 => {
+                                    // SchnorrkelVSS (Fast Schnorr)
                                     match hash_scheme {
                                         0 => Some(HashScheme::Merlin),
                                         _ => None,
@@ -349,13 +439,21 @@ mod tests {
             "Secp256k1 Taproot should support SHA256"
         );
 
+        // TaprootVSS (Fast Schnorr) is intentionally NOT in the externally-supported
+        // map — it is internal-only (NOA sign). See `network_presign_pool_algorithms`
+        // for the internal iteration source.
+        assert!(
+            secp256k1_entry.get(&2).is_none(),
+            "TaprootVSS must NOT be in the externally-supported map",
+        );
+
         // Validate Secp256k1 curve / no invalid signature algorithm
         let mut all_signature_algorithm_keys: Vec<_> = secp256k1_entry.keys().copied().collect();
         all_signature_algorithm_keys.sort();
         assert_eq!(
             all_signature_algorithm_keys,
             vec![0, 1],
-            "Secp256k1 have only ECDSA and Taproot signature algorithms"
+            "Secp256k1 have only ECDSA and Taproot signature algorithms externally"
         );
 
         // Validate Secp256r1 curve
@@ -399,13 +497,21 @@ mod tests {
             "Curve25519 EdDSA should support SHA512"
         );
 
+        // EdDSAVSS (Fast Schnorr) is intentionally NOT in the externally-supported
+        // map — it is internal-only (NOA sign).
+        assert!(
+            curve25519_entry.get(&1).is_none(),
+            "EdDSAVSS must NOT be in the externally-supported map",
+        );
+
         // Validate Curve25519 curve / no invalid signature algorithm
-        let all_curve25519_signature_algorithm_keys: Vec<_> =
+        let mut all_curve25519_signature_algorithm_keys: Vec<_> =
             curve25519_entry.keys().copied().collect();
+        all_curve25519_signature_algorithm_keys.sort();
         assert_eq!(
             all_curve25519_signature_algorithm_keys,
             vec![0],
-            "Curve25519 have only EdDSA signature algorithm"
+            "Curve25519 has only EdDSA signature algorithm externally"
         );
 
         // Validate Ristretto curve
@@ -424,13 +530,79 @@ mod tests {
             "Ristretto Schnorrkel should support Merlin"
         );
 
+        // SchnorrkelVSS (Fast Schnorr) is intentionally NOT in the
+        // externally-supported map — it is internal-only (NOA sign).
+        assert!(
+            ristretto_entry.get(&1).is_none(),
+            "SchnorrkelVSS must NOT be in the externally-supported map",
+        );
+
         // Validate Ristretto curve / no invalid signature algorithm
-        let all_ristretto_signature_algorithm_keys: Vec<_> =
+        let mut all_ristretto_signature_algorithm_keys: Vec<_> =
             ristretto_entry.keys().copied().collect();
+        all_ristretto_signature_algorithm_keys.sort();
         assert_eq!(
             all_ristretto_signature_algorithm_keys,
             vec![0],
-            "Ristretto have only Schnorrkel signature algorithm"
+            "Ristretto has only Schnorrkel signature algorithm externally"
+        );
+    }
+
+    #[test]
+    fn validate_vss_is_externally_inaccessible() {
+        // VSS (Fast Schnorr) variants are internal-only (NOA sign) and must not
+        // be externally decodable from on-chain (curve, signature_algorithm)
+        // indices: `try_into_signature_algorithm` is gated by the externally-
+        // supported map, which deliberately omits VSS. The internal NOA path
+        // passes the `DWalletSignatureAlgorithm` enum directly and does not
+        // depend on this decoder.
+        assert!(
+            super::try_into_signature_algorithm(0, 2).is_err(),
+            "TaprootVSS (Secp256k1, 2) must NOT decode externally",
+        );
+        assert!(
+            super::try_into_signature_algorithm(2, 1).is_err(),
+            "EdDSAVSS (Curve25519, 1) must NOT decode externally",
+        );
+        assert!(
+            super::try_into_signature_algorithm(3, 1).is_err(),
+            "SchnorrkelVSS (Ristretto, 1) must NOT decode externally",
+        );
+
+        // Same for hash-scheme decoding.
+        assert!(super::try_into_hash_scheme(0, 2, 0).is_err());
+        assert!(super::try_into_hash_scheme(2, 1, 0).is_err());
+        assert!(super::try_into_hash_scheme(3, 1, 0).is_err());
+
+        // VSS variants are intentionally NOT in the externally-requestable
+        // global-presign DKG map — they are internal-only (NOA sign). See
+        // `network_presign_pool_algorithms` for the internal iteration source.
+        assert!(
+            !super::GLOBAL_PRESIGN_SUPPORTED_CURVE_TO_SIGNATURE_ALGORITHMS_FOR_DKG[&0].contains(&2)
+        );
+        assert!(
+            !super::GLOBAL_PRESIGN_SUPPORTED_CURVE_TO_SIGNATURE_ALGORITHMS_FOR_DKG[&2].contains(&1)
+        );
+        assert!(
+            !super::GLOBAL_PRESIGN_SUPPORTED_CURVE_TO_SIGNATURE_ALGORITHMS_FOR_DKG[&3].contains(&1)
+        );
+
+        // ... and NOT supported for imported keys (Shamir-share constraint).
+        assert!(
+            !super::GLOBAL_PRESIGN_SUPPORTED_CURVE_TO_SIGNATURE_ALGORITHMS_FOR_IMPORTED_KEY[&0]
+                .contains(&2)
+        );
+        assert!(
+            !super::GLOBAL_PRESIGN_SUPPORTED_CURVE_TO_SIGNATURE_ALGORITHMS_FOR_IMPORTED_KEY
+                .get(&2)
+                .map(|v| v.contains(&1))
+                .unwrap_or(false)
+        );
+        assert!(
+            !super::GLOBAL_PRESIGN_SUPPORTED_CURVE_TO_SIGNATURE_ALGORITHMS_FOR_IMPORTED_KEY
+                .get(&3)
+                .map(|v| v.contains(&1))
+                .unwrap_or(false)
         );
     }
 }

--- a/crates/dwallet-rng/src/lib.rs
+++ b/crates/dwallet-rng/src/lib.rs
@@ -151,6 +151,28 @@ impl RootSeed {
         ChaCha20Rng::from_seed(self.pvss_ristretto_decryption_key_seed())
     }
 
+    fn vss_hpke_secret_key_seed(&self) -> [u8; Self::SEED_LENGTH] {
+        let mut transcript = Transcript::new(b"VSS HPKE Secret Key Seed (curve25519)");
+        transcript.append_message(b"root seed", &self.0);
+        let mut seed = [0u8; Self::SEED_LENGTH];
+        transcript.challenge_bytes(b"seed", &mut seed);
+        seed
+    }
+
+    /// Instantiates a deterministic secure pseudo-random generator (ChaCha20)
+    /// from which this validator's VSS HPKE *secret* key is sampled (the matching
+    /// public encryption key and UC-secure proof are then derived from it). It is
+    /// a single curve25519 keypair used as the threshold-encryption-to-sharing
+    /// transport for all VSS curves: the HPKE layer is curve25519 regardless of
+    /// the signing curve, so one keypair suffices.
+    ///
+    /// Domain-separated from `class_groups_decryption_key_rng` and the three
+    /// per-curve class-groups PVSS RNGs so the secret never coincides with any
+    /// of them.
+    pub fn vss_hpke_secret_key_rng(&self) -> ChaCha20Rng {
+        ChaCha20Rng::from_seed(self.vss_hpke_secret_key_seed())
+    }
+
     /// Instantiates a deterministic secure pseudo-random generator (using the ChaCha20 algorithm)
     /// with which to advance an MPC round.
     pub fn mpc_round_rng(

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -55,6 +55,7 @@ use crate::system_checkpoints::{
     PendingSystemCheckpointV1, SystemCheckpointHeight, SystemCheckpointService,
     SystemCheckpointServiceNotify,
 };
+use commitment::CommitmentSizedNumber;
 use dwallet_mpc_types::dwallet_mpc::DWalletSignatureAlgorithm;
 use group::PartyID;
 use ika_network::mpc_artifacts::mpc_data_blob_hash;
@@ -334,6 +335,26 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
         presign_session_id: SessionIdentifier,
         presign_blending_index: u16,
     ) -> IkaResult<bool>;
+
+    /// Persists a single Fast Schnorr (VSS) presign's private output
+    /// (`bcs(PrivatePresignOutput)`) keyed by `(presign session id, blending index)`,
+    /// so the later sign can recover the nonce shares for that exact blended presign.
+    /// Self-prunes at epoch rotation. VSS sessions only.
+    fn store_presign_private_output(
+        &self,
+        presign_session_id: CommitmentSizedNumber,
+        presign_blending_index: u16,
+        private_output: Vec<u8>,
+    ) -> IkaResult<()>;
+
+    /// Loads a persisted VSS presign private output by `(session id, blending index)`,
+    /// if present. Absent on a non-VSS presign, after epoch rotation, or on disk loss
+    /// — the sign treats `None` as a soft-fail (this validator drops out of the quorum).
+    fn get_presign_private_output(
+        &self,
+        presign_session_id: CommitmentSizedNumber,
+        presign_blending_index: u16,
+    ) -> IkaResult<Option<Vec<u8>>>;
 
     /// Assigns a presign to a user by moving it from the internal pool to the assigned pool.
     /// This is used for external presign requests.
@@ -640,6 +661,29 @@ impl AuthorityPerEpochStoreTrait for AuthorityPerEpochStore {
     ) -> IkaResult<bool> {
         let tables = self.tables()?;
         tables.is_presign_used(presign_session_id, presign_blending_index)
+    }
+
+    fn store_presign_private_output(
+        &self,
+        presign_session_id: CommitmentSizedNumber,
+        presign_blending_index: u16,
+        private_output: Vec<u8>,
+    ) -> IkaResult<()> {
+        let tables = self.tables()?;
+        tables.store_presign_private_output(
+            presign_session_id,
+            presign_blending_index,
+            private_output,
+        )
+    }
+
+    fn get_presign_private_output(
+        &self,
+        presign_session_id: CommitmentSizedNumber,
+        presign_blending_index: u16,
+    ) -> IkaResult<Option<Vec<u8>>> {
+        let tables = self.tables()?;
+        tables.get_presign_private_output(presign_session_id, presign_blending_index)
     }
 
     fn assign_presign(
@@ -1062,6 +1106,22 @@ pub struct AuthorityEpochTables {
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
     internal_presign_pool_schnorrkel_substrate:
         DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
+    /// Fast Schnorr (VSS) internal presign pools. Same structure as the AHE pools
+    /// above: keyed by `(network_encryption_key_id: ObjectID, session_sequence_number:
+    /// u64)`, value `(SessionIdentifier, Vec<(blending_index, presign_bytes)>)` — the
+    /// session that produced the presigns plus its blending-index-tagged serialized
+    /// presigns, consumed lowest-sequence-number-first within a given key ID. Kept
+    /// separate from their AHE siblings because VSS presign bytes are a different
+    /// format (a VSS sign must never pop an AHE presign, or vice versa).
+    #[default_options_override_fn = "internal_presign_pool_table_default_config"]
+    internal_presign_pool_taproot_vss:
+        DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
+    #[default_options_override_fn = "internal_presign_pool_table_default_config"]
+    internal_presign_pool_eddsa_vss:
+        DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
+    #[default_options_override_fn = "internal_presign_pool_table_default_config"]
+    internal_presign_pool_schnorrkel_substrate_vss:
+        DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
 
     /// Tracks the total count of presigns in each pool by (signature algorithm, network encryption key ID).
     /// Value is the count.
@@ -1104,6 +1164,28 @@ pub struct AuthorityEpochTables {
     assigned_presigns_taproot: DBMap<(SessionIdentifier, u16), AssignedPresign>,
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
     assigned_presigns_schnorrkel_substrate: DBMap<(SessionIdentifier, u16), AssignedPresign>,
+    // Fast Schnorr (VSS) assigned-presign pools (separate from AHE siblings).
+    #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
+    assigned_presigns_taproot_vss: DBMap<(SessionIdentifier, u16), AssignedPresign>,
+    #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
+    assigned_presigns_eddsa_vss: DBMap<(SessionIdentifier, u16), AssignedPresign>,
+    #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
+    assigned_presigns_schnorrkel_substrate_vss: DBMap<(SessionIdentifier, u16), AssignedPresign>,
+
+    /// Per-validator secret nonce shares from Fast Schnorr (VSS) presign sessions,
+    /// persisted between presign-finalize and sign so the sign party can rebuild its
+    /// `PrivateInput`. AHE Schnorr has no such secret presign output (its nonce lives
+    /// encrypted inside the on-chain presign), so only VSS sessions write here.
+    ///
+    /// Key: `(presign session_id, blending_index)` — uniquely identifies a single
+    ///      blended presign, matching the pool/`used_presigns` keying. Carried from
+    ///      the presign pop, so the sign no longer re-parses it from the public presign.
+    /// Value: `bcs(PrivatePresignOutput)` — the single output for that blending index.
+    ///
+    /// Self-prunes on epoch rotation (per-epoch physical DB drop). A missing row at
+    /// sign time is a soft-fail that excludes this validator's contribution, not a
+    /// hard error — the 2f+1 quorum absorbs it.
+    presign_private_outputs: DBMap<(CommitmentSizedNumber, u16), Vec<u8>>,
 
     /// Latest `ValidatorMpcDataAnnouncement` observed for each
     /// current-committee validator this epoch, signed with their
@@ -1292,6 +1374,11 @@ impl AuthorityEpochTables {
             DWalletSignatureAlgorithm::Schnorrkel => {
                 &self.internal_presign_pool_schnorrkel_substrate
             }
+            DWalletSignatureAlgorithm::TaprootVSS => &self.internal_presign_pool_taproot_vss,
+            DWalletSignatureAlgorithm::EdDSAVSS => &self.internal_presign_pool_eddsa_vss,
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
+                &self.internal_presign_pool_schnorrkel_substrate_vss
+            }
         }
     }
 
@@ -1472,6 +1559,29 @@ impl AuthorityEpochTables {
             .contains_key(&(presign_session_id, presign_blending_index))?)
     }
 
+    pub fn store_presign_private_output(
+        &self,
+        presign_session_id: CommitmentSizedNumber,
+        presign_blending_index: u16,
+        private_output: Vec<u8>,
+    ) -> IkaResult<()> {
+        self.presign_private_outputs.insert(
+            &(presign_session_id, presign_blending_index),
+            &private_output,
+        )?;
+        Ok(())
+    }
+
+    pub fn get_presign_private_output(
+        &self,
+        presign_session_id: CommitmentSizedNumber,
+        presign_blending_index: u16,
+    ) -> IkaResult<Option<Vec<u8>>> {
+        Ok(self
+            .presign_private_outputs
+            .get(&(presign_session_id, presign_blending_index))?)
+    }
+
     /// Returns a reference to the assigned presign pool table for the given signature algorithm.
     fn assigned_presign_pool_table(
         &self,
@@ -1483,6 +1593,11 @@ impl AuthorityEpochTables {
             DWalletSignatureAlgorithm::EdDSA => &self.assigned_presigns_eddsa,
             DWalletSignatureAlgorithm::Taproot => &self.assigned_presigns_taproot,
             DWalletSignatureAlgorithm::Schnorrkel => &self.assigned_presigns_schnorrkel_substrate,
+            DWalletSignatureAlgorithm::TaprootVSS => &self.assigned_presigns_taproot_vss,
+            DWalletSignatureAlgorithm::EdDSAVSS => &self.assigned_presigns_eddsa_vss,
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
+                &self.assigned_presigns_schnorrkel_substrate_vss
+            }
         }
     }
 
@@ -1768,6 +1883,12 @@ impl AuthorityPerEpochStore {
             self.committee.secp256k1_pvss_public_keys_and_proofs.clone(),
             self.committee.secp256r1_pvss_public_keys_and_proofs.clone(),
             self.committee.ristretto_pvss_public_keys_and_proofs.clone(),
+            // Test-only helper: the prior committee retains only the verified
+            // public-key values, not the raw VSS HPKE proofs, so the next-epoch
+            // committee starts with an empty raw input. Tests that need a
+            // populated VSS-verified map should call
+            // `Committee::set_vss_hpke_verified_for_testing` on the result.
+            std::collections::HashMap::new(),
             self.committee.quorum_threshold,
             self.committee.validity_threshold,
         );
@@ -2507,7 +2628,7 @@ impl AuthorityPerEpochStore {
             // reconfig. Without this, off_chain mode's overlay
             // returns `None` for any key whose output was produced in
             // a prior epoch, which propagates as `BcsError(Eof)` in
-            // `instantiate_dwallet_mpc_network_encryption_key_public_data_from_public_output`.
+            // `spawn_network_encryption_key_public_data_instantiation`.
             let perpetual_insert = match kind {
                 ProtocolOutputKind::Dkg => perpetual
                     .insert_network_dkg_output_digest(dwallet_network_encryption_key_id, digest),

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations.rs
@@ -20,8 +20,11 @@ use crate::dwallet_mpc::protocol_cryptographic_data::ProtocolCryptographicData;
 use crate::dwallet_mpc::reconfiguration::advance_network_reconfiguration_bwd_compat;
 use crate::dwallet_mpc::sign::{
     DKGAndSignPublicInputByProtocol, DWalletDKGAndSignAdvanceRequestByProtocol,
-    SignAdvanceRequestByProtocol, SignPublicInputByProtocol, compute_dwallet_dkg_and_sign,
-    compute_sign, update_expected_decrypters_metrics,
+    SignAdvanceRequestByProtocol, SignPublicInputByProtocol,
+    build_curve25519_eddsa_vss_sign_private_input,
+    build_ristretto_schnorrkel_vss_sign_private_input,
+    build_secp256k1_taproot_vss_sign_private_input, compute_dwallet_dkg_and_sign, compute_sign,
+    update_expected_decrypters_metrics,
 };
 use crate::dwallet_session_request::DWalletSessionRequestMetricData;
 use crate::request_protocol_data::{
@@ -37,8 +40,9 @@ use group::PartyID;
 use ika_protocol_config::ProtocolConfig;
 use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use ika_types::messages_dwallet_mpc::{
-    Curve25519AsyncDKGProtocol, Curve25519EdDSAProtocol, RistrettoAsyncDKGProtocol,
-    RistrettoSchnorrkelProtocol, Secp256k1AsyncDKGProtocol, Secp256k1TaprootProtocol,
+    Curve25519AsyncDKGProtocol, Curve25519EdDSAProtocol, Curve25519EdDSAVSSProtocol,
+    RistrettoAsyncDKGProtocol, RistrettoSchnorrkelProtocol, RistrettoSchnorrkelVSSProtocol,
+    Secp256k1AsyncDKGProtocol, Secp256k1TaprootProtocol, Secp256k1TaprootVSSProtocol,
     Secp256r1AsyncDKGProtocol, Secp256r1ECDSAProtocol,
 };
 use ika_types::messages_dwallet_mpc::{Secp256k1ECDSAProtocol, SessionIdentifier};
@@ -73,7 +77,11 @@ impl ProtocolCryptographicData {
         schnorr_presign_second_round_delay: u64,
         class_groups_decryption_key: ClassGroupsDecryptionKey,
         decryption_key_shares: &DwalletMPCNetworkKeys,
-        _protocol_config: &ProtocolConfig,
+        // Persisted VSS presign `PrivateOutput` (`bcs(Vec<PrivatePresignOutput>)`)
+        // for this sign's presign session, read by the manager (which has the
+        // epoch store). Only populated for Fast Schnorr (VSS) sign requests.
+        presign_private_output: Option<Vec<u8>>,
+        protocol_config: &ProtocolConfig,
     ) -> Result<Option<Self>, DwalletMPCError> {
         let res = match protocol_specific_data {
             ProtocolData::ImportedKeyVerification { data, .. } => {
@@ -134,6 +142,7 @@ impl ProtocolCryptographicData {
                     access_structure,
                     consensus_round,
                     schnorr_presign_second_round_delay,
+                    protocol_config.schnorr_presign_third_round_delay(),
                     serialized_messages_by_consensus_round,
                 )?;
 
@@ -158,6 +167,7 @@ impl ProtocolCryptographicData {
                     access_structure,
                     consensus_round,
                     schnorr_presign_second_round_delay,
+                    protocol_config.schnorr_presign_third_round_delay(),
                     serialized_messages_by_consensus_round,
                 )?;
 
@@ -192,14 +202,32 @@ impl ProtocolCryptographicData {
                     return Ok(None);
                 };
 
-                let decryption_key_shares = decryption_key_shares
-                    .decryption_key_shares(dwallet_network_encryption_key_id)?;
+                if data.signature_algorithm.is_vss() {
+                    // Fast Schnorr (VSS): carry the secret-key-share source (the
+                    // reconfiguration output if the key reconfigured, else the network
+                    // DKG output) for secret-key-share recovery at compute time, plus
+                    // the persisted presign nonce data, instead of the AHE decryption
+                    // key shares.
+                    let vss_shamir_cache = decryption_key_shares
+                        .vss_shamir_cache(dwallet_network_encryption_key_id)?
+                        .clone();
+                    ProtocolCryptographicData::SignVSS {
+                        data: data.clone(),
+                        public_input: public_input.clone(),
+                        advance_request,
+                        vss_shamir_cache,
+                        presign_private_output,
+                    }
+                } else {
+                    let decryption_key_shares = decryption_key_shares
+                        .decryption_key_shares(dwallet_network_encryption_key_id)?;
 
-                ProtocolCryptographicData::Sign {
-                    data: data.clone(),
-                    public_input: public_input.clone(),
-                    advance_request,
-                    decryption_key_shares: decryption_key_shares.clone(),
+                    ProtocolCryptographicData::Sign {
+                        data: data.clone(),
+                        public_input: public_input.clone(),
+                        advance_request,
+                        decryption_key_shares: decryption_key_shares.clone(),
+                    }
                 }
             }
             ProtocolData::NetworkOwnedAddressSign {
@@ -223,14 +251,33 @@ impl ProtocolCryptographicData {
                     return Ok(None);
                 };
 
-                let decryption_key_shares = decryption_key_shares
-                    .decryption_key_shares(dwallet_network_encryption_key_id)?;
+                if data.signature_algorithm.is_vss() {
+                    // Fast Schnorr (VSS) NOA sign reuses the external-sign compute path
+                    // (`SignVSS`): VSS has no AHE decryption-key shares / decrypters, so
+                    // the NOA-vs-external compute distinction collapses. Output is still
+                    // routed to the NOA channel by the request's session type. The
+                    // presign (popped from the internal VSS pool) carries the private
+                    // nonce output, read by the manager as for external VSS sign.
+                    let vss_shamir_cache = decryption_key_shares
+                        .vss_shamir_cache(dwallet_network_encryption_key_id)?
+                        .clone();
+                    ProtocolCryptographicData::NetworkOwnedAddressSignVSS {
+                        data: data.clone(),
+                        public_input: public_input.clone(),
+                        advance_request,
+                        vss_shamir_cache,
+                        presign_private_output,
+                    }
+                } else {
+                    let decryption_key_shares = decryption_key_shares
+                        .decryption_key_shares(dwallet_network_encryption_key_id)?;
 
-                ProtocolCryptographicData::NetworkOwnedAddressSign {
-                    data: data.clone(),
-                    public_input: public_input.clone(),
-                    advance_request,
-                    decryption_key_shares: decryption_key_shares.clone(),
+                    ProtocolCryptographicData::NetworkOwnedAddressSign {
+                        data: data.clone(),
+                        public_input: public_input.clone(),
+                        advance_request,
+                        decryption_key_shares: decryption_key_shares.clone(),
+                    }
                 }
             }
             ProtocolData::DWalletDKGAndSign {
@@ -254,14 +301,32 @@ impl ProtocolCryptographicData {
                     return Ok(None);
                 };
 
-                let decryption_key_shares = decryption_key_shares
-                    .decryption_key_shares(dwallet_network_encryption_key_id)?;
+                if data.signature_algorithm.is_vss() {
+                    // Fast Schnorr (VSS) combined DKG-and-sign: as for `SignVSS`, carry the
+                    // secret-key-share source (reconfiguration output if the key
+                    // reconfigured, else the network DKG output) for secret-key-share
+                    // recovery at compute time, plus the persisted presign nonce data,
+                    // instead of the AHE decryption key shares.
+                    let vss_shamir_cache = decryption_key_shares
+                        .vss_shamir_cache(dwallet_network_encryption_key_id)?
+                        .clone();
+                    ProtocolCryptographicData::DWalletDKGAndSignVSS {
+                        data: data.clone(),
+                        public_input: public_input.clone(),
+                        advance_request,
+                        vss_shamir_cache,
+                        presign_private_output,
+                    }
+                } else {
+                    let decryption_key_shares = decryption_key_shares
+                        .decryption_key_shares(dwallet_network_encryption_key_id)?;
 
-                ProtocolCryptographicData::DWalletDKGAndSign {
-                    data: data.clone(),
-                    public_input: public_input.clone(),
-                    advance_request,
-                    decryption_key_shares: decryption_key_shares.clone(),
+                    ProtocolCryptographicData::DWalletDKGAndSign {
+                        data: data.clone(),
+                        public_input: public_input.clone(),
+                        advance_request,
+                        decryption_key_shares: decryption_key_shares.clone(),
+                    }
                 }
             }
             ProtocolData::NetworkEncryptionKeyDkg {
@@ -401,6 +466,7 @@ impl ProtocolCryptographicData {
         consensus_round: u64,
         session_identifier: SessionIdentifier,
         root_seed: RootSeed,
+        vss_hpke_secret_key: group::curve25519::Scalar,
         dwallet_mpc_metrics: Arc<DWalletMPCMetrics>,
     ) -> DwalletMPCResult<GuaranteedOutputDeliveryRoundResult> {
         let protocol_metadata: DWalletSessionRequestMetricData = (&self).into();
@@ -568,6 +634,7 @@ impl ProtocolCryptographicData {
                 session_id,
                 advance_request,
                 public_input,
+                None,
                 false,
                 &mut rng,
             )?),
@@ -581,6 +648,7 @@ impl ProtocolCryptographicData {
                 session_id,
                 advance_request,
                 public_input,
+                None,
                 false,
                 &mut rng,
             )?),
@@ -594,6 +662,7 @@ impl ProtocolCryptographicData {
                 session_id,
                 advance_request,
                 public_input,
+                None,
                 false,
                 &mut rng,
             )?),
@@ -607,6 +676,7 @@ impl ProtocolCryptographicData {
                 session_id,
                 advance_request,
                 public_input,
+                None,
                 false,
                 &mut rng,
             )?),
@@ -620,6 +690,7 @@ impl ProtocolCryptographicData {
                 session_id,
                 advance_request,
                 public_input,
+                None,
                 false,
                 &mut rng,
             )?),
@@ -633,6 +704,7 @@ impl ProtocolCryptographicData {
                 session_id,
                 advance_request,
                 public_input,
+                None,
                 true,
                 &mut rng,
             )?),
@@ -646,6 +718,7 @@ impl ProtocolCryptographicData {
                 session_id,
                 advance_request,
                 public_input,
+                None,
                 true,
                 &mut rng,
             )?),
@@ -659,6 +732,7 @@ impl ProtocolCryptographicData {
                 session_id,
                 advance_request,
                 public_input,
+                None,
                 true,
                 &mut rng,
             )?),
@@ -672,6 +746,7 @@ impl ProtocolCryptographicData {
                 session_id,
                 advance_request,
                 public_input,
+                None,
                 true,
                 &mut rng,
             )?),
@@ -685,6 +760,95 @@ impl ProtocolCryptographicData {
                 session_id,
                 advance_request,
                 public_input,
+                None,
+                true,
+                &mut rng,
+            )?),
+            // Fast Schnorr (VSS) presign: the `PrivateInput` is the validator's
+            // curve25519 HPKE secret (one keypair serves all VSS curves), derived
+            // locally from `root_seed`. It is deliberately non-serializable, so it
+            // is constructed here rather than threaded through the serialized seam.
+            ProtocolCryptographicData::Presign {
+                public_input: PresignPublicInputByProtocol::TaprootVSS(public_input),
+                advance_request: PresignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => Ok(compute_presign::<Secp256k1TaprootVSSProtocol>(
+                party_id,
+                access_structure,
+                session_id,
+                advance_request,
+                public_input,
+                Some(vss_presign_private_input(vss_hpke_secret_key)),
+                false,
+                &mut rng,
+            )?),
+            ProtocolCryptographicData::Presign {
+                public_input: PresignPublicInputByProtocol::EdDSAVSS(public_input),
+                advance_request: PresignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => Ok(compute_presign::<Curve25519EdDSAVSSProtocol>(
+                party_id,
+                access_structure,
+                session_id,
+                advance_request,
+                public_input,
+                Some(vss_presign_private_input(vss_hpke_secret_key)),
+                false,
+                &mut rng,
+            )?),
+            ProtocolCryptographicData::Presign {
+                public_input: PresignPublicInputByProtocol::SchnorrkelVSS(public_input),
+                advance_request: PresignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                ..
+            } => Ok(compute_presign::<RistrettoSchnorrkelVSSProtocol>(
+                party_id,
+                access_structure,
+                session_id,
+                advance_request,
+                public_input,
+                Some(vss_presign_private_input(vss_hpke_secret_key)),
+                false,
+                &mut rng,
+            )?),
+            ProtocolCryptographicData::InternalPresign {
+                public_input: PresignPublicInputByProtocol::TaprootVSS(public_input),
+                advance_request: PresignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => Ok(compute_presign::<Secp256k1TaprootVSSProtocol>(
+                party_id,
+                access_structure,
+                session_id,
+                advance_request,
+                public_input,
+                Some(vss_presign_private_input(vss_hpke_secret_key)),
+                true,
+                &mut rng,
+            )?),
+            ProtocolCryptographicData::InternalPresign {
+                public_input: PresignPublicInputByProtocol::EdDSAVSS(public_input),
+                advance_request: PresignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => Ok(compute_presign::<Curve25519EdDSAVSSProtocol>(
+                party_id,
+                access_structure,
+                session_id,
+                advance_request,
+                public_input,
+                Some(vss_presign_private_input(vss_hpke_secret_key)),
+                true,
+                &mut rng,
+            )?),
+            ProtocolCryptographicData::InternalPresign {
+                public_input: PresignPublicInputByProtocol::SchnorrkelVSS(public_input),
+                advance_request: PresignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                ..
+            } => Ok(compute_presign::<RistrettoSchnorrkelVSSProtocol>(
+                party_id,
+                access_structure,
+                session_id,
+                advance_request,
+                public_input,
+                Some(vss_presign_private_input(vss_hpke_secret_key)),
                 true,
                 &mut rng,
             )?),
@@ -829,6 +993,179 @@ impl ProtocolCryptographicData {
                 )
             }
             ProtocolCryptographicData::Sign {
+                public_input,
+                advance_request,
+                ..
+            } => Err(DwalletMPCError::MPCParametersMissmatchInputToRequest(
+                public_input.to_string(),
+                advance_request.to_string(),
+            )),
+            // Fast Schnorr (VSS) sign: assemble the 8-field VSS PrivateInput here
+            // (root_seed is available) — secret-key Shamir shares recovered from the
+            // reconfiguration output + the persisted presign nonce data — then run
+            // the generic sign. VSS has no expected_decrypters metrics.
+            ProtocolCryptographicData::SignVSS {
+                public_input: SignPublicInputByProtocol::TaprootVSS(public_input),
+                advance_request: SignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                vss_shamir_cache,
+                presign_private_output,
+                data,
+                ..
+            } => {
+                let private_input = build_secp256k1_taproot_vss_sign_private_input(
+                    &vss_shamir_cache,
+                    presign_private_output,
+                    public_input.presign.session_id,
+                    public_input.presign.presign_blending_index,
+                )?;
+                compute_sign::<Secp256k1TaprootVSSProtocol>(
+                    party_id,
+                    access_structure,
+                    session_id,
+                    advance_request,
+                    public_input,
+                    Some(private_input),
+                    &data,
+                    &mut rng,
+                )
+            }
+            ProtocolCryptographicData::SignVSS {
+                public_input: SignPublicInputByProtocol::EdDSAVSS(public_input),
+                advance_request: SignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                vss_shamir_cache,
+                presign_private_output,
+                data,
+                ..
+            } => {
+                let private_input = build_curve25519_eddsa_vss_sign_private_input(
+                    &vss_shamir_cache,
+                    presign_private_output,
+                    public_input.presign.session_id,
+                    public_input.presign.presign_blending_index,
+                )?;
+                compute_sign::<Curve25519EdDSAVSSProtocol>(
+                    party_id,
+                    access_structure,
+                    session_id,
+                    advance_request,
+                    public_input,
+                    Some(private_input),
+                    &data,
+                    &mut rng,
+                )
+            }
+            ProtocolCryptographicData::SignVSS {
+                public_input: SignPublicInputByProtocol::SchnorrkelVSS(public_input),
+                advance_request: SignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                vss_shamir_cache,
+                presign_private_output,
+                data,
+                ..
+            } => {
+                let private_input = build_ristretto_schnorrkel_vss_sign_private_input(
+                    &vss_shamir_cache,
+                    presign_private_output,
+                    public_input.presign.session_id,
+                    public_input.presign.presign_blending_index,
+                )?;
+                compute_sign::<RistrettoSchnorrkelVSSProtocol>(
+                    party_id,
+                    access_structure,
+                    session_id,
+                    advance_request,
+                    public_input,
+                    Some(private_input),
+                    &data,
+                    &mut rng,
+                )
+            }
+            ProtocolCryptographicData::SignVSS {
+                public_input,
+                advance_request,
+                ..
+            } => Err(DwalletMPCError::MPCParametersMissmatchInputToRequest(
+                public_input.to_string(),
+                advance_request.to_string(),
+            )),
+            // NOA Fast Schnorr (VSS) sign: identical compute to `SignVSS`, but `data`
+            // is the native `NetworkOwnedAddressSignData`, coerced to `SignData` only
+            // here (mirroring the AHE `NetworkOwnedAddressSign` compute arms).
+            ProtocolCryptographicData::NetworkOwnedAddressSignVSS {
+                public_input: SignPublicInputByProtocol::TaprootVSS(public_input),
+                advance_request: SignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                vss_shamir_cache,
+                presign_private_output,
+                data,
+                ..
+            } => {
+                let private_input = build_secp256k1_taproot_vss_sign_private_input(
+                    &vss_shamir_cache,
+                    presign_private_output,
+                    public_input.presign.session_id,
+                    public_input.presign.presign_blending_index,
+                )?;
+                compute_sign::<Secp256k1TaprootVSSProtocol>(
+                    party_id,
+                    access_structure,
+                    session_id,
+                    advance_request,
+                    public_input,
+                    Some(private_input),
+                    &SignData::from(&data),
+                    &mut rng,
+                )
+            }
+            ProtocolCryptographicData::NetworkOwnedAddressSignVSS {
+                public_input: SignPublicInputByProtocol::EdDSAVSS(public_input),
+                advance_request: SignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                vss_shamir_cache,
+                presign_private_output,
+                data,
+                ..
+            } => {
+                let private_input = build_curve25519_eddsa_vss_sign_private_input(
+                    &vss_shamir_cache,
+                    presign_private_output,
+                    public_input.presign.session_id,
+                    public_input.presign.presign_blending_index,
+                )?;
+                compute_sign::<Curve25519EdDSAVSSProtocol>(
+                    party_id,
+                    access_structure,
+                    session_id,
+                    advance_request,
+                    public_input,
+                    Some(private_input),
+                    &SignData::from(&data),
+                    &mut rng,
+                )
+            }
+            ProtocolCryptographicData::NetworkOwnedAddressSignVSS {
+                public_input: SignPublicInputByProtocol::SchnorrkelVSS(public_input),
+                advance_request: SignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                vss_shamir_cache,
+                presign_private_output,
+                data,
+                ..
+            } => {
+                let private_input = build_ristretto_schnorrkel_vss_sign_private_input(
+                    &vss_shamir_cache,
+                    presign_private_output,
+                    public_input.presign.session_id,
+                    public_input.presign.presign_blending_index,
+                )?;
+                compute_sign::<RistrettoSchnorrkelVSSProtocol>(
+                    party_id,
+                    access_structure,
+                    session_id,
+                    advance_request,
+                    public_input,
+                    Some(private_input),
+                    &SignData::from(&data),
+                    &mut rng,
+                )
+            }
+            ProtocolCryptographicData::NetworkOwnedAddressSignVSS {
                 public_input,
                 advance_request,
                 ..
@@ -987,6 +1324,101 @@ impl ProtocolCryptographicData {
                 )
             }
             ProtocolCryptographicData::DWalletDKGAndSign {
+                public_input,
+                advance_request,
+                ..
+            } => Err(DwalletMPCError::MPCParametersMissmatchInputToRequest(
+                public_input.to_string(),
+                advance_request.to_string(),
+            )),
+            // Fast Schnorr (VSS) combined DKG-and-sign: assemble the VSS `PrivateInput`
+            // from the secret-key-share source + persisted presign nonce data (the
+            // builder is shared verbatim with standalone VSS sign — the private-input
+            // type is identical), reading the presign id/index from
+            // `public_input.presign`. VSS has no AHE decrypters, so there is no
+            // `update_expected_decrypters_metrics` here (as in the `SignVSS` arms).
+            ProtocolCryptographicData::DWalletDKGAndSignVSS {
+                public_input: DKGAndSignPublicInputByProtocol::TaprootVSS(public_input),
+                advance_request:
+                    DWalletDKGAndSignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                vss_shamir_cache,
+                presign_private_output,
+                data,
+                ..
+            } => {
+                let private_input = build_secp256k1_taproot_vss_sign_private_input(
+                    &vss_shamir_cache,
+                    presign_private_output,
+                    public_input.presign.session_id,
+                    public_input.presign.presign_blending_index,
+                )?;
+                compute_dwallet_dkg_and_sign::<Secp256k1TaprootVSSProtocol>(
+                    data.curve,
+                    party_id,
+                    access_structure,
+                    session_id,
+                    advance_request,
+                    public_input,
+                    Some(private_input),
+                    &data.signature_algorithm,
+                    &mut rng,
+                )
+            }
+            ProtocolCryptographicData::DWalletDKGAndSignVSS {
+                public_input: DKGAndSignPublicInputByProtocol::EdDSAVSS(public_input),
+                advance_request:
+                    DWalletDKGAndSignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                vss_shamir_cache,
+                presign_private_output,
+                data,
+                ..
+            } => {
+                let private_input = build_curve25519_eddsa_vss_sign_private_input(
+                    &vss_shamir_cache,
+                    presign_private_output,
+                    public_input.presign.session_id,
+                    public_input.presign.presign_blending_index,
+                )?;
+                compute_dwallet_dkg_and_sign::<Curve25519EdDSAVSSProtocol>(
+                    data.curve,
+                    party_id,
+                    access_structure,
+                    session_id,
+                    advance_request,
+                    public_input,
+                    Some(private_input),
+                    &data.signature_algorithm,
+                    &mut rng,
+                )
+            }
+            ProtocolCryptographicData::DWalletDKGAndSignVSS {
+                public_input: DKGAndSignPublicInputByProtocol::SchnorrkelVSS(public_input),
+                advance_request:
+                    DWalletDKGAndSignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                vss_shamir_cache,
+                presign_private_output,
+                data,
+                ..
+            } => {
+                let private_input = build_ristretto_schnorrkel_vss_sign_private_input(
+                    &vss_shamir_cache,
+                    presign_private_output,
+                    public_input.presign.session_id,
+                    public_input.presign.presign_blending_index,
+                )?;
+                compute_dwallet_dkg_and_sign::<RistrettoSchnorrkelVSSProtocol>(
+                    data.curve,
+                    party_id,
+                    access_structure,
+                    session_id,
+                    advance_request,
+                    public_input,
+                    Some(private_input),
+                    &data.signature_algorithm,
+                    &mut rng,
+                )
+            }
+            ProtocolCryptographicData::DWalletDKGAndSignVSS {
                 public_input,
                 advance_request,
                 ..
@@ -1208,7 +1640,7 @@ impl ProtocolCryptographicData {
                         private_output,
                     } => {
                         // Wrap the public output with its version. Main
-                        // Reconfig writes V3; the
+                        // Reconfig writes V3 (post-PR-#1707 shape); the
                         // bwd-compat path in `advance_network_reconfiguration_bwd_compat`
                         // writes V2.
                         let public_output_value = bcs::to_bytes(
@@ -1232,6 +1664,17 @@ impl ProtocolCryptographicData {
             }
         }
     }
+}
+
+/// Constructs the Fast Schnorr (VSS) presign `PrivateInput` — the validator's
+/// curve25519 HPKE secret — from its `RootSeed`. One curve25519 keypair serves
+/// all VSS signing curves, so the same `PrivateInput` type is used for every VSS
+/// presign protocol. The secret is non-serializable and so is built here at the
+/// compute layer rather than threaded through the serialized `MPCPrivateInput`.
+fn vss_presign_private_input(
+    vss_hpke_secret_key: group::curve25519::Scalar,
+) -> twopc_mpc::schnorr::vss::presign::decentralized_party::PrivateInput {
+    twopc_mpc::schnorr::vss::presign::decentralized_party::PrivateInput::new(vss_hpke_secret_key)
 }
 
 fn parse_signature_from_sign_output(
@@ -1261,6 +1704,22 @@ fn parse_signature_from_sign_output(
         }
         DWalletSignatureAlgorithm::Taproot => {
             let signature: TaprootSignature = bcs::from_bytes(&public_output_value)?;
+
+            Ok(signature.to_bytes().to_vec())
+        }
+        // Fast Schnorr (VSS) produces the same signature object as its AHE sibling.
+        DWalletSignatureAlgorithm::TaprootVSS => {
+            let signature: TaprootSignature = bcs::from_bytes(&public_output_value)?;
+
+            Ok(signature.to_bytes().to_vec())
+        }
+        DWalletSignatureAlgorithm::EdDSAVSS => {
+            let signature: EdDSASignature = bcs::from_bytes(&public_output_value)?;
+
+            Ok(signature.to_bytes().to_vec())
+        }
+        DWalletSignatureAlgorithm::SchnorrkelVSS => {
+            let signature: SchnorrkelSignature = bcs::from_bytes(&public_output_value)?;
 
             Ok(signature.to_bytes().to_vec())
         }

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -12,7 +12,9 @@ use crate::dwallet_mpc::dwallet_mpc_metrics::DWalletMPCMetrics;
 use crate::dwallet_mpc::reconfiguration::instantiate_dwallet_mpc_network_encryption_key_public_data_from_reconfiguration_public_output;
 use class_groups::SecretKeyShareSizedInteger;
 use commitment::CommitmentSizedNumber;
-use dwallet_classgroups_types::ClassGroupsDecryptionKey;
+use dwallet_classgroups_types::{
+    ClassGroupsDecryptionKey, RistrettoPvssDecryptionKey, Secp256k1PvssDecryptionKey,
+};
 use dwallet_mpc_types::dwallet_mpc::{
     DWalletCurve, NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicData,
     SerializedWrappedMPCPublicOutput, VersionedDecryptionKeyReconfigurationOutput,
@@ -47,6 +49,82 @@ pub struct DwalletMPCNetworkKeys {
     pub(crate) validator_private_dec_key_data: ValidatorPrivateDecryptionKeyData,
 }
 
+/// SECRET. Validator's own PVSS HPKE decryption keys (secp256k1 + ristretto)
+/// used by `compute_*_shamir_shares_of_secret_key_share_parts` at network-key
+/// ingestion. secp256r1 PVSS isn't used by VSS at all; the Curve25519 `EdDSA`
+/// VSS curve also decrypts off the *ristretto* PVSS key (same
+/// `RISTRETTO_FUNDAMENTAL_DISCRIMINANT_LIMBS`).
+///
+/// Holds only secret material — the matching public encryption keys live
+/// alongside in [`ValidatorPvssEncryptionKeysForVss`].
+#[derive(Clone, Debug)]
+pub struct ValidatorPvssSecretsForVss {
+    pub secp256k1_decryption_key: Secp256k1PvssDecryptionKey,
+    pub ristretto_decryption_key: RistrettoPvssDecryptionKey,
+}
+
+/// Validator's own PVSS HPKE encryption keys (public). Co-input to the
+/// `compute_*_shamir_shares_of_secret_key_share_parts` derivation alongside
+/// [`ValidatorPvssSecretsForVss`]; kept separate from the secrets so this
+/// struct (public) doesn't share a type with the secret one.
+#[derive(Clone, Debug)]
+pub struct ValidatorPvssEncryptionKeysForVss {
+    pub secp256k1_encryption_key: class_groups::CompactIbqf<
+        { twopc_mpc::secp256k1::class_groups::NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+    >,
+    pub ristretto_encryption_key: class_groups::CompactIbqf<
+        { twopc_mpc::ristretto::class_groups::NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+    >,
+}
+
+/// Pre-derived Fast Schnorr (VSS) Shamir shares + secret-key polynomial
+/// commitments for the secp256k1 curve, computed once per network key at
+/// ingestion (`decrypt_and_store_secret_key_shares`) and consumed verbatim by
+/// VSS sign without any per-sign re-derivation.
+#[derive(Clone, Debug)]
+pub struct VssSecp256k1ShamirCache {
+    pub secret_key_share_first_part: group::Value<group::secp256k1::Scalar>,
+    pub secret_key_share_second_part: group::Value<group::secp256k1::Scalar>,
+    pub first_secret_key_polynomial_commitments: Vec<group::Value<group::secp256k1::GroupElement>>,
+    pub second_secret_key_polynomial_commitments: Vec<group::Value<group::secp256k1::GroupElement>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct VssCurve25519ShamirCache {
+    pub secret_key_share_first_part: group::Value<group::curve25519::Scalar>,
+    pub secret_key_share_second_part: group::Value<group::curve25519::Scalar>,
+    pub first_secret_key_polynomial_commitments: Vec<group::Value<group::curve25519::GroupElement>>,
+    pub second_secret_key_polynomial_commitments:
+        Vec<group::Value<group::curve25519::GroupElement>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct VssRistrettoShamirCache {
+    pub secret_key_share_first_part: group::Value<group::ristretto::Scalar>,
+    pub secret_key_share_second_part: group::Value<group::ristretto::Scalar>,
+    pub first_secret_key_polynomial_commitments: Vec<group::Value<group::ristretto::GroupElement>>,
+    pub second_secret_key_polynomial_commitments: Vec<group::Value<group::ristretto::GroupElement>>,
+}
+
+/// Per-network-key Fast Schnorr (VSS) Shamir-share cache, all three curves.
+///
+/// Computed once at network-key ingestion via
+/// [`ValidatorPrivateDecryptionKeyData::decrypt_and_store_secret_key_shares`];
+/// VSS sign reads from here at compute time without re-deserializing the DKG /
+/// reconfiguration output and without redoing the Shamir derivation.
+///
+/// All three curves are populated atomically — they all derive from the same
+/// (V3) DKG / reconfiguration output. If that output is unavailable or any
+/// per-curve derivation fails, no `VssShamirCachePerKey` is inserted into the
+/// per-key map for that network key (and VSS sign sites then `?`-propagate
+/// `WaitingForNetworkKey`, same as the AHE wait path).
+#[derive(Clone, Debug)]
+pub struct VssShamirCachePerKey {
+    pub secp256k1: VssSecp256k1ShamirCache,
+    pub curve25519: VssCurve25519ShamirCache,
+    pub ristretto: VssRistrettoShamirCache,
+}
+
 /// Holds the private decryption key data for a validator node.
 pub struct ValidatorPrivateDecryptionKeyData {
     /// The unique party ID of the validator, representing its index within the committee.
@@ -54,6 +132,21 @@ pub struct ValidatorPrivateDecryptionKeyData {
 
     /// The validator's class groups decryption key.
     pub class_groups_decryption_key: ClassGroupsDecryptionKey,
+
+    /// Validator-private PVSS HPKE secret decryption keys (secp256k1 +
+    /// ristretto). Used at network-key ingestion to pre-derive the Fast
+    /// Schnorr (VSS) Shamir shares; paired with `validator_pvss_publics_for_vss`
+    /// (the matching public encryption keys). Always derived from this
+    /// validator's `RootSeed` at startup. The VSS HPKE curve25519 **secret**
+    /// key isn't here — it's needed only at the presign hot path and is
+    /// cached on `CryptographicComputationsOrchestrator`.
+    pub validator_pvss_secrets_for_vss: ValidatorPvssSecretsForVss,
+
+    /// Public counterpart of [`Self::validator_pvss_secrets_for_vss`]: this
+    /// validator's own PVSS encryption keys (per curve). Kept separate from
+    /// the secrets struct so the secret type never shares a struct with
+    /// public material.
+    pub validator_pvss_publics_for_vss: ValidatorPvssEncryptionKeysForVss,
 
     /// A map of the validator's decryption key shares.
     ///
@@ -64,6 +157,12 @@ pub struct ValidatorPrivateDecryptionKeyData {
     /// NOTE 2: `ObjectID` is the ID of the network decryption key, not the party.
     pub validator_decryption_key_shares:
         HashMap<ObjectID, HashMap<PartyID, SecretKeyShareSizedInteger>>,
+
+    /// Per-network-key Fast Schnorr (VSS) Shamir-share + polynomial-commitments
+    /// cache, populated alongside `validator_decryption_key_shares` from the
+    /// same network DKG / reconfiguration output. Read verbatim by VSS sign
+    /// (no per-sign re-derivation).
+    pub validator_vss_shamir_cache: HashMap<ObjectID, VssShamirCachePerKey>,
 }
 
 async fn get_decryption_key_shares_from_public_output(
@@ -178,7 +277,10 @@ async fn get_decryption_key_shares_from_public_output(
 impl ValidatorPrivateDecryptionKeyData {
     /// Stores the new decryption key shares of the validator.
     /// Decrypts the decryption key shares (for all the virtual parties)
-    /// from the public output of the network DKG protocol.
+    /// from the public output of the network DKG protocol, and ALSO pre-derives
+    /// the Fast Schnorr (VSS) Shamir shares + secret-key polynomial commitments
+    /// for all three VSS curves from the same output — so the VSS sign hot path
+    /// is a cache lookup, not a deserialize-and-derive.
     pub async fn decrypt_and_store_secret_key_shares(
         &mut self,
         key_id: ObjectID,
@@ -195,8 +297,143 @@ impl ValidatorPrivateDecryptionKeyData {
 
         self.validator_decryption_key_shares
             .insert(key_id, decryption_key_shares);
+
+        // Pre-derive VSS Shamir shares + commitments at ingestion. All-or-
+        // nothing: if the network key is pre-V3 OR any per-curve derivation
+        // fails, we insert nothing into the cache and VSS sign sites then
+        // `?`-propagate `WaitingForNetworkKey` like the AHE wait path.
+        if let Some(vss_cache) = derive_vss_shamir_cache_for_key(
+            &key,
+            self.party_id,
+            &self.validator_pvss_secrets_for_vss,
+            &self.validator_pvss_publics_for_vss,
+        ) {
+            self.validator_vss_shamir_cache.insert(key_id, vss_cache);
+        }
+
         Ok(())
     }
+}
+
+/// Pre-derive the Fast Schnorr (VSS) Shamir shares + secret-key polynomial
+/// commitments for all three VSS curves from a single network DKG /
+/// reconfiguration output. The output is deserialized at most once. Returns
+/// `None` if the network key has no V3 output (pre-V3) or any per-curve
+/// derivation fails — the three curves are always populated together.
+fn derive_vss_shamir_cache_for_key(
+    key: &NetworkEncryptionKeyPublicData,
+    party_id: PartyID,
+    secrets: &ValidatorPvssSecretsForVss,
+    publics: &ValidatorPvssEncryptionKeysForVss,
+) -> Option<VssShamirCachePerKey> {
+    use twopc_mpc::decentralized_party::{dkg as dec_dkg, reconfiguration as dec_reconf};
+
+    enum DeserializedSource {
+        Reconfiguration(<dec_reconf::Party as mpc::Party>::PublicOutput),
+        NetworkDkg(<dec_dkg::Party as mpc::Party>::PublicOutput),
+    }
+
+    let source: DeserializedSource = match key.latest_network_reconfiguration_public_output() {
+        Some(VersionedDecryptionKeyReconfigurationOutput::V3(bytes)) => {
+            DeserializedSource::Reconfiguration(bcs::from_bytes(&bytes).ok()?)
+        }
+        // Pre-V3 reconfiguration (or none yet) → fall through to network DKG output.
+        _ => match key.network_dkg_output() {
+            VersionedNetworkDkgOutput::V3(bytes) => {
+                DeserializedSource::NetworkDkg(bcs::from_bytes(bytes).ok()?)
+            }
+            _ => return None,
+        },
+    };
+
+    let (secp256k1_shares, secp256k1_first_commitments, secp256k1_second_commitments) =
+        match &source {
+            DeserializedSource::Reconfiguration(o) => (
+                o.compute_secp256k1_shamir_shares_of_secret_key_share_parts(
+                    party_id,
+                    secrets.secp256k1_decryption_key,
+                    publics.secp256k1_encryption_key.clone(),
+                ),
+                o.secp256k1_polynomial_commitments().0.clone(),
+                o.secp256k1_polynomial_commitments().1.clone(),
+            ),
+            DeserializedSource::NetworkDkg(o) => (
+                o.derive_shamir_shares_of_secp256k1_secret_key_share_parts(
+                    party_id,
+                    secrets.secp256k1_decryption_key,
+                    publics.secp256k1_encryption_key.clone(),
+                ),
+                o.secp256k1_polynomial_commitments().0.clone(),
+                o.secp256k1_polynomial_commitments().1.clone(),
+            ),
+        };
+    let (curve25519_shares, curve25519_first_commitments, curve25519_second_commitments) =
+        match &source {
+            DeserializedSource::Reconfiguration(o) => (
+                o.compute_curve25519_shamir_shares_of_secret_key_share_parts(
+                    party_id,
+                    secrets.ristretto_decryption_key,
+                    publics.ristretto_encryption_key.clone(),
+                ),
+                o.curve25519_polynomial_commitments().0.clone(),
+                o.curve25519_polynomial_commitments().1.clone(),
+            ),
+            DeserializedSource::NetworkDkg(o) => (
+                o.derive_shamir_shares_of_curve25519_secret_key_share_parts(
+                    party_id,
+                    secrets.ristretto_decryption_key,
+                    publics.ristretto_encryption_key.clone(),
+                ),
+                o.curve25519_polynomial_commitments().0.clone(),
+                o.curve25519_polynomial_commitments().1.clone(),
+            ),
+        };
+    let (ristretto_shares, ristretto_first_commitments, ristretto_second_commitments) =
+        match &source {
+            DeserializedSource::Reconfiguration(o) => (
+                o.compute_ristretto_shamir_shares_of_secret_key_share_parts(
+                    party_id,
+                    secrets.ristretto_decryption_key,
+                    publics.ristretto_encryption_key.clone(),
+                ),
+                o.ristretto_polynomial_commitments().0.clone(),
+                o.ristretto_polynomial_commitments().1.clone(),
+            ),
+            DeserializedSource::NetworkDkg(o) => (
+                o.derive_shamir_shares_of_ristretto_secret_key_share_parts(
+                    party_id,
+                    secrets.ristretto_decryption_key,
+                    publics.ristretto_encryption_key.clone(),
+                ),
+                o.ristretto_polynomial_commitments().0.clone(),
+                o.ristretto_polynomial_commitments().1.clone(),
+            ),
+        };
+
+    let (secp256k1_first, secp256k1_second) = secp256k1_shares.ok()?;
+    let (curve25519_first, curve25519_second) = curve25519_shares.ok()?;
+    let (ristretto_first, ristretto_second) = ristretto_shares.ok()?;
+
+    Some(VssShamirCachePerKey {
+        secp256k1: VssSecp256k1ShamirCache {
+            secret_key_share_first_part: secp256k1_first,
+            secret_key_share_second_part: secp256k1_second,
+            first_secret_key_polynomial_commitments: secp256k1_first_commitments,
+            second_secret_key_polynomial_commitments: secp256k1_second_commitments,
+        },
+        curve25519: VssCurve25519ShamirCache {
+            secret_key_share_first_part: curve25519_first,
+            secret_key_share_second_part: curve25519_second,
+            first_secret_key_polynomial_commitments: curve25519_first_commitments,
+            second_secret_key_polynomial_commitments: curve25519_second_commitments,
+        },
+        ristretto: VssRistrettoShamirCache {
+            secret_key_share_first_part: ristretto_first,
+            secret_key_share_second_part: ristretto_second,
+            first_secret_key_polynomial_commitments: ristretto_first_commitments,
+            second_secret_key_polynomial_commitments: ristretto_second_commitments,
+        },
+    })
 }
 
 impl DwalletMPCNetworkKeys {
@@ -228,6 +465,20 @@ impl DwalletMPCNetworkKeys {
             .validator_decryption_key_shares
             .get(key_id)
             .cloned()
+            .ok_or(DwalletMPCError::WaitingForNetworkKey(*key_id))
+    }
+
+    /// Retrieves the pre-derived Fast Schnorr (VSS) Shamir-share + commitments
+    /// cache for the given network key. Mirrors [`Self::decryption_key_shares`]
+    /// for the AHE path: derivation happens once at network-key ingestion
+    /// (`decrypt_and_store_secret_key_shares`); VSS sign reads from here.
+    pub(crate) fn vss_shamir_cache(
+        &self,
+        key_id: &ObjectID,
+    ) -> DwalletMPCResult<&VssShamirCachePerKey> {
+        self.validator_private_dec_key_data
+            .validator_vss_shamir_cache
+            .get(key_id)
             .ok_or(DwalletMPCError::WaitingForNetworkKey(*key_id))
     }
 

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/presign.rs
@@ -5,6 +5,7 @@
 //!
 //! It integrates both Presign parties (each representing a round in the Presign protocol).
 
+use crate::dwallet_mpc::ValidatorMpcKeysByPartyId;
 use crate::dwallet_mpc::crytographic_computation::mpc_computations;
 use commitment::CommitmentSizedNumber;
 use dwallet_mpc_types::dwallet_mpc::VersionedPresignOutput;
@@ -13,17 +14,22 @@ use dwallet_mpc_types::dwallet_mpc::{
     NetworkEncryptionKeyPublicData, SerializedWrappedMPCPublicOutput,
     VersionedDwalletDKGPublicOutput,
 };
+use group::GroupElement as _;
+use group::curve25519;
 use group::{CsRng, PartyID};
 use ika_types::dwallet_mpc_error::DwalletMPCError;
 use ika_types::dwallet_mpc_error::DwalletMPCResult;
 use ika_types::messages_dwallet_mpc::{
-    Curve25519EdDSAProtocol, RistrettoSchnorrkelProtocol, Secp256k1AsyncDKGProtocol,
-    Secp256k1ECDSAProtocol, Secp256k1TaprootProtocol, Secp256r1AsyncDKGProtocol,
+    Curve25519EdDSAProtocol, Curve25519EdDSAVSSProtocol, RistrettoSchnorrkelProtocol,
+    RistrettoSchnorrkelVSSProtocol, Secp256k1AsyncDKGProtocol, Secp256k1ECDSAProtocol,
+    Secp256k1TaprootProtocol, Secp256k1TaprootVSSProtocol, Secp256r1AsyncDKGProtocol,
     Secp256r1ECDSAProtocol,
 };
 use mpc::guaranteed_output_delivery::AdvanceRequest;
+use mpc::hybrid_public_key_encryption::EncryptionPublicKey;
 use mpc::{
-    GuaranteedOutputDeliveryRoundResult, GuaranteesOutputDelivery, WeightedThresholdAccessStructure,
+    AsynchronouslyAdvanceable, GuaranteedOutputDeliveryRoundResult, GuaranteesOutputDelivery,
+    WeightedThresholdAccessStructure,
 };
 use std::collections::HashMap;
 use twopc_mpc::dkg::decentralized_party::VersionedOutput;
@@ -46,6 +52,12 @@ pub(crate) enum PresignPublicInputByProtocol {
         to_string = "Presign Public Input - curve: Ristretto, protocol: Schnorrkel (Substrate)"
     )]
     Schnorrkel(<PresignParty<RistrettoSchnorrkelProtocol> as mpc::Party>::PublicInput),
+    #[strum(to_string = "Presign Public Input - curve: Secp256k1, protocol: TaprootVSS")]
+    TaprootVSS(<PresignParty<Secp256k1TaprootVSSProtocol> as mpc::Party>::PublicInput),
+    #[strum(to_string = "Presign Public Input - curve: Curve25519, protocol: EdDSAVSS")]
+    EdDSAVSS(<PresignParty<Curve25519EdDSAVSSProtocol> as mpc::Party>::PublicInput),
+    #[strum(to_string = "Presign Public Input - curve: Ristretto, protocol: SchnorrkelVSS")]
+    SchnorrkelVSS(<PresignParty<RistrettoSchnorrkelVSSProtocol> as mpc::Party>::PublicInput),
 }
 
 #[derive(strum_macros::Display)]
@@ -62,6 +74,14 @@ pub(crate) enum PresignAdvanceRequestByProtocol {
         to_string = "Presign Advance Request - curve: Ristretto, protocol: Schnorrkel (Substrate)"
     )]
     Schnorrkel(AdvanceRequest<<PresignParty<RistrettoSchnorrkelProtocol> as mpc::Party>::Message>),
+    #[strum(to_string = "Presign Advance Request - curve: Secp256k1, protocol: TaprootVSS")]
+    TaprootVSS(AdvanceRequest<<PresignParty<Secp256k1TaprootVSSProtocol> as mpc::Party>::Message>),
+    #[strum(to_string = "Presign Advance Request - curve: Curve25519, protocol: EdDSAVSS")]
+    EdDSAVSS(AdvanceRequest<<PresignParty<Curve25519EdDSAVSSProtocol> as mpc::Party>::Message>),
+    #[strum(to_string = "Presign Advance Request - curve: Ristretto, protocol: SchnorrkelVSS")]
+    SchnorrkelVSS(
+        AdvanceRequest<<PresignParty<RistrettoSchnorrkelVSSProtocol> as mpc::Party>::Message>,
+    ),
 }
 
 impl PresignAdvanceRequestByProtocol {
@@ -71,6 +91,9 @@ impl PresignAdvanceRequestByProtocol {
         access_structure: &WeightedThresholdAccessStructure,
         consensus_round: u64,
         schnorr_presign_second_round_delay: u64,
+        // Consensus-round delay for the VSS presign Aggregation round (round 3).
+        // Only the VSS arms use it; AHE presign is 2 rounds and ignores it.
+        schnorr_presign_third_round_delay: u64,
         serialized_messages_by_consensus_round: HashMap<u64, HashMap<PartyID, Vec<u8>>>,
     ) -> DwalletMPCResult<Option<Self>> {
         let advance_request = match protocol {
@@ -137,6 +160,57 @@ impl PresignAdvanceRequestByProtocol {
 
                 advance_request.map(PresignAdvanceRequestByProtocol::Secp256r1ECDSA)
             }
+            // VSS (Fast Schnorr) presign is 3 rounds: Dealing → Accusation (round 2)
+            // → Aggregation (round 3). Round 2 reuses the schnorr second-round delay;
+            // round 3 uses the dedicated third-round delay.
+            DWalletSignatureAlgorithm::TaprootVSS => {
+                let advance_request = mpc_computations::try_ready_to_advance::<
+                    PresignParty<Secp256k1TaprootVSSProtocol>,
+                >(
+                    party_id,
+                    access_structure,
+                    consensus_round,
+                    HashMap::from([
+                        (2, schnorr_presign_second_round_delay),
+                        (3, schnorr_presign_third_round_delay),
+                    ]),
+                    &serialized_messages_by_consensus_round,
+                )?;
+
+                advance_request.map(PresignAdvanceRequestByProtocol::TaprootVSS)
+            }
+            DWalletSignatureAlgorithm::EdDSAVSS => {
+                let advance_request = mpc_computations::try_ready_to_advance::<
+                    PresignParty<Curve25519EdDSAVSSProtocol>,
+                >(
+                    party_id,
+                    access_structure,
+                    consensus_round,
+                    HashMap::from([
+                        (2, schnorr_presign_second_round_delay),
+                        (3, schnorr_presign_third_round_delay),
+                    ]),
+                    &serialized_messages_by_consensus_round,
+                )?;
+
+                advance_request.map(PresignAdvanceRequestByProtocol::EdDSAVSS)
+            }
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
+                let advance_request = mpc_computations::try_ready_to_advance::<
+                    PresignParty<RistrettoSchnorrkelVSSProtocol>,
+                >(
+                    party_id,
+                    access_structure,
+                    consensus_round,
+                    HashMap::from([
+                        (2, schnorr_presign_second_round_delay),
+                        (3, schnorr_presign_third_round_delay),
+                    ]),
+                    &serialized_messages_by_consensus_round,
+                )?;
+
+                advance_request.map(PresignAdvanceRequestByProtocol::SchnorrkelVSS)
+            }
         };
 
         Ok(advance_request)
@@ -148,9 +222,15 @@ impl PresignPublicInputByProtocol {
         protocol: DWalletSignatureAlgorithm,
         network_encryption_key_public_data: &NetworkEncryptionKeyPublicData,
         dwallet_public_output: Option<SerializedWrappedMPCPublicOutput>,
+        validator_mpc_keys_by_party_id: &ValidatorMpcKeysByPartyId,
     ) -> DwalletMPCResult<Self> {
         if dwallet_public_output.is_none() {
-            return Self::try_new_v2(protocol, network_encryption_key_public_data, None);
+            return Self::try_new_v2(
+                protocol,
+                network_encryption_key_public_data,
+                None,
+                validator_mpc_keys_by_party_id,
+            );
         }
         // Safe to unwrap as we checked for None above
         match bcs::from_bytes(&dwallet_public_output.unwrap())? {
@@ -161,6 +241,7 @@ impl PresignPublicInputByProtocol {
                 protocol,
                 network_encryption_key_public_data,
                 Some(dkg_output),
+                validator_mpc_keys_by_party_id,
             ),
         }
     }
@@ -187,6 +268,7 @@ impl PresignPublicInputByProtocol {
         protocol: DWalletSignatureAlgorithm,
         network_encryption_key_public_data: &NetworkEncryptionKeyPublicData,
         dwallet_dkg_output: Option<MPCPublicOutput>,
+        validator_mpc_keys_by_party_id: &ValidatorMpcKeysByPartyId,
     ) -> DwalletMPCResult<Self> {
         let input = match protocol {
             DWalletSignatureAlgorithm::ECDSASecp256k1 => {
@@ -271,10 +353,92 @@ impl PresignPublicInputByProtocol {
 
                 PresignPublicInputByProtocol::Taproot(pub_input)
             }
+            // VSS (Fast Schnorr) presign PublicInput carries the per-party
+            // curve25519 HPKE encryption keys + the UC-verified party set.
+            // UC proofs were verified ONCE at `Committee::new`; the verified
+            // public-key values live in
+            // `validator_mpc_keys_by_party_id.vss_hpke_verified_party_encryption_key_values`.
+            // Here we only re-parse them into `EncryptionPublicKey` (a cheap
+            // curve-point check), with no per-session UC proof re-verification.
+            DWalletSignatureAlgorithm::TaprootVSS => {
+                let _ = dwallet_dkg_output;
+                let protocol_public_parameters =
+                    network_encryption_key_public_data.secp256k1_protocol_public_parameters();
+                let (party_encryption_keys, parties_with_uc_verified_public_keys) =
+                    rebuild_vss_party_encryption_keys(
+                        &validator_mpc_keys_by_party_id
+                            .vss_hpke_verified_party_encryption_key_values,
+                    );
+                let pub_input: <PresignParty<Secp256k1TaprootVSSProtocol> as mpc::Party>::PublicInput =
+                    twopc_mpc::schnorr::vss::presign::decentralized_party::PublicInput {
+                        protocol_public_parameters,
+                        party_encryption_keys,
+                        parties_with_uc_verified_public_keys,
+                    };
+                PresignPublicInputByProtocol::TaprootVSS(pub_input)
+            }
+            DWalletSignatureAlgorithm::EdDSAVSS => {
+                let _ = dwallet_dkg_output;
+                let protocol_public_parameters =
+                    network_encryption_key_public_data.curve25519_protocol_public_parameters();
+                let (party_encryption_keys, parties_with_uc_verified_public_keys) =
+                    rebuild_vss_party_encryption_keys(
+                        &validator_mpc_keys_by_party_id
+                            .vss_hpke_verified_party_encryption_key_values,
+                    );
+                let pub_input: <PresignParty<Curve25519EdDSAVSSProtocol> as mpc::Party>::PublicInput =
+                    twopc_mpc::schnorr::vss::presign::decentralized_party::PublicInput {
+                        protocol_public_parameters,
+                        party_encryption_keys,
+                        parties_with_uc_verified_public_keys,
+                    };
+                PresignPublicInputByProtocol::EdDSAVSS(pub_input)
+            }
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
+                let _ = dwallet_dkg_output;
+                let protocol_public_parameters =
+                    network_encryption_key_public_data.ristretto_protocol_public_parameters();
+                let (party_encryption_keys, parties_with_uc_verified_public_keys) =
+                    rebuild_vss_party_encryption_keys(
+                        &validator_mpc_keys_by_party_id
+                            .vss_hpke_verified_party_encryption_key_values,
+                    );
+                let pub_input: <PresignParty<RistrettoSchnorrkelVSSProtocol> as mpc::Party>::PublicInput =
+                    twopc_mpc::schnorr::vss::presign::decentralized_party::PublicInput {
+                        protocol_public_parameters,
+                        party_encryption_keys,
+                        parties_with_uc_verified_public_keys,
+                    };
+                PresignPublicInputByProtocol::SchnorrkelVSS(pub_input)
+            }
         };
 
         Ok(input)
     }
+}
+
+/// Reconstruct `EncryptionPublicKey` curve points from the verified key VALUES
+/// cached on [`Committee`]. Cheap (just `EncryptionPublicKey::new(value, &pp)`)
+/// — no UC proof verification, that already happened once at committee
+/// construction. Parties whose value somehow fails the curve-point check are
+/// silently dropped (should not happen for values that passed verification).
+fn rebuild_vss_party_encryption_keys(
+    values: &HashMap<PartyID, curve25519::Value>,
+) -> (
+    HashMap<PartyID, EncryptionPublicKey>,
+    std::collections::HashSet<PartyID>,
+) {
+    let public_parameters = curve25519::PublicParameters::default();
+    let party_encryption_keys: HashMap<PartyID, EncryptionPublicKey> = values
+        .iter()
+        .filter_map(|(party_id, value)| {
+            EncryptionPublicKey::new(*value, &public_parameters)
+                .ok()
+                .map(|ek| (*party_id, ek))
+        })
+        .collect();
+    let parties = party_encryption_keys.keys().copied().collect();
+    (party_encryption_keys, parties)
 }
 
 pub fn compute_presign<P: presign::Protocol>(
@@ -283,6 +447,11 @@ pub fn compute_presign<P: presign::Protocol>(
     session_id: CommitmentSizedNumber,
     advance_request: AdvanceRequest<<P::PresignParty as mpc::Party>::Message>,
     public_input: <P::PresignParty as mpc::Party>::PublicInput,
+    // AHE Schnorr / ECDSA presign has a `()` private input (`None`). VSS presign
+    // needs the validator's curve25519 HPKE secret as `PrivateInput`, constructed
+    // at the compute layer (it is deliberately non-serializable, so it can't ride
+    // the serialized `MPCPrivateInput` seam).
+    private_input: Option<<P::PresignParty as AsynchronouslyAdvanceable>::PrivateInput>,
     is_internal: bool,
     rng: &mut impl CsRng,
 ) -> DwalletMPCResult<GuaranteedOutputDeliveryRoundResult> {
@@ -292,7 +461,7 @@ pub fn compute_presign<P: presign::Protocol>(
             party_id,
             access_structure,
             advance_request,
-            None,
+            private_input,
             &public_input,
             rng,
         )

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/sign.rs
@@ -21,9 +21,11 @@ use group::CsRng;
 use group::{HashContext, HashScheme, OsCsRng, PartyID};
 use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use ika_types::messages_dwallet_mpc::{
-    Curve25519AsyncDKGProtocol, Curve25519EdDSAProtocol, RistrettoAsyncDKGProtocol,
-    RistrettoSchnorrkelProtocol, Secp256k1AsyncDKGProtocol, Secp256k1ECDSAProtocol,
-    Secp256k1TaprootProtocol, Secp256r1AsyncDKGProtocol, Secp256r1ECDSAProtocol, SessionIdentifier,
+    Curve25519AsyncDKGProtocol, Curve25519EdDSAProtocol, Curve25519EdDSAVSSProtocol,
+    RistrettoAsyncDKGProtocol, RistrettoSchnorrkelProtocol, RistrettoSchnorrkelVSSProtocol,
+    Secp256k1AsyncDKGProtocol, Secp256k1ECDSAProtocol, Secp256k1TaprootProtocol,
+    Secp256k1TaprootVSSProtocol, Secp256r1AsyncDKGProtocol, Secp256r1ECDSAProtocol,
+    SessionIdentifier,
 };
 use mpc::guaranteed_output_delivery::AdvanceRequest;
 use mpc::{AsynchronouslyAdvanceable, GuaranteesOutputDelivery};
@@ -51,6 +53,12 @@ pub(crate) enum SignPublicInputByProtocol {
     Curve25519(<SignParty<Curve25519EdDSAProtocol> as mpc::Party>::PublicInput),
     #[strum(to_string = "Sign Public Input - curve: Ristretto, protocol: Schnorrkel")]
     Ristretto(<SignParty<RistrettoSchnorrkelProtocol> as mpc::Party>::PublicInput),
+    #[strum(to_string = "Sign Public Input - curve: Secp256k1, protocol: TaprootVSS")]
+    TaprootVSS(<SignParty<Secp256k1TaprootVSSProtocol> as mpc::Party>::PublicInput),
+    #[strum(to_string = "Sign Public Input - curve: Curve25519, protocol: EdDSAVSS")]
+    EdDSAVSS(<SignParty<Curve25519EdDSAVSSProtocol> as mpc::Party>::PublicInput),
+    #[strum(to_string = "Sign Public Input - curve: Ristretto, protocol: SchnorrkelVSS")]
+    SchnorrkelVSS(<SignParty<RistrettoSchnorrkelVSSProtocol> as mpc::Party>::PublicInput),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, strum_macros::Display)]
@@ -66,6 +74,12 @@ pub(crate) enum DKGAndSignPublicInputByProtocol {
     Curve25519(<DKGAndSignParty<Curve25519EdDSAProtocol> as mpc::Party>::PublicInput),
     #[strum(to_string = "DKG and Sign Public Input - curve: Ristretto, protocol: Schnorrkel")]
     Ristretto(<DKGAndSignParty<RistrettoSchnorrkelProtocol> as mpc::Party>::PublicInput),
+    #[strum(to_string = "DKG and Sign Public Input - curve: Secp256k1, protocol: TaprootVSS")]
+    TaprootVSS(<DKGAndSignParty<Secp256k1TaprootVSSProtocol> as mpc::Party>::PublicInput),
+    #[strum(to_string = "DKG and Sign Public Input - curve: Curve25519, protocol: EdDSAVSS")]
+    EdDSAVSS(<DKGAndSignParty<Curve25519EdDSAVSSProtocol> as mpc::Party>::PublicInput),
+    #[strum(to_string = "DKG and Sign Public Input - curve: Ristretto, protocol: SchnorrkelVSS")]
+    SchnorrkelVSS(<DKGAndSignParty<RistrettoSchnorrkelVSSProtocol> as mpc::Party>::PublicInput),
 }
 
 #[derive(strum_macros::Display)]
@@ -100,6 +114,24 @@ pub(crate) enum SignAdvanceRequestByProtocol {
             <SignParty<RistrettoSchnorrkelProtocol> as mpc::Party>::Message,
         >,
     ),
+    #[strum(to_string = "Sign Advance Request - curve: Secp256k1, protocol: TaprootVSS")]
+    TaprootVSS(
+        mpc::guaranteed_output_delivery::AdvanceRequest<
+            <SignParty<Secp256k1TaprootVSSProtocol> as mpc::Party>::Message,
+        >,
+    ),
+    #[strum(to_string = "Sign Advance Request - curve: Curve25519, protocol: EdDSAVSS")]
+    EdDSAVSS(
+        mpc::guaranteed_output_delivery::AdvanceRequest<
+            <SignParty<Curve25519EdDSAVSSProtocol> as mpc::Party>::Message,
+        >,
+    ),
+    #[strum(to_string = "Sign Advance Request - curve: Ristretto, protocol: SchnorrkelVSS")]
+    SchnorrkelVSS(
+        mpc::guaranteed_output_delivery::AdvanceRequest<
+            <SignParty<RistrettoSchnorrkelVSSProtocol> as mpc::Party>::Message,
+        >,
+    ),
 }
 
 #[derive(strum_macros::Display)]
@@ -132,6 +164,24 @@ pub(crate) enum DWalletDKGAndSignAdvanceRequestByProtocol {
     Ristretto(
         mpc::guaranteed_output_delivery::AdvanceRequest<
             <DKGAndSignParty<RistrettoSchnorrkelProtocol> as mpc::Party>::Message,
+        >,
+    ),
+    #[strum(to_string = "DKG and Sign Advance Request - curve: Secp256k1, protocol: TaprootVSS")]
+    TaprootVSS(
+        mpc::guaranteed_output_delivery::AdvanceRequest<
+            <DKGAndSignParty<Secp256k1TaprootVSSProtocol> as mpc::Party>::Message,
+        >,
+    ),
+    #[strum(to_string = "DKG and Sign Advance Request - curve: Curve25519, protocol: EdDSAVSS")]
+    EdDSAVSS(
+        mpc::guaranteed_output_delivery::AdvanceRequest<
+            <DKGAndSignParty<Curve25519EdDSAVSSProtocol> as mpc::Party>::Message,
+        >,
+    ),
+    #[strum(to_string = "DKG and Sign Advance Request - curve: Ristretto, protocol: SchnorrkelVSS")]
+    SchnorrkelVSS(
+        mpc::guaranteed_output_delivery::AdvanceRequest<
+            <DKGAndSignParty<RistrettoSchnorrkelVSSProtocol> as mpc::Party>::Message,
         >,
     ),
 }
@@ -238,6 +288,45 @@ impl SignAdvanceRequestByProtocol {
 
                 advance_request.map(SignAdvanceRequestByProtocol::Secp256r1)
             }
+            DWalletSignatureAlgorithm::TaprootVSS => {
+                let advance_request = mpc_computations::try_ready_to_advance::<
+                    SignParty<Secp256k1TaprootVSSProtocol>,
+                >(
+                    party_id,
+                    access_structure,
+                    consensus_round,
+                    HashMap::new(),
+                    &serialized_messages_by_consensus_round,
+                )?;
+
+                advance_request.map(SignAdvanceRequestByProtocol::TaprootVSS)
+            }
+            DWalletSignatureAlgorithm::EdDSAVSS => {
+                let advance_request = mpc_computations::try_ready_to_advance::<
+                    SignParty<Curve25519EdDSAVSSProtocol>,
+                >(
+                    party_id,
+                    access_structure,
+                    consensus_round,
+                    HashMap::new(),
+                    &serialized_messages_by_consensus_round,
+                )?;
+
+                advance_request.map(SignAdvanceRequestByProtocol::EdDSAVSS)
+            }
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
+                let advance_request = mpc_computations::try_ready_to_advance::<
+                    SignParty<RistrettoSchnorrkelVSSProtocol>,
+                >(
+                    party_id,
+                    access_structure,
+                    consensus_round,
+                    HashMap::new(),
+                    &serialized_messages_by_consensus_round,
+                )?;
+
+                advance_request.map(SignAdvanceRequestByProtocol::SchnorrkelVSS)
+            }
         };
 
         Ok(advance_request)
@@ -318,6 +407,49 @@ impl DWalletDKGAndSignAdvanceRequestByProtocol {
 
                 advance_request.map(Self::Secp256r1)
             }
+            // Fast Schnorr (VSS) combined DKG-and-sign uses the same per-round delays
+            // as the standalone VSS *sign* advance request (`HashMap::new()` — no
+            // artificial delay), since the combined party delegates to the standalone
+            // VSS `SignParty` after the inline DKG-proof verification.
+            DWalletSignatureAlgorithm::TaprootVSS => {
+                let advance_request = mpc_computations::try_ready_to_advance::<
+                    DKGAndSignParty<Secp256k1TaprootVSSProtocol>,
+                >(
+                    party_id,
+                    access_structure,
+                    consensus_round,
+                    HashMap::new(),
+                    &serialized_messages_by_consensus_round,
+                )?;
+
+                advance_request.map(Self::TaprootVSS)
+            }
+            DWalletSignatureAlgorithm::EdDSAVSS => {
+                let advance_request = mpc_computations::try_ready_to_advance::<
+                    DKGAndSignParty<Curve25519EdDSAVSSProtocol>,
+                >(
+                    party_id,
+                    access_structure,
+                    consensus_round,
+                    HashMap::new(),
+                    &serialized_messages_by_consensus_round,
+                )?;
+
+                advance_request.map(Self::EdDSAVSS)
+            }
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
+                let advance_request = mpc_computations::try_ready_to_advance::<
+                    DKGAndSignParty<RistrettoSchnorrkelVSSProtocol>,
+                >(
+                    party_id,
+                    access_structure,
+                    consensus_round,
+                    HashMap::new(),
+                    &serialized_messages_by_consensus_round,
+                )?;
+
+                advance_request.map(Self::SchnorrkelVSS)
+            }
         };
 
         Ok(advance_request)
@@ -335,6 +467,10 @@ impl SignPublicInputByProtocol {
         hash_context: HashContext,
         access_structure: &WeightedThresholdAccessStructure,
         network_encryption_key_public_data: &NetworkEncryptionKeyPublicData,
+        // Pre-derived VSS Shamir-share + commitments cache for this network
+        // key. Empty (all-`None`) for non-VSS callers; required (and per-curve
+        // populated) for the three VSS protocols.
+        vss_shamir_cache: &crate::dwallet_mpc::network_dkg::VssShamirCachePerKey,
         protocol: DWalletSignatureAlgorithm,
     ) -> DwalletMPCResult<Self> {
         let expected_decrypters =
@@ -401,6 +537,48 @@ impl SignPublicInputByProtocol {
                     network_encryption_key_public_data,
                 )?,
             )),
+            // Fast Schnorr (VSS) sign PublicInput: the 8-field struct. Commitments
+            // come from the latest reconfiguration output (see
+            // `vss_reconfiguration_public_output`); dkg_output/presign/sign_data
+            // decode exactly like the AHE Schnorr path (generic over the protocol).
+            DWalletSignatureAlgorithm::TaprootVSS => Ok(SignPublicInputByProtocol::TaprootVSS(
+                build_secp256k1_taproot_vss_sign_public_input(
+                    dwallet_decentralized_public_output,
+                    message,
+                    presign,
+                    message_centralized_signature,
+                    hash_scheme,
+                    hash_context,
+                    network_encryption_key_public_data,
+                    vss_shamir_cache,
+                )?,
+            )),
+            DWalletSignatureAlgorithm::EdDSAVSS => Ok(SignPublicInputByProtocol::EdDSAVSS(
+                build_curve25519_eddsa_vss_sign_public_input(
+                    dwallet_decentralized_public_output,
+                    message,
+                    presign,
+                    message_centralized_signature,
+                    hash_scheme,
+                    hash_context,
+                    network_encryption_key_public_data,
+                    vss_shamir_cache,
+                )?,
+            )),
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
+                Ok(SignPublicInputByProtocol::SchnorrkelVSS(
+                    build_ristretto_schnorrkel_vss_sign_public_input(
+                        dwallet_decentralized_public_output,
+                        message,
+                        presign,
+                        message_centralized_signature,
+                        hash_scheme,
+                        hash_context,
+                        network_encryption_key_public_data,
+                        vss_shamir_cache,
+                    )?,
+                ))
+            }
         }
     }
 }
@@ -411,6 +589,354 @@ impl SignPublicInputByProtocol {
 // decentralized `PublicInput` via struct literal. An empty
 // `message_centralized_signature` selects `SignData::ToBeEmulated` (NOA path);
 // otherwise `SignData::Unverified(deserialized_sign_message)` (user-driven path).
+
+/// Recovers BOTH the presign `session_id` and the `presign_blending_index` from a
+/// public VSS presign — the composite key under which this presign's private nonce
+/// output was persisted at presign-finalize. Parses the curve-specific public
+/// `schnorr::vss::Presign` exactly once.
+pub(crate) fn vss_public_presign_identity(
+    signature_algorithm: DWalletSignatureAlgorithm,
+    presign: &SerializedWrappedMPCPublicOutput,
+) -> DwalletMPCResult<(commitment::CommitmentSizedNumber, u16)> {
+    let versioned: VersionedPresignOutput = bcs::from_bytes(presign).map_err(|e| {
+        DwalletMPCError::BcsError(bcs::Error::Custom(format!(
+            "failed to deserialize VSS presign output: {e}"
+        )))
+    })?;
+    let VersionedPresignOutput::V3(inner) = versioned else {
+        return Err(DwalletMPCError::InvalidInput(
+            "Fast Schnorr (VSS) presign must be V3".to_string(),
+        ));
+    };
+    match signature_algorithm {
+        DWalletSignatureAlgorithm::TaprootVSS => {
+            let presign = bcs::from_bytes::<
+                <Secp256k1TaprootVSSProtocol as twopc_mpc::presign::Protocol>::Presign,
+            >(&inner)
+            .map_err(|e| DwalletMPCError::BcsError(bcs::Error::Custom(e.to_string())))?;
+            Ok((presign.session_id, presign.presign_blending_index))
+        }
+        DWalletSignatureAlgorithm::EdDSAVSS => {
+            let presign = bcs::from_bytes::<
+                <Curve25519EdDSAVSSProtocol as twopc_mpc::presign::Protocol>::Presign,
+            >(&inner)
+            .map_err(|e| DwalletMPCError::BcsError(bcs::Error::Custom(e.to_string())))?;
+            Ok((presign.session_id, presign.presign_blending_index))
+        }
+        DWalletSignatureAlgorithm::SchnorrkelVSS => {
+            let presign = bcs::from_bytes::<
+                <RistrettoSchnorrkelVSSProtocol as twopc_mpc::presign::Protocol>::Presign,
+            >(&inner)
+            .map_err(|e| DwalletMPCError::BcsError(bcs::Error::Custom(e.to_string())))?;
+            Ok((presign.session_id, presign.presign_blending_index))
+        }
+        _ => Err(DwalletMPCError::InvalidInput(format!(
+            "{signature_algorithm} is not a Fast Schnorr (VSS) algorithm"
+        ))),
+    }
+}
+
+/// Splits a blended VSS presign `PrivateOutput` (`bcs(Vec<PrivatePresignOutput>)`,
+/// as produced by the GOD layer at presign-finalize) into one serialized
+/// `PrivatePresignOutput` per blending index. Each persisted row is then keyed by
+/// `(session_id, blending_index)`. Non-VSS algorithms cannot reach this path (the
+/// caller guards with `is_vss()`); they return an `InvalidInput` error.
+///
+/// The concrete `Vec<PrivatePresignOutput>` type is deserialized per arm so the entry
+/// `.presign_blending_index` field is reachable directly (a generic over the protocol's
+/// associated `PrivateOutput` cannot name that field without a bespoke trait).
+fn blended_vss_private_output_bcs_error(e: bcs::Error) -> DwalletMPCError {
+    DwalletMPCError::BcsError(bcs::Error::Custom(format!(
+        "failed to (de)serialize blended VSS presign private output: {e}"
+    )))
+}
+
+pub(crate) fn split_vss_presign_private_outputs(
+    signature_algorithm: DWalletSignatureAlgorithm,
+    private_output: &[u8],
+) -> DwalletMPCResult<Vec<(u16, Vec<u8>)>> {
+    match signature_algorithm {
+        DWalletSignatureAlgorithm::TaprootVSS => bcs::from_bytes::<
+            <<Secp256k1TaprootVSSProtocol as twopc_mpc::presign::Protocol>::PresignParty as Party>::PrivateOutput,
+        >(private_output)
+        .map_err(blended_vss_private_output_bcs_error)?
+        .into_iter()
+        .map(|entry| {
+            Ok((
+                entry.presign_blending_index,
+                bcs::to_bytes(&entry).map_err(blended_vss_private_output_bcs_error)?,
+            ))
+        })
+        .collect(),
+        DWalletSignatureAlgorithm::EdDSAVSS => bcs::from_bytes::<
+            <<Curve25519EdDSAVSSProtocol as twopc_mpc::presign::Protocol>::PresignParty as Party>::PrivateOutput,
+        >(private_output)
+        .map_err(blended_vss_private_output_bcs_error)?
+        .into_iter()
+        .map(|entry| {
+            Ok((
+                entry.presign_blending_index,
+                bcs::to_bytes(&entry).map_err(blended_vss_private_output_bcs_error)?,
+            ))
+        })
+        .collect(),
+        DWalletSignatureAlgorithm::SchnorrkelVSS => bcs::from_bytes::<
+            <<RistrettoSchnorrkelVSSProtocol as twopc_mpc::presign::Protocol>::PresignParty as Party>::PrivateOutput,
+        >(private_output)
+        .map_err(blended_vss_private_output_bcs_error)?
+        .into_iter()
+        .map(|entry| {
+            Ok((
+                entry.presign_blending_index,
+                bcs::to_bytes(&entry).map_err(blended_vss_private_output_bcs_error)?,
+            ))
+        })
+        .collect(),
+        _ => Err(DwalletMPCError::InvalidInput(format!(
+            "{signature_algorithm} is not a Fast Schnorr (VSS) algorithm"
+        ))),
+    }
+}
+
+/// Deserializes a single persisted VSS presign entry. Each row is now keyed by
+/// `(session_id, presign_blending_index)` and stores exactly one serialized
+/// `PrivatePresignOutput`, so no per-entry selection is needed; the args are used only
+/// for the error message. `None` private output (missing row) → soft-fail error so this
+/// validator drops out of the sign quorum rather than crashing the session.
+fn vss_presign_private_output<Entry>(
+    presign_private_output: Option<Vec<u8>>,
+    session_id: commitment::CommitmentSizedNumber,
+    presign_blending_index: u16,
+) -> DwalletMPCResult<Entry>
+where
+    Entry: serde::de::DeserializeOwned,
+{
+    let bytes = presign_private_output.ok_or_else(|| {
+        DwalletMPCError::InvalidInput(format!(
+            "VSS presign private output missing for session {session_id:?} blending index \
+             {presign_blending_index}; this validator cannot contribute to the sign"
+        ))
+    })?;
+    bcs::from_bytes(&bytes).map_err(|e| {
+        DwalletMPCError::BcsError(bcs::Error::Custom(format!(
+            "failed to deserialize persisted VSS presign private output: {e}"
+        )))
+    })
+}
+
+// The VSS sign `PrivateInput` is the SAME concrete type for the standalone VSS
+// `SignParty` and the combined `DKGSignParty`, so each builder serves both call
+// sites. Each takes the pre-derived per-network-key VSS Shamir cache (computed
+// once at network-key ingestion in
+// `ValidatorPrivateDecryptionKeyData::decrypt_and_store_secret_key_shares`),
+// the presign's `session_id`/`blending_index`, and the persisted presign
+// private output — no re-derivation, no `root_seed`, no `from_seed` call.
+pub(crate) fn build_secp256k1_taproot_vss_sign_private_input(
+    vss_shamir_cache: &crate::dwallet_mpc::network_dkg::VssShamirCachePerKey,
+    presign_private_output: Option<Vec<u8>>,
+    presign_session_id: commitment::CommitmentSizedNumber,
+    presign_blending_index: u16,
+) -> DwalletMPCResult<
+    <SignParty<Secp256k1TaprootVSSProtocol> as AsynchronouslyAdvanceable>::PrivateInput,
+> {
+    let curve_cache = &vss_shamir_cache.secp256k1;
+
+    let entry = vss_presign_private_output::<
+        <<<Secp256k1TaprootVSSProtocol as twopc_mpc::presign::Protocol>::PresignParty as Party>::PrivateOutput as IntoIterator>::Item,
+    >(presign_private_output, presign_session_id, presign_blending_index)?;
+
+    Ok(
+        twopc_mpc::schnorr::vss::sign::decentralized_party::PrivateInput {
+            secret_key_share_first_part: curve_cache.secret_key_share_first_part,
+            secret_key_share_second_part: curve_cache.secret_key_share_second_part,
+            session_id: entry.session_id,
+            presign_blending_index: entry.presign_blending_index,
+            nonce_share_first_part: entry.nonce_share_first_part,
+            nonce_share_second_part: entry.nonce_share_second_part,
+            first_nonce_polynomial_commitments: entry
+                .nonce_share_first_part_coefficient_commitments,
+            second_nonce_polynomial_commitments: entry
+                .nonce_share_second_part_coefficient_commitments,
+        },
+    )
+}
+
+pub(crate) fn build_curve25519_eddsa_vss_sign_private_input(
+    vss_shamir_cache: &crate::dwallet_mpc::network_dkg::VssShamirCachePerKey,
+    presign_private_output: Option<Vec<u8>>,
+    presign_session_id: commitment::CommitmentSizedNumber,
+    presign_blending_index: u16,
+) -> DwalletMPCResult<
+    <SignParty<Curve25519EdDSAVSSProtocol> as AsynchronouslyAdvanceable>::PrivateInput,
+> {
+    let curve_cache = &vss_shamir_cache.curve25519;
+
+    let entry = vss_presign_private_output::<
+        <<<Curve25519EdDSAVSSProtocol as twopc_mpc::presign::Protocol>::PresignParty as Party>::PrivateOutput as IntoIterator>::Item,
+    >(presign_private_output, presign_session_id, presign_blending_index)?;
+
+    Ok(
+        twopc_mpc::schnorr::vss::sign::decentralized_party::PrivateInput {
+            secret_key_share_first_part: curve_cache.secret_key_share_first_part,
+            secret_key_share_second_part: curve_cache.secret_key_share_second_part,
+            session_id: entry.session_id,
+            presign_blending_index: entry.presign_blending_index,
+            nonce_share_first_part: entry.nonce_share_first_part,
+            nonce_share_second_part: entry.nonce_share_second_part,
+            first_nonce_polynomial_commitments: entry
+                .nonce_share_first_part_coefficient_commitments,
+            second_nonce_polynomial_commitments: entry
+                .nonce_share_second_part_coefficient_commitments,
+        },
+    )
+}
+
+pub(crate) fn build_ristretto_schnorrkel_vss_sign_private_input(
+    vss_shamir_cache: &crate::dwallet_mpc::network_dkg::VssShamirCachePerKey,
+    presign_private_output: Option<Vec<u8>>,
+    presign_session_id: commitment::CommitmentSizedNumber,
+    presign_blending_index: u16,
+) -> DwalletMPCResult<
+    <SignParty<RistrettoSchnorrkelVSSProtocol> as AsynchronouslyAdvanceable>::PrivateInput,
+> {
+    let curve_cache = &vss_shamir_cache.ristretto;
+
+    let entry = vss_presign_private_output::<
+        <<<RistrettoSchnorrkelVSSProtocol as twopc_mpc::presign::Protocol>::PresignParty as Party>::PrivateOutput as IntoIterator>::Item,
+    >(presign_private_output, presign_session_id, presign_blending_index)?;
+
+    Ok(
+        twopc_mpc::schnorr::vss::sign::decentralized_party::PrivateInput {
+            secret_key_share_first_part: curve_cache.secret_key_share_first_part,
+            secret_key_share_second_part: curve_cache.secret_key_share_second_part,
+            session_id: entry.session_id,
+            presign_blending_index: entry.presign_blending_index,
+            nonce_share_first_part: entry.nonce_share_first_part,
+            nonce_share_second_part: entry.nonce_share_second_part,
+            first_nonce_polynomial_commitments: entry
+                .nonce_share_first_part_coefficient_commitments,
+            second_nonce_polynomial_commitments: entry
+                .nonce_share_second_part_coefficient_commitments,
+        },
+    )
+}
+
+fn build_secp256k1_taproot_vss_sign_public_input(
+    dwallet_decentralized_public_output: &SerializedWrappedMPCPublicOutput,
+    message: Vec<u8>,
+    presign: &SerializedWrappedMPCPublicOutput,
+    message_centralized_signature: &SerializedWrappedMPCPublicOutput,
+    hash_scheme: HashScheme,
+    hash_context: HashContext,
+    network_encryption_key_public_data: &NetworkEncryptionKeyPublicData,
+    vss_shamir_cache: &crate::dwallet_mpc::network_dkg::VssShamirCachePerKey,
+) -> DwalletMPCResult<<SignParty<Secp256k1TaprootVSSProtocol> as Party>::PublicInput> {
+    let protocol_public_parameters =
+        network_encryption_key_public_data.secp256k1_protocol_public_parameters();
+    let (dkg_output, presign_value) = decode_schnorr_vss_dkg_and_presign::<
+        Secp256k1AsyncDKGProtocol,
+        Secp256k1TaprootVSSProtocol,
+    >(dwallet_decentralized_public_output, presign)?;
+    let sign_data =
+        decode_schnorr_sign_data::<Secp256k1TaprootVSSProtocol>(message_centralized_signature)?;
+    let curve_cache = &vss_shamir_cache.secp256k1;
+
+    Ok(
+        twopc_mpc::schnorr::vss::sign::decentralized_party::PublicInput {
+            message,
+            hash_scheme,
+            hash_context,
+            dkg_output,
+            presign: presign_value,
+            centralized_party_partial_signature: sign_data,
+            protocol_public_parameters,
+            first_secret_key_polynomial_commitments: curve_cache
+                .first_secret_key_polynomial_commitments
+                .clone(),
+            second_secret_key_polynomial_commitments: curve_cache
+                .second_secret_key_polynomial_commitments
+                .clone(),
+        },
+    )
+}
+
+fn build_curve25519_eddsa_vss_sign_public_input(
+    dwallet_decentralized_public_output: &SerializedWrappedMPCPublicOutput,
+    message: Vec<u8>,
+    presign: &SerializedWrappedMPCPublicOutput,
+    message_centralized_signature: &SerializedWrappedMPCPublicOutput,
+    hash_scheme: HashScheme,
+    hash_context: HashContext,
+    network_encryption_key_public_data: &NetworkEncryptionKeyPublicData,
+    vss_shamir_cache: &crate::dwallet_mpc::network_dkg::VssShamirCachePerKey,
+) -> DwalletMPCResult<<SignParty<Curve25519EdDSAVSSProtocol> as Party>::PublicInput> {
+    let protocol_public_parameters =
+        network_encryption_key_public_data.curve25519_protocol_public_parameters();
+    let (dkg_output, presign_value) = decode_schnorr_vss_dkg_and_presign::<
+        Curve25519AsyncDKGProtocol,
+        Curve25519EdDSAVSSProtocol,
+    >(dwallet_decentralized_public_output, presign)?;
+    let sign_data =
+        decode_schnorr_sign_data::<Curve25519EdDSAVSSProtocol>(message_centralized_signature)?;
+    let curve_cache = &vss_shamir_cache.curve25519;
+
+    Ok(
+        twopc_mpc::schnorr::vss::sign::decentralized_party::PublicInput {
+            message,
+            hash_scheme,
+            hash_context,
+            dkg_output,
+            presign: presign_value,
+            centralized_party_partial_signature: sign_data,
+            protocol_public_parameters,
+            first_secret_key_polynomial_commitments: curve_cache
+                .first_secret_key_polynomial_commitments
+                .clone(),
+            second_secret_key_polynomial_commitments: curve_cache
+                .second_secret_key_polynomial_commitments
+                .clone(),
+        },
+    )
+}
+
+fn build_ristretto_schnorrkel_vss_sign_public_input(
+    dwallet_decentralized_public_output: &SerializedWrappedMPCPublicOutput,
+    message: Vec<u8>,
+    presign: &SerializedWrappedMPCPublicOutput,
+    message_centralized_signature: &SerializedWrappedMPCPublicOutput,
+    hash_scheme: HashScheme,
+    hash_context: HashContext,
+    network_encryption_key_public_data: &NetworkEncryptionKeyPublicData,
+    vss_shamir_cache: &crate::dwallet_mpc::network_dkg::VssShamirCachePerKey,
+) -> DwalletMPCResult<<SignParty<RistrettoSchnorrkelVSSProtocol> as Party>::PublicInput> {
+    let protocol_public_parameters =
+        network_encryption_key_public_data.ristretto_protocol_public_parameters();
+    let (dkg_output, presign_value) = decode_schnorr_vss_dkg_and_presign::<
+        RistrettoAsyncDKGProtocol,
+        RistrettoSchnorrkelVSSProtocol,
+    >(dwallet_decentralized_public_output, presign)?;
+    let sign_data =
+        decode_schnorr_sign_data::<RistrettoSchnorrkelVSSProtocol>(message_centralized_signature)?;
+    let curve_cache = &vss_shamir_cache.ristretto;
+
+    Ok(
+        twopc_mpc::schnorr::vss::sign::decentralized_party::PublicInput {
+            message,
+            hash_scheme,
+            hash_context,
+            dkg_output,
+            presign: presign_value,
+            centralized_party_partial_signature: sign_data,
+            protocol_public_parameters,
+            first_secret_key_polynomial_commitments: curve_cache
+                .first_secret_key_polynomial_commitments
+                .clone(),
+            second_secret_key_polynomial_commitments: curve_cache
+                .second_secret_key_polynomial_commitments
+                .clone(),
+        },
+    )
+}
 
 fn build_secp256k1_ecdsa_sign_public_input(
     expected_decrypters: HashSet<PartyID>,
@@ -455,6 +981,11 @@ fn build_secp256k1_ecdsa_sign_public_input(
             Secp256k1AsyncDKGProtocol,
             Secp256k1ECDSAProtocol,
         >(dwallet_decentralized_public_output, presign)?,
+        VersionedPresignOutput::V3(_) => {
+            return Err(DwalletMPCError::InvalidInput(
+                "ECDSA sign cannot consume a Fast Schnorr (VSS) presign (V3)".to_string(),
+            ));
+        }
     };
 
     let sign_data =
@@ -674,6 +1205,11 @@ where
             unreachable!("Presign V1 only valid for Secp256k1ECDSA — handled inline there")
         }
         VersionedPresignOutput::V2(p) => p,
+        VersionedPresignOutput::V3(_) => {
+            return Err(DwalletMPCError::InvalidInput(
+                "AHE sign cannot consume a Fast Schnorr (VSS) presign (V3)".to_string(),
+            ));
+        }
     };
     let presign_value: <P as twopc_mpc::presign::Protocol>::Presign =
         bcs::from_bytes(&presign_bytes).map_err(|e| {
@@ -684,8 +1220,10 @@ where
     Ok((dkg_output, presign_value))
 }
 
-// Schnorr-AHE shares the same DKG/presign decode shape as ECDSA at this rev — the
-// per-curve structs differ but the BCS wire layout is the same versioned wrapper.
+/// AHE Schnorr DKG + presign decode. Shares the BCS wire shape with ECDSA at
+/// this rev (same versioned wrapper, same `D`/`P` shape); only the per-curve
+/// struct differs. Delegates to [`decode_ecdsa_dkg_and_presign`], which
+/// accepts the V2-tagged AHE presign.
 fn decode_schnorr_ahe_dkg_and_presign<D, P>(
     dwallet_decentralized_public_output: &SerializedWrappedMPCPublicOutput,
     presign: &SerializedWrappedMPCPublicOutput,
@@ -698,6 +1236,41 @@ where
     P: twopc_mpc::presign::Protocol,
 {
     decode_ecdsa_dkg_and_presign::<D, P>(dwallet_decentralized_public_output, presign)
+}
+
+/// Fast Schnorr (VSS) DKG + presign decode. The dWallet DKG output uses the
+/// same per-curve shape as AHE; the presign is the V3-tagged
+/// `schnorr::vss::Presign` variant.
+fn decode_schnorr_vss_dkg_and_presign<D, P>(
+    dwallet_decentralized_public_output: &SerializedWrappedMPCPublicOutput,
+    presign: &SerializedWrappedMPCPublicOutput,
+) -> DwalletMPCResult<(
+    <D as twopc_mpc::dkg::Protocol>::DecentralizedPartyDKGOutput,
+    <P as twopc_mpc::presign::Protocol>::Presign,
+)>
+where
+    D: twopc_mpc::dkg::Protocol,
+    P: twopc_mpc::presign::Protocol,
+{
+    let dkg_output = decode_ecdsa_dkg::<D>(dwallet_decentralized_public_output)?;
+
+    let presign_versioned: VersionedPresignOutput = bcs::from_bytes(presign).map_err(|e| {
+        DwalletMPCError::BcsError(bcs::Error::Custom(format!(
+            "Failed to deserialize VSS presign output: {e}"
+        )))
+    })?;
+    let VersionedPresignOutput::V3(presign_bytes) = presign_versioned else {
+        return Err(DwalletMPCError::InvalidInput(
+            "Fast Schnorr (VSS) sign requires a V3 presign".to_string(),
+        ));
+    };
+    let presign_value: <P as twopc_mpc::presign::Protocol>::Presign =
+        bcs::from_bytes(&presign_bytes).map_err(|e| {
+            DwalletMPCError::BcsError(bcs::Error::Custom(format!(
+                "Failed to deserialize VSS presign V3 inner: {e}"
+            )))
+        })?;
+    Ok((dkg_output, presign_value))
 }
 
 fn decode_ecdsa_sign_data<P>(
@@ -759,6 +1332,7 @@ impl DKGAndSignPublicInputByProtocol {
         hash_context: HashContext,
         access_structure: &WeightedThresholdAccessStructure,
         network_encryption_key_public_data: &NetworkEncryptionKeyPublicData,
+        vss_shamir_cache: &crate::dwallet_mpc::network_dkg::VssShamirCachePerKey,
         protocol: DWalletSignatureAlgorithm,
     ) -> DwalletMPCResult<Self> {
         let expected_decrypters =
@@ -856,6 +1430,63 @@ impl DKGAndSignPublicInputByProtocol {
                         hash_scheme,
                         hash_context,
                         network_encryption_key_public_data,
+                    )?,
+                ))
+            }
+            DWalletSignatureAlgorithm::TaprootVSS => {
+                let DWalletDKGPublicInputByCurve::Secp256k1DWalletDKG(dkg_public_input) =
+                    dwallet_dkg_public_input
+                else {
+                    unreachable!("Curve and DKG public input type mismatch");
+                };
+                Ok(DKGAndSignPublicInputByProtocol::TaprootVSS(
+                    build_secp256k1_taproot_vss_dkg_and_sign_public_input(
+                        dkg_public_input,
+                        message,
+                        presign,
+                        message_centralized_signature,
+                        hash_scheme,
+                        hash_context,
+                        network_encryption_key_public_data,
+                        vss_shamir_cache,
+                    )?,
+                ))
+            }
+            DWalletSignatureAlgorithm::EdDSAVSS => {
+                let DWalletDKGPublicInputByCurve::Curve25519DWalletDKG(dkg_public_input) =
+                    dwallet_dkg_public_input
+                else {
+                    unreachable!("Curve and DKG public input type mismatch");
+                };
+                Ok(DKGAndSignPublicInputByProtocol::EdDSAVSS(
+                    build_curve25519_eddsa_vss_dkg_and_sign_public_input(
+                        dkg_public_input,
+                        message,
+                        presign,
+                        message_centralized_signature,
+                        hash_scheme,
+                        hash_context,
+                        network_encryption_key_public_data,
+                        vss_shamir_cache,
+                    )?,
+                ))
+            }
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
+                let DWalletDKGPublicInputByCurve::RistrettoDWalletDKG(dkg_public_input) =
+                    dwallet_dkg_public_input
+                else {
+                    unreachable!("Curve and DKG public input type mismatch");
+                };
+                Ok(DKGAndSignPublicInputByProtocol::SchnorrkelVSS(
+                    build_ristretto_schnorrkel_vss_dkg_and_sign_public_input(
+                        dkg_public_input,
+                        message,
+                        presign,
+                        message_centralized_signature,
+                        hash_scheme,
+                        hash_context,
+                        network_encryption_key_public_data,
+                        vss_shamir_cache,
                     )?,
                 ))
             }
@@ -1033,6 +1664,131 @@ fn build_ristretto_schnorrkel_dkg_and_sign_public_input(
     )
 }
 
+// Per-curve concrete VSS dkg-and-sign-public-input builders, producing the VSS
+// `DKGSignPublicInput`. Shape combines the two existing patterns: `protocol_public_parameters`
+// + the two secret-key polynomial-commitment vecs come from the network key's secret-key-shares
+// source (as in `build_*_vss_sign_public_input`), while `dkg_public_input` + presign decode +
+// sign-data decode come from the AHE combined path (`build_*_dkg_and_sign_public_input`).
+//
+// `decryption_key_share_public_parameters` is `Arc::new(())`: VSS has no AHE decryption-key
+// shares, and the crypto types this field as `Arc<()>`. `expected_signers` is the empty set:
+// the upstream VSS `DKGSignParty` declares the field but never reads it (it delegates to the
+// standalone VSS `SignParty`, whose `PublicInput` has no such field), so any value is inert;
+// the empty set avoids implying a meaning the crypto does not honor.
+fn build_secp256k1_taproot_vss_dkg_and_sign_public_input(
+    dkg_public_input: <Secp256k1AsyncDKGProtocol as twopc_mpc::dkg::Protocol>::DKGDecentralizedPartyPublicInput,
+    message: Vec<u8>,
+    presign: &SerializedWrappedMPCPublicOutput,
+    message_centralized_signature: &SerializedWrappedMPCPublicOutput,
+    hash_scheme: HashScheme,
+    hash_context: HashContext,
+    network_encryption_key_public_data: &NetworkEncryptionKeyPublicData,
+    vss_shamir_cache: &crate::dwallet_mpc::network_dkg::VssShamirCachePerKey,
+) -> DwalletMPCResult<<DKGAndSignParty<Secp256k1TaprootVSSProtocol> as Party>::PublicInput> {
+    let protocol_public_parameters =
+        network_encryption_key_public_data.secp256k1_protocol_public_parameters();
+    let presign_value = decode_presign_v2::<Secp256k1TaprootVSSProtocol>(presign)?;
+    let sign_data =
+        decode_schnorr_sign_data::<Secp256k1TaprootVSSProtocol>(message_centralized_signature)?;
+    let curve_cache = &vss_shamir_cache.secp256k1;
+
+    Ok(
+        twopc_mpc::schnorr::vss::sign::decentralized_party::DKGSignPublicInput {
+            expected_signers: HashSet::new(),
+            message,
+            hash_scheme,
+            hash_context,
+            dkg_public_input,
+            presign: presign_value,
+            centralized_party_partial_signature: sign_data,
+            decryption_key_share_public_parameters: Arc::new(()),
+            protocol_public_parameters,
+            first_secret_key_polynomial_commitments: curve_cache
+                .first_secret_key_polynomial_commitments
+                .clone(),
+            second_secret_key_polynomial_commitments: curve_cache
+                .second_secret_key_polynomial_commitments
+                .clone(),
+        },
+    )
+}
+
+fn build_curve25519_eddsa_vss_dkg_and_sign_public_input(
+    dkg_public_input: <Curve25519AsyncDKGProtocol as twopc_mpc::dkg::Protocol>::DKGDecentralizedPartyPublicInput,
+    message: Vec<u8>,
+    presign: &SerializedWrappedMPCPublicOutput,
+    message_centralized_signature: &SerializedWrappedMPCPublicOutput,
+    hash_scheme: HashScheme,
+    hash_context: HashContext,
+    network_encryption_key_public_data: &NetworkEncryptionKeyPublicData,
+    vss_shamir_cache: &crate::dwallet_mpc::network_dkg::VssShamirCachePerKey,
+) -> DwalletMPCResult<<DKGAndSignParty<Curve25519EdDSAVSSProtocol> as Party>::PublicInput> {
+    let protocol_public_parameters =
+        network_encryption_key_public_data.curve25519_protocol_public_parameters();
+    let presign_value = decode_presign_v2::<Curve25519EdDSAVSSProtocol>(presign)?;
+    let sign_data =
+        decode_schnorr_sign_data::<Curve25519EdDSAVSSProtocol>(message_centralized_signature)?;
+    let curve_cache = &vss_shamir_cache.curve25519;
+
+    Ok(
+        twopc_mpc::schnorr::vss::sign::decentralized_party::DKGSignPublicInput {
+            expected_signers: HashSet::new(),
+            message,
+            hash_scheme,
+            hash_context,
+            dkg_public_input,
+            presign: presign_value,
+            centralized_party_partial_signature: sign_data,
+            decryption_key_share_public_parameters: Arc::new(()),
+            protocol_public_parameters,
+            first_secret_key_polynomial_commitments: curve_cache
+                .first_secret_key_polynomial_commitments
+                .clone(),
+            second_secret_key_polynomial_commitments: curve_cache
+                .second_secret_key_polynomial_commitments
+                .clone(),
+        },
+    )
+}
+
+fn build_ristretto_schnorrkel_vss_dkg_and_sign_public_input(
+    dkg_public_input: <RistrettoAsyncDKGProtocol as twopc_mpc::dkg::Protocol>::DKGDecentralizedPartyPublicInput,
+    message: Vec<u8>,
+    presign: &SerializedWrappedMPCPublicOutput,
+    message_centralized_signature: &SerializedWrappedMPCPublicOutput,
+    hash_scheme: HashScheme,
+    hash_context: HashContext,
+    network_encryption_key_public_data: &NetworkEncryptionKeyPublicData,
+    vss_shamir_cache: &crate::dwallet_mpc::network_dkg::VssShamirCachePerKey,
+) -> DwalletMPCResult<<DKGAndSignParty<RistrettoSchnorrkelVSSProtocol> as Party>::PublicInput> {
+    let protocol_public_parameters =
+        network_encryption_key_public_data.ristretto_protocol_public_parameters();
+    let presign_value = decode_presign_v2::<RistrettoSchnorrkelVSSProtocol>(presign)?;
+    let sign_data =
+        decode_schnorr_sign_data::<RistrettoSchnorrkelVSSProtocol>(message_centralized_signature)?;
+    let curve_cache = &vss_shamir_cache.ristretto;
+
+    Ok(
+        twopc_mpc::schnorr::vss::sign::decentralized_party::DKGSignPublicInput {
+            expected_signers: HashSet::new(),
+            message,
+            hash_scheme,
+            hash_context,
+            dkg_public_input,
+            presign: presign_value,
+            centralized_party_partial_signature: sign_data,
+            decryption_key_share_public_parameters: Arc::new(()),
+            protocol_public_parameters,
+            first_secret_key_polynomial_commitments: curve_cache
+                .first_secret_key_polynomial_commitments
+                .clone(),
+            second_secret_key_polynomial_commitments: curve_cache
+                .second_secret_key_polynomial_commitments
+                .clone(),
+        },
+    )
+}
+
 fn decode_presign_v2<P>(
     presign: &SerializedWrappedMPCPublicOutput,
 ) -> DwalletMPCResult<<P as twopc_mpc::presign::Protocol>::Presign>
@@ -1045,6 +1801,11 @@ where
             unreachable!("Presign V1 should have been handled separately")
         }
         VersionedPresignOutput::V2(p) => p,
+        VersionedPresignOutput::V3(_) => {
+            return Err(DwalletMPCError::InvalidInput(
+                "decode_presign_v2 cannot consume a Fast Schnorr (VSS) presign (V3)".to_string(),
+            ));
+        }
     };
     bcs::from_bytes(&presign_bytes).map_err(|e| {
         DwalletMPCError::BcsError(bcs::Error::Custom(format!(
@@ -1104,6 +1865,12 @@ where
             unreachable!("Presign V1 should have been handled separately")
         }
         VersionedPresignOutput::V2(presign) => presign,
+        VersionedPresignOutput::V3(_) => {
+            return Err(DwalletMPCError::InvalidInput(
+                "verify_partial_signature cannot consume a Fast Schnorr (VSS) presign (V3)"
+                    .to_string(),
+            ));
+        }
     };
     let dkg_output: VersionedDwalletDKGPublicOutput =
         bcs::from_bytes(dwallet_decentralized_output)?;

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/native_computations.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/native_computations.rs
@@ -143,6 +143,14 @@ impl ProtocolCryptographicData {
                             .map_err(DwalletMPCError::from)?;
                     Vec::new()
                 }
+                VersionedPresignOutput::V3(_) => {
+                    // V3 is Fast Schnorr (VSS) presign, which is NOA-only and
+                    // never goes through user-driven partial-signature verification.
+                    return Err(DwalletMPCError::InvalidInput(
+                        "PartialSignatureVerification is not supported for VSS presigns (V3)"
+                            .to_string(),
+                    ));
+                }
                 VersionedPresignOutput::V2(_) => {
                     match data.signature_algorithm {
                         DWalletSignatureAlgorithm::ECDSASecp256k1 => {

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
@@ -80,6 +80,20 @@ pub(crate) struct CryptographicComputationsOrchestrator {
     /// advancing this session.
     /// SECURITY NOTICE: *MUST KEEP PRIVATE*.
     root_seed: RootSeed,
+
+    /// Fast Schnorr (VSS) HPKE curve25519 secret key, derived once at startup
+    /// from `root_seed` and reused for every VSS presign — avoids re-running
+    /// the HPKE keypair generation per presign.
+    vss_hpke_secret_key: group::curve25519::Scalar,
+
+    /// Under msim, the simulated node this orchestrator belongs to, captured at
+    /// construction (which runs inside the validator's node context). The rayon
+    /// worker that runs a cryptographic computation has no node context, so it uses
+    /// this handle to re-enter the node (for the compute's tracing) and to spawn the
+    /// completion task via `NodeHandle::spawn` — `Handle::spawn` would call
+    /// `NodeHandle::current().unwrap()` on the rayon worker and abort the process.
+    #[cfg(msim)]
+    sim_node: Option<sui_simulator::runtime::NodeHandle>,
 }
 
 impl CryptographicComputationsOrchestrator {
@@ -101,6 +115,17 @@ impl CryptographicComputationsOrchestrator {
             "Available CPU cores for Rayon cryptographic computations"
         );
 
+        // Capture the simulated node here: construction runs in the validator's
+        // node context (the log above succeeds via tracing), whereas `try_spawn`'s
+        // rayon-dispatching task can run outside one. No-op under non-msim.
+        #[cfg(msim)]
+        let sim_node = sui_simulator::runtime::NodeHandle::try_current();
+
+        let vss_hpke_secret_key =
+            dwallet_classgroups_types::ValidatorMPCSecrets::vss_hpke_secret_key_from_seed(
+                &root_seed,
+            );
+
         Ok(CryptographicComputationsOrchestrator {
             available_cores_for_cryptographic_computations: available_cores_for_computations,
             completed_computation_sender: report_computation_completed_sender,
@@ -108,6 +133,9 @@ impl CryptographicComputationsOrchestrator {
             currently_running_cryptographic_computations: HashSet::new(),
             completed_cryptographic_computations: HashSet::new(),
             root_seed,
+            vss_hpke_secret_key,
+            #[cfg(msim)]
+            sim_node,
         })
     }
 
@@ -150,7 +178,7 @@ impl CryptographicComputationsOrchestrator {
                     "Cryptographic computation failed"
                 );
             } else {
-                debug!(
+                info!(
                     party_id,
                     ?session_identifier,
                     ?computation_result_data,
@@ -232,7 +260,7 @@ impl CryptographicComputationsOrchestrator {
         }
 
         if !self.has_available_cores_to_perform_computation() {
-            debug!(
+            info!(
                 session_identifier=?computation_id.session_identifier,
                 mpc_round=?computation_id.mpc_round,
                 attempt_number=?computation_id.attempt_number,
@@ -244,11 +272,13 @@ impl CryptographicComputationsOrchestrator {
 
             return false;
         }
+        let handle = Handle::current();
+
         let party_id = computation_request.party_id;
         let protocol_metadata: DWalletSessionRequestMetricData =
             (&computation_request.protocol_cryptographic_data).into();
 
-        debug!(
+        info!(
             party_id,
             session_identifier=?computation_id.session_identifier,
             current_round=?computation_id.mpc_round,
@@ -259,68 +289,59 @@ impl CryptographicComputationsOrchestrator {
 
         let computation_channel_sender = self.completed_computation_sender.clone();
         let root_seed = self.root_seed.clone();
+        let vss_hpke_secret_key = self.vss_hpke_secret_key;
 
-        // Under msim, run the computation INLINE in the calling task instead
-        // of on rayon. Crypto is sequential under msim anyway (the `parallel`
-        // feature is dropped in that profile), and a rayon worker has no
-        // simulated-node context: even with a captured-NodeHandle re-entry
-        // guard, msim's `Handle::spawn` re-resolves the CURRENT node at spawn
-        // time, so a computation whose node was torn down mid-compute (an
-        // epoch swap in the simulation) panics at
-        // `NodeHandle::current().unwrap()` and rayon-core aborts the whole
-        // process. Inline, the send happens in the same task context — which
-        // dies cleanly WITH the node, dropping the now-moot result.
+        // Under msim, tokio APIs and tracing instrumentation require a simulated
+        // node context; rayon worker threads have none and abort at
+        // `NodeHandle::current().unwrap()`. Use the node captured at construction
+        // (`try_current()` on this rayon-dispatching task can already be outside a
+        // node). Enter it for the compute's tracing, and spawn the completion via
+        // `NodeHandle::spawn` (targets the node directly) rather than `Handle::spawn`
+        // (which calls `NodeHandle::current()`). No-op under non-msim.
         #[cfg(msim)]
-        {
+        let sim_node = self.sim_node.clone();
+
+        rayon::spawn_fifo(move || {
+            #[cfg(msim)]
+            let _node_guard = sim_node.as_ref().map(|n| n.enter_node());
+
             let advance_start_time = Instant::now();
-            let computation_result =
-                computation_request.compute(computation_id, root_seed, dwallet_mpc_metrics.clone());
-            let elapsed_ms = advance_start_time.elapsed().as_millis();
-            if let Err(err) = computation_channel_sender
-                .send(ComputationCompletionUpdate {
-                    computation_id,
-                    party_id,
-                    protocol_metadata,
-                    computation_result,
-                    elapsed_ms,
-                })
-                .await
-            {
-                error!(error=?err, "failed to send a computation completion update");
+
+            let computation_result = computation_request.compute(
+                computation_id,
+                root_seed,
+                vss_hpke_secret_key,
+                dwallet_mpc_metrics.clone(),
+            );
+
+            let elapsed = advance_start_time.elapsed();
+            let elapsed_ms = elapsed.as_millis();
+
+            let completion_update = ComputationCompletionUpdate {
+                computation_id,
+                party_id,
+                protocol_metadata,
+                computation_result,
+                elapsed_ms,
+            };
+            let send_completion = async move {
+                if let Err(err) = computation_channel_sender.send(completion_update).await {
+                    error!(error=?err, "failed to send a computation completion update");
+                }
+            };
+
+            #[cfg(msim)]
+            match sim_node.as_ref() {
+                Some(node) => {
+                    node.spawn(send_completion);
+                }
+                None => {
+                    handle.spawn(send_completion);
+                }
             }
-        }
-
-        #[cfg(not(msim))]
-        {
-            let handle = Handle::current();
-            rayon::spawn_fifo(move || {
-                let advance_start_time = Instant::now();
-
-                let computation_result = computation_request.compute(
-                    computation_id,
-                    root_seed,
-                    dwallet_mpc_metrics.clone(),
-                );
-
-                let elapsed = advance_start_time.elapsed();
-                let elapsed_ms = elapsed.as_millis();
-
-                handle.spawn(async move {
-                    if let Err(err) = computation_channel_sender
-                        .send(ComputationCompletionUpdate {
-                            computation_id,
-                            party_id,
-                            protocol_metadata,
-                            computation_result,
-                            elapsed_ms,
-                        })
-                        .await
-                    {
-                        error!(error=?err, "failed to send a computation completion update");
-                    }
-                });
-            });
-        }
+            #[cfg(not(msim))]
+            handle.spawn(send_completion);
+        });
 
         self.currently_running_cryptographic_computations
             .insert(computation_id);

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/protocol_cryptographic_data.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/protocol_cryptographic_data.rs
@@ -6,6 +6,7 @@ use crate::dwallet_mpc::dwallet_dkg::{
 };
 use crate::dwallet_mpc::mpc_manager::DWalletMPCManager;
 use crate::dwallet_mpc::mpc_session::{PublicInput, SessionComputationType};
+use crate::dwallet_mpc::network_dkg::VssShamirCachePerKey;
 use crate::dwallet_mpc::presign::{PresignAdvanceRequestByProtocol, PresignPublicInputByProtocol};
 use crate::dwallet_mpc::sign::{
     DKGAndSignPublicInputByProtocol, DWalletDKGAndSignAdvanceRequestByProtocol,
@@ -73,11 +74,55 @@ pub(crate) enum ProtocolCryptographicData {
         decryption_key_shares: HashMap<PartyID, SecretKeyShareSizedInteger>,
     },
 
+    /// Fast Schnorr (VSS) sign for the EXTERNAL (`ProtocolData::Sign`) path only.
+    /// VSS has no AHE decrypters, so unlike AHE `Sign`, the private input is the
+    /// validator's pre-derived VSS secret-key Shamir shares (looked up by
+    /// network key id at the build site — derivation happens once at
+    /// network-key ingestion, NOT per sign) joined with the persisted presign
+    /// nonce data (`presign_private_output`).
+    SignVSS {
+        data: SignData,
+        public_input: SignPublicInputByProtocol,
+        advance_request: SignAdvanceRequestByProtocol,
+        /// Pre-derived (at network-key ingestion) per-curve VSS Shamir-share +
+        /// polynomial-commitments cache for this network key. The sign compute
+        /// site picks the curve matching `data.signature_algorithm`.
+        vss_shamir_cache: VssShamirCachePerKey,
+        /// `bcs(PrivatePresignOutput)` for this presign's `(session_id, blending_index)`;
+        /// `None` if the row is missing (disk loss / cross-epoch) → this validator
+        /// soft-fails.
+        presign_private_output: Option<Vec<u8>>,
+    },
+
+    /// Fast Schnorr (VSS) sign for the NOA (`ProtocolData::NetworkOwnedAddressSign`)
+    /// path. Compute is identical to `SignVSS` (VSS has no AHE decrypters, so the
+    /// AHE NOA-vs-external compute split collapses), but kept a separate variant for
+    /// symmetry with the AHE `Sign`/`NetworkOwnedAddressSign` split. Its `data` stays
+    /// the native `NetworkOwnedAddressSignData` and is coerced to `SignData` only at
+    /// the compute site (mirroring the AHE `NetworkOwnedAddressSign` compute arms).
+    NetworkOwnedAddressSignVSS {
+        data: NetworkOwnedAddressSignData,
+        public_input: SignPublicInputByProtocol,
+        advance_request: SignAdvanceRequestByProtocol,
+        vss_shamir_cache: VssShamirCachePerKey,
+        presign_private_output: Option<Vec<u8>>,
+    },
+
     DWalletDKGAndSign {
         data: DWalletDKGAndSignData,
         public_input: DKGAndSignPublicInputByProtocol,
         advance_request: DWalletDKGAndSignAdvanceRequestByProtocol,
         decryption_key_shares: HashMap<PartyID, SecretKeyShareSizedInteger>,
+    },
+
+    /// Fast Schnorr (VSS) combined DKG-and-sign fast path. Same pre-derived
+    /// shamir-cache plumbing as `SignVSS`.
+    DWalletDKGAndSignVSS {
+        data: DWalletDKGAndSignData,
+        public_input: DKGAndSignPublicInputByProtocol,
+        advance_request: DWalletDKGAndSignAdvanceRequestByProtocol,
+        vss_shamir_cache: VssShamirCachePerKey,
+        presign_private_output: Option<Vec<u8>>,
     },
     /// Backward-compatible network DKG — runs the mainnet-v1.1.8-shape Party
     /// (`twopc_mpc::decentralized_party_backward_compatible::dkg::Party`).
@@ -88,7 +133,7 @@ pub(crate) enum ProtocolCryptographicData {
         advance_request: AdvanceRequest<<bwd_compat_dkg::Party as mpc::Party>::Message>,
         class_groups_decryption_key: ClassGroupsDecryptionKey,
     },
-    /// Network DKG running the version-3 main Party
+    /// Network DKG running the post-PR-#1707 main Party
     /// (`twopc_mpc::decentralized_party::dkg::Party`). Selected when
     /// `ProtocolConfig::is_network_encryption_key_version_v3()` is `true`.
     NetworkEncryptionKeyDkg {
@@ -152,6 +197,18 @@ impl ProtocolCryptographicData {
                 advance_request: PresignAdvanceRequestByProtocol::Schnorrkel(advance_request),
                 ..
             } => advance_request.attempt_number,
+            ProtocolCryptographicData::Presign {
+                advance_request: PresignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::Presign {
+                advance_request: PresignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::Presign {
+                advance_request: PresignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
             ProtocolCryptographicData::InternalPresign {
                 advance_request: PresignAdvanceRequestByProtocol::Secp256k1ECDSA(advance_request),
                 ..
@@ -170,6 +227,18 @@ impl ProtocolCryptographicData {
             } => advance_request.attempt_number,
             ProtocolCryptographicData::InternalPresign {
                 advance_request: PresignAdvanceRequestByProtocol::Schnorrkel(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::InternalPresign {
+                advance_request: PresignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::InternalPresign {
+                advance_request: PresignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::InternalPresign {
+                advance_request: PresignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
                 ..
             } => advance_request.attempt_number,
             ProtocolCryptographicData::Sign {
@@ -192,6 +261,51 @@ impl ProtocolCryptographicData {
                 advance_request: SignAdvanceRequestByProtocol::Ristretto(advance_request),
                 ..
             } => advance_request.attempt_number,
+            ProtocolCryptographicData::Sign {
+                advance_request: SignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::Sign {
+                advance_request: SignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::Sign {
+                advance_request: SignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::SignVSS {
+                advance_request: SignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::SignVSS {
+                advance_request: SignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::SignVSS {
+                advance_request: SignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            // A VSS sign session always carries a VSS advance request (built by
+            // `SignAdvanceRequestByProtocol::try_new` for a VSS algorithm), so the
+            // AHE advance variants are structurally unreachable here.
+            ProtocolCryptographicData::SignVSS { .. } => {
+                unreachable!("VSS sign session carries a non-VSS advance request")
+            }
+            ProtocolCryptographicData::NetworkOwnedAddressSignVSS {
+                advance_request: SignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::NetworkOwnedAddressSignVSS {
+                advance_request: SignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::NetworkOwnedAddressSignVSS {
+                advance_request: SignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::NetworkOwnedAddressSignVSS { .. } => {
+                unreachable!("VSS sign session carries a non-VSS advance request")
+            }
             ProtocolCryptographicData::DWalletDKGAndSign {
                 advance_request:
                     DWalletDKGAndSignAdvanceRequestByProtocol::Secp256k1ECDSA(advance_request),
@@ -217,6 +331,31 @@ impl ProtocolCryptographicData {
                     DWalletDKGAndSignAdvanceRequestByProtocol::Ristretto(advance_request),
                 ..
             } => advance_request.attempt_number,
+            // An AHE DKG-and-sign session always carries an AHE advance request, so the
+            // VSS advance variants are structurally unreachable here.
+            ProtocolCryptographicData::DWalletDKGAndSign { .. } => {
+                unreachable!("AHE DKG-and-sign session carries a VSS advance request")
+            }
+            ProtocolCryptographicData::DWalletDKGAndSignVSS {
+                advance_request:
+                    DWalletDKGAndSignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::DWalletDKGAndSignVSS {
+                advance_request:
+                    DWalletDKGAndSignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::DWalletDKGAndSignVSS {
+                advance_request:
+                    DWalletDKGAndSignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            // A VSS DKG-and-sign session always carries a VSS advance request, so the
+            // AHE advance variants are structurally unreachable here.
+            ProtocolCryptographicData::DWalletDKGAndSignVSS { .. } => {
+                unreachable!("VSS DKG-and-sign session carries a non-VSS advance request")
+            }
             ProtocolCryptographicData::NetworkOwnedAddressSign {
                 advance_request: SignAdvanceRequestByProtocol::Secp256k1ECDSA(advance_request),
                 ..
@@ -235,6 +374,18 @@ impl ProtocolCryptographicData {
             } => advance_request.attempt_number,
             ProtocolCryptographicData::NetworkOwnedAddressSign {
                 advance_request: SignAdvanceRequestByProtocol::Ristretto(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::NetworkOwnedAddressSign {
+                advance_request: SignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::NetworkOwnedAddressSign {
+                advance_request: SignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => advance_request.attempt_number,
+            ProtocolCryptographicData::NetworkOwnedAddressSign {
+                advance_request: SignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
                 ..
             } => advance_request.attempt_number,
             ProtocolCryptographicData::EncryptedShareVerification { .. } => 1,
@@ -335,6 +486,18 @@ impl ProtocolCryptographicData {
                 advance_request: PresignAdvanceRequestByProtocol::Schnorrkel(advance_request),
                 ..
             } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::Presign {
+                advance_request: PresignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::Presign {
+                advance_request: PresignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::Presign {
+                advance_request: PresignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
             ProtocolCryptographicData::InternalPresign {
                 advance_request: PresignAdvanceRequestByProtocol::Secp256k1ECDSA(advance_request),
                 ..
@@ -353,6 +516,18 @@ impl ProtocolCryptographicData {
             } => Some(advance_request.mpc_round_number),
             ProtocolCryptographicData::InternalPresign {
                 advance_request: PresignAdvanceRequestByProtocol::Schnorrkel(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::InternalPresign {
+                advance_request: PresignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::InternalPresign {
+                advance_request: PresignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::InternalPresign {
+                advance_request: PresignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
                 ..
             } => Some(advance_request.mpc_round_number),
             ProtocolCryptographicData::Sign {
@@ -375,6 +550,48 @@ impl ProtocolCryptographicData {
                 advance_request: SignAdvanceRequestByProtocol::Ristretto(advance_request),
                 ..
             } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::Sign {
+                advance_request: SignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::Sign {
+                advance_request: SignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::Sign {
+                advance_request: SignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::SignVSS {
+                advance_request: SignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::SignVSS {
+                advance_request: SignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::SignVSS {
+                advance_request: SignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::SignVSS { .. } => {
+                unreachable!("VSS sign session carries a non-VSS advance request")
+            }
+            ProtocolCryptographicData::NetworkOwnedAddressSignVSS {
+                advance_request: SignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::NetworkOwnedAddressSignVSS {
+                advance_request: SignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::NetworkOwnedAddressSignVSS {
+                advance_request: SignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::NetworkOwnedAddressSignVSS { .. } => {
+                unreachable!("VSS sign session carries a non-VSS advance request")
+            }
             ProtocolCryptographicData::DWalletDKGAndSign {
                 advance_request:
                     DWalletDKGAndSignAdvanceRequestByProtocol::Secp256k1ECDSA(advance_request),
@@ -400,6 +617,27 @@ impl ProtocolCryptographicData {
                     DWalletDKGAndSignAdvanceRequestByProtocol::Ristretto(advance_request),
                 ..
             } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::DWalletDKGAndSign { .. } => {
+                unreachable!("AHE DKG-and-sign session carries a VSS advance request")
+            }
+            ProtocolCryptographicData::DWalletDKGAndSignVSS {
+                advance_request:
+                    DWalletDKGAndSignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::DWalletDKGAndSignVSS {
+                advance_request:
+                    DWalletDKGAndSignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::DWalletDKGAndSignVSS {
+                advance_request:
+                    DWalletDKGAndSignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::DWalletDKGAndSignVSS { .. } => {
+                unreachable!("VSS DKG-and-sign session carries a non-VSS advance request")
+            }
             ProtocolCryptographicData::NetworkOwnedAddressSign {
                 advance_request: SignAdvanceRequestByProtocol::Secp256k1ECDSA(advance_request),
                 ..
@@ -418,6 +656,18 @@ impl ProtocolCryptographicData {
             } => Some(advance_request.mpc_round_number),
             ProtocolCryptographicData::NetworkOwnedAddressSign {
                 advance_request: SignAdvanceRequestByProtocol::Ristretto(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::NetworkOwnedAddressSign {
+                advance_request: SignAdvanceRequestByProtocol::TaprootVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::NetworkOwnedAddressSign {
+                advance_request: SignAdvanceRequestByProtocol::EdDSAVSS(advance_request),
+                ..
+            } => Some(advance_request.mpc_round_number),
+            ProtocolCryptographicData::NetworkOwnedAddressSign {
+                advance_request: SignAdvanceRequestByProtocol::SchnorrkelVSS(advance_request),
                 ..
             } => Some(advance_request.mpc_round_number),
             ProtocolCryptographicData::ImportedKeyVerification {
@@ -473,22 +723,90 @@ impl DWalletMPCManager {
             SessionComputationType::MPC {
                 messages_by_consensus_round,
                 ..
-            } => ProtocolCryptographicData::try_new_mpc(
-                protocol_data,
-                self.party_id,
-                &self.access_structure,
-                consensus_round,
-                messages_by_consensus_round.clone(),
-                public_input.clone(),
-                self.network_dkg_third_round_delay,
-                self.decryption_key_reconfiguration_third_round_delay,
-                self.schnorr_presign_second_round_delay,
-                self.network_keys
-                    .validator_private_dec_key_data
-                    .class_groups_decryption_key,
-                &self.network_keys,
-                protocol_config,
-            ),
+            } => {
+                // For a Fast Schnorr (VSS) sign — external (`Sign`) or NOA
+                // (`NetworkOwnedAddressSign`) — load this presign session's persisted
+                // private nonce output (keyed by the presign `session_id`, recovered
+                // from the public presign). `None` (missing row) is a soft-fail handled
+                // downstream — this validator drops out of the sign quorum.
+                let vss_presign = match protocol_data {
+                    ProtocolData::Sign { data, presign, .. }
+                        if data.signature_algorithm.is_vss() =>
+                    {
+                        Some((data.signature_algorithm, presign))
+                    }
+                    ProtocolData::NetworkOwnedAddressSign { data, presign, .. }
+                        if data.signature_algorithm.is_vss() =>
+                    {
+                        Some((data.signature_algorithm, presign))
+                    }
+                    // The combined DKG-and-sign request carries its presign inside `data`
+                    // (not as a sibling enum field); VSS DKG-and-sign reads the same
+                    // persisted presign private output as standalone VSS sign.
+                    ProtocolData::DWalletDKGAndSign { data, .. }
+                        if data.signature_algorithm.is_vss() =>
+                    {
+                        Some((data.signature_algorithm, &data.presign))
+                    }
+                    _ => None,
+                };
+                let presign_private_output = match vss_presign {
+                    Some((signature_algorithm, presign)) => {
+                        let (presign_session_id, presign_blending_index) =
+                            crate::dwallet_mpc::sign::vss_public_presign_identity(
+                                signature_algorithm,
+                                presign,
+                            )?;
+                        self.epoch_store
+                            .get_presign_private_output(presign_session_id, presign_blending_index)
+                            .map_err(|e| {
+                                DwalletMPCError::InvalidInput(format!(
+                                    "failed to read persisted VSS presign output: {e}"
+                                ))
+                            })?
+                    }
+                    None => None,
+                };
+
+                // Fast Schnorr (VSS) requires a uniform weight-1 access structure
+                // (the upstream VSS presign/sign parties reject anything else). ika's
+                // count-based committee satisfies this today, but it is not an asserted
+                // invariant — guard here so a future move to genuine stake-weighting
+                // fails loudly at the VSS boundary with a clear error rather than deep
+                // in the crypto layer.
+                if protocol_data
+                    .signature_algorithm()
+                    .is_some_and(|algorithm| algorithm.is_vss())
+                    && !self
+                        .access_structure
+                        .party_to_weight
+                        .values()
+                        .all(|&weight| weight == 1)
+                {
+                    return Err(DwalletMPCError::InvalidInput(
+                        "Fast Schnorr (VSS) requires a uniform weight-1 access \
+                         structure, but this committee has non-unit weights"
+                            .to_string(),
+                    ));
+                }
+                ProtocolCryptographicData::try_new_mpc(
+                    protocol_data,
+                    self.party_id,
+                    &self.access_structure,
+                    consensus_round,
+                    messages_by_consensus_round.clone(),
+                    public_input.clone(),
+                    self.network_dkg_third_round_delay,
+                    self.decryption_key_reconfiguration_third_round_delay,
+                    self.schnorr_presign_second_round_delay,
+                    self.network_keys
+                        .validator_private_dec_key_data
+                        .class_groups_decryption_key,
+                    &self.network_keys,
+                    presign_private_output,
+                    protocol_config,
+                )
+            }
         }
     }
 }

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/request.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/request.rs
@@ -28,6 +28,7 @@ impl Request {
         self,
         computation_id: ComputationId,
         root_seed: RootSeed,
+        vss_hpke_secret_key: group::curve25519::Scalar,
         dwallet_mpc_metrics: Arc<DWalletMPCMetrics>,
     ) -> DwalletMPCResult<GuaranteedOutputDeliveryRoundResult> {
         debug!(
@@ -47,6 +48,7 @@ impl Request {
                 computation_id.consensus_round,
                 computation_id.session_identifier,
                 root_seed,
+                vss_hpke_secret_key,
                 dwallet_mpc_metrics,
             )
         } else {

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -26,7 +26,8 @@ use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionReques
 use crate::epoch::submit_to_consensus::DWalletMPCSubmitToConsensus;
 use crate::noa_checkpoints::NOACheckpointHandler;
 use crate::request_protocol_data::ProtocolData;
-use dwallet_classgroups_types::ClassGroupsAndPvssKeyPairAndProof;
+use commitment::CommitmentSizedNumber;
+use dwallet_classgroups_types::ValidatorMPCSecrets;
 use dwallet_mpc_types::dwallet_mpc::MPCDataTrait;
 use dwallet_mpc_types::dwallet_mpc::VersionedPresignOutput;
 use dwallet_mpc_types::dwallet_mpc::{DWalletCurve, MPCMessage};
@@ -1649,7 +1650,7 @@ impl DWalletMPCService {
                 }
                 Ok(GuaranteedOutputDeliveryRoundResult::Finalize {
                     malicious_parties,
-                    private_output: _,
+                    private_output,
                     public_output_value,
                 }) => {
                     debug!(
@@ -1657,6 +1658,61 @@ impl DWalletMPCService {
                         validator=?validator_name,
                         "Reached output for session"
                     );
+
+                    // Fast Schnorr (VSS) presign: persist the private nonce-share
+                    // output. The GOD layer produces a blended
+                    // `bcs(Vec<PrivatePresignOutput>)`; split it into one serialized
+                    // `PrivatePresignOutput` per blending index and persist each row
+                    // keyed by `(presign session id, blending index)`, for the later
+                    // sign to recover. All other protocols (AHE presign, DKG, reconfig,
+                    // sign) have empty/irrelevant private outputs — skip.
+                    if matches!(
+                        request.protocol_data,
+                        ProtocolData::Presign { .. } | ProtocolData::InternalPresign { .. }
+                    ) && let Some(signature_algorithm) = request
+                        .protocol_data
+                        .signature_algorithm()
+                        .filter(|algorithm| algorithm.is_vss())
+                    {
+                        let presign_session_id = CommitmentSizedNumber::from_le_slice(
+                            session_identifier.to_vec().as_slice(),
+                        );
+                        match crate::dwallet_mpc::sign::split_vss_presign_private_outputs(
+                            signature_algorithm,
+                            &private_output,
+                        ) {
+                            Ok(entries) => {
+                                entries
+                                    .into_iter()
+                                    .for_each(|(blending_index, entry_bytes)| {
+                                        if let Err(err) =
+                                            self.epoch_store.store_presign_private_output(
+                                                presign_session_id,
+                                                blending_index,
+                                                entry_bytes,
+                                            )
+                                        {
+                                            error!(
+                                                ?session_identifier,
+                                                validator=?validator_name,
+                                                ?blending_index,
+                                                error=?err,
+                                                "failed to persist VSS presign private output"
+                                            );
+                                        }
+                                    });
+                            }
+                            Err(err) => {
+                                error!(
+                                    ?session_identifier,
+                                    validator=?validator_name,
+                                    error=?err,
+                                    "failed to split blended VSS presign private output"
+                                );
+                            }
+                        }
+                    }
+
                     let consensus_adapter = self.dwallet_submit_to_consensus.clone();
                     let malicious_authorities = if !malicious_parties.is_empty() {
                         let malicious_authorities =
@@ -2375,36 +2431,31 @@ impl DWalletMPCService {
             .root_seed()
             .clone();
 
-        let class_groups_key_pair = ClassGroupsAndPvssKeyPairAndProof::from_seed(&root_seed);
+        let (_validator_mpc_secrets, validator_encryption_keys_and_proofs) =
+            ValidatorMPCSecrets::from_seed(&root_seed);
 
         // Verify that the validator's local class-groups key is the same as stored
         // in the system state object on-chain. This makes sure the seed we are using
         // is the same seed we used at setup to create the encryption key, and thus it
         // assures we will generate the same decryption key too.
         //
-        // The on-chain bytes are shape-versioned: mainnet-v1.1.8 publishes the bare
-        // `ClassGroupsEncryptionKeyAndProof`, while the post-bump combined
-        // `ValidatorEncryptionKeysAndProofs` (class groups + 3 PVSS keys) travels
-        // off-chain via validator P2P. During the upgrade window the on-chain record
-        // is always the bare shape, so this boot-time identity check must be
-        // shape-tolerant: decode whatever shape is on-chain and compare only the
-        // class-groups component — the part both shapes carry and the only part that
-        // identifies the seed. (PVSS keys are verified off-chain on the assembly path
-        // in `assemble_committee_mpc_data_off_chain`.)
-        let onchain_bytes = onchain_validator
-            .get_mpc_data()
-            .unwrap()
-            .class_groups_public_key_and_proof();
+        // The on-chain bytes are shape-versioned: mainnet-v1.1.8 publishes the
+        // bare `ClassGroupsEncryptionKeyAndProof`, while the full
+        // `ValidatorEncryptionKeysAndProofs` bundle (class groups + per-curve
+        // PVSS + the Fast Schnorr VSS HPKE key) travels off-chain via validator
+        // P2P. During the upgrade window the on-chain record is always the bare
+        // shape, so this boot-time identity check must be shape-tolerant: decode
+        // whatever shape is on-chain and compare only the class-groups component
+        // — the part both shapes carry and the only part that identifies the
+        // seed. (PVSS / VSS keys are verified off-chain on the assembly path in
+        // `assemble_committee_mpc_data_off_chain`.)
+        let onchain_bytes = onchain_validator.get_mpc_data().unwrap().mpc_data_bytes();
         let Some(onchain_keys) = decode_validator_encryption_keys(&onchain_bytes) else {
             return Err(DwalletMPCError::MPCManagerError(
                 "could not decode the validator's class-groups key stored in the system state object".to_string(),
             ));
         };
-        if onchain_keys.class_groups
-            != class_groups_key_pair
-                .class_groups
-                .encryption_key_and_proof()
-        {
+        if onchain_keys.class_groups != validator_encryption_keys_and_proofs.class_groups {
             return Err(DwalletMPCError::MPCManagerError(
                 "validator's class-groups key does not match the one stored in the system state object".to_string(),
             ));

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg.rs
@@ -7,6 +7,7 @@
 //! and forward them to the [`DWalletMPCManager`].
 
 use crate::SuiDataSenders;
+use crate::dwallet_mpc::crytographic_computation::mpc_computations::network_dkg::spawn_network_encryption_key_public_data_instantiation;
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::{
     IntegrationTestState, send_start_network_dkg_event_to_all_parties,
@@ -425,4 +426,150 @@ pub(crate) fn send_start_network_key_reconfiguration_event(
             epoch_id,
         ));
     });
+}
+
+/// Like [`create_network_key_test`] but additionally runs a network reconfiguration
+/// (to the **same** committee at the next epoch) and installs the resulting **V3
+/// reconfiguration output** on every validator's network key.
+///
+/// Fast Schnorr (VSS) sign requires a reconfigured key: the DKG-only public output
+/// does not expose the per-curve secret-key polynomial commitments / masked parts
+/// the VSS sign reads, and each validator recovers its Shamir share from the
+/// reconfiguration dealings using its own (seed-derived, hence committee-stable)
+/// PVSS key — so reconfiguring to the *same* committee keeps those shares
+/// recoverable by the signing validators.
+///
+/// Returns `(next_unused_consensus_round, network_dkg_public_output_bytes, network_key_id)`.
+pub(crate) async fn create_reconfigured_network_key_test(
+    test_state: &mut IntegrationTestState,
+) -> (Round, Vec<u8>, ObjectID) {
+    let (consensus_round, network_key_bytes, key_id) = create_network_key_test(test_state).await;
+    let consensus_round = reconfigure_network_key(
+        test_state,
+        consensus_round,
+        key_id,
+        network_key_bytes.clone(),
+    )
+    .await;
+    (consensus_round, network_key_bytes, key_id)
+}
+
+/// Runs a network reconfiguration (to the same key-bearing committee at the next
+/// epoch) on an already-created network key, then installs the resulting V3
+/// reconfiguration output on every validator's key in place. Returns the next
+/// unused consensus round.
+///
+/// Split out of [`create_reconfigured_network_key_test`] so a caller can create
+/// dWallets *before* reconfiguring — the dWallet DKG runs against the pre-reconfig
+/// key, exactly as the user-driven sign flow does.
+pub(crate) async fn reconfigure_network_key(
+    test_state: &mut IntegrationTestState,
+    consensus_round: Round,
+    key_id: ObjectID,
+    network_key_bytes: Vec<u8>,
+) -> Round {
+    let epoch_id = test_state
+        .dwallet_mpc_services
+        .first()
+        .expect("at least one service should exist")
+        .epoch;
+
+    // Reconfigure to the same validators at the next epoch. Use the services'
+    // key-bearing committee, NOT `test_state.committee` (the simple/keyless
+    // committee used only for message routing): reconfiguration decodes the
+    // upcoming committee members' published class-groups + PVSS key bundles, which
+    // only the key-bearing committee carries. Same validators ⇒ the signing
+    // validators can still recover their Shamir shares from the reconfig dealings.
+    let mut next_committee = (*test_state.dwallet_mpc_services[0].committee).clone();
+    next_committee.epoch = epoch_id + 1;
+    for sui_data_sender in &test_state.sui_data_senders {
+        let _ = sui_data_sender
+            .next_epoch_committee_sender
+            .send(next_committee.clone());
+    }
+
+    send_start_network_key_reconfiguration_event(
+        epoch_id,
+        &mut test_state.sui_data_senders,
+        [10u8; 32],
+        10,
+        key_id,
+    );
+
+    let (consensus_round, reconfiguration_checkpoint) =
+        utils::advance_mpc_flow_until_completion(test_state, consensus_round).await;
+
+    // Reassemble the (chunked) reconfiguration public output across all
+    // `RespondDWalletMPCNetworkReconfigurationOutput` messages. These bytes are
+    // already `bcs(VersionedDecryptionKeyReconfigurationOutput::V3(..))`, so they go
+    // into `current_reconfiguration_public_output` verbatim.
+    let mut reconfiguration_output_bytes = vec![];
+    for message in reconfiguration_checkpoint.messages() {
+        let DWalletCheckpointMessageKind::RespondDWalletMPCNetworkReconfigurationOutput(message) =
+            message
+        else {
+            continue;
+        };
+        assert!(!message.rejected, "reconfiguration should not be rejected");
+        reconfiguration_output_bytes.extend(message.public_output.clone());
+    }
+    assert!(
+        !reconfiguration_output_bytes.is_empty(),
+        "reconfiguration output should not be empty"
+    );
+
+    // Install the V3 reconfiguration output on every validator's network key.
+    // `create_network_key_test` installed the key with an EMPTY reconfiguration
+    // output (DKG-only public data, which VSS sign rejects). The consensus
+    // status-vote path cannot carry this update: it dedups already-agreed keys
+    // (`handle_network_key_data_messages`) and already-loaded keys
+    // (`instantiate_agreed_keys_from_voted_data`). In production the reconfigured key
+    // is loaded fresh by the next-epoch manager; here we update each manager's key in
+    // place via the same path the installer uses (`update_network_key`).
+    for service in test_state.dwallet_mpc_services.iter_mut() {
+        let manager = service.dwallet_mpc_manager_mut();
+        let access_structure = manager.access_structure.clone();
+        let metrics = manager.dwallet_mpc_metrics.clone();
+        let reconfigured_key_data = DWalletNetworkEncryptionKeyData {
+            id: key_id,
+            current_epoch: epoch_id,
+            dkg_at_epoch: 1,
+            current_reconfiguration_public_output: reconfiguration_output_bytes.clone(),
+            network_dkg_public_output: network_key_bytes.clone(),
+            state: DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted,
+        };
+        let reconfigured_key = spawn_network_encryption_key_public_data_instantiation(
+            epoch_id,
+            access_structure.clone(),
+            reconfigured_key_data,
+            metrics,
+        )
+        .await
+        .expect("recv reconfigured network key public data")
+        .expect("instantiate reconfigured network key public data");
+        manager
+            .network_keys
+            .update_network_key(key_id, &reconfigured_key, &access_structure)
+            .await
+            .expect("update validator network key with reconfiguration output");
+    }
+
+    // Verify every validator now exposes a reconfiguration output on the key.
+    for (i, service) in test_state.dwallet_mpc_services.iter().enumerate() {
+        let public_data = service
+            .dwallet_mpc_manager()
+            .network_keys
+            .get_network_encryption_key_public_data(&key_id)
+            .unwrap_or_else(|e| {
+                panic!("validator {i} should have the reconfigured network key installed: {e:?}")
+            });
+        assert!(
+            public_data
+                .latest_network_reconfiguration_public_output()
+                .is_some(),
+            "validator {i} should expose a reconfiguration output after reconfiguration",
+        );
+    }
+
+    consensus_round
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
@@ -13,7 +13,9 @@
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStoreTrait;
 use crate::dwallet_mpc::NetworkOwnedAddressSignRequest;
 use crate::dwallet_mpc::crytographic_computation::mpc_computations::network_owned_address_sign_dkg_emulation::network_owned_address_sign_dkg_session_identifier;
-use crate::dwallet_mpc::integration_tests::network_dkg::create_network_key_test;
+use crate::dwallet_mpc::integration_tests::network_dkg::{
+    create_network_key_test, create_reconfigured_network_key_test,
+};
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::{
     IntegrationTestState, build_test_state, create_test_protocol_config_guard,
@@ -557,4 +559,154 @@ async fn test_presign_pool_exhaustion_buffers_excess_sign_requests() {
     info!(
         "Test passed: presign pool exhaustion correctly buffers and later processes excess requests"
     );
+}
+
+// === Fast Schnorr (VSS) NOA sign E2E tests ===
+
+/// End-to-end NOA sign for a Fast Schnorr (VSS) algorithm.
+///
+/// Same shape as [`network_owned_address_sign_flow`], but on a **reconfigured**
+/// network key (VSS sign reads the per-curve secret-key polynomial commitments from
+/// the reconfiguration output and recovers each validator's Shamir share from the
+/// reconfiguration dealings). The NOA DKG emulation yields a `UniversalPublicDKGOutput`
+/// with `X_A = identity`, so the VSS sign's `ToBeEmulated` (emulated centralized
+/// party) path applies — exactly as for AHE NOA sign.
+async fn network_owned_address_vss_sign_flow(
+    curve: DWalletCurve,
+    signature_algorithm: DWalletSignatureAlgorithm,
+    hash_scheme: DWalletHashScheme,
+) {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard();
+
+    let mut test_state = build_test_state(4);
+
+    // VSS sign requires a reconfigured network key.
+    let (consensus_round, _network_key_bytes, network_key_id) =
+        create_reconfigured_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+
+    info!(
+        ?curve,
+        ?signature_algorithm,
+        ?hash_scheme,
+        "Fast Schnorr (VSS) network-owned-address signing test"
+    );
+
+    // Wait for the internal VSS presign pool to populate.
+    let start_round = test_state.consensus_round as u64;
+    let consensus_round = utils::advance_rounds_while_presign_pool_empty(
+        &mut test_state,
+        signature_algorithm,
+        network_key_id,
+        start_round,
+    )
+    .await;
+    test_state.consensus_round = consensus_round as usize;
+
+    let pool_size_before = test_state.epoch_stores[0]
+        .presign_pool_size(signature_algorithm, network_key_id)
+        .expect("failed to get pool size");
+    assert!(
+        pool_size_before > 0,
+        "VSS presign pool should have at least one presign"
+    );
+    let presign_keys_before: HashSet<(SessionIdentifier, u16)> = test_state.epoch_stores[0]
+        .presign_pools
+        .lock()
+        .unwrap()
+        .get(&(signature_algorithm, network_key_id))
+        .map(|pool| {
+            pool.iter()
+                .map(|(id, blending_index, _)| (*id, *blending_index))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Send a NetworkOwnedAddressSignRequest to all validators.
+    let test_message = b"test message for network-owned-address VSS sign".to_vec();
+    for sender in &test_state.network_owned_address_sign_request_senders {
+        sender
+            .send(NetworkOwnedAddressSignRequest {
+                message: test_message.clone(),
+                curve,
+                signature_algorithm,
+                hash_scheme,
+            })
+            .await
+            .expect("failed to send network-owned-address VSS sign request");
+    }
+    for service in test_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration(vec![]).await;
+    }
+
+    let sign_output = wait_for_network_owned_address_sign_output(&mut test_state).await;
+    assert_eq!(
+        sign_output.message, test_message,
+        "output message should match request"
+    );
+    assert!(
+        !sign_output.signature.is_empty(),
+        "VSS signature should not be empty"
+    );
+    info!(
+        ?sign_output.session_identifier,
+        signature_len = sign_output.signature.len(),
+        "Received NetworkOwnedAddressSignOutput for VSS"
+    );
+
+    // Verify exactly one presign from the pre-sign snapshot was consumed.
+    let used_presigns = test_state.epoch_stores[0]
+        .used_presigns
+        .lock()
+        .unwrap()
+        .clone();
+    let consumed_from_snapshot: HashSet<_> = presign_keys_before
+        .iter()
+        .filter(|key| used_presigns.contains_key(key))
+        .collect();
+    assert_eq!(
+        consumed_from_snapshot.len(),
+        1,
+        "exactly one VSS presign from the pre-sign pool snapshot should have been consumed"
+    );
+
+    info!(
+        ?curve,
+        ?signature_algorithm,
+        "Fast Schnorr (VSS) network-owned-address sign E2E test completed"
+    );
+}
+
+#[tokio::test]
+#[cfg(test)]
+async fn test_network_owned_address_sign_taproot_vss() {
+    network_owned_address_vss_sign_flow(
+        DWalletCurve::Secp256k1,
+        DWalletSignatureAlgorithm::TaprootVSS,
+        DWalletHashScheme::SHA256,
+    )
+    .await;
+}
+
+#[tokio::test]
+#[cfg(test)]
+async fn test_network_owned_address_sign_eddsa_vss() {
+    network_owned_address_vss_sign_flow(
+        DWalletCurve::Curve25519,
+        DWalletSignatureAlgorithm::EdDSAVSS,
+        DWalletHashScheme::SHA512,
+    )
+    .await;
+}
+
+#[tokio::test]
+#[cfg(test)]
+async fn test_network_owned_address_sign_schnorrkel_substrate_vss() {
+    network_owned_address_vss_sign_flow(
+        DWalletCurve::Ristretto,
+        DWalletSignatureAlgorithm::SchnorrkelVSS,
+        DWalletHashScheme::Merlin,
+    )
+    .await;
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/sign.rs
@@ -3,7 +3,9 @@ use crate::authority::authority_per_epoch_store::AuthorityPerEpochStoreTrait;
 use crate::dwallet_mpc::integration_tests::create_dwallet::{
     DWalletTestResult, create_dwallet_test_inner,
 };
-use crate::dwallet_mpc::integration_tests::network_dkg::create_network_key_test;
+use crate::dwallet_mpc::integration_tests::network_dkg::{
+    create_network_key_test, reconfigure_network_key,
+};
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::IntegrationTestState;
 use crate::dwallet_session_request::DWalletSessionRequest;
@@ -307,8 +309,8 @@ pub(crate) fn send_start_sign_event(
                     data: SignData {
                         curve,
                         hash_scheme,
-                        hash_context: signature_algorithm.hash_context(),
                         signature_algorithm,
+                        hash_context: signature_algorithm.hash_context(),
                     },
                     dwallet_id,
                     sign_id,
@@ -359,8 +361,8 @@ pub(crate) fn send_start_future_sign_event(
                     data: SignData {
                         curve,
                         hash_scheme,
-                        hash_context: signature_algorithm.hash_context(),
                         signature_algorithm,
+                        hash_context: signature_algorithm.hash_context(),
                     },
                     dwallet_id,
                     sign_id,
@@ -412,8 +414,8 @@ pub(crate) fn send_start_partial_signature_verification_event(
                         curve,
                         message: message.clone(),
                         hash_scheme,
-                        hash_context: signature_algorithm.hash_context(),
                         signature_algorithm,
+                        hash_context: signature_algorithm.hash_context(),
                         dwallet_decentralized_output: dwallet_public_output.clone(),
                         presign: presign.clone(),
                         partially_signed_message: message_centralized_signature.clone(),
@@ -635,3 +637,179 @@ async fn global_presign_request_uses_correct_metadata_test() {
 
     info!("Global presign request test completed successfully!");
 }
+
+// === Fast Schnorr (VSS) external (user-driven) sign E2E tests ===
+
+/// Full external VSS sign flow for a standard (universal) user dWallet:
+/// reconfigured network key → user DKG → fill the internal VSS presign pool →
+/// global presign → centralized party's partial signature (the `Unverified` path,
+/// unlike NOA's emulated `ToBeEmulated` path) → VSS sign.
+///
+/// This exercises external/global VSS presign and the user-driven VSS sign path,
+/// complementing the NOA VSS tests (which cover the emulated-centralized-party path).
+/// `signature_algorithm_index` is the per-curve algorithm index the centralized party
+/// expects (TaprootVSS=2, EdDSAVSS=1, SchnorrkelVSS=1); each VSS algorithm
+/// has a single hash at index 0.
+async fn external_vss_sign_flow(
+    curve: DWalletCurve,
+    signature_algorithm: DWalletSignatureAlgorithm,
+    signature_algorithm_index: u32,
+    hash_scheme: HashScheme,
+) {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = utils::create_test_protocol_config_guard();
+    let epoch_id = 1;
+    let mut test_state = utils::build_test_state(4);
+    for service in &mut test_state.dwallet_mpc_services {
+        service
+            .dwallet_mpc_manager_mut()
+            .last_session_to_complete_in_current_epoch = 400;
+    }
+
+    // Create a standard (universal) user dWallet on the curve, on the ORIGINAL
+    // (pre-reconfig) network key. VSS sign requires a UniversalPublicDKGOutput, which
+    // the standard DKG flow produces, and the DKG runs against the pre-reconfig key
+    // exactly as the user-driven sign flow does.
+    let (consensus_round, network_key_bytes, network_key_id) =
+        create_network_key_test(&mut test_state).await;
+    let DWalletTestResult {
+        flow_completion_consensus_round: consensus_round,
+        dkg_output: dwallet_dkg_output,
+        dwallet_secret_key_share,
+        ..
+    } = create_dwallet_test_inner(
+        &mut test_state,
+        consensus_round,
+        network_key_id,
+        network_key_bytes.clone(),
+        curve,
+    )
+    .await;
+    info!(?curve, ?signature_algorithm, "VSS dWallet DKG completed");
+
+    // Now reconfigure the network key — VSS sign reads the per-curve secret-key
+    // polynomial commitments and recovers each validator's share from the
+    // reconfiguration output.
+    let consensus_round = reconfigure_network_key(
+        &mut test_state,
+        consensus_round + 1,
+        network_key_id,
+        network_key_bytes.clone(),
+    )
+    .await;
+
+    // Fill the internal VSS presign pool, then request a global presign.
+    let consensus_round = utils::advance_rounds_while_presign_pool_empty(
+        &mut test_state,
+        signature_algorithm,
+        network_key_id,
+        consensus_round,
+    )
+    .await;
+    let presign_id = ObjectID::random();
+    send_global_presign_request_event(
+        epoch_id,
+        &test_state.sui_data_senders,
+        [11; 32],
+        11,
+        presign_id,
+        network_key_id,
+        curve,
+        signature_algorithm,
+    );
+    let (consensus_round, presign_checkpoint) =
+        utils::advance_mpc_flow_until_completion(&mut test_state, consensus_round).await;
+    let DWalletCheckpointMessageKind::RespondDWalletPresign(presign_output) =
+        presign_checkpoint.messages().clone().pop().unwrap()
+    else {
+        panic!("Expected DWallet presign output message");
+    };
+
+    // The centralized party produces its partial signature (Unverified path).
+    let protocol_pp =
+        network_dkg_public_output_to_protocol_pp_inner(curve as u32, network_key_bytes).unwrap();
+    let message_to_sign = bcs::to_bytes("Hello Fast Schnorr World!").unwrap();
+    let centralized_sign = advance_centralized_sign_party(
+        protocol_pp,
+        dwallet_dkg_output.output.clone(),
+        dwallet_secret_key_share,
+        presign_output.presign.clone(),
+        message_to_sign.clone(),
+        curve as u32,
+        signature_algorithm_index,
+        0, // each VSS algorithm has its single hash at index 0
+    )
+    .unwrap();
+    send_start_sign_event(
+        epoch_id,
+        &test_state.sui_data_senders,
+        [12; 32],
+        12,
+        network_key_id,
+        ObjectID::from_bytes(dwallet_dkg_output.dwallet_id).unwrap(),
+        dwallet_dkg_output.output,
+        presign_output.presign,
+        centralized_sign,
+        message_to_sign,
+        curve,
+        signature_algorithm,
+        hash_scheme,
+    );
+    let (_, sign_checkpoint) =
+        utils::advance_mpc_flow_until_completion(&mut test_state, consensus_round + 1).await;
+    let DWalletCheckpointMessageKind::RespondDWalletSign(_sign_output) =
+        sign_checkpoint.messages().clone().pop().unwrap()
+    else {
+        panic!("Expected DWallet sign output message");
+    };
+    info!(
+        ?curve,
+        ?signature_algorithm,
+        "Fast Schnorr (VSS) external sign E2E test completed"
+    );
+}
+
+// External (user-driven) VSS sign is not externally accessible for now —
+// Fast Schnorr is internal-NOA-only. VSS variants were removed from
+// `SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES` and the SDK's
+// `SignatureAlgorithm` enum, so on-chain `validate_curve_and_signature_algorithm`
+// aborts external `request_sign` / `request_presign` for VSS. These tests
+// exercise that now-unreachable path; they are kept in-tree (the underlying
+// `external_vss_sign_flow` Rust path is preserved) and will be re-enabled when
+// VSS is opened up externally.
+
+#[ignore = "external VSS sign is gated off; VSS is internal-NOA-only for now"]
+#[tokio::test]
+#[cfg(test)]
+async fn test_external_vss_sign_eddsa() {
+    external_vss_sign_flow(
+        DWalletCurve::Curve25519,
+        DWalletSignatureAlgorithm::EdDSAVSS,
+        1,
+        HashScheme::SHA512,
+    )
+    .await;
+}
+
+#[ignore = "external VSS sign is gated off; VSS is internal-NOA-only for now"]
+#[tokio::test]
+#[cfg(test)]
+async fn test_external_vss_sign_taproot() {
+    external_vss_sign_flow(
+        DWalletCurve::Secp256k1,
+        DWalletSignatureAlgorithm::TaprootVSS,
+        2,
+        HashScheme::SHA256,
+    )
+    .await;
+}
+
+// NOTE: external (user-driven) SchnorrkelVSS sign is intentionally NOT
+// tested here. It needs a *user* Ristretto dWallet, but the create-dWallet test
+// helper's encrypted-user-share path fails for Ristretto
+// (`encrypt_secret_key_share_and_prove_v2` returns a group error at
+// `create_dwallet.rs:368`) — a pre-existing harness/curve limitation unrelated to
+// Fast Schnorr (the existing create-dWallet tests only ever use Secp256k1).
+// SchnorrkelVSS sign is covered by
+// `test_network_owned_address_sign_schnorrkel_substrate_vss` (the NOA path, which
+// uses the emulated threshold DKG and encrypts no user share).

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -7,7 +7,7 @@ use crate::dwallet_mpc::dwallet_mpc_service::DWalletMPCService;
 use crate::dwallet_mpc::{NetworkOwnedAddressSignOutput, NetworkOwnedAddressSignRequest};
 use crate::epoch::submit_to_consensus::DWalletMPCSubmitToConsensus;
 use crate::{SuiDataReceivers, SuiDataSenders};
-use dwallet_classgroups_types::ClassGroupsAndPvssKeyPairAndProof;
+use dwallet_classgroups_types::ValidatorMPCSecrets;
 use dwallet_mpc_types::dwallet_mpc::DWalletCurve;
 use dwallet_mpc_types::dwallet_mpc::DWalletSignatureAlgorithm;
 use dwallet_rng::RootSeed;
@@ -69,6 +69,9 @@ pub(crate) struct TestingAuthorityPerEpochStore {
     /// Keyed by (session_identifier, blending_index) to uniquely identify a single presign
     /// within the blended vector produced by a presign session.
     pub(crate) used_presigns: Arc<Mutex<HashMap<(SessionIdentifier, u16), ()>>>,
+    /// Fast Schnorr (VSS) presign private outputs, keyed by (presign session id, blending index).
+    pub(crate) presign_private_outputs:
+        Arc<Mutex<HashMap<(commitment::CommitmentSizedNumber, u16), Vec<u8>>>>,
     /// Assigned presigns keyed by (signature_algorithm, session_identifier, blending_index).
     pub(crate) assigned_presigns:
         Arc<Mutex<HashMap<(DWalletSignatureAlgorithm, SessionIdentifier, u16), AssignedPresign>>>,
@@ -140,6 +143,7 @@ impl TestingAuthorityPerEpochStore {
             round_to_noa_observations: Arc::new(Mutex::new(HashMap::from([(0, vec![])]))),
             presign_pools: Arc::new(Mutex::new(Default::default())),
             used_presigns: Arc::new(Mutex::new(HashMap::new())),
+            presign_private_outputs: Arc::new(Mutex::new(HashMap::new())),
             assigned_presigns: Arc::new(Mutex::new(HashMap::new())),
             certified_handoff_attestations: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -301,6 +305,32 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
             .unwrap()
             .insert((presign_session_id, presign_blending_index), ());
         Ok(())
+    }
+
+    fn store_presign_private_output(
+        &self,
+        presign_session_id: commitment::CommitmentSizedNumber,
+        presign_blending_index: u16,
+        private_output: Vec<u8>,
+    ) -> IkaResult<()> {
+        self.presign_private_outputs
+            .lock()
+            .unwrap()
+            .insert((presign_session_id, presign_blending_index), private_output);
+        Ok(())
+    }
+
+    fn get_presign_private_output(
+        &self,
+        presign_session_id: commitment::CommitmentSizedNumber,
+        presign_blending_index: u16,
+    ) -> IkaResult<Option<Vec<u8>>> {
+        Ok(self
+            .presign_private_outputs
+            .lock()
+            .unwrap()
+            .get(&(presign_session_id, presign_blending_index))
+            .cloned())
     }
 
     fn is_presign_used(
@@ -591,33 +621,40 @@ pub fn build_committee_with_random_seeds(
 ) -> (Committee, HashMap<AuthorityName, RootSeed>) {
     let (mut committee, _) = Committee::new_simple_test_committee_of_size(size);
     let mut seeds: HashMap<AuthorityName, RootSeed> = Default::default();
+    // Collect raw VSS HPKE inputs first; verification (`parse_and_uc_verify_encryption_keys`)
+    // is a Committee-construction step and must see the full set at once.
+    let mut vss_hpke_raw: HashMap<
+        AuthorityName,
+        ika_types::committee::VssHpkeEncryptionKeyAndProof,
+    > = Default::default();
     for (authority_name, _) in committee.voting_rights.iter() {
         let seed = RootSeed::random_seed();
         seeds.insert(*authority_name, seed.clone());
-        let class_groups_key_pair = ClassGroupsAndPvssKeyPairAndProof::from_seed(&seed);
-        committee.class_groups_public_keys_and_proofs.insert(
-            *authority_name,
-            class_groups_key_pair
-                .class_groups
-                .encryption_key_and_proof(),
-        );
+        let (_validator_mpc_secrets, validator_publics) = ValidatorMPCSecrets::from_seed(&seed);
+        committee
+            .class_groups_public_keys_and_proofs
+            .insert(*authority_name, validator_publics.class_groups.clone());
         // PVSS HPKE per-curve public keys + proofs (added at the cryptography-private @
         // 9d35fa76 bump). The integration-test committee mirrors what `Committee::new`
         // expects post-bump so `network_dkg_v2_public_input` and the reconfiguration
         // PublicInput constructors get real per-curve maps instead of empty placeholders.
-        committee.secp256k1_pvss_public_keys_and_proofs.insert(
+        committee
+            .secp256k1_pvss_public_keys_and_proofs
+            .insert(*authority_name, validator_publics.secp256k1_pvss.clone());
+        committee
+            .secp256r1_pvss_public_keys_and_proofs
+            .insert(*authority_name, validator_publics.secp256r1_pvss.clone());
+        committee
+            .ristretto_pvss_public_keys_and_proofs
+            .insert(*authority_name, validator_publics.ristretto_pvss.clone());
+        // Fast Schnorr (VSS) curve25519 HPKE public key + UC proof.
+        vss_hpke_raw.insert(
             *authority_name,
-            class_groups_key_pair.secp256k1_pvss_encryption_key_and_proof(),
-        );
-        committee.secp256r1_pvss_public_keys_and_proofs.insert(
-            *authority_name,
-            class_groups_key_pair.secp256r1_pvss_encryption_key_and_proof(),
-        );
-        committee.ristretto_pvss_public_keys_and_proofs.insert(
-            *authority_name,
-            class_groups_key_pair.ristretto_pvss_encryption_key_and_proof(),
+            validator_publics.vss_hpke_public_key_and_proof.clone(),
         );
     }
+    // Run the same verify-once that `Committee::new` would run in production.
+    committee.set_vss_hpke_verified_for_testing(vss_hpke_raw);
     (committee, seeds)
 }
 

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -3,6 +3,7 @@
 
 use dwallet_mpc_types::dwallet_mpc::{DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm};
 use group::PartyID;
+use group::curve25519;
 use ika_types::committee::{
     ClassGroupsEncryptionKeyAndProof, Committee, RistrettoPvssEncryptionKeyAndProof,
     Secp256k1PvssEncryptionKeyAndProof, Secp256r1PvssEncryptionKeyAndProof,
@@ -98,6 +99,12 @@ pub(crate) struct ValidatorMpcKeysByPartyId {
     pub secp256k1_pvss: HashMap<PartyID, Secp256k1PvssEncryptionKeyAndProof>,
     pub secp256r1_pvss: HashMap<PartyID, Secp256r1PvssEncryptionKeyAndProof>,
     pub ristretto_pvss: HashMap<PartyID, RistrettoPvssEncryptionKeyAndProof>,
+    /// Fast Schnorr (VSS) HPKE encryption public **key values** (curve25519,
+    /// serializable form), already filtered to the parties whose UC proof of
+    /// knowledge verified at [`Committee::new`]. Read sites rebuild
+    /// `EncryptionPublicKey` via `EncryptionPublicKey::new(value, &pp)` — a
+    /// cheap curve-point parse — without re-running the UC proof verification.
+    pub vss_hpke_verified_party_encryption_key_values: HashMap<PartyID, curve25519::Value>,
 }
 
 pub(crate) fn get_validator_mpc_keys_by_party_id(
@@ -143,6 +150,10 @@ pub(crate) fn get_validator_mpc_keys_by_party_id(
         secp256k1_pvss,
         secp256r1_pvss,
         ristretto_pvss,
+        // Verified-once at Committee::new — copy the cached values directly.
+        vss_hpke_verified_party_encryption_key_values: committee
+            .vss_hpke_verified_party_encryption_key_values
+            .clone(),
     })
 }
 

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -19,12 +19,12 @@ use crate::dwallet_mpc::{
     party_id_to_authority_name,
 };
 use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionRequestMetricData};
-use dwallet_classgroups_types::ClassGroupsKeyPairAndProof;
+use dwallet_classgroups_types::ValidatorMPCSecrets;
 use dwallet_mpc_types::dwallet_mpc::{
     DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm, NetworkEncryptionKeyPublicData,
     VersionedPresignOutput,
 };
-use dwallet_mpc_types::mpc_protocol_configuration::supported_curve_to_signature_algorithms;
+use dwallet_mpc_types::mpc_protocol_configuration::network_presign_pool_algorithms;
 use dwallet_rng::RootSeed;
 use fastcrypto::hash::HashFunction;
 use group::PartyID;
@@ -39,10 +39,12 @@ use ika_types::handoff::HandoffItemKey;
 use ika_types::message::DWalletCheckpointMessageKind;
 use ika_types::messages_dwallet_mpc::{
     ConsensusGlobalPresignRequest, ConsensusNOAObservation, Curve25519EdDSAProtocol,
-    DWalletInternalMPCOutputKind, DWalletMPCMessage, DWalletMPCOutputKind, DWalletMPCOutputReport,
-    DWalletNetworkEncryptionKeyData, GlobalPresignRequest, IdleStatusUpdate,
-    RistrettoSchnorrkelProtocol, Secp256k1ECDSAProtocol, Secp256k1TaprootProtocol,
-    Secp256r1ECDSAProtocol, SessionIdentifier, SessionType, SuiChainObservationUpdate,
+    Curve25519EdDSAVSSProtocol, DWalletInternalMPCOutputKind, DWalletMPCMessage,
+    DWalletMPCOutputKind, DWalletMPCOutputReport, DWalletNetworkEncryptionKeyData,
+    GlobalPresignRequest, IdleStatusUpdate, RistrettoSchnorrkelProtocol,
+    RistrettoSchnorrkelVSSProtocol, Secp256k1ECDSAProtocol, Secp256k1TaprootProtocol,
+    Secp256k1TaprootVSSProtocol, Secp256r1ECDSAProtocol, SessionIdentifier, SessionType,
+    SuiChainObservationUpdate,
 };
 use ika_types::noa_checkpoint::CounterpartyChainKind;
 use mpc::{MajorityVote, WeightedThresholdAccessStructure};
@@ -345,12 +347,33 @@ impl DWalletMPCManager {
             CryptographicComputationsOrchestrator::try_new(root_seed.clone())?;
         let party_id = authority_name_to_party_id_from_committee(&committee, &validator_name)?;
 
-        let class_groups_key_pair_and_proof = ClassGroupsKeyPairAndProof::from_seed(&root_seed);
+        // Derive ALL of this validator's MPC key material once from the seed:
+        // class-groups secret (AHE) + per-curve PVSS decryption keys (used by
+        // VSS Shamir-share pre-derivation at network-key ingestion). The
+        // matching public encryption keys come from the same derivation and
+        // feed the publics struct so VSS shamir pre-derivation has both
+        // halves without re-running `from_seed` per network key. Secrets and
+        // publics are deliberately split into separate structs so the secret
+        // type never shares a struct with public material.
+        let (validator_mpc_secrets, validator_publics) = ValidatorMPCSecrets::from_seed(&root_seed);
+        let validator_pvss_secrets_for_vss =
+            crate::dwallet_mpc::network_dkg::ValidatorPvssSecretsForVss {
+                secp256k1_decryption_key: validator_mpc_secrets.secp256k1_pvss_decryption_key,
+                ristretto_decryption_key: validator_mpc_secrets.ristretto_pvss_decryption_key,
+            };
+        let validator_pvss_publics_for_vss =
+            crate::dwallet_mpc::network_dkg::ValidatorPvssEncryptionKeysForVss {
+                secp256k1_encryption_key: validator_publics.secp256k1_pvss.0.clone(),
+                ristretto_encryption_key: validator_publics.ristretto_pvss.0.clone(),
+            };
 
         let validator_private_data = ValidatorPrivateDecryptionKeyData {
             party_id,
-            class_groups_decryption_key: class_groups_key_pair_and_proof.decryption_key(),
+            class_groups_decryption_key: validator_mpc_secrets.class_groups.decryption_key,
+            validator_pvss_secrets_for_vss,
+            validator_pvss_publics_for_vss,
             validator_decryption_key_shares: HashMap::new(),
+            validator_vss_shamir_cache: HashMap::new(),
         };
         let dwallet_network_keys = DwalletMPCNetworkKeys::new(validator_private_data);
 
@@ -1326,123 +1349,124 @@ impl DWalletMPCManager {
                 None => return,
             };
 
+        // Iterate the dedicated internal-pool driver — `network_presign_pool_algorithms`
+        // is decoupled from `SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES`
+        // (the externally-requestable list serialized into the on-chain
+        // `support_config`). VSS variants live ONLY here, gated on the feature
+        // flag: they feed NOA (network-owned-address) VSS sign but are not
+        // externally requestable on-chain.
+        let pool_algorithms =
+            network_presign_pool_algorithms(self.protocol_config.fast_schnorr_supported());
         // Ordered (`BTreeSet`) on purpose: the loop below assigns internal presign
         // session sequence numbers from a single shared counter in iteration order,
         // and the sequence number is bound into the session identifier. Every
-        // validator must iterate keys (and curves/algorithms — see
-        // `SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES`) in the same
-        // order, or they derive different session identifiers for the same work
-        // and the sessions never reach quorum.
+        // validator must iterate keys in the same order (and `pool_algorithms` is
+        // already a deterministically-ordered list), or they derive different
+        // session identifiers for the same work and the sessions never reach quorum.
         let agreed_key_ids: BTreeSet<_> = self.adopted_network_key_data.keys().copied().collect();
         let mut pools_filled: Vec<String> = Vec::new();
         for key_id in agreed_key_ids {
-            for (curve, signature_algorithms) in supported_curve_to_signature_algorithms() {
-                for signature_algorithm in signature_algorithms {
-                    let is_network_owned_address_signing_presign =
-                        agreed_network_owned_address_signing_key_id == key_id;
+            for (curve, signature_algorithm) in pool_algorithms.iter().copied() {
+                let is_network_owned_address_signing_presign =
+                    agreed_network_owned_address_signing_key_id == key_id;
 
-                    let (
-                        minimal_pool_size,
-                        maximum_pool_size,
-                        consensus_round_delay,
-                        sessions_to_instantiate,
-                    ) = if is_network_owned_address_signing_presign {
-                        (
-                            self.protocol_config
-                                .get_network_owned_address_presign_pool_minimum_size(
-                                    signature_algorithm,
-                                ),
-                            self.protocol_config
-                                .get_network_owned_address_presign_pool_maximum_size(
-                                    signature_algorithm,
-                                ),
-                            self.protocol_config
-                                .get_network_owned_address_presign_consensus_round_delay(
-                                    signature_algorithm,
-                                ),
-                            self.protocol_config
-                                .get_network_owned_address_presign_sessions_to_instantiate(
-                                    signature_algorithm,
-                                ),
-                        )
-                    } else {
-                        (
-                            self.protocol_config
-                                .get_internal_presign_pool_minimum_size(curve, signature_algorithm),
-                            self.protocol_config
-                                .get_internal_presign_pool_maximum_size(curve, signature_algorithm),
-                            self.protocol_config
-                                .get_internal_presign_consensus_round_delay(
-                                    curve,
-                                    signature_algorithm,
-                                ),
-                            self.protocol_config
-                                .get_internal_presign_sessions_to_instantiate(
-                                    curve,
-                                    signature_algorithm,
-                                ),
-                        )
-                    };
-
-                    // Export the pool size BEFORE the in-flight skip below,
-                    // so a pool wedged behind never-completing sessions is
-                    // still observable. The key dimension is reduced to a
-                    // bounded `key_role` label — see the metric's docs.
-                    let current_pool_size =
-                        self.internal_presign_pool_size(key_id, curve, signature_algorithm);
-                    let key_role = if is_network_owned_address_signing_presign {
-                        "network_owned_address_signing"
-                    } else {
-                        "other"
-                    };
-                    let curve_label = format!("{curve:?}");
-                    let signature_algorithm_label = format!("{signature_algorithm:?}");
-                    self.dwallet_mpc_metrics
-                        .internal_presign_pool_size
-                        .with_label_values(&[
-                            curve_label.as_str(),
-                            signature_algorithm_label.as_str(),
-                            key_role,
-                        ])
-                        .set(current_pool_size as i64);
-
-                    // Skip instantiation if previous sessions for this (curve, algorithm)
-                    // haven't completed yet. Each session produces a variable number of
-                    // presigns (1 to n-t), so overlapping batches cause pool overshoot.
-                    let instantiated = self
-                        .instantiated_internal_presign_sessions
-                        .get(&(curve, signature_algorithm))
-                        .copied()
-                        .unwrap_or(0);
-                    let completed = self
-                        .completed_internal_presign_sessions
-                        .get(&(curve, signature_algorithm))
-                        .copied()
-                        .unwrap_or(0);
-                    if instantiated != completed {
-                        continue;
-                    }
-
-                    if (number_of_consensus_rounds.is_multiple_of(consensus_round_delay)
-                        && current_pool_size < minimal_pool_size)
-                        || (network_is_idle && current_pool_size < maximum_pool_size)
-                    {
-                        for _ in 1..=sessions_to_instantiate {
-                            self.instantiate_internal_presign_session(
-                                consensus_round,
-                                key_id,
+                let (
+                    minimal_pool_size,
+                    maximum_pool_size,
+                    consensus_round_delay,
+                    sessions_to_instantiate,
+                ) = if is_network_owned_address_signing_presign {
+                    (
+                        self.protocol_config
+                            .get_network_owned_address_presign_pool_minimum_size(
+                                signature_algorithm,
+                            ),
+                        self.protocol_config
+                            .get_network_owned_address_presign_pool_maximum_size(
+                                signature_algorithm,
+                            ),
+                        self.protocol_config
+                            .get_network_owned_address_presign_consensus_round_delay(
+                                signature_algorithm,
+                            ),
+                        self.protocol_config
+                            .get_network_owned_address_presign_sessions_to_instantiate(
+                                signature_algorithm,
+                            ),
+                    )
+                } else {
+                    (
+                        self.protocol_config
+                            .get_internal_presign_pool_minimum_size(curve, signature_algorithm),
+                        self.protocol_config
+                            .get_internal_presign_pool_maximum_size(curve, signature_algorithm),
+                        self.protocol_config
+                            .get_internal_presign_consensus_round_delay(curve, signature_algorithm),
+                        self.protocol_config
+                            .get_internal_presign_sessions_to_instantiate(
                                 curve,
                                 signature_algorithm,
-                            );
-                            *self
-                                .instantiated_internal_presign_sessions
-                                .entry((curve, signature_algorithm))
-                                .or_insert(0) += 1;
-                        }
-                        pools_filled.push(format!(
-                            "{curve:?}/{signature_algorithm:?}={current_pool_size}(min{minimal_pool_size})+{sessions_to_instantiate}"
-                        ));
+                            ),
+                    )
+                };
+
+                // Export the pool size BEFORE the in-flight skip below, so a pool
+                // wedged behind never-completing sessions is still observable. The
+                // key dimension is reduced to a bounded `key_role` label.
+                let current_pool_size =
+                    self.internal_presign_pool_size(key_id, curve, signature_algorithm);
+                let key_role = if is_network_owned_address_signing_presign {
+                    "network_owned_address_signing"
+                } else {
+                    "other"
+                };
+                let curve_label = format!("{curve:?}");
+                let signature_algorithm_label = format!("{signature_algorithm:?}");
+                self.dwallet_mpc_metrics
+                    .internal_presign_pool_size
+                    .with_label_values(&[
+                        curve_label.as_str(),
+                        signature_algorithm_label.as_str(),
+                        key_role,
+                    ])
+                    .set(current_pool_size as i64);
+
+                // Skip instantiation if previous sessions for this (curve, algorithm)
+                // haven't completed yet. Each session produces a variable number of
+                // presigns (1 to n-t), so overlapping batches cause pool overshoot.
+                let instantiated = self
+                    .instantiated_internal_presign_sessions
+                    .get(&(curve, signature_algorithm))
+                    .copied()
+                    .unwrap_or(0);
+                let completed = self
+                    .completed_internal_presign_sessions
+                    .get(&(curve, signature_algorithm))
+                    .copied()
+                    .unwrap_or(0);
+                if instantiated != completed {
+                    continue;
+                }
+
+                if (number_of_consensus_rounds.is_multiple_of(consensus_round_delay)
+                    && current_pool_size < minimal_pool_size)
+                    || (network_is_idle && current_pool_size < maximum_pool_size)
+                {
+                    for _ in 1..=sessions_to_instantiate {
+                        self.instantiate_internal_presign_session(
+                            consensus_round,
+                            key_id,
+                            curve,
+                            signature_algorithm,
+                        );
+                        *self
+                            .instantiated_internal_presign_sessions
+                            .entry((curve, signature_algorithm))
+                            .or_insert(0) += 1;
                     }
+                    pools_filled.push(format!(
+                        "{curve:?}/{signature_algorithm:?}={current_pool_size}(min{minimal_pool_size})+{sessions_to_instantiate}"
+                    ));
                 }
             }
         }
@@ -1610,9 +1634,15 @@ impl DWalletMPCManager {
             return false;
         }
 
-        // Wrap the raw presign bytes in VersionedPresignOutput::V2 for consistency
-        // with the sign session input path, which expects this wrapping.
-        let wrapped_presign = match bcs::to_bytes(&VersionedPresignOutput::V2(presign)) {
+        // Wrap the raw presign bytes for consistency with the sign session
+        // input path, which expects a versioned wrapper. AHE presigns use V2;
+        // Fast Schnorr (VSS) presigns are a different shape and use V3.
+        let versioned = if signature_algorithm.is_vss() {
+            VersionedPresignOutput::V3(presign)
+        } else {
+            VersionedPresignOutput::V2(presign)
+        };
+        let wrapped_presign = match bcs::to_bytes(&versioned) {
             Ok(bytes) => bytes,
             Err(e) => {
                 error!(
@@ -2441,6 +2471,33 @@ impl DWalletMPCManager {
                     }
                     DWalletSignatureAlgorithm::Taproot => {
                         self.record_internal_presign_output::<Secp256k1TaprootProtocol>(
+                            signature_algorithm,
+                            dwallet_network_encryption_key_id,
+                            session_sequence_number,
+                            session_identifier,
+                            output,
+                        );
+                    }
+                    DWalletSignatureAlgorithm::TaprootVSS => {
+                        self.record_internal_presign_output::<Secp256k1TaprootVSSProtocol>(
+                            signature_algorithm,
+                            dwallet_network_encryption_key_id,
+                            session_sequence_number,
+                            session_identifier,
+                            output,
+                        );
+                    }
+                    DWalletSignatureAlgorithm::EdDSAVSS => {
+                        self.record_internal_presign_output::<Curve25519EdDSAVSSProtocol>(
+                            signature_algorithm,
+                            dwallet_network_encryption_key_id,
+                            session_sequence_number,
+                            session_identifier,
+                            output,
+                        );
+                    }
+                    DWalletSignatureAlgorithm::SchnorrkelVSS => {
+                        self.record_internal_presign_output::<RistrettoSchnorrkelVSSProtocol>(
                             signature_algorithm,
                             dwallet_network_encryption_key_id,
                             session_sequence_number,

--- a/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
@@ -83,6 +83,21 @@ pub(crate) fn session_input_from_request(
 ) -> DwalletMPCResult<(PublicInput, MPCPrivateInput)> {
     let session_id =
         CommitmentSizedNumber::from_le_slice(request.session_identifier.to_vec().as_slice());
+
+    // Defense-in-depth protocol-version gate for Fast Schnorr (VSS): the primary
+    // enforcement is the on-chain supported-algorithm map population, but reject
+    // any VSS presign/sign request here too if the active protocol version does
+    // not enable it. (Move has no version gate; this is the Rust-side gate.)
+    if let Some(signature_algorithm) = request.protocol_data.signature_algorithm()
+        && signature_algorithm.is_vss()
+        && !protocol_config.fast_schnorr_supported()
+    {
+        return Err(DwalletMPCError::InvalidInput(format!(
+            "Fast Schnorr (VSS) algorithm {signature_algorithm} requested but \
+             fast_schnorr_supported is disabled at this protocol version"
+        )));
+    }
+
     match &request.protocol_data {
         ProtocolData::DWalletDKG {
             dwallet_network_encryption_key_id,
@@ -116,6 +131,16 @@ pub(crate) fn session_input_from_request(
                 &data.centralized_public_key_share_and_proof,
                 BytesCentralizedPartyKeyShareVerification::from(data.user_secret_key_share.clone()),
             )?;
+            // Mirror the AHE "no decryption key shares" wait path: a missing
+            // cache means the network key hasn't been ingested yet (the cache
+            // is populated atomically with the AHE shares in
+            // `decrypt_and_store_secret_key_shares`). Propagate the
+            // `WaitingForNetworkKey` error so the session isn't processed
+            // until the key arrives — same shape as
+            // `get_network_encryption_key_public_data` above.
+            let vss_shamir_cache = network_keys
+                .vss_shamir_cache(dwallet_network_encryption_key_id)?
+                .clone();
             Ok((
                 PublicInput::DWalletDKGAndSign(DKGAndSignPublicInputByProtocol::try_new(
                     request.session_identifier,
@@ -127,6 +152,7 @@ pub(crate) fn session_input_from_request(
                     data.hash_context.clone(),
                     access_structure,
                     encryption_key_public_data,
+                    &vss_shamir_cache,
                     data.signature_algorithm,
                 )?),
                 None,
@@ -181,10 +207,10 @@ pub(crate) fn session_input_from_request(
             // protocol_version. At `_version == 2` (mainnet-v1.1.8 era) peers
             // publish bare `ClassGroupsEncryptionKeyAndProof` and the
             // bwd-compat DKG `PublicInput::new` takes only the class-groups
-            // CRT map. At `_version == 3` we have per-curve
+            // CRT map. At `_version == 3` (post-PR-#1707) we have per-curve
             // PVSS HPKE keys too and call the main DKG `PublicInput::new`.
             let dkg_public_input = if protocol_config.is_network_encryption_key_version_v3() {
-                // At `_version == 3` every committee member MUST publish the version-3
+                // At `_version == 3` every committee member MUST publish the post-PR-#1707
                 // bundle shape (class-groups + per-curve PVSS HPKE). The shape-tolerant
                 // decoder accepts old-shape submissions silently, so a validator that
                 // hasn't migrated would land here with empty PVSS entries while their
@@ -202,8 +228,7 @@ pub(crate) fn session_input_from_request(
                 {
                     return Err(DwalletMPCError::InvalidMPCPartyType(format!(
                         "at network_encryption_key_version == 3 every committee member \
-                         must publish the version-3 bundle shape (class-groups + per-curve \
-                         PVSS HPKE keys), but only \
+                         must publish the post-PR-#1707 bundle shape, but only \
                          {class_groups_count}/{expected} class-groups, \
                          {secp256k1_pvss_count}/{expected} secp256k1 PVSS, \
                          {secp256r1_pvss_count}/{expected} secp256r1 PVSS, \
@@ -285,6 +310,7 @@ pub(crate) fn session_input_from_request(
                     *signature_algorithm,
                     encryption_key_public_data,
                     None,
+                    &validator_mpc_keys_by_party_id,
                 )?),
                 None,
             ))
@@ -307,6 +333,7 @@ pub(crate) fn session_input_from_request(
                     *signature_algorithm,
                     encryption_key_public_data,
                     dwallet_public_output.clone(),
+                    &validator_mpc_keys_by_party_id,
                 )?),
                 None,
             ))
@@ -319,22 +346,36 @@ pub(crate) fn session_input_from_request(
             presign,
             message_centralized_signature,
             ..
-        } => Ok((
-            PublicInput::Sign(SignPublicInputByProtocol::try_new(
-                request.session_identifier,
-                dwallet_decentralized_public_output,
-                message.clone(),
-                presign,
-                message_centralized_signature,
-                data.hash_scheme,
-                data.hash_context.clone(),
-                access_structure,
-                network_keys
-                    .get_network_encryption_key_public_data(dwallet_network_encryption_key_id)?,
-                data.signature_algorithm,
-            )?),
-            None,
-        )),
+        } => {
+            // Mirror the AHE "no decryption key shares" wait path: a missing
+            // cache means the network key hasn't been ingested yet (the cache
+            // is populated atomically with the AHE shares in
+            // `decrypt_and_store_secret_key_shares`). Propagate the
+            // `WaitingForNetworkKey` error so the session isn't processed
+            // until the key arrives — same shape as
+            // `get_network_encryption_key_public_data` above.
+            let vss_shamir_cache = network_keys
+                .vss_shamir_cache(dwallet_network_encryption_key_id)?
+                .clone();
+            Ok((
+                PublicInput::Sign(SignPublicInputByProtocol::try_new(
+                    request.session_identifier,
+                    dwallet_decentralized_public_output,
+                    message.clone(),
+                    presign,
+                    message_centralized_signature,
+                    data.hash_scheme,
+                    data.hash_context.clone(),
+                    access_structure,
+                    network_keys.get_network_encryption_key_public_data(
+                        dwallet_network_encryption_key_id,
+                    )?,
+                    &vss_shamir_cache,
+                    data.signature_algorithm,
+                )?),
+                None,
+            ))
+        }
         ProtocolData::NetworkOwnedAddressSign {
             data,
             dwallet_network_encryption_key_id,
@@ -352,6 +393,16 @@ pub(crate) fn session_input_from_request(
                 encryption_key_public_data.network_owned_address_dkg_output(data.curve);
 
             let stored_dkg_output_bytes = stored_dkg_output_bytes.to_vec();
+            // Mirror the AHE "no decryption key shares" wait path: a missing
+            // cache means the network key hasn't been ingested yet (the cache
+            // is populated atomically with the AHE shares in
+            // `decrypt_and_store_secret_key_shares`). Propagate the
+            // `WaitingForNetworkKey` error so the session isn't processed
+            // until the key arrives — same shape as
+            // `get_network_encryption_key_public_data` above.
+            let vss_shamir_cache = network_keys
+                .vss_shamir_cache(dwallet_network_encryption_key_id)?
+                .clone();
             Ok((
                 PublicInput::Sign(SignPublicInputByProtocol::try_new(
                     request.session_identifier,
@@ -363,6 +414,7 @@ pub(crate) fn session_input_from_request(
                     data.hash_context.clone(),
                     access_structure,
                     encryption_key_public_data,
+                    &vss_shamir_cache,
                     data.signature_algorithm,
                 )?),
                 None,

--- a/crates/ika-core/src/dwallet_session_request.rs
+++ b/crates/ika-core/src/dwallet_session_request.rs
@@ -381,7 +381,22 @@ impl From<&ProtocolCryptographicData> for DWalletSessionRequestMetricData {
                 hash_scheme: Some(data.hash_scheme),
                 signature_algorithm: Some(data.signature_algorithm),
             },
-            ProtocolCryptographicData::DWalletDKGAndSign { data, .. } => {
+            ProtocolCryptographicData::SignVSS { data, .. } => DWalletSessionRequestMetricData {
+                name: data.to_string(),
+                curve: Some(data.curve),
+                hash_scheme: Some(data.hash_scheme),
+                signature_algorithm: Some(data.signature_algorithm),
+            },
+            ProtocolCryptographicData::NetworkOwnedAddressSignVSS { data, .. } => {
+                DWalletSessionRequestMetricData {
+                    name: data.to_string(),
+                    curve: Some(data.curve),
+                    hash_scheme: Some(data.hash_scheme),
+                    signature_algorithm: Some(data.signature_algorithm),
+                }
+            }
+            ProtocolCryptographicData::DWalletDKGAndSign { data, .. }
+            | ProtocolCryptographicData::DWalletDKGAndSignVSS { data, .. } => {
                 DWalletSessionRequestMetricData {
                     name: data.to_string(),
                     curve: Some(data.curve),

--- a/crates/ika-core/src/request_protocol_data.rs
+++ b/crates/ika-core/src/request_protocol_data.rs
@@ -223,6 +223,22 @@ pub enum ProtocolData {
 }
 
 impl ProtocolData {
+    /// Returns the signature algorithm this request operates on, if any. Used by
+    /// the protocol-version feature gate (e.g. Fast Schnorr / VSS).
+    pub fn signature_algorithm(&self) -> Option<DWalletSignatureAlgorithm> {
+        match self {
+            ProtocolData::Presign { data, .. } => Some(data.signature_algorithm),
+            ProtocolData::InternalPresign { data, .. } => Some(data.signature_algorithm),
+            ProtocolData::Sign { data, .. } => Some(data.signature_algorithm),
+            ProtocolData::NetworkOwnedAddressSign { data, .. } => Some(data.signature_algorithm),
+            ProtocolData::DWalletDKGAndSign { data, .. } => Some(data.signature_algorithm),
+            ProtocolData::PartialSignatureVerification { data, .. } => {
+                Some(data.signature_algorithm)
+            }
+            _ => None,
+        }
+    }
+
     /// Returns `None` if this request is not a global presign one (either not a presign, or a targeted presign),
     /// and `Some((presign_id, curve, signature_algorithm, network_key_id))` if it is.
     pub fn is_global_presign(
@@ -242,6 +258,11 @@ impl ProtocolData {
                     DWalletSignatureAlgorithm::EdDSA => true,
                     DWalletSignatureAlgorithm::Taproot => true,
                     DWalletSignatureAlgorithm::Schnorrkel => true,
+                    // VSS (Fast Schnorr) variants are global-presign Schnorr,
+                    // DKG-created keys only (never imported).
+                    DWalletSignatureAlgorithm::TaprootVSS => true,
+                    DWalletSignatureAlgorithm::EdDSAVSS => true,
+                    DWalletSignatureAlgorithm::SchnorrkelVSS => true,
                 };
 
                 if is_global_presign {
@@ -316,7 +337,6 @@ pub fn dwallet_dkg_and_sign_protocol_data(
         request_event_data.curve,
         sign_during_dkg_request.signature_algorithm,
     )?;
-    let hash_context = signature_algorithm.hash_context();
     Ok(ProtocolData::DWalletDKGAndSign {
         data: DWalletDKGAndSignData {
             curve: try_into_curve(request_event_data.curve)?,
@@ -331,7 +351,7 @@ pub fn dwallet_dkg_and_sign_protocol_data(
                 sign_during_dkg_request.signature_algorithm,
                 sign_during_dkg_request.hash_scheme,
             )?,
-            hash_context,
+            hash_context: signature_algorithm.hash_context(),
             message: sign_during_dkg_request.message.clone(),
             message_centralized_signature: sign_during_dkg_request
                 .message_centralized_signature
@@ -365,13 +385,12 @@ pub fn network_owned_address_sign_protocol_data(
     message: Vec<u8>,
     presign: SerializedWrappedMPCPublicOutput,
 ) -> ProtocolData {
-    let hash_context = signature_algorithm.hash_context();
     ProtocolData::NetworkOwnedAddressSign {
         data: NetworkOwnedAddressSignData {
             curve,
             signature_algorithm,
             hash_scheme,
-            hash_context,
+            hash_context: signature_algorithm.hash_context(),
         },
         dwallet_network_encryption_key_id,
         message,

--- a/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
+++ b/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
@@ -158,6 +158,9 @@ pub async fn fetch_previous_committee<C: SuiClientInner>(
         HashMap::new(),
         HashMap::new(),
         HashMap::new(),
+        // VSS HPKE keys arrive via the off-chain pipeline; empty for this
+        // chain-derived prior-committee bootstrap anchor.
+        HashMap::new(),
         bls_committee.quorum_threshold,
         bls_committee.validity_threshold,
     ))

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -49,7 +49,7 @@ pub struct SuiSyncer<C> {
 struct AssemblyLogState {
     /// Last `(epoch, frozen, members, secp256k1, secp256r1, ristretto)`
     /// assembly summary logged at info — identical repeats demote to debug.
-    last_logged_assembly: Option<(EpochId, bool, usize, usize, usize, usize)>,
+    last_logged_assembly: Option<(EpochId, bool, usize, usize, usize, usize, usize)>,
     /// Epoch for which the PERMANENT `EverythingExcluded` wedge was
     /// already logged at error — repeats demote to debug (the
     /// `off_chain_assembly_wedged` gauge carries the ongoing state).
@@ -532,6 +532,7 @@ where
                         bundles.secp256k1_pvss.len(),
                         bundles.secp256r1_pvss.len(),
                         bundles.ristretto_pvss.len(),
+                        bundles.vss_hpke.len(),
                     );
                     if log_state.last_logged_assembly != Some(assembly_summary) {
                         info!(
@@ -562,6 +563,7 @@ where
                         bundles.secp256k1_pvss,
                         bundles.secp256r1_pvss,
                         bundles.ristretto_pvss,
+                        bundles.vss_hpke,
                         quorum_threshold,
                         validity_threshold,
                     ));
@@ -660,41 +662,56 @@ where
             .await
             .map_err(DwalletMPCError::IkaError)?;
 
-        // Shape-tolerant decode per validator. PVSS HashMaps gain an entry only
-        // when the validator published the version-3 bundle shape;
-        // mainnet-v1.1.8-shape validators contribute only their class-groups key.
+        // Chain reads are shape-tolerant: a validator's Move-side
+        // `MPCDataV1::mpc_data_bytes` is either the bare mainnet-v1.1.8
+        // `ClassGroupsEncryptionKeyAndProof` or the full version-3
+        // `ValidatorEncryptionKeysAndProofs` bundle — the `become-candidate` /
+        // `set-next-epoch-mpc-data` CLI publishes the bundle unless
+        // `--legacy-class-groups-only` is set. Decode whichever shape is present
+        // and populate every key map from it (PVSS + VSS HPKE are absent for the
+        // bare shape). When the off-chain validator-metadata pipeline (PR #1721)
+        // is available it overlays the full bundle above and we never reach
+        // here; this chain read is the fallback and must not silently drop a
+        // bundle-shape validator from the load-bearing class-groups map.
         let decoded_per_validator: Vec<_> = committee
             .iter()
             .filter_map(|(id, (name, _))| {
                 let mpc_data = committee_mpc_data.get(id)?;
-                let decoded = decode_validator_encryption_keys(
-                    &mpc_data.class_groups_public_key_and_proof(),
-                );
+                let decoded = decode_validator_encryption_keys(&mpc_data.mpc_data_bytes());
                 if decoded.is_none() {
-                    warn!(
+                    error!(
                         authority = ?name,
-                        "Failed to decode validator encryption keys (neither mainnet-v1.1.8 nor version-3 shape)"
+                        "Failed to decode validator encryption keys from chain mpc_data \
+                         (neither bare class-groups nor version-3 bundle shape)"
                     );
                 }
-                decoded.map(|d| (*name, d))
+                decoded.map(|decoded| (*name, decoded))
             })
             .collect();
-
         let class_group_encryption_keys_and_proofs: HashMap<_, _> = decoded_per_validator
             .iter()
-            .map(|(n, v)| (*n, v.class_groups.clone()))
+            .map(|(name, decoded)| (*name, decoded.class_groups.clone()))
             .collect();
         let secp256k1_pvss_public_keys_and_proofs: HashMap<_, _> = decoded_per_validator
             .iter()
-            .filter_map(|(n, v)| v.secp256k1_pvss.clone().map(|k| (*n, k)))
+            .filter_map(|(name, decoded)| decoded.secp256k1_pvss.clone().map(|key| (*name, key)))
             .collect();
         let secp256r1_pvss_public_keys_and_proofs: HashMap<_, _> = decoded_per_validator
             .iter()
-            .filter_map(|(n, v)| v.secp256r1_pvss.clone().map(|k| (*n, k)))
+            .filter_map(|(name, decoded)| decoded.secp256r1_pvss.clone().map(|key| (*name, key)))
             .collect();
         let ristretto_pvss_public_keys_and_proofs: HashMap<_, _> = decoded_per_validator
             .iter()
-            .filter_map(|(n, v)| v.ristretto_pvss.clone().map(|k| (*n, k)))
+            .filter_map(|(name, decoded)| decoded.ristretto_pvss.clone().map(|key| (*name, key)))
+            .collect();
+        let vss_hpke_public_keys_and_proofs: HashMap<_, _> = decoded_per_validator
+            .iter()
+            .filter_map(|(name, decoded)| {
+                decoded
+                    .vss_hpke_public_key_and_proof
+                    .clone()
+                    .map(|key| (*name, key))
+            })
             .collect();
 
         Ok(Committee::new(
@@ -707,6 +724,7 @@ where
             secp256k1_pvss_public_keys_and_proofs,
             secp256r1_pvss_public_keys_and_proofs,
             ristretto_pvss_public_keys_and_proofs,
+            vss_hpke_public_keys_and_proofs,
             quorum_threshold,
             validity_threshold,
         ))

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -29,7 +29,7 @@
 //! so producer-side and any verifier re-derivation produce
 //! byte-identical results.
 
-use dwallet_classgroups_types::ClassGroupsAndPvssKeyPairAndProof;
+use dwallet_classgroups_types::ValidatorMPCSecrets;
 use dwallet_mpc_types::dwallet_mpc::{MPCDataV1, VersionedMPCData};
 use dwallet_rng::RootSeed;
 use fastcrypto::ed25519::{Ed25519KeyPair, Ed25519PublicKey, Ed25519Signature};
@@ -290,13 +290,16 @@ pub fn reevaluate_buffered_joiner_announcements(
 /// committee key sets on a v4 cluster and avoid the "0/N PVSS
 /// keys decoded" rejection during network DKG and reconfig.
 pub fn derive_mpc_data_blob(seed: &RootSeed) -> IkaResult<Vec<u8>> {
-    let bundle =
-        ClassGroupsAndPvssKeyPairAndProof::from_seed(seed).validator_encryption_keys_and_proofs();
+    // Off-chain validators always publish the full v1
+    // `ValidatorEncryptionKeysAndProofs` bundle (class-groups + 3 PVSS + the
+    // Fast Schnorr VSS HPKE key, all together) — distinct from the bare
+    // mainnet-v1.1.8 `ClassGroupsEncryptionKeyAndProof` shape published on chain.
+    let bundle = ValidatorMPCSecrets::from_seed(seed).1;
     let inner = bcs::to_bytes(&bundle).map_err(|e| {
         IkaError::Unknown(format!("bcs encode ValidatorEncryptionKeysAndProofs: {e}"))
     })?;
     let mpc_data = VersionedMPCData::V1(MPCDataV1 {
-        class_groups_public_key_and_proof: inner,
+        mpc_data_bytes: inner,
     });
     bcs::to_bytes(&mpc_data)
         .map_err(|e| IkaError::Unknown(format!("bcs encode versioned mpc data: {e}")))
@@ -611,7 +614,7 @@ pub fn blob_decodes_to_valid_mpc_data(blob: &[u8]) -> bool {
     let Ok(versioned) = bcs::from_bytes::<VersionedMPCData>(blob) else {
         return false;
     };
-    let inner = versioned.class_groups_public_key_and_proof();
+    let inner = versioned.mpc_data_bytes();
     ika_types::committee::decode_validator_encryption_keys(&inner).is_some()
 }
 
@@ -892,6 +895,13 @@ pub struct OffChainCommitteeBundles {
         AuthorityName,
         ika_types::committee::RistrettoPvssEncryptionKeyAndProof,
     >,
+    /// Fast Schnorr (VSS) curve25519 HPKE key + proof, per authority. Always
+    /// populated off-chain (the v1 bundle carries it for every member); the VSS
+    /// presign / sign sessions read it from the constructed `Committee`.
+    pub vss_hpke: std::collections::HashMap<
+        AuthorityName,
+        ika_types::committee::VssHpkeEncryptionKeyAndProof,
+    >,
 }
 
 /// Outcome of trying to assemble the committee's class-groups
@@ -950,6 +960,7 @@ where
     let mut secp256k1_pvss = std::collections::HashMap::new();
     let mut secp256r1_pvss = std::collections::HashMap::new();
     let mut ristretto_pvss = std::collections::HashMap::new();
+    let mut vss_hpke = std::collections::HashMap::new();
     let mut missing = Vec::new();
     let mut saw_any = false;
     for (authority, digest) in announcements {
@@ -962,21 +973,39 @@ where
             missing.push(authority);
             continue;
         };
-        let inner_bytes = versioned.class_groups_public_key_and_proof();
+        let inner_bytes = versioned.mpc_data_bytes();
         let Some(decoded) = decode_validator_encryption_keys(&inner_bytes) else {
             missing.push(authority);
             continue;
         };
+        // Off-chain bundles are always the full v1
+        // `ValidatorEncryptionKeysAndProofs` (class-groups + 3 PVSS + the Fast
+        // Schnorr VSS HPKE key, all together). A blob missing any of the four
+        // non-class-groups keys is a malformed / wrong-shape off-chain payload —
+        // treat the validator as missing so assembly stays `Incomplete` and
+        // retries, rather than building a `Committee` without a complete VSS /
+        // PVSS key set. (The bare class-groups-only shape lives on chain, never
+        // here.)
+        let (
+            Some(secp256k1_pvss_key),
+            Some(secp256r1_pvss_key),
+            Some(ristretto_pvss_key),
+            Some(vss_hpke_key),
+        ) = (
+            decoded.secp256k1_pvss,
+            decoded.secp256r1_pvss,
+            decoded.ristretto_pvss,
+            decoded.vss_hpke_public_key_and_proof,
+        )
+        else {
+            missing.push(authority);
+            continue;
+        };
         class_groups.insert(authority, decoded.class_groups);
-        if let Some(k) = decoded.secp256k1_pvss {
-            secp256k1_pvss.insert(authority, k);
-        }
-        if let Some(k) = decoded.secp256r1_pvss {
-            secp256r1_pvss.insert(authority, k);
-        }
-        if let Some(k) = decoded.ristretto_pvss {
-            ristretto_pvss.insert(authority, k);
-        }
+        secp256k1_pvss.insert(authority, secp256k1_pvss_key);
+        secp256r1_pvss.insert(authority, secp256r1_pvss_key);
+        ristretto_pvss.insert(authority, ristretto_pvss_key);
+        vss_hpke.insert(authority, vss_hpke_key);
     }
     // Empty input -> never `Complete`. `Complete` with empty maps
     // would silently build a `Committee` whose
@@ -994,6 +1023,7 @@ where
             secp256k1_pvss,
             secp256r1_pvss,
             ristretto_pvss,
+            vss_hpke,
         })
     } else {
         OffChainMpcDataAssembly::Incomplete { missing }
@@ -1979,6 +2009,7 @@ mod tests {
             std::collections::HashMap::new(),
             std::collections::HashMap::new(),
             std::collections::HashMap::new(),
+            std::collections::HashMap::new(),
             q,
             v,
         ));
@@ -2076,6 +2107,7 @@ mod tests {
         let committee = Arc::new(Committee::new(
             5,
             voting_rights,
+            std::collections::HashMap::new(),
             std::collections::HashMap::new(),
             std::collections::HashMap::new(),
             std::collections::HashMap::new(),

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::{
     cell::RefCell,
-    collections::BTreeSet,
     sync::atomic::{AtomicBool, Ordering},
 };
 use sui_protocol_config_macros::{
@@ -171,7 +170,7 @@ struct FeatureFlags {
     noa_checkpoints: bool,
 
     // If true, enables Fast Schnorr (VSS) signature algorithms: TaprootVSS,
-    // EdDSAVSS, SchnorrkelSubstrateVSS. DKG-created keys only.
+    // EdDSAVSS, SchnorrkelVSS. DKG-created keys only.
     #[serde(skip_serializing_if = "is_false")]
     fast_schnorr_supported: bool,
 
@@ -189,11 +188,6 @@ struct FeatureFlags {
 #[allow(unused)]
 fn is_false(b: &bool) -> bool {
     !b
-}
-
-#[allow(unused)]
-fn is_empty(b: &BTreeSet<String>) -> bool {
-    b.is_empty()
 }
 
 /// Ordering mechanism for transactions in one Narwhal consensus output.
@@ -826,7 +820,7 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSA => {
                 self.network_owned_address_eddsa_presign_pool_minimum_size()
             }
-            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
+            DWalletSignatureAlgorithm::Schnorrkel => {
                 self.network_owned_address_schnorrkel_substrate_presign_pool_minimum_size()
             }
             DWalletSignatureAlgorithm::Taproot => {
@@ -839,7 +833,7 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSAVSS => {
                 self.network_owned_address_eddsa_presign_pool_minimum_size()
             }
-            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
                 self.network_owned_address_schnorrkel_substrate_presign_pool_minimum_size()
             }
         }
@@ -860,7 +854,7 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSA => {
                 self.network_owned_address_eddsa_presign_consensus_round_delay()
             }
-            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
+            DWalletSignatureAlgorithm::Schnorrkel => {
                 self.network_owned_address_schnorrkel_substrate_presign_consensus_round_delay()
             }
             DWalletSignatureAlgorithm::Taproot => {
@@ -873,7 +867,7 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSAVSS => {
                 self.network_owned_address_eddsa_presign_consensus_round_delay()
             }
-            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
                 self.network_owned_address_schnorrkel_substrate_presign_consensus_round_delay()
             }
         }
@@ -894,7 +888,7 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSA => {
                 self.network_owned_address_eddsa_presign_sessions_to_instantiate()
             }
-            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
+            DWalletSignatureAlgorithm::Schnorrkel => {
                 self.network_owned_address_schnorrkel_substrate_presign_sessions_to_instantiate()
             }
             DWalletSignatureAlgorithm::Taproot => {
@@ -907,7 +901,7 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSAVSS => {
                 self.network_owned_address_eddsa_presign_sessions_to_instantiate()
             }
-            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
                 self.network_owned_address_schnorrkel_substrate_presign_sessions_to_instantiate()
             }
         }
@@ -928,7 +922,7 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSA => {
                 self.network_owned_address_eddsa_presign_pool_maximum_size()
             }
-            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
+            DWalletSignatureAlgorithm::Schnorrkel => {
                 self.network_owned_address_schnorrkel_substrate_presign_pool_maximum_size()
             }
             DWalletSignatureAlgorithm::Taproot => {
@@ -941,7 +935,7 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSAVSS => {
                 self.network_owned_address_eddsa_presign_pool_maximum_size()
             }
-            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
                 self.network_owned_address_schnorrkel_substrate_presign_pool_maximum_size()
             }
         }
@@ -962,7 +956,7 @@ impl ProtocolConfig {
                 self.internal_secp256r1_ecdsa_presign_pool_minimum_size()
             }
             DWalletSignatureAlgorithm::EdDSA => self.internal_eddsa_presign_pool_minimum_size(),
-            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
+            DWalletSignatureAlgorithm::Schnorrkel => {
                 self.internal_schnorrkel_substrate_presign_pool_minimum_size()
             }
             DWalletSignatureAlgorithm::Taproot => self.internal_taproot_presign_pool_minimum_size(),
@@ -971,7 +965,7 @@ impl ProtocolConfig {
                 self.internal_taproot_presign_pool_minimum_size()
             }
             DWalletSignatureAlgorithm::EdDSAVSS => self.internal_eddsa_presign_pool_minimum_size(),
-            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
                 self.internal_schnorrkel_substrate_presign_pool_minimum_size()
             }
         }
@@ -991,7 +985,7 @@ impl ProtocolConfig {
                 self.internal_secp256r1_ecdsa_presign_consensus_round_delay()
             }
             DWalletSignatureAlgorithm::EdDSA => self.internal_eddsa_presign_consensus_round_delay(),
-            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
+            DWalletSignatureAlgorithm::Schnorrkel => {
                 self.internal_schnorrkel_substrate_presign_consensus_round_delay()
             }
             DWalletSignatureAlgorithm::Taproot => {
@@ -1004,7 +998,7 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSAVSS => {
                 self.internal_eddsa_presign_consensus_round_delay()
             }
-            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
                 self.internal_schnorrkel_substrate_presign_consensus_round_delay()
             }
         }
@@ -1026,7 +1020,7 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSA => {
                 self.internal_eddsa_presign_sessions_to_instantiate()
             }
-            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
+            DWalletSignatureAlgorithm::Schnorrkel => {
                 self.internal_schnorrkel_substrate_presign_sessions_to_instantiate()
             }
             DWalletSignatureAlgorithm::Taproot => {
@@ -1039,7 +1033,7 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSAVSS => {
                 self.internal_eddsa_presign_sessions_to_instantiate()
             }
-            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
                 self.internal_schnorrkel_substrate_presign_sessions_to_instantiate()
             }
         }
@@ -1060,7 +1054,7 @@ impl ProtocolConfig {
                 self.internal_secp256r1_ecdsa_presign_pool_maximum_size()
             }
             DWalletSignatureAlgorithm::EdDSA => self.internal_eddsa_presign_pool_maximum_size(),
-            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
+            DWalletSignatureAlgorithm::Schnorrkel => {
                 self.internal_schnorrkel_substrate_presign_pool_maximum_size()
             }
             DWalletSignatureAlgorithm::Taproot => self.internal_taproot_presign_pool_maximum_size(),
@@ -1069,7 +1063,7 @@ impl ProtocolConfig {
                 self.internal_taproot_presign_pool_maximum_size()
             }
             DWalletSignatureAlgorithm::EdDSAVSS => self.internal_eddsa_presign_pool_maximum_size(),
-            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+            DWalletSignatureAlgorithm::SchnorrkelVSS => {
                 self.internal_schnorrkel_substrate_presign_pool_maximum_size()
             }
         }

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::{
     cell::RefCell,
+    collections::BTreeSet,
     sync::atomic::{AtomicBool, Ordering},
 };
 use sui_protocol_config_macros::{
@@ -24,8 +25,9 @@ const MAX_PROTOCOL_VERSION: u64 = 4;
 // Version 2: network_encryption_key_version = 2.
 // Version 3: reconfiguration_message_version = 2 (mainnet-v1.1.8).
 // Version 4: off_chain_validator_metadata pipeline on; internal_presign_sessions on;
-//            consensus_skip_gced_blocks_in_direct_finalization on; version-3 crypto
-//            (network_encryption_key_version = 3, reconfiguration_message_version = 3; #1707) —
+//            consensus_skip_gced_blocks_in_direct_finalization on; bls_checkpoints on;
+//            fast_schnorr_supported on (internal NOA-VSS only); post-PR-#1707 crypto
+//            (network_encryption_key_version = 3, reconfiguration_message_version = 3) —
 //            validators publish `ValidatorEncryptionKeysAndProofs` (class-groups + per-curve
 //            PVSS HPKE) and DKG/Reconfiguration use `twopc_mpc::decentralized_party::*`.
 // Version 5: noa_checkpoints on.
@@ -168,6 +170,11 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     noa_checkpoints: bool,
 
+    // If true, enables Fast Schnorr (VSS) signature algorithms: TaprootVSS,
+    // EdDSAVSS, SchnorrkelSubstrateVSS. DKG-created keys only.
+    #[serde(skip_serializing_if = "is_false")]
+    fast_schnorr_supported: bool,
+
     // If true, enables the off-chain validator-metadata pipeline:
     // per-epoch `ValidatorMpcDataAnnouncement` + ready signals
     // broadcast over consensus, the step-14 kickoff gate, the
@@ -179,8 +186,14 @@ struct FeatureFlags {
     off_chain_validator_metadata: bool,
 }
 
+#[allow(unused)]
 fn is_false(b: &bool) -> bool {
     !b
+}
+
+#[allow(unused)]
+fn is_empty(b: &BTreeSet<String>) -> bool {
+    b.is_empty()
 }
 
 /// Ordering mechanism for transactions in one Narwhal consensus output.
@@ -291,6 +304,11 @@ pub struct ProtocolConfig {
     consensus_gc_depth: Option<u32>,
     decryption_key_reconfiguration_third_round_delay: Option<u64>,
     schnorr_presign_second_round_delay: Option<u64>,
+    /// Consensus-round delay for the VSS (Fast Schnorr) presign Aggregation
+    /// round (round 3). AHE Schnorr presign is 2 rounds and ignores this; only
+    /// VSS presign (Dealing → Accusation → Aggregation) uses it. Defaults to the
+    /// same value as `schnorr_presign_second_round_delay`.
+    schnorr_presign_third_round_delay: Option<u64>,
     network_dkg_third_round_delay: Option<u64>,
     network_encryption_key_version: Option<u64>,
     reconfiguration_message_version: Option<u64>,
@@ -383,8 +401,15 @@ impl ProtocolConfig {
         self.feature_flags.internal_presign_sessions
     }
 
-    /// True iff this protocol_version uses the version-3 network DKG /
-    /// validator-key-publication shape (#1707) — `ValidatorEncryptionKeysAndProofs`
+    /// True iff Fast Schnorr (VSS) signature algorithms are enabled at this
+    /// protocol version (>= 4). Gates the internal NOA-VSS presign pool and
+    /// the Rust-side defense-in-depth VSS request guard.
+    pub fn fast_schnorr_supported(&self) -> bool {
+        self.feature_flags.fast_schnorr_supported
+    }
+
+    /// True iff this protocol_version uses the post-PR-#1707 network DKG /
+    /// validator-key-publication shape — `ValidatorEncryptionKeysAndProofs`
     /// (class-groups + per-curve PVSS HPKE) and
     /// `twopc_mpc::decentralized_party::dkg::Party`. False at protocol_version
     /// <= 3 (mainnet-v1.1.8), where the publication is bare
@@ -394,8 +419,8 @@ impl ProtocolConfig {
         self.network_encryption_key_version.is_some_and(|v| v == 3)
     }
 
-    /// True iff this protocol_version uses the version-3 reconfiguration
-    /// shape (#1707) — `twopc_mpc::decentralized_party::reconfiguration::Party` with
+    /// True iff this protocol_version uses the post-PR-#1707 reconfiguration
+    /// shape — `twopc_mpc::decentralized_party::reconfiguration::Party` with
     /// per-curve PVSS HPKE keys in `PublicInput`. False at protocol_version
     /// <= 3, where reconfiguration runs against
     /// `twopc_mpc::decentralized_party_backward_compatible::reconfiguration::Party`.
@@ -465,6 +490,10 @@ static POISON_VERSION_METHODS: AtomicBool = AtomicBool::new(false);
 thread_local! {
     static POISON_VERSION_METHODS: AtomicBool = AtomicBool::new(false);
 }
+
+/// Set once by `enable_small_presign_pools_for_local_swarm` so a single host
+/// running the whole validator set keeps its presign pools fillable.
+static SHRINK_PRESIGN_POOLS_FOR_LOCAL_SWARM: AtomicBool = AtomicBool::new(false);
 
 // Instantiations for each protocol version.
 impl ProtocolConfig {
@@ -612,6 +641,7 @@ impl ProtocolConfig {
             // The delay is measured in consensus rounds.
             decryption_key_reconfiguration_third_round_delay: Some(10),
             schnorr_presign_second_round_delay: Some(8),
+            schnorr_presign_third_round_delay: Some(8),
             network_dkg_third_round_delay: Some(10),
             network_encryption_key_version: Some(1),
             reconfiguration_message_version: Some(1),
@@ -699,6 +729,7 @@ impl ProtocolConfig {
                         .consensus_skip_gced_blocks_in_direct_finalization = true;
                     cfg.feature_flags.bls_checkpoints = true;
                     cfg.feature_flags.off_chain_validator_metadata = true;
+                    cfg.feature_flags.fast_schnorr_supported = true;
                     cfg.network_encryption_key_version = Some(3);
                     cfg.reconfiguration_message_version = Some(3);
                 }
@@ -750,6 +781,22 @@ impl ProtocolConfig {
         cfg
     }
 
+    /// Enable the small-presign-pool override for this process. Called by the
+    /// local in-memory swarm / `ika start` so a single host running the whole
+    /// validator set can keep both the internal and network-owned-address
+    /// presign pools filled instead of pegging the CPU and stalling epoch
+    /// advance. No-op (production sizes retained) when the
+    /// `IKA_DISABLE_SMALL_PRESIGN_POOLS` env var is set.
+    pub fn enable_small_presign_pools_for_local_swarm() {
+        if std::env::var("IKA_DISABLE_SMALL_PRESIGN_POOLS").is_ok() {
+            info!(
+                "IKA_DISABLE_SMALL_PRESIGN_POOLS set; keeping production presign pool sizes for the local swarm"
+            );
+            return;
+        }
+        SHRINK_PRESIGN_POOLS_FOR_LOCAL_SWARM.store(true, Ordering::Relaxed);
+    }
+
     /// Override one or more settings in the config, for testing.
     /// This must be called at the beginning of the test, before get_for_(min|max)_version is
     /// called, since those functions cache their return value.
@@ -762,24 +809,6 @@ impl ProtocolConfig {
             *cur = Some(Box::new(override_fn));
             OverrideGuard
         })
-    }
-
-    /// Enable the small-presign-pool override for this process. Called by the
-    /// local in-memory swarm / `ika start` so a single host running the whole
-    /// validator set can keep both the internal and network-owned-address
-    /// presign pools filled instead of pegging the CPU and stalling epoch
-    /// advance. No-op (production sizes retained) when the
-    /// `IKA_DISABLE_SMALL_PRESIGN_POOLS` env var is set, so a local network can
-    /// still exercise production-scale pools. Validator binaries never call it,
-    /// so testnet/mainnet are unaffected.
-    pub fn enable_small_presign_pools_for_local_swarm() {
-        if std::env::var("IKA_DISABLE_SMALL_PRESIGN_POOLS").is_ok() {
-            info!(
-                "IKA_DISABLE_SMALL_PRESIGN_POOLS set; keeping production presign pool sizes for the local swarm"
-            );
-            return;
-        }
-        SHRINK_PRESIGN_POOLS_FOR_LOCAL_SWARM.store(true, Ordering::Relaxed);
     }
 
     /// Get the minimum size of the NOA sign presign pool for a given signature algorithm.
@@ -797,11 +826,21 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSA => {
                 self.network_owned_address_eddsa_presign_pool_minimum_size()
             }
-            DWalletSignatureAlgorithm::Schnorrkel => {
+            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
                 self.network_owned_address_schnorrkel_substrate_presign_pool_minimum_size()
             }
             DWalletSignatureAlgorithm::Taproot => {
                 self.network_owned_address_taproot_presign_pool_minimum_size()
+            }
+            // VSS (Fast Schnorr) variants reuse their AHE curve-sibling's pool sizing.
+            DWalletSignatureAlgorithm::TaprootVSS => {
+                self.network_owned_address_taproot_presign_pool_minimum_size()
+            }
+            DWalletSignatureAlgorithm::EdDSAVSS => {
+                self.network_owned_address_eddsa_presign_pool_minimum_size()
+            }
+            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+                self.network_owned_address_schnorrkel_substrate_presign_pool_minimum_size()
             }
         }
     }
@@ -821,11 +860,21 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSA => {
                 self.network_owned_address_eddsa_presign_consensus_round_delay()
             }
-            DWalletSignatureAlgorithm::Schnorrkel => {
+            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
                 self.network_owned_address_schnorrkel_substrate_presign_consensus_round_delay()
             }
             DWalletSignatureAlgorithm::Taproot => {
                 self.network_owned_address_taproot_presign_consensus_round_delay()
+            }
+            // VSS (Fast Schnorr) variants reuse their AHE curve-sibling's delay.
+            DWalletSignatureAlgorithm::TaprootVSS => {
+                self.network_owned_address_taproot_presign_consensus_round_delay()
+            }
+            DWalletSignatureAlgorithm::EdDSAVSS => {
+                self.network_owned_address_eddsa_presign_consensus_round_delay()
+            }
+            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+                self.network_owned_address_schnorrkel_substrate_presign_consensus_round_delay()
             }
         }
     }
@@ -845,11 +894,21 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSA => {
                 self.network_owned_address_eddsa_presign_sessions_to_instantiate()
             }
-            DWalletSignatureAlgorithm::Schnorrkel => {
+            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
                 self.network_owned_address_schnorrkel_substrate_presign_sessions_to_instantiate()
             }
             DWalletSignatureAlgorithm::Taproot => {
                 self.network_owned_address_taproot_presign_sessions_to_instantiate()
+            }
+            // VSS (Fast Schnorr) variants reuse their AHE curve-sibling's instantiation rate.
+            DWalletSignatureAlgorithm::TaprootVSS => {
+                self.network_owned_address_taproot_presign_sessions_to_instantiate()
+            }
+            DWalletSignatureAlgorithm::EdDSAVSS => {
+                self.network_owned_address_eddsa_presign_sessions_to_instantiate()
+            }
+            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+                self.network_owned_address_schnorrkel_substrate_presign_sessions_to_instantiate()
             }
         }
     }
@@ -869,11 +928,21 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSA => {
                 self.network_owned_address_eddsa_presign_pool_maximum_size()
             }
-            DWalletSignatureAlgorithm::Schnorrkel => {
+            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
                 self.network_owned_address_schnorrkel_substrate_presign_pool_maximum_size()
             }
             DWalletSignatureAlgorithm::Taproot => {
                 self.network_owned_address_taproot_presign_pool_maximum_size()
+            }
+            // VSS (Fast Schnorr) variants reuse their AHE curve-sibling's pool cap.
+            DWalletSignatureAlgorithm::TaprootVSS => {
+                self.network_owned_address_taproot_presign_pool_maximum_size()
+            }
+            DWalletSignatureAlgorithm::EdDSAVSS => {
+                self.network_owned_address_eddsa_presign_pool_maximum_size()
+            }
+            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+                self.network_owned_address_schnorrkel_substrate_presign_pool_maximum_size()
             }
         }
     }
@@ -893,10 +962,18 @@ impl ProtocolConfig {
                 self.internal_secp256r1_ecdsa_presign_pool_minimum_size()
             }
             DWalletSignatureAlgorithm::EdDSA => self.internal_eddsa_presign_pool_minimum_size(),
-            DWalletSignatureAlgorithm::Schnorrkel => {
+            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
                 self.internal_schnorrkel_substrate_presign_pool_minimum_size()
             }
             DWalletSignatureAlgorithm::Taproot => self.internal_taproot_presign_pool_minimum_size(),
+            // VSS (Fast Schnorr) variants reuse their AHE curve-sibling's pool sizing.
+            DWalletSignatureAlgorithm::TaprootVSS => {
+                self.internal_taproot_presign_pool_minimum_size()
+            }
+            DWalletSignatureAlgorithm::EdDSAVSS => self.internal_eddsa_presign_pool_minimum_size(),
+            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+                self.internal_schnorrkel_substrate_presign_pool_minimum_size()
+            }
         }
     }
 
@@ -914,11 +991,21 @@ impl ProtocolConfig {
                 self.internal_secp256r1_ecdsa_presign_consensus_round_delay()
             }
             DWalletSignatureAlgorithm::EdDSA => self.internal_eddsa_presign_consensus_round_delay(),
-            DWalletSignatureAlgorithm::Schnorrkel => {
+            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
                 self.internal_schnorrkel_substrate_presign_consensus_round_delay()
             }
             DWalletSignatureAlgorithm::Taproot => {
                 self.internal_taproot_presign_consensus_round_delay()
+            }
+            // VSS (Fast Schnorr) variants reuse their AHE curve-sibling's delay.
+            DWalletSignatureAlgorithm::TaprootVSS => {
+                self.internal_taproot_presign_consensus_round_delay()
+            }
+            DWalletSignatureAlgorithm::EdDSAVSS => {
+                self.internal_eddsa_presign_consensus_round_delay()
+            }
+            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+                self.internal_schnorrkel_substrate_presign_consensus_round_delay()
             }
         }
     }
@@ -939,11 +1026,21 @@ impl ProtocolConfig {
             DWalletSignatureAlgorithm::EdDSA => {
                 self.internal_eddsa_presign_sessions_to_instantiate()
             }
-            DWalletSignatureAlgorithm::Schnorrkel => {
+            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
                 self.internal_schnorrkel_substrate_presign_sessions_to_instantiate()
             }
             DWalletSignatureAlgorithm::Taproot => {
                 self.internal_taproot_presign_sessions_to_instantiate()
+            }
+            // VSS (Fast Schnorr) variants reuse their AHE curve-sibling's instantiation rate.
+            DWalletSignatureAlgorithm::TaprootVSS => {
+                self.internal_taproot_presign_sessions_to_instantiate()
+            }
+            DWalletSignatureAlgorithm::EdDSAVSS => {
+                self.internal_eddsa_presign_sessions_to_instantiate()
+            }
+            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+                self.internal_schnorrkel_substrate_presign_sessions_to_instantiate()
             }
         }
     }
@@ -963,10 +1060,18 @@ impl ProtocolConfig {
                 self.internal_secp256r1_ecdsa_presign_pool_maximum_size()
             }
             DWalletSignatureAlgorithm::EdDSA => self.internal_eddsa_presign_pool_maximum_size(),
-            DWalletSignatureAlgorithm::Schnorrkel => {
+            DWalletSignatureAlgorithm::SchnorrkelSubstrate => {
                 self.internal_schnorrkel_substrate_presign_pool_maximum_size()
             }
             DWalletSignatureAlgorithm::Taproot => self.internal_taproot_presign_pool_maximum_size(),
+            // VSS (Fast Schnorr) variants reuse their AHE curve-sibling's pool cap.
+            DWalletSignatureAlgorithm::TaprootVSS => {
+                self.internal_taproot_presign_pool_maximum_size()
+            }
+            DWalletSignatureAlgorithm::EdDSAVSS => self.internal_eddsa_presign_pool_maximum_size(),
+            DWalletSignatureAlgorithm::SchnorrkelSubstrateVSS => {
+                self.internal_schnorrkel_substrate_presign_pool_maximum_size()
+            }
         }
     }
 }
@@ -1006,16 +1111,6 @@ type OverrideFn = dyn Fn(ProtocolVersion, ProtocolConfig) -> ProtocolConfig + Se
 thread_local! {
     static CONFIG_OVERRIDE: RefCell<Option<Box<OverrideFn>>> = RefCell::new(None);
 }
-
-/// Process-global switch, set by the local in-memory swarm / `ika start`, to
-/// shrink both the internal and network-owned-address presign pools so a single
-/// host running the whole validator set can keep them filled. The production
-/// pool sizes (thousands of presigns per curve) peg the CPU there and stall
-/// epoch advance. Unlike the thread-local `CONFIG_OVERRIDE` (which only the
-/// calling thread sees), this is honored by `get_for_version_impl` on every
-/// thread and every epoch. Off by default — only the local swarm turns it on,
-/// so testnet/mainnet binaries keep the production sizes.
-static SHRINK_PRESIGN_POOLS_FOR_LOCAL_SWARM: AtomicBool = AtomicBool::new(false);
 
 #[must_use]
 pub struct OverrideGuard;

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Mainnet_version_3.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Mainnet_version_3.snap
@@ -23,9 +23,12 @@ consensus_max_transactions_in_block_bytes: 315218930
 consensus_gc_depth: 60
 decryption_key_reconfiguration_third_round_delay: 10
 schnorr_presign_second_round_delay: 8
+schnorr_presign_third_round_delay: 8
 network_dkg_third_round_delay: 10
 network_encryption_key_version: 2
 reconfiguration_message_version: 2
+end_of_publish_grace_rounds: 50
+mpc_data_freeze_grace_rounds: 50
 network_owned_address_ecdsa_secp256k1_presign_pool_minimum_size: 2500
 network_owned_address_ecdsa_secp256r1_presign_pool_minimum_size: 1000
 network_owned_address_eddsa_presign_pool_minimum_size: 5000

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Mainnet_version_4.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Mainnet_version_4.snap
@@ -12,6 +12,7 @@ feature_flags:
   enforce_checkpoint_timestamp_monotonicity: true
   internal_presign_sessions: true
   bls_checkpoints: true
+  fast_schnorr_supported: true
   off_chain_validator_metadata: true
 max_messages_per_dwallet_checkpoint: 500
 max_messages_per_system_checkpoint: 500
@@ -26,9 +27,12 @@ consensus_max_transactions_in_block_bytes: 315218930
 consensus_gc_depth: 60
 decryption_key_reconfiguration_third_round_delay: 10
 schnorr_presign_second_round_delay: 8
+schnorr_presign_third_round_delay: 8
 network_dkg_third_round_delay: 10
 network_encryption_key_version: 3
 reconfiguration_message_version: 3
+end_of_publish_grace_rounds: 50
+mpc_data_freeze_grace_rounds: 50
 network_owned_address_ecdsa_secp256k1_presign_pool_minimum_size: 2500
 network_owned_address_ecdsa_secp256r1_presign_pool_minimum_size: 1000
 network_owned_address_eddsa_presign_pool_minimum_size: 5000

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Testnet_version_3.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Testnet_version_3.snap
@@ -23,9 +23,12 @@ consensus_max_transactions_in_block_bytes: 315218930
 consensus_gc_depth: 60
 decryption_key_reconfiguration_third_round_delay: 10
 schnorr_presign_second_round_delay: 8
+schnorr_presign_third_round_delay: 8
 network_dkg_third_round_delay: 10
 network_encryption_key_version: 2
 reconfiguration_message_version: 2
+end_of_publish_grace_rounds: 50
+mpc_data_freeze_grace_rounds: 50
 network_owned_address_ecdsa_secp256k1_presign_pool_minimum_size: 2500
 network_owned_address_ecdsa_secp256r1_presign_pool_minimum_size: 1000
 network_owned_address_eddsa_presign_pool_minimum_size: 5000

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Testnet_version_4.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Testnet_version_4.snap
@@ -12,6 +12,7 @@ feature_flags:
   enforce_checkpoint_timestamp_monotonicity: true
   internal_presign_sessions: true
   bls_checkpoints: true
+  fast_schnorr_supported: true
   off_chain_validator_metadata: true
 max_messages_per_dwallet_checkpoint: 500
 max_messages_per_system_checkpoint: 500
@@ -26,9 +27,12 @@ consensus_max_transactions_in_block_bytes: 315218930
 consensus_gc_depth: 60
 decryption_key_reconfiguration_third_round_delay: 10
 schnorr_presign_second_round_delay: 8
+schnorr_presign_third_round_delay: 8
 network_dkg_third_round_delay: 10
 network_encryption_key_version: 3
 reconfiguration_message_version: 3
+end_of_publish_grace_rounds: 50
+mpc_data_freeze_grace_rounds: 50
 network_owned_address_ecdsa_secp256k1_presign_pool_minimum_size: 2500
 network_owned_address_ecdsa_secp256r1_presign_pool_minimum_size: 1000
 network_owned_address_eddsa_presign_pool_minimum_size: 5000

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__version_3.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__version_3.snap
@@ -23,9 +23,12 @@ consensus_max_transactions_in_block_bytes: 315218930
 consensus_gc_depth: 60
 decryption_key_reconfiguration_third_round_delay: 10
 schnorr_presign_second_round_delay: 8
+schnorr_presign_third_round_delay: 8
 network_dkg_third_round_delay: 10
 network_encryption_key_version: 2
 reconfiguration_message_version: 2
+end_of_publish_grace_rounds: 50
+mpc_data_freeze_grace_rounds: 50
 network_owned_address_ecdsa_secp256k1_presign_pool_minimum_size: 2500
 network_owned_address_ecdsa_secp256r1_presign_pool_minimum_size: 1000
 network_owned_address_eddsa_presign_pool_minimum_size: 5000

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__version_4.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__version_4.snap
@@ -12,6 +12,7 @@ feature_flags:
   enforce_checkpoint_timestamp_monotonicity: true
   internal_presign_sessions: true
   bls_checkpoints: true
+  fast_schnorr_supported: true
   off_chain_validator_metadata: true
 max_messages_per_dwallet_checkpoint: 500
 max_messages_per_system_checkpoint: 500
@@ -26,9 +27,12 @@ consensus_max_transactions_in_block_bytes: 315218930
 consensus_gc_depth: 60
 decryption_key_reconfiguration_third_round_delay: 10
 schnorr_presign_second_round_delay: 8
+schnorr_presign_third_round_delay: 8
 network_dkg_third_round_delay: 10
 network_encryption_key_version: 3
 reconfiguration_message_version: 3
+end_of_publish_grace_rounds: 50
+mpc_data_freeze_grace_rounds: 50
 network_owned_address_ecdsa_secp256k1_presign_pool_minimum_size: 2500
 network_owned_address_ecdsa_secp256r1_presign_pool_minimum_size: 1000
 network_owned_address_eddsa_presign_pool_minimum_size: 5000

--- a/crates/ika-swarm-config/src/validator_initialization_config.rs
+++ b/crates/ika-swarm-config/src/validator_initialization_config.rs
@@ -3,7 +3,7 @@
 
 use std::net::{IpAddr, SocketAddr};
 
-use dwallet_classgroups_types::ClassGroupsAndPvssKeyPairAndProof;
+use dwallet_classgroups_types::ValidatorMPCSecrets;
 use dwallet_mpc_types::dwallet_mpc::{MPCDataV1, VersionedMPCData};
 use dwallet_rng::RootSeed;
 use fastcrypto::traits::KeyPair;
@@ -64,21 +64,21 @@ impl ValidatorInitializationConfig {
         // The genesis publish shape follows the genesis protocol version's
         // network-encryption-key version. At v4 (`network_encryption_key_version == 3`)
         // the network-key DKG requires every member's full
-        // `ValidatorEncryptionKeysAndProofs` bundle (class-groups + per-curve PVSS), so
-        // publish it — otherwise the genesis DKG wedges with 0 PVSS decoded. Pre-v4
-        // (mainnet-v1.1.8, version 2) publishes only the bare
-        // `ClassGroupsEncryptionKeyAndProof` so a mainnet-v1.1.8 binary can decode the
-        // genesis record in the cross-binary upgrade rehearsal. Reads are shape-tolerant
-        // either way via `decode_validator_encryption_keys`.
-        let keypair = ClassGroupsAndPvssKeyPairAndProof::from_seed(&self.root_seed);
-        let class_groups_public_key_and_proof = if legacy_class_groups_only {
-            bcs::to_bytes(&keypair.class_groups.encryption_key_and_proof()).unwrap()
+        // `ValidatorEncryptionKeysAndProofs` bundle (class-groups + per-curve PVSS +
+        // the Fast Schnorr VSS HPKE key), so publish it — otherwise the genesis DKG
+        // wedges with 0 PVSS decoded. Pre-v4 (mainnet-v1.1.8, version 2) publishes only
+        // the bare `ClassGroupsEncryptionKeyAndProof` (the `.class_groups` component of
+        // the bundle) so a mainnet-v1.1.8 binary can decode the genesis record in the
+        // cross-binary upgrade rehearsal. Reads are shape-tolerant either way via
+        // `decode_validator_encryption_keys`.
+        let validator_encryption_keys_and_proofs =
+            ValidatorMPCSecrets::from_seed(&self.root_seed).1;
+        let mpc_data_bytes = if legacy_class_groups_only {
+            bcs::to_bytes(&validator_encryption_keys_and_proofs.class_groups).unwrap()
         } else {
-            bcs::to_bytes(&keypair.validator_encryption_keys_and_proofs()).unwrap()
+            bcs::to_bytes(&validator_encryption_keys_and_proofs).unwrap()
         };
-        let mpc_data = VersionedMPCData::V1(MPCDataV1 {
-            class_groups_public_key_and_proof,
-        });
+        let mpc_data = VersionedMPCData::V1(MPCDataV1 { mpc_data_bytes });
 
         ValidatorInfo {
             name,

--- a/crates/ika-types/src/committee.rs
+++ b/crates/ika-types/src/committee.rs
@@ -13,7 +13,12 @@ use class_groups::publicly_verifiable_secret_sharing::chinese_remainder_theorem:
 };
 use fastcrypto::traits::KeyPair;
 use group::PartyID;
+use group::curve25519;
 pub use ika_protocol_config::ProtocolVersion;
+use mpc::hybrid_public_key_encryption::{
+    KnowledgeOfDecryptionKeyUCProof as VssHpkeKnowledgeOfDecryptionKeyUCProof,
+    parse_and_uc_verify_encryption_keys,
+};
 use rand::rngs::{StdRng, ThreadRng};
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
@@ -83,6 +88,18 @@ pub struct Committee {
     /// Per-validator PVSS HPKE encryption key + proof, ristretto plaintext space.
     pub ristretto_pvss_public_keys_and_proofs:
         HashMap<AuthorityName, RistrettoPvssEncryptionKeyAndProof>,
+    /// Per-party Fast Schnorr (VSS) HPKE encryption public key values
+    /// (curve25519, serializable form), filtered to **only** the parties whose
+    /// published UC proof of knowledge of the matching decryption key verified.
+    ///
+    /// Computed once at [`Self::new`] from the raw
+    /// `vss_hpke_public_keys_and_proofs` input by
+    /// `mpc::hybrid_public_key_encryption::parse_and_uc_verify_encryption_keys`.
+    /// The raw proofs are NOT retained — we keep only the verified result so the
+    /// per-presign session cost is a cheap curve-point parse, not a UC proof
+    /// re-verification. Parties whose key didn't parse or whose proof didn't
+    /// verify are simply absent.
+    pub vss_hpke_verified_party_encryption_key_values: HashMap<PartyID, curve25519::Value>,
     pub quorum_threshold: u64,
     pub validity_threshold: u64,
     expanded_keys: HashMap<AuthorityName, AuthorityPublicKey>,
@@ -110,6 +127,7 @@ impl Committee {
             AuthorityName,
             RistrettoPvssEncryptionKeyAndProof,
         >,
+        vss_hpke_public_keys_and_proofs: HashMap<AuthorityName, VssHpkeEncryptionKeyAndProof>,
         quorum_threshold: u64,
         validity_threshold: u64,
     ) -> Self {
@@ -118,6 +136,20 @@ impl Committee {
 
         let (expanded_keys, index_map) = Self::load_inner(&voting_rights);
 
+        // Verify the Fast Schnorr (VSS) HPKE UC proofs once, here at committee
+        // construction — not per presign session. We keep only the *verified*
+        // public key values; the raw proofs are dropped. Any party whose key
+        // failed to parse or whose proof didn't verify is simply absent from
+        // the resulting map (per upstream's per-party filter; a single
+        // malformed submission excludes only that party). On a systemic
+        // failure (the function itself errs), we store an empty map — no VSS
+        // presign can run, but the committee is still otherwise usable.
+        let vss_hpke_verified_party_encryption_key_values =
+            verify_vss_hpke_keys_at_committee_construction(
+                &vss_hpke_public_keys_and_proofs,
+                &index_map,
+            );
+
         Committee {
             epoch,
             voting_rights,
@@ -125,6 +157,7 @@ impl Committee {
             secp256k1_pvss_public_keys_and_proofs,
             secp256r1_pvss_public_keys_and_proofs,
             ristretto_pvss_public_keys_and_proofs,
+            vss_hpke_verified_party_encryption_key_values,
             expanded_keys,
             index_map,
             quorum_threshold,
@@ -160,6 +193,7 @@ impl Committee {
         Self::new(
             epoch,
             voting_weights.into_iter().collect(),
+            HashMap::new(),
             HashMap::new(),
             HashMap::new(),
             HashMap::new(),
@@ -353,6 +387,45 @@ impl Committee {
     /// Generate a simple committee with 4 validators each with equal voting stake of 1.
     pub fn new_simple_test_committee() -> (Self, Vec<AuthorityKeyPair>) {
         Self::new_simple_test_committee_of_size(4)
+    }
+
+    /// Test-only: re-runs the VSS HPKE UC-proof verification on a raw input map
+    /// and replaces this committee's verified-key cache with the result. Used
+    /// by integration-test helpers that build the committee first and inject
+    /// per-validator VSS HPKE keys afterwards. Production code lets
+    /// [`Self::new`] do the verification once at construction.
+    pub fn set_vss_hpke_verified_for_testing(
+        &mut self,
+        raw: HashMap<AuthorityName, VssHpkeEncryptionKeyAndProof>,
+    ) {
+        self.vss_hpke_verified_party_encryption_key_values =
+            verify_vss_hpke_keys_at_committee_construction(&raw, &self.index_map);
+    }
+}
+
+/// Verify per-validator VSS HPKE UC proofs once and return only the verified
+/// public key values, keyed by [`PartyID`] (1-based index into voting_rights).
+fn verify_vss_hpke_keys_at_committee_construction(
+    raw: &HashMap<AuthorityName, VssHpkeEncryptionKeyAndProof>,
+    index_map: &HashMap<AuthorityName, usize>,
+) -> HashMap<PartyID, curve25519::Value> {
+    let by_party_id: HashMap<PartyID, VssHpkeEncryptionKeyAndProof> = raw
+        .iter()
+        .filter_map(|(name, kp)| {
+            let index = index_map.get(name)?;
+            let party_id = u16::try_from(index.checked_add(1)?).ok()?;
+            Some((party_id, kp.clone()))
+        })
+        .collect();
+    match parse_and_uc_verify_encryption_keys(&by_party_id) {
+        Ok(verified) => verified
+            .into_iter()
+            .map(|(pid, ek)| {
+                use group::GroupElement as _;
+                (pid, ek.value())
+            })
+            .collect(),
+        Err(_) => HashMap::new(),
     }
 }
 
@@ -559,19 +632,35 @@ pub type RistrettoPvssEncryptionKeyAndProof = (
     >,
 );
 
-/// Combined per-validator on-chain encryption-keys-and-proofs payload.
+/// Fast Schnorr (VSS) HPKE encryption public key (curve25519, serializable
+/// `Value` form) plus the UC-secure proof of knowledge of the corresponding
+/// decryption key. The proof is verified — and the holder kept only if it passes
+/// — via `mpc::hybrid_public_key_encryption::
+/// verify_uc_proofs_of_knowledge_of_encryption_secret_keys` when building the VSS
+/// presign input; the verified set becomes the presign's
+/// `parties_with_uc_verified_public_keys`.
 ///
-/// BCS-serialized into the Move-side validator field that historically carried
-/// only `ClassGroupsEncryptionKeyAndProof` (`ValidatorInfo.class_groups_public_-
-/// key_and_proof` and the equivalent on `NetworkMetadata`). The Move side
-/// stores opaque `vector<u8>`; the publication shape — bare class-groups vs
-/// this bundle — is gated by the validator binary's `ProtocolConfig` (see the
-/// publication call sites in `crates/ika/src/validator_commands.rs`).
+/// A single curve25519 key per validator serves all VSS signing curves (the HPKE
+/// transport layer is curve-independent), unlike the three class-groups `*_pvss`
+/// keys which are per plaintext space.
+pub type VssHpkeEncryptionKeyAndProof = (curve25519::Value, VssHpkeKnowledgeOfDecryptionKeyUCProof);
+
+/// Full per-validator MPC public-key payload propagated via the off-chain
+/// validator-metadata pipeline (see PR #1721): the class-groups CRT key, the
+/// three per-curve PVSS HPKE keys, and the Fast Schnorr (VSS) curve25519 HPKE
+/// key — all with their respective UC-secure proofs.
 ///
-/// Reading code MUST go through [`decode_validator_encryption_keys`] rather
-/// than calling `bcs::from_bytes::<ValidatorEncryptionKeysAndProofs>` directly,
-/// so mainnet-v1.1.8-shape payloads (bare class-groups only) decode without
-/// silently dropping the validator.
+/// The Move field `MPCDataV1::mpc_data_bytes` may carry EITHER shape: the
+/// `become-candidate` / `set-next-epoch-mpc-data` CLI publishes this full
+/// bundle by default and the bare `ClassGroupsEncryptionKeyAndProof`
+/// (mainnet-v1.1.8 shape) only under `--legacy-class-groups-only`. The same
+/// bundle is also broadcast off-chain (consensus-signed announcement + P2P
+/// blob fetch), reaches consensus via `EpochMpcDataReadySignal`, and is
+/// overlaid onto `Committee` at the off-chain sites. Both chain reads and
+/// off-chain reads decode shape-tolerantly via
+/// [`decode_validator_encryption_keys`], which accepts either shape — so a
+/// bundle-shape validator is never dropped from the load-bearing class-groups
+/// map by a strict decode.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ValidatorEncryptionKeysAndProofs {
     /// Existing class-groups CRT-decryption-key encryption key + proof of
@@ -588,6 +677,17 @@ pub struct ValidatorEncryptionKeysAndProofs {
     pub secp256r1_pvss: Secp256r1PvssEncryptionKeyAndProof,
     /// PVSS HPKE key + proof for the ristretto plaintext space.
     pub ristretto_pvss: RistrettoPvssEncryptionKeyAndProof,
+    /// Fast Schnorr (VSS) HPKE encryption public key (curve25519) + UC proof of
+    /// knowledge of the decryption key. This is the curve25519 HPKE key the VSS
+    /// presign's `party_encryption_keys` requires (distinct from the three
+    /// class-groups `*_pvss` keys above, which share the class-groups decryption
+    /// key over the integers); one key serves all VSS signing curves.
+    ///
+    /// The proof is verified once at [`Committee`] construction by
+    /// `mpc::hybrid_public_key_encryption::parse_and_uc_verify_encryption_keys`;
+    /// only validators whose proof verifies are admitted to subsequent VSS
+    /// presign / sign sessions.
+    pub vss_hpke_public_key_and_proof: VssHpkeEncryptionKeyAndProof,
 }
 
 /// Result of shape-tolerant decoding of the Move-side validator encryption-key
@@ -611,6 +711,10 @@ pub struct DecodedValidatorEncryptionKeys {
     pub secp256k1_pvss: Option<Secp256k1PvssEncryptionKeyAndProof>,
     pub secp256r1_pvss: Option<Secp256r1PvssEncryptionKeyAndProof>,
     pub ristretto_pvss: Option<RistrettoPvssEncryptionKeyAndProof>,
+    /// Fast Schnorr (VSS) curve25519 HPKE key + proof. `Some` only when the
+    /// validator published the full version-3 bundle; `None` for the bare
+    /// mainnet-v1.1.8 shape (which carries no VSS key).
+    pub vss_hpke_public_key_and_proof: Option<VssHpkeEncryptionKeyAndProof>,
 }
 
 /// Decode the bytes from `MPCDataV1::class_groups_public_key_and_proof()`
@@ -643,6 +747,7 @@ pub fn decode_validator_encryption_keys(bytes: &[u8]) -> Option<DecodedValidator
             secp256k1_pvss: Some(bundle.secp256k1_pvss),
             secp256r1_pvss: Some(bundle.secp256r1_pvss),
             ristretto_pvss: Some(bundle.ristretto_pvss),
+            vss_hpke_public_key_and_proof: Some(bundle.vss_hpke_public_key_and_proof),
         });
     }
     bcs::from_bytes::<ClassGroupsEncryptionKeyAndProof>(bytes)
@@ -652,6 +757,7 @@ pub fn decode_validator_encryption_keys(bytes: &[u8]) -> Option<DecodedValidator
             secp256k1_pvss: None,
             secp256r1_pvss: None,
             ristretto_pvss: None,
+            vss_hpke_public_key_and_proof: None,
         })
 }
 

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -176,6 +176,14 @@ pub struct ConsensusGlobalPresignRequest {
     pub request: GlobalPresignRequest,
 }
 
+/// Individual consensus message for network encryption key data.
+/// One message per key, keyed by `authority + key_id`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct ConsensusNetworkKeyData {
+    pub authority: AuthorityName,
+    pub key_data: DWalletNetworkEncryptionKeyData,
+}
+
 /// Individual consensus message for an NOA checkpoint observation.
 /// One message per observation, keyed by `authority + nonce`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -550,6 +558,12 @@ pub type Secp256k1TaprootProtocol = twopc_mpc::secp256k1::class_groups::TaprootP
 pub type Secp256r1ECDSAProtocol = twopc_mpc::secp256r1::class_groups::ECDSAProtocol;
 pub type Curve25519EdDSAProtocol = twopc_mpc::curve25519::class_groups::EdDSAProtocol;
 pub type RistrettoSchnorrkelProtocol = twopc_mpc::ristretto::class_groups::SchnorrkelProtocol;
+
+// Fast Schnorr (VSS) protocol aliases. Note the module path is `<curve>::vss`,
+// a sibling of `class_groups` (not `class_groups::vss`).
+pub type Secp256k1TaprootVSSProtocol = twopc_mpc::secp256k1::vss::TaprootVSSProtocol;
+pub type Curve25519EdDSAVSSProtocol = twopc_mpc::curve25519::vss::EdDSAVSSProtocol;
+pub type RistrettoSchnorrkelVSSProtocol = twopc_mpc::ristretto::vss::SchnorrkelVSSProtocol;
 
 pub type Secp256k1AsyncDKGProtocol = twopc_mpc::secp256k1::class_groups::DKGProtocol;
 pub type Secp256r1AsyncDKGProtocol = twopc_mpc::secp256r1::class_groups::DKGProtocol;

--- a/crates/ika-types/src/sui/epoch_start_system.rs
+++ b/crates/ika-types/src/sui/epoch_start_system.rs
@@ -140,27 +140,28 @@ impl EpochStartSystemTrait for EpochStartSystemV1 {
             .active_validators
             .iter()
             .map(|validator| {
-                // Shape-tolerant decode: accepts both the mainnet-v1.1.8
-                // bare-class-groups payload and the version-3 bundle. PVSS
-                // halves come back as `None` for validators publishing the old
-                // shape; downstream DKG/Reconfig dispatch picks the bwd-compat
-                // Party in that case.
-                let (
-                    class_groups_public_key_and_proof,
-                    secp256k1_pvss_public_key_and_proof,
-                    secp256r1_pvss_public_key_and_proof,
-                    ristretto_pvss_public_key_and_proof,
-                ) = match validator.mpc_data.as_ref().and_then(|mpc_data| {
-                    decode_validator_encryption_keys(&mpc_data.class_groups_public_key_and_proof())
-                }) {
-                    Some(v) => (
-                        Some(v.class_groups),
-                        v.secp256k1_pvss,
-                        v.secp256r1_pvss,
-                        v.ristretto_pvss,
-                    ),
-                    None => (None, None, None, None),
-                };
+                // Chain reads are shape-tolerant: the Move-side
+                // `MPCDataV1::mpc_data_bytes` is either the bare mainnet-v1.1.8
+                // `ClassGroupsEncryptionKeyAndProof` or the full version-3
+                // `ValidatorEncryptionKeysAndProofs` bundle (the CLI publishes
+                // the bundle unless `--legacy-class-groups-only`). Decode either
+                // and populate the per-curve PVSS keys when present; they're
+                // `None` for the bare shape. (`NetworkMetadata` carries no VSS
+                // HPKE key — that reaches `Committee` via the off-chain pipeline.)
+                let decoded = validator.mpc_data.as_ref().and_then(|mpc_data| {
+                    decode_validator_encryption_keys(&mpc_data.mpc_data_bytes())
+                });
+                let class_groups_public_key_and_proof =
+                    decoded.as_ref().map(|decoded| decoded.class_groups.clone());
+                let secp256k1_pvss_public_key_and_proof = decoded
+                    .as_ref()
+                    .and_then(|decoded| decoded.secp256k1_pvss.clone());
+                let secp256r1_pvss_public_key_and_proof = decoded
+                    .as_ref()
+                    .and_then(|decoded| decoded.secp256r1_pvss.clone());
+                let ristretto_pvss_public_key_and_proof = decoded
+                    .as_ref()
+                    .and_then(|decoded| decoded.ristretto_pvss.clone());
 
                 (
                     validator.authority_name(),
@@ -191,43 +192,56 @@ impl EpochStartSystemTrait for EpochStartSystemV1 {
             .map(|validator| (validator.authority_name(), validator.voting_power))
             .collect();
 
-        // Shape-tolerant decode per validator. Mainnet-v1.1.8-shape payloads
-        // (bare class-groups) populate only the class-groups HashMap; PVSS
-        // HashMaps gain an entry only when the validator published the
-        // version-3 bundle shape.
+        // Chain reads are shape-tolerant: the Move-side
+        // `MPCDataV1::mpc_data_bytes` is either the bare mainnet-v1.1.8
+        // `ClassGroupsEncryptionKeyAndProof` or the full version-3
+        // `ValidatorEncryptionKeysAndProofs` bundle (the CLI publishes the
+        // bundle unless `--legacy-class-groups-only`). Decode either shape and
+        // populate every key map from it; PVSS + VSS HPKE are absent for the
+        // bare shape. The off-chain validator-metadata pipeline (PR #1721)
+        // overlays the full bundle onto `Committee` separately; this chain read
+        // must not silently drop a bundle-shape validator from the load-bearing
+        // class-groups map.
         let decoded_per_validator: Vec<_> = self
             .active_validators
             .iter()
             .filter_map(|validator| {
                 let mpc_data = validator.mpc_data.as_ref()?;
-                let decoded = decode_validator_encryption_keys(
-                    &mpc_data.class_groups_public_key_and_proof(),
-                );
+                let decoded = decode_validator_encryption_keys(&mpc_data.mpc_data_bytes());
                 if decoded.is_none() {
                     error!(
                         authority = ?validator.authority_name(),
-                        "Failed to decode validator encryption keys (neither mainnet-v1.1.8 nor version-3 shape)"
+                        "Failed to decode validator encryption keys from Move-side mpc_data \
+                         (neither bare class-groups nor version-3 bundle shape)"
                     );
                 }
-                decoded.map(|d| (validator.authority_name(), d))
+                decoded.map(|decoded| (validator.authority_name(), decoded))
             })
             .collect();
-
         let class_groups_public_keys_and_proofs = decoded_per_validator
             .iter()
-            .map(|(name, v)| (*name, v.class_groups.clone()))
+            .map(|(name, decoded)| (*name, decoded.class_groups.clone()))
             .collect();
         let secp256k1_pvss_public_keys_and_proofs = decoded_per_validator
             .iter()
-            .filter_map(|(name, v)| v.secp256k1_pvss.clone().map(|k| (*name, k)))
+            .filter_map(|(name, decoded)| decoded.secp256k1_pvss.clone().map(|key| (*name, key)))
             .collect();
         let secp256r1_pvss_public_keys_and_proofs = decoded_per_validator
             .iter()
-            .filter_map(|(name, v)| v.secp256r1_pvss.clone().map(|k| (*name, k)))
+            .filter_map(|(name, decoded)| decoded.secp256r1_pvss.clone().map(|key| (*name, key)))
             .collect();
         let ristretto_pvss_public_keys_and_proofs = decoded_per_validator
             .iter()
-            .filter_map(|(name, v)| v.ristretto_pvss.clone().map(|k| (*name, k)))
+            .filter_map(|(name, decoded)| decoded.ristretto_pvss.clone().map(|key| (*name, key)))
+            .collect();
+        let vss_hpke_public_keys_and_proofs = decoded_per_validator
+            .iter()
+            .filter_map(|(name, decoded)| {
+                decoded
+                    .vss_hpke_public_key_and_proof
+                    .clone()
+                    .map(|key| (*name, key))
+            })
             .collect();
 
         Committee::new(
@@ -237,6 +251,7 @@ impl EpochStartSystemTrait for EpochStartSystemV1 {
             secp256k1_pvss_public_keys_and_proofs,
             secp256r1_pvss_public_keys_and_proofs,
             ristretto_pvss_public_keys_and_proofs,
+            vss_hpke_public_keys_and_proofs,
             self.quorum_threshold,
             self.validity_threshold,
         )

--- a/crates/ika/src/validator_commands.rs
+++ b/crates/ika/src/validator_commands.rs
@@ -14,7 +14,7 @@ use sui_types::{base_types::SuiAddress, multiaddr::Multiaddr};
 use crate::{IkaPackagesConfigFile, read_ika_sui_config_yaml};
 use clap::*;
 use colored::Colorize;
-use dwallet_classgroups_types::ClassGroupsAndPvssKeyPairAndProof;
+use dwallet_classgroups_types::ValidatorMPCSecrets;
 use dwallet_mpc_types::dwallet_mpc::{MPCDataV1, VersionedMPCData};
 use dwallet_rng::RootSeed;
 use fastcrypto::traits::{KeyPair, ToFromBytes};
@@ -460,26 +460,26 @@ impl IkaValidatorCommand {
                     read_network_keypair_from_file(network_key_file_name)?;
                 let pop = generate_proof_of_possession(&keypair, sender_sui_address);
 
-                let class_groups_public_key_and_proof =
+                let (validator_mpc_secrets, validator_encryption_keys_and_proofs) =
                     read_or_generate_root_seed(dir.join("root-seed.key"))?;
-                // Publication shape is version-gated: set `legacy_class_groups_only`
-                // during the v3→v4 protocol upgrade window so mainnet-v1.1.8 peers
-                // can decode this validator's bytes. Reading is shape-tolerant
-                // on either side via `decode_validator_encryption_keys`.
+                // Publication shape is version-gated. Reading-side decoders
+                // are NOT shape-tolerant: chain reads always decode the bare
+                // `ClassGroupsEncryptionKeyAndProof`, and the full
+                // `ValidatorEncryptionKeysAndProofs` bundle is propagated by
+                // the off-chain validator-metadata pipeline (PR #1721) — not
+                // by this Move-side field. The non-bare branch below stays for
+                // operator compatibility during rollout windows but is the
+                // wrong shape to publish under the off-chain design.
+                // `validator_mpc_secrets` is held locally; `validator_encryption_keys_and_proofs`
+                // is the public payload — the v3-shape only publishes the
+                // class-groups slice of it.
+                let _ = validator_mpc_secrets;
                 let mpc_data_bytes = if legacy_class_groups_only {
-                    bcs::to_bytes(
-                        &class_groups_public_key_and_proof
-                            .class_groups
-                            .encryption_key_and_proof(),
-                    )?
+                    bcs::to_bytes(&validator_encryption_keys_and_proofs.class_groups)?
                 } else {
-                    bcs::to_bytes(
-                        &class_groups_public_key_and_proof.validator_encryption_keys_and_proofs(),
-                    )?
+                    bcs::to_bytes(&validator_encryption_keys_and_proofs)?
                 };
-                let mpc_data = VersionedMPCData::V1(MPCDataV1 {
-                    class_groups_public_key_and_proof: mpc_data_bytes,
-                });
+                let mpc_data = VersionedMPCData::V1(MPCDataV1 { mpc_data_bytes });
 
                 let validator_info = ValidatorInfo {
                     name,
@@ -995,25 +995,25 @@ impl IkaValidatorCommand {
                 let config = read_ika_sui_config_yaml(context, &config_path)?;
 
                 // Build the publication payload. The Move-side `mpc_data_bytes`
-                // field is opaque `vector<u8>`; the contents are version-gated:
-                // pre-upgrade (mainnet-v1.1.8 peers in the committee) we publish
-                // bare `ClassGroupsEncryptionKeyAndProof` so old binaries can
-                // decode; post-upgrade we publish the full
-                // `ValidatorEncryptionKeysAndProofs` bundle. Reading is shape-
-                // tolerant on either side via `decode_validator_encryption_keys`.
+                // field stays the bare `ClassGroupsEncryptionKeyAndProof`
+                // (mainnet-v1.1.8 shape) under the off-chain design: chain
+                // readers decode that shape directly, and the full
+                // `ValidatorEncryptionKeysAndProofs` bundle (PVSS + VSS HPKE)
+                // is propagated by the off-chain validator-metadata pipeline
+                // (PR #1721). The non-bare branch stays for operator-rollout
+                // compatibility but should not be selected on a v4+ network.
                 let mpc_root_seed = RootSeed::random_seed();
-                let new_validator_keys =
-                    ClassGroupsAndPvssKeyPairAndProof::from_seed(&mpc_root_seed);
+                let (new_validator_secrets, new_validator_publics) =
+                    ValidatorMPCSecrets::from_seed(&mpc_root_seed);
 
+                let _ = new_validator_secrets;
                 let mpc_data_bytes = if legacy_class_groups_only {
-                    bcs::to_bytes(&new_validator_keys.class_groups.encryption_key_and_proof())?
+                    bcs::to_bytes(&new_validator_publics.class_groups)?
                 } else {
-                    bcs::to_bytes(&new_validator_keys.validator_encryption_keys_and_proofs())?
+                    bcs::to_bytes(&new_validator_publics)?
                 };
 
-                let mpc_data = VersionedMPCData::V1(MPCDataV1 {
-                    class_groups_public_key_and_proof: mpc_data_bytes,
-                });
+                let mpc_data = VersionedMPCData::V1(MPCDataV1 { mpc_data_bytes });
 
                 let response = set_next_epoch_mpc_data_bytes(
                     context,
@@ -1268,11 +1268,16 @@ fn make_key_files(
     Ok(())
 }
 
-/// Generates the validator's complete MPC key material (class groups + per-curve PVSS HPKE)
-/// from a seed file if it exists, otherwise generates and saves the seed.
+/// Generates the validator's complete MPC key material (class groups + per-curve PVSS HPKE
+/// + VSS HPKE) from a seed file if it exists, otherwise generates and saves the seed.
+/// Returns both the secrets (held locally) and the public encryption-keys-and-proofs payload
+/// (published in the on-chain validator record).
 fn read_or_generate_root_seed(
     seed_path: PathBuf,
-) -> Result<Box<ClassGroupsAndPvssKeyPairAndProof>> {
+) -> Result<(
+    ValidatorMPCSecrets,
+    ika_types::committee::ValidatorEncryptionKeysAndProofs,
+)> {
     let seed = match RootSeed::from_file(seed_path.clone()) {
         Ok(seed) => {
             println!("Use existing seed: {seed_path:?}.",);
@@ -1286,9 +1291,7 @@ fn read_or_generate_root_seed(
         }
     };
 
-    Ok(Box::new(ClassGroupsAndPvssKeyPairAndProof::from_seed(
-        &seed,
-    )))
+    Ok(ValidatorMPCSecrets::from_seed(&seed))
 }
 
 pub fn write_transaction_response(

--- a/dev-docs/plans/fast-schnorr-vss.md
+++ b/dev-docs/plans/fast-schnorr-vss.md
@@ -1,0 +1,128 @@
+# Fast Schnorr (VSS) signing — integration plan
+
+Status: active (2026-06-15) — integrating the VSS Schnorr feature onto
+`dev`. Supersedes an earlier integration attempt whose dev merge dropped
+the shape-tolerant on-chain decode (see the pitfall below); this plan
+keeps that decode load-bearing.
+
+Adds VSS-based Schnorr signing to the dWallet MPC network: Taproot,
+EdDSA, and Schnorrkel (Substrate) variants that produce signatures via a
+publicly-verifiable-secret-sharing (VSS) presign instead of the existing
+additively-homomorphic-encryption (AHE) path. The feature is gated off
+until protocol version 4 and, at v4, runs **internal NOA-VSS only** — it
+is not yet exposed to end users (the external VSS sign entry points stay
+`#[ignore]`d). This document is the contract for the change so a reader
+without the original context can extend or debug it safely.
+
+## Why VSS
+
+The AHE Schnorr path encrypts signing shares under the class-groups
+threshold key. The VSS path instead distributes shares with a per-curve
+PVSS (publicly verifiable secret sharing) scheme keyed by HPKE encryption
+keys, which removes a round of class-groups work from the presign and
+makes Schnorr presigns cheaper to produce in bulk. The two paths
+coexist; a request selects one via its signature algorithm.
+
+## Key material and where it lives
+
+Each validator now publishes, in addition to its class-groups
+encryption key, three **per-curve PVSS HPKE keys** (secp256k1, secp256r1,
+ristretto plaintext spaces) and one **VSS HPKE key** (curve25519) — all
+with UC-secure proofs of knowledge of the matching decryption key. These
+are bundled as `ValidatorEncryptionKeysAndProofs`
+(`crates/ika-types/src/committee.rs`). One curve25519 VSS HPKE key serves
+every VSS signing curve; the three PVSS keys serve the network-DKG /
+reconfiguration threshold-encryption sub-protocol.
+
+The VSS HPKE proofs are verified **once, at `Committee` construction**
+(`verify_vss_hpke_keys_at_committee_construction`), not per presign
+session. Only validators whose proof verifies are admitted to subsequent
+VSS presign / sign sessions; a single malformed submission excludes only
+that one party.
+
+### On-chain vs off-chain shape — load-bearing
+
+The Move field `MPCDataV1::mpc_data_bytes` can carry **either** shape:
+
+- the **bare** `ClassGroupsEncryptionKeyAndProof` (the mainnet-v1.1.8
+  shape — class-groups key only), or
+- the **full** `ValidatorEncryptionKeysAndProofs` bundle.
+
+The `become-candidate` / `set-next-epoch-mpc-data` CLI publishes the full
+bundle **by default**; the bare shape is published only under
+`--legacy-class-groups-only`. The same bundle is also broadcast off-chain
+(consensus-signed announcement + P2P blob fetch) and overlaid onto the
+`Committee` by the off-chain validator-metadata pipeline.
+
+**Every on-chain read of validator key material MUST be shape-tolerant.**
+Use `decode_validator_encryption_keys` (`crates/ika-types/src/committee.rs`),
+which accepts either shape — BCS's trailing-byte rejection means a bundle
+never silently parses as the bare shape. The committee-construction sites
+that read the chain are:
+
+- `crates/ika-core/src/sui_connector/sui_syncer.rs::new_committee`
+- `crates/ika-types/src/sui/epoch_start_system.rs` (both
+  `get_ika_committee` and `get_ika_committee_with_network_metadata`)
+
+Each decodes the bytes, always populates `class_groups_public_keys_and_proofs`
+(both shapes carry it), and populates the per-curve PVSS maps and the VSS
+HPKE map only when the bundle shape is present (`Some`). A bare-shape
+validator still contributes its class-groups key — it is never dropped.
+
+> Pitfall: a strict `bcs::from_bytes::<ClassGroupsEncryptionKeyAndProof>`
+> with no fallback at these sites silently drops every validator that
+> published the (default) bundle shape from the load-bearing
+> `class_groups_public_keys_and_proofs` map — the swarm config publishes
+> bare, so no test catches it. Keep the shape-tolerant decode.
+
+## Version axes
+
+Two independent versions move at this feature:
+
+- **Protocol version** (governance, capability vote at an epoch
+  boundary): `fast_schnorr_supported` flips on at v4 (internal NOA-VSS
+  only); `schnorr_presign_third_round_delay` is set at v4. See
+  `crates/ika-protocol-config/src/lib.rs`.
+- **Network-key version** (per key): the VSS shamir cache derives only
+  from a **V3** network-key output. A pre-existing key is V2 until its
+  first v4 reconfiguration, so there is a one-epoch-per-key transition
+  window after v4 activation; a fresh v4 genesis never hits it.
+
+## Integration points
+
+- **Types**: `ValidatorEncryptionKeysAndProofs` +
+  `VssHpkeEncryptionKeyAndProof` + the shape-tolerant
+  `decode_validator_encryption_keys` and `DecodedValidatorEncryptionKeys`
+  (`ika-types`); the VSS protocol variants and the `MPCDataV1.mpc_data_bytes`
+  reshape (`dwallet-mpc-types`); VSS HPKE keypair derivation from the
+  validator root seed (`dwallet-classgroups-types`, `dwallet-rng`).
+- **`Committee::new`** gains a `vss_hpke_public_keys_and_proofs` argument
+  (between the ristretto PVSS map and the thresholds) and verifies the
+  proofs at construction.
+- **Cryptographic computations** (`crates/ika-core/src/dwallet_mpc/crytographic_computation/`):
+  VSS presign + sign for each curve in `sign.rs` / `presign.rs` /
+  `mpc_computations.rs`; the request/round dispatch in
+  `protocol_cryptographic_data.rs`.
+- **Wiring**: VSS request classification in `request_protocol_data.rs`
+  and `dwallet_session_request.rs`; pool sizing + serving in
+  `mpc_manager.rs`; the sign-input gate that waits on the VSS shamir
+  cache in `mpc_session/input.rs`; the centralized (user-side) VSS sign
+  in `dwallet-mpc-centralized-party`.
+- **CLI**: `crates/ika/src/validator_commands.rs` publishes the full
+  bundle by default.
+
+## Testing
+
+- Integration tests (`crates/ika-core/src/dwallet_mpc/integration_tests/`)
+  exercise network DKG + reconfiguration and the VSS internal-presign /
+  sign path across curves. Note the network-key public-data
+  instantiation is split into a dkg variant and a reconfiguration variant
+  behind the `spawn_network_encryption_key_public_data_instantiation`
+  dispatcher; test helpers must drive the dispatcher, not the removed
+  single-shape entry point.
+- `cargo test -p ika-protocol-config` snapshot tests pin the v4 flag set;
+  regenerate the `version_4` snapshots when the flag set changes.
+- The bundle-on-chain decode path has no end-to-end test because the
+  swarm config publishes the bare shape; the decoder itself is covered by
+  the round-trip tests in `dwallet-classgroups-types` and the off-chain
+  assembly round-trip in `validator_metadata`.


### PR DESCRIPTION
## What

Adds VSS-based Schnorr signing (Taproot / EdDSA / Schnorrkel) alongside the existing AHE path. A request selects the path via its signature algorithm; the VSS path produces signatures from a publicly-verifiable-secret-sharing presign instead of class-groups threshold encryption. Gated off until protocol **v4**, and at v4 runs **internal NOA-VSS only** (external VSS sign entry points stay ignored).

Design + integration contract: [`dev-docs/plans/fast-schnorr-vss.md`](dev-docs/plans/fast-schnorr-vss.md).

## Why a new PR (replaces #1714)

Clean reconstruction of #1714 on top of current `dev`, authored from scratch (plan → protocol-config gate → feature). #1714 was built on `feat/ika-upgrade-test` + a take-theirs dev merge, which dropped several things this PR gets right from the start:

- **shape-tolerant on-chain key decode** at every committee-construction site (the strict decode in #1714 silently dropped default-bundle validators from the load-bearing class-groups map);
- **the split network-key instantiation dispatcher** in the integration tests;
- **#1726's `cryptography-private` bump** — this PR is on dev's rev `de3cddd` (`HashContext` + the `Schnorrkel`-not-`SchnorrkelSubstrate` rename + `Blake2b256`); the VSS feature has been ported across that crypto-API bump (threading `HashContext` through the VSS sign/presign paths, mirroring how #1726 did it for the AHE paths).

#1714 is left untouched.

## Key points

- Each validator publishes three per-curve PVSS HPKE keys + one curve25519 VSS HPKE key (with UC proofs) as `ValidatorEncryptionKeysAndProofs`; the VSS HPKE proofs are verified once at `Committee` construction. `Committee::new` gains the `vss_hpke_public_keys_and_proofs` argument.
- `MPCDataV1::mpc_data_bytes` carries either the bare class-groups key or the full bundle (CLI publishes the bundle by default, bare only under `--legacy-class-groups-only`); every chain read decodes either shape via `decode_validator_encryption_keys`.
- Protocol gate: `fast_schnorr_supported` (v4) + `schnorr_presign_third_round_delay`.

## Verification

- `cargo check --workspace --all-targets` — clean.
- `cargo test -p ika-protocol-config` — snapshot tests pass.
- `cargo test --release -p ika-core dwallet_mpc::integration_tests::sign::` — 3 passed / 2 ignored (full DKG → presign → sign; validates the `HashContext` threading through real signing).
- `cargo test --release -p ika-core … test_network_key_reconfiguration` — passes (network DKG + reconfiguration + VSS internal-presigns across curves, on `de3cddd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)