### PR TITLE
fix(swarm-config): publish genesis validator MPC-data shape per protocol version

### DIFF
--- a/crates/ika-swarm-config/src/sui_client.rs
+++ b/crates/ika-swarm-config/src/sui_client.rs
@@ -15,7 +15,7 @@ use ika_move_contracts::{
     save_contracts_to_temp_dir, save_contracts_to_temp_dir_for_simtest,
     save_mainnet_contracts_to_temp_dir, save_testnet_contracts_to_temp_dir,
 };
-use ika_protocol_config::Chain;
+use ika_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use ika_types::ika_coin::IKACoin;
 use ika_types::sui::system_inner_v1::ValidatorCapV1;
 use ika_types::sui::{
@@ -452,11 +452,22 @@ pub async fn initialize_ika_system(
 
     let mut validator_ids = Vec::new();
     let mut validator_cap_ids = Vec::new();
+    // Pre-v4 genesis (mainnet-v1.1.8, network_encryption_key_version 2) publishes the
+    // bare class-groups shape so a mainnet binary can decode genesis records; v4+
+    // (version 3) publishes the full `ValidatorEncryptionKeysAndProofs` bundle with
+    // PVSS, which the v4 network-key DKG requires (otherwise it wedges with 0 PVSS).
+    // Keyed off the genesis protocol version; the gate is chain-independent.
+    let legacy_class_groups_only = !ProtocolConfig::get_for_version(
+        ProtocolVersion::new(initiation_parameters.protocol_version),
+        Chain::Unknown,
+    )
+    .is_network_encryption_key_version_v3();
     for validator_initialization_config in validator_initialization_configs {
         let validator_address: SuiAddress =
             (&validator_initialization_config.account_key_pair.public()).into();
 
-        let validator_initialization_metadata = validator_initialization_config.to_validator_info();
+        let validator_initialization_metadata =
+            validator_initialization_config.to_validator_info(legacy_class_groups_only);
         let (validator_id, validator_cap_id) = request_add_validator_candidate(
             validator_address,
             context,

--- a/crates/ika-swarm-config/src/validator_initialization_config.rs
+++ b/crates/ika-swarm-config/src/validator_initialization_config.rs
@@ -49,7 +49,7 @@ pub struct ValidatorInitializationConfig {
 }
 
 impl ValidatorInitializationConfig {
-    pub fn to_validator_info(&self) -> ValidatorInfo {
+    pub fn to_validator_info(&self, legacy_class_groups_only: bool) -> ValidatorInfo {
         let name = self.name.clone().unwrap_or("".to_string());
         let protocol_public_key: AuthorityPublicKeyBytes = self.key_pair.public().into();
         let account_key: PublicKey = self.account_key_pair.public();
@@ -61,19 +61,23 @@ impl ValidatorInitializationConfig {
 
         // It is okay to unwrap here because we are using ValidatorInitializationConfig only on swarm.
         //
-        // Publish the BARE mainnet-v1.1.8 `ClassGroupsEncryptionKeyAndProof` shape
-        // on-chain (matching the off-chain-metadata PR's `legacy_class_groups_only`
-        // publication path), so a mainnet-v1.1.8 binary can decode this record. The
-        // richer `ValidatorEncryptionKeysAndProofs` bundle (class groups + per-curve
-        // PVSS) travels off-chain via validator P2P. Reading is shape-tolerant on the
-        // dev side via `decode_validator_encryption_keys`.
+        // The genesis publish shape follows the genesis protocol version's
+        // network-encryption-key version. At v4 (`network_encryption_key_version == 3`)
+        // the network-key DKG requires every member's full
+        // `ValidatorEncryptionKeysAndProofs` bundle (class-groups + per-curve PVSS), so
+        // publish it — otherwise the genesis DKG wedges with 0 PVSS decoded. Pre-v4
+        // (mainnet-v1.1.8, version 2) publishes only the bare
+        // `ClassGroupsEncryptionKeyAndProof` so a mainnet-v1.1.8 binary can decode the
+        // genesis record in the cross-binary upgrade rehearsal. Reads are shape-tolerant
+        // either way via `decode_validator_encryption_keys`.
+        let keypair = ClassGroupsAndPvssKeyPairAndProof::from_seed(&self.root_seed);
+        let class_groups_public_key_and_proof = if legacy_class_groups_only {
+            bcs::to_bytes(&keypair.class_groups.encryption_key_and_proof()).unwrap()
+        } else {
+            bcs::to_bytes(&keypair.validator_encryption_keys_and_proofs()).unwrap()
+        };
         let mpc_data = VersionedMPCData::V1(MPCDataV1 {
-            class_groups_public_key_and_proof: bcs::to_bytes(
-                &ClassGroupsAndPvssKeyPairAndProof::from_seed(&self.root_seed)
-                    .class_groups
-                    .encryption_key_and_proof(),
-            )
-            .unwrap(),
+            class_groups_public_key_and_proof,
         });
 
         ValidatorInfo {

--- a/crates/ika-test-cluster/src/lib.rs
+++ b/crates/ika-test-cluster/src/lib.rs
@@ -16,7 +16,7 @@ use fastcrypto::traits::{KeyPair as _, Signer, ToFromBytes};
 use ika_config::initiation::InitiationParameters;
 use ika_config::local_ip_utils;
 use ika_node::IkaNodeHandle;
-use ika_protocol_config::ProtocolVersion;
+use ika_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use ika_sui_client::SuiConnectorClient;
 use ika_sui_client::ika_dwallet_transactions::{
     PaymentCoinArgs, register_encryption_key, request_dwallet_dkg,
@@ -48,8 +48,6 @@ use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::crypto::SignatureScheme;
 use test_cluster::{TestCluster, TestClusterBuilder};
 
-#[cfg(not(msim))]
-use ika_protocol_config::Chain;
 #[cfg(not(msim))]
 use ika_swarm_config::sui_client::setup_contract_paths;
 
@@ -255,7 +253,13 @@ impl IkaTestCluster {
             .sign_and_execute_transaction(&tx_data)
             .await;
 
-        let metadata = joiner_init.to_validator_info();
+        // Joiner publishes the shape matching the cluster's current protocol version:
+        // bare pre-v4, full `ValidatorEncryptionKeysAndProofs` bundle at v4+ (see
+        // `ValidatorInitializationConfig::to_validator_info`).
+        let legacy_class_groups_only =
+            !ProtocolConfig::get_for_version(self.current_protocol_version(), Chain::Unknown)
+                .is_network_encryption_key_version_v3();
+        let metadata = joiner_init.to_validator_info(legacy_class_groups_only);
         let (validator_id, validator_cap_id) = retry_on_object_contention!(
             "request_add_validator_candidate",
             request_add_validator_candidate(

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use anyhow::{Context, Result, bail};
 use ika_config::initiation::InitiationParameters;
 use ika_config::node::NodeConfig;
-use ika_protocol_config::ProtocolVersion;
+use ika_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use ika_sui_client::SuiClient as IkaClient;
 use ika_sui_client::metrics::SuiClientMetrics;
 use ika_swarm_config::node_config_builder::{FullnodeConfigBuilder, ValidatorConfigBuilder};
@@ -514,7 +514,16 @@ impl ClusterOfProcesses {
             .await
             .context("faucet-fund joiner")?;
 
-        let metadata = init.to_validator_info();
+        // Publish the shape matching the current protocol version: bare pre-v4
+        // (mainnet-v1.1.8), full `ValidatorEncryptionKeysAndProofs` bundle at v4+
+        // (see `ValidatorInitializationConfig::to_validator_info`).
+        let protocol_version = self.current_protocol_version().await?;
+        let legacy_class_groups_only = !ProtocolConfig::get_for_version(
+            ProtocolVersion::new(protocol_version),
+            Chain::Unknown,
+        )
+        .is_network_encryption_key_version_v3();
+        let metadata = init.to_validator_info(legacy_class_groups_only);
         let (validator_id, validator_cap_id) = retry_on_object_contention!(
             "request_add_validator_candidate",
             request_add_validator_candidate(


### PR DESCRIPTION
## Problem

The TS integration suite fails **0/9** on `dev` (confirmed by a clean-dev baseline run): every test aborts with `MoveAbort 22` in `coordinator_inner::validate_network_encryption_key_supports_curve`, because the **genesis network-key DKG wedges**.

## Root cause: #1727

#1727 hardcoded the swarm/localnet genesis publish (`ValidatorInitializationConfig::to_validator_info`) to the **bare** `ClassGroupsEncryptionKeyAndProof` shape — so a mainnet-v1.1.8 binary can decode genesis records in the cross-binary upgrade rehearsal. But the **normal localnet starts at protocol v4**, where `network_encryption_key_version == 3` requires every committee member's full `ValidatorEncryptionKeysAndProofs` bundle (class-groups + per-curve PVSS) for the genesis network DKG. The off-chain pipeline only assembles **epoch-2+** committees, so the genesis (epoch-1) committee had **0 PVSS** and the DKG could never run:

```
InvalidMPCPartyType("at network_encryption_key_version == 3 every committee member must
publish the post-PR-#1707 bundle shape, but only 4/4 class-groups, 0/4 secp256k1 PVSS … decoded")
```

## Fix

Decide the publish shape from the **protocol config** instead of hardcoding it: publish the full bundle iff `ProtocolConfig::get_for_version(v).is_network_encryption_key_version_v3()` for the protocol version the validator starts at.

- **Genesis** (`initialize_ika_system`) keys off `initiation_parameters.protocol_version` — v4 default → full bundle (PVSS on chain → DKG completes); pre-v4 (mainnet-v1.1.8) → bare (mainnet-decodable, preserves the upgrade rehearsal).
- **Joiners** (in-process cluster + upgrade-test) key off the live protocol version.

## Validation

- `cargo check --workspace --all-targets` clean (simtest symbols too).
- TS integration + cluster suites dispatched on this branch (will update with verdicts). The genesis DKG should now complete at v4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)