### PR TITLE
feat(dwallet-mpc): V2->V3 canonical network DKG migration

### DIFF
--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -110,31 +110,33 @@ pub struct NetworkEncryptionKeyPublicData {
     /// On first instance it will be equal to `latest_public_output`.
     pub network_dkg_output: VersionedNetworkDkgOutput,
 
-    /// Forward-looking full-shape (V3) network DKG output, reconstructed in
-    /// memory from [`Self::network_dkg_output`] and the latest reconfiguration
-    /// output.
+    /// Full-shape (V3) network DKG output, reconstructed in memory from
+    /// [`Self::network_dkg_output`] and the latest reconfiguration output.
     ///
-    /// The deployed network key's DKG output is a V2 (backward-compatible)
-    /// `PublicOutputCore`, which lacks the trailing
+    /// The deployed (mainnet-v1.1.8-origin) network key's DKG output is a V2
+    /// (backward-compatible) `PublicOutputCore`, which lacks the trailing
     /// `threshold_encryption_to_sharing_output` that the full V3
     /// `decentralized_party::dkg::PublicOutput` carries. That field is produced
     /// only by the threshold-encryption-to-sharing sub-protocol, which the
-    /// backward-compatible reconfiguration predates. Once a reconfiguration
+    /// backward-compatible reconfiguration predates. Once a v4 reconfiguration
     /// produces a full V3 reconfiguration output, the field becomes available
     /// and the full V3 DKG output is reconstructed by combining the V2 output's
     /// reconfiguration-invariant class-group DKG output with the V3
     /// reconfiguration output.
     ///
-    /// `Some` only when [`Self::network_dkg_output`] is V2 AND a V3
-    /// reconfiguration output is available; `None` otherwise (a natively-V3 DKG
+    /// `Some` only at the one-time migration epoch — when
+    /// [`Self::network_dkg_output`] is still V2 AND a V3 reconfiguration output
+    /// is available; `None` otherwise (a natively-V3 or already-migrated DKG
     /// output needs no reconstruction, and a V2-only reconfiguration output
     /// lacks the trailing field).
     ///
-    /// In-memory-only and NOT a consensus anchor: [`Self::network_dkg_output`]
-    /// feeds the internal-presign / sign session identifiers and the
-    /// cross-epoch handoff digest and MUST stay the V2 bytes. This
-    /// reconstruction exists for a future network-owned-address Shamir-sharing
-    /// consumer.
+    /// This `Some` value DRIVES the one-time canonical V2->V3 migration: the
+    /// instantiation-completion path mirrors it via `cache_network_dkg_output`,
+    /// which flips the perpetual digest mirror and persists the V3 blob, after
+    /// which the off-chain overlay (and hence [`Self::network_dkg_output`]
+    /// itself) resolves V3 and this becomes `None`. Session identifiers are
+    /// keyed on the migration-invariant `NetworkKeyId`, not these bytes, so the
+    /// flip does not perturb them.
     pub reconstructed_full_network_dkg_output: Option<VersionedNetworkDkgOutput>,
     pub secp256k1_protocol_public_parameters:
         Arc<twopc_mpc::secp256k1::class_groups::ProtocolPublicParameters>,

--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -109,6 +109,33 @@ pub struct NetworkEncryptionKeyPublicData {
     /// The public output of the `NetworkDKG` process (the first and only one).
     /// On first instance it will be equal to `latest_public_output`.
     pub network_dkg_output: VersionedNetworkDkgOutput,
+
+    /// Forward-looking full-shape (V3) network DKG output, reconstructed in
+    /// memory from [`Self::network_dkg_output`] and the latest reconfiguration
+    /// output.
+    ///
+    /// The deployed network key's DKG output is a V2 (backward-compatible)
+    /// `PublicOutputCore`, which lacks the trailing
+    /// `threshold_encryption_to_sharing_output` that the full V3
+    /// `decentralized_party::dkg::PublicOutput` carries. That field is produced
+    /// only by the threshold-encryption-to-sharing sub-protocol, which the
+    /// backward-compatible reconfiguration predates. Once a reconfiguration
+    /// produces a full V3 reconfiguration output, the field becomes available
+    /// and the full V3 DKG output is reconstructed by combining the V2 output's
+    /// reconfiguration-invariant class-group DKG output with the V3
+    /// reconfiguration output.
+    ///
+    /// `Some` only when [`Self::network_dkg_output`] is V2 AND a V3
+    /// reconfiguration output is available; `None` otherwise (a natively-V3 DKG
+    /// output needs no reconstruction, and a V2-only reconfiguration output
+    /// lacks the trailing field).
+    ///
+    /// In-memory-only and NOT a consensus anchor: [`Self::network_dkg_output`]
+    /// feeds the internal-presign / sign session identifiers and the
+    /// cross-epoch handoff digest and MUST stay the V2 bytes. This
+    /// reconstruction exists for a future network-owned-address Shamir-sharing
+    /// consumer.
+    pub reconstructed_full_network_dkg_output: Option<VersionedNetworkDkgOutput>,
     pub secp256k1_protocol_public_parameters:
         Arc<twopc_mpc::secp256k1::class_groups::ProtocolPublicParameters>,
     /// The public parameters of the decryption key shares,
@@ -567,6 +594,16 @@ impl NetworkEncryptionKeyPublicData {
     pub fn network_dkg_output(&self) -> &VersionedNetworkDkgOutput {
         &self.network_dkg_output
     }
+
+    /// The forward-looking full-shape (V3) network DKG output reconstructed in
+    /// memory, or `None` when no reconstruction was possible this epoch. See
+    /// [`Self::reconstructed_full_network_dkg_output`] — this is NOT the
+    /// consensus anchor; use [`Self::network_dkg_output`] for session
+    /// identifiers and handoff digests.
+    pub fn reconstructed_full_network_dkg_output(&self) -> Option<&VersionedNetworkDkgOutput> {
+        self.reconstructed_full_network_dkg_output.as_ref()
+    }
+
     pub fn state(&self) -> &NetworkDecryptionKeyPublicOutputType {
         &self.state
     }

--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -501,6 +501,15 @@ impl VersionedNetworkDkgOutput {
             Self::V1(bytes) | Self::V2(bytes) | Self::V3(bytes) => bytes,
         }
     }
+
+    /// The wire version tag (1, 2, or 3).
+    pub fn version(&self) -> u64 {
+        match self {
+            Self::V1(_) => 1,
+            Self::V2(_) => 2,
+            Self::V3(_) => 3,
+        }
+    }
 }
 
 /// Wire-tagged decentralized-reconfiguration public output.

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -967,6 +967,60 @@ mod network_key_id_derivation_tool {
     }
 }
 
+/// Reconstructs the full-shape (V3) network DKG output in memory from a V2
+/// (backward-compatible) DKG output and a full V3 reconfiguration output.
+///
+/// The V2 DKG output is a `decentralized_party::dkg::PublicOutputCore` and
+/// lacks the trailing `threshold_encryption_to_sharing_output` that the full V3
+/// `decentralized_party::dkg::PublicOutput` carries; that field is produced
+/// only by the threshold-encryption-to-sharing sub-protocol, which the
+/// backward-compatible reconfiguration predates. Once a full V3 reconfiguration
+/// output is available it supplies that field, and the full V3 DKG output is
+/// reconstructed by combining the V2 output's reconfiguration-invariant
+/// class-group DKG output (`PublicOutputCore::class_group_dkg_output`) with the
+/// V3 reconfiguration output (`PublicOutput::new_from_reconfiguration_output`,
+/// the inverse of `class_group_dkg_output`).
+///
+/// Returns `Some(V3)` only when `network_dkg_output` is V2 AND a V3
+/// reconfiguration output is available; `None` otherwise. The reconstruction is
+/// a pure (RNG-free) function of its inputs, so every validator holding the same
+/// V2 DKG output and the same quorum-agreed V3 reconfiguration output derives
+/// byte-identical V3 bytes.
+fn reconstruct_full_network_dkg_output(
+    network_dkg_output: &VersionedNetworkDkgOutput,
+    latest_network_reconfiguration_public_output: Option<
+        &VersionedDecryptionKeyReconfigurationOutput,
+    >,
+) -> DwalletMPCResult<Option<VersionedNetworkDkgOutput>> {
+    let (
+        VersionedNetworkDkgOutput::V2(dkg_public_output_core_bytes),
+        Some(VersionedDecryptionKeyReconfigurationOutput::V3(reconfiguration_output_bytes)),
+    ) = (
+        network_dkg_output,
+        latest_network_reconfiguration_public_output,
+    )
+    else {
+        return Ok(None);
+    };
+
+    let dkg_public_output_core: dkg::PublicOutputCore =
+        bcs::from_bytes(dkg_public_output_core_bytes)?;
+    let class_group_dkg_output = dkg_public_output_core.class_group_dkg_output();
+
+    let reconfiguration_output: twopc_mpc::decentralized_party::reconfiguration::PublicOutput =
+        bcs::from_bytes(reconfiguration_output_bytes)?;
+
+    let full_network_dkg_output = dkg::PublicOutput::new_from_reconfiguration_output(
+        class_group_dkg_output,
+        reconfiguration_output,
+    )
+    .map_err(DwalletMPCError::from)?;
+
+    Ok(Some(VersionedNetworkDkgOutput::V3(bcs::to_bytes(
+        &full_network_dkg_output,
+    )?)))
+}
+
 /// Builds the `NetworkEncryptionKeyPublicData` from per-curve DKG data.
 pub(crate) fn build_network_encryption_key_public_data(
     epoch: u64,
@@ -1001,13 +1055,19 @@ pub(crate) fn build_network_encryption_key_public_data(
         class_groups::Curve25519DecryptionKeySharePublicParameters,
     >,
     noa_dkg_data: &AllCurvesNetworkOwnedAddressDkgData,
-) -> NetworkEncryptionKeyPublicData {
-    NetworkEncryptionKeyPublicData {
+) -> DwalletMPCResult<NetworkEncryptionKeyPublicData> {
+    let reconstructed_full_network_dkg_output = reconstruct_full_network_dkg_output(
+        &network_dkg_output,
+        latest_network_reconfiguration_public_output.as_ref(),
+    )?;
+
+    Ok(NetworkEncryptionKeyPublicData {
         epoch,
         dkg_at_epoch,
         state,
         latest_network_reconfiguration_public_output,
         network_dkg_output,
+        reconstructed_full_network_dkg_output,
         secp256k1_protocol_public_parameters,
         secp256k1_decryption_key_share_public_parameters,
         secp256r1_protocol_public_parameters,
@@ -1024,7 +1084,7 @@ pub(crate) fn build_network_encryption_key_public_data(
         secp256r1_network_owned_address_public_key: noa_dkg_data.secp256r1.public_key.clone(),
         curve25519_network_owned_address_public_key: noa_dkg_data.curve25519.public_key.clone(),
         ristretto_network_owned_address_public_key: noa_dkg_data.ristretto.public_key.clone(),
-    }
+    })
 }
 
 /// Times one instantiation sub-call, logs its duration at info level, and
@@ -1124,23 +1184,21 @@ fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_dkg_public_ou
                 )
             })?;
 
-            Ok::<NetworkEncryptionKeyPublicData, DwalletMPCError>(
-                build_network_encryption_key_public_data(
-                    epoch,
-                    dkg_at_epoch,
-                    NetworkDecryptionKeyPublicOutputType::NetworkDkg,
-                    None,
-                    mpc_public_output.clone(),
-                    secp256k1_protocol_public_parameters,
-                    secp256k1_decryption_key_share_public_parameters,
-                    secp256r1_protocol_public_parameters,
-                    secp256r1_decryption_key_share_public_parameters,
-                    ristretto_protocol_public_parameters,
-                    ristretto_decryption_key_share_public_parameters,
-                    curve25519_protocol_public_parameters,
-                    curve25519_decryption_key_share_public_parameters,
-                    &noa_dkg_data,
-                ),
+            build_network_encryption_key_public_data(
+                epoch,
+                dkg_at_epoch,
+                NetworkDecryptionKeyPublicOutputType::NetworkDkg,
+                None,
+                mpc_public_output.clone(),
+                secp256k1_protocol_public_parameters,
+                secp256k1_decryption_key_share_public_parameters,
+                secp256r1_protocol_public_parameters,
+                secp256r1_decryption_key_share_public_parameters,
+                ristretto_protocol_public_parameters,
+                ristretto_decryption_key_share_public_parameters,
+                curve25519_protocol_public_parameters,
+                curve25519_decryption_key_share_public_parameters,
+                &noa_dkg_data,
             )
         }};
     }
@@ -1160,5 +1218,63 @@ fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_dkg_public_ou
                 bcs::from_bytes(public_output_bytes)?;
             build_from_public_output!(public_output)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reconstruct_full_network_dkg_output;
+    use dwallet_mpc_types::dwallet_mpc::{
+        VersionedDecryptionKeyReconfigurationOutput, VersionedNetworkDkgOutput,
+    };
+
+    /// The reconstruction must fire ONLY for a V2 DKG output paired with a full
+    /// V3 reconfiguration output. Every other combination returns `None` without
+    /// touching the crypto decoders (so dummy bytes are fine here). The `Some`
+    /// path needs a real V2 DKG output + V3 reconfiguration output and is
+    /// exercised end-to-end by the v4 reconfiguration integration path.
+    #[test]
+    fn reconstruct_full_network_dkg_output_gating() {
+        use VersionedDecryptionKeyReconfigurationOutput as Reconfiguration;
+        use VersionedNetworkDkgOutput as Dkg;
+
+        // Natively-V3 DKG output: already full shape, no reconstruction.
+        assert!(
+            reconstruct_full_network_dkg_output(
+                &Dkg::V3(vec![]),
+                Some(&Reconfiguration::V3(vec![])),
+            )
+            .unwrap()
+            .is_none()
+        );
+
+        // V2 DKG output but no reconfiguration output yet (e.g. fresh DKG).
+        assert!(
+            reconstruct_full_network_dkg_output(&Dkg::V2(vec![]), None)
+                .unwrap()
+                .is_none()
+        );
+
+        // V2 DKG output with a V2 (core-only) reconfiguration output: the
+        // trailing threshold-encryption-to-sharing field is absent, so the full
+        // V3 DKG output cannot be reconstructed.
+        assert!(
+            reconstruct_full_network_dkg_output(
+                &Dkg::V2(vec![]),
+                Some(&Reconfiguration::V2(vec![])),
+            )
+            .unwrap()
+            .is_none()
+        );
+
+        // V1 is never produced anymore.
+        assert!(
+            reconstruct_full_network_dkg_output(
+                &Dkg::V1(vec![]),
+                Some(&Reconfiguration::V3(vec![])),
+            )
+            .unwrap()
+            .is_none()
+        );
     }
 }

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -496,23 +496,21 @@ pub(crate) fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_re
                 )
             })?;
 
-            Ok::<NetworkEncryptionKeyPublicData, DwalletMPCError>(
-                build_network_encryption_key_public_data(
-                    epoch,
-                    dkg_at_epoch,
-                    NetworkDecryptionKeyPublicOutputType::Reconfiguration,
-                    Some(mpc_public_output.clone()),
-                    bcs::from_bytes(network_dkg_public_output)?,
-                    secp256k1_protocol_public_parameters,
-                    secp256k1_decryption_key_share_public_parameters,
-                    secp256r1_protocol_public_parameters,
-                    secp256r1_decryption_key_share_public_parameters,
-                    ristretto_protocol_public_parameters,
-                    ristretto_decryption_key_share_public_parameters,
-                    curve25519_protocol_public_parameters,
-                    curve25519_decryption_key_share_public_parameters,
-                    &noa_dkg_data,
-                ),
+            build_network_encryption_key_public_data(
+                epoch,
+                dkg_at_epoch,
+                NetworkDecryptionKeyPublicOutputType::Reconfiguration,
+                Some(mpc_public_output.clone()),
+                bcs::from_bytes(network_dkg_public_output)?,
+                secp256k1_protocol_public_parameters,
+                secp256k1_decryption_key_share_public_parameters,
+                secp256r1_protocol_public_parameters,
+                secp256r1_decryption_key_share_public_parameters,
+                ristretto_protocol_public_parameters,
+                ristretto_decryption_key_share_public_parameters,
+                curve25519_protocol_public_parameters,
+                curve25519_decryption_key_share_public_parameters,
+                &noa_dkg_data,
             )
         }};
     }

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -131,6 +131,14 @@ pub struct DWalletMPCMetrics {
     /// rayon pool.
     pub(crate) network_key_instantiations_in_flight: IntGauge,
 
+    /// Version (2 or 3) of the canonical network DKG output this validator most
+    /// recently mirrored into the off-chain handoff. Migrates 2 -> 3 once, when
+    /// a deployed key's cert-pinned reconfiguration output becomes V3 (protocol
+    /// v4) and the validator reconstructs the full V3 output. `0` until the
+    /// first off-chain instantiation. (With one network key this reflects that
+    /// key; with several it reflects the most recently instantiated.)
+    pub(crate) network_encryption_key_canonical_dkg_output_version: IntGauge,
+
     /// Network-key instantiation failures by reason (`channel_closed`,
     /// `epoch_mismatch`, `decrypt_failed`, `instantiate_failed`). Note
     /// `decrypt_failed` is an expected transient for recently-joined
@@ -294,6 +302,12 @@ impl DWalletMPCMetrics {
             network_key_instantiations_in_flight: register_int_gauge_with_registry!(
                 "dwallet_mpc_network_key_instantiations_in_flight",
                 "Network-key instantiations currently in flight on the rayon pool",
+                registry
+            )
+            .unwrap(),
+            network_encryption_key_canonical_dkg_output_version: register_int_gauge_with_registry!(
+                "ika_dwallet_mpc_network_encryption_key_canonical_dkg_output_version",
+                "Version (2 or 3) of the canonical network DKG output mirrored into the off-chain handoff; migrates 2 -> 3 at the V2->V3 anchor migration",
                 registry
             )
             .unwrap(),

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -238,3 +238,112 @@ async fn stale_epoch_network_key_data_is_not_spawned() {
         "current-epoch key data must spawn an instantiation"
     );
 }
+
+/// The canonical network DKG output migrates V2->V3 exactly once — when the
+/// cert-pinned reconfiguration output becomes V3 and the validator mirrors the
+/// reconstructed full output. For that one epoch the overlay's DKG digest moves
+/// past the PRIOR epoch's V2 cert. An ALREADY-adopted key must survive that
+/// mismatch (keeping its adopted value), not be dropped — mirroring how a moved
+/// reconfiguration output is tolerated. (An unadopted key contradicting the cert
+/// is still rejected; covered by the empty-overlay test above.)
+#[tokio::test]
+async fn already_adopted_key_survives_dkg_output_migration() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (
+        mut dwallet_mpc_services,
+        _sui_data_senders,
+        _sent_consensus_messages_collectors,
+        epoch_stores,
+        _notify_services,
+        _network_owned_address_sign_request_senders,
+        _network_owned_address_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services(1);
+    let service = dwallet_mpc_services.first_mut().unwrap();
+    let epoch_id = service.epoch;
+    let prior_epoch = epoch_id - 1;
+
+    let key_id = ObjectID::random();
+    let network_key_id = NetworkKeyId([0x42; 32]);
+    crate::network_key_id_mapping::register(key_id, network_key_id);
+
+    let v2_dkg_output = b"v2 anchor network dkg output".to_vec();
+    let reconfiguration_output = b"v3 network reconfiguration output".to_vec();
+
+    // The prior epoch's cert pins the V2 DKG digest and the reconfiguration
+    // digest (items sorted by `HandoffItemKey`: DKG < reconfiguration).
+    let attestation = HandoffAttestation {
+        epoch: prior_epoch,
+        next_committee_pubkey_set_hash: [0u8; 32],
+        items: vec![
+            (
+                HandoffItemKey::NetworkDkgOutput {
+                    key_id: network_key_id,
+                },
+                mpc_data_blob_hash(&v2_dkg_output),
+            ),
+            (
+                HandoffItemKey::NetworkReconfigurationOutput {
+                    key_id: network_key_id,
+                },
+                mpc_data_blob_hash(&reconfiguration_output),
+            ),
+        ],
+    };
+    epoch_stores
+        .first()
+        .unwrap()
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(
+            prior_epoch,
+            CertifiedHandoffAttestation {
+                attestation,
+                signatures: vec![],
+            },
+        );
+
+    let manager = service.dwallet_mpc_manager_mut();
+
+    // First adopt: the overlay's V2 DKG output and reconfiguration output both
+    // match the prior cert, so the key is adopted.
+    let v2_overlay = Arc::new(HashMap::from([(
+        key_id,
+        network_key_data(
+            key_id,
+            epoch_id,
+            v2_dkg_output.clone(),
+            reconfiguration_output.clone(),
+        ),
+    )]));
+    manager.adopt_cert_verified_keys(&v2_overlay);
+    assert!(
+        manager.adopted_network_key_data.contains_key(&key_id),
+        "the cert-matching V2 key must be adopted"
+    );
+
+    // Second adopt: the overlay's DKG output has migrated to a different (V3)
+    // value while the prior cert still pins V2. The already-adopted key must
+    // survive — kept at its adopted V2 value, not dropped, not overwritten by
+    // the mismatching overlay.
+    let v3_dkg_output = b"v3 reconstructed full network dkg output".to_vec();
+    let v3_overlay = Arc::new(HashMap::from([(
+        key_id,
+        network_key_data(
+            key_id,
+            epoch_id,
+            v3_dkg_output,
+            reconfiguration_output.clone(),
+        ),
+    )]));
+    manager.adopt_cert_verified_keys(&v3_overlay);
+    let adopted = manager
+        .adopted_network_key_data
+        .get(&key_id)
+        .expect("the already-adopted key must survive the DKG-output migration");
+    assert_eq!(
+        adopted.network_dkg_public_output, v2_dkg_output,
+        "the migration epoch keeps the prior adopted (V2) value, not the \
+         mismatching overlay"
+    );
+}

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -1059,27 +1059,47 @@ impl DWalletMPCManager {
             } else if off_chain_on && cert.is_some() {
                 // Reconfigured key, off-chain mode with a prior handoff cert:
                 // the overlay carries locally-cached blobs, so anchor them
-                // against the prior epoch's cert — both the stable DKG digest
-                // and the epoch-specific reconfiguration digest must match.
+                // against the prior epoch's cert — the DKG digest and the
+                // epoch-specific reconfiguration digest must match.
                 if cert_dkg_digest != Some(&local_dkg_digest) {
-                    // Same anomaly as above for a reconfigured key's
-                    // stable DKG digest.
-                    if self
-                        .warned_cert_digest_mismatches
-                        .insert((*key_id, local_dkg_digest))
-                    {
-                        warn!(
-                            ?key_id,
-                            cert_dkg_digest = ?cert_dkg_digest,
-                            local_dkg_digest = ?local_dkg_digest,
-                            "local network-key DKG output digest does not match the prior \
-                             epoch's handoff cert — skipping adoption"
-                        );
+                    // The DKG digest is stable WITHIN a representation but
+                    // migrates once, V2->V3: when the cert-pinned
+                    // reconfiguration output becomes V3 and this validator
+                    // flips its mirror to the reconstructed V3 output, the
+                    // overlay's DKG digest moves past the PRIOR epoch's V2 cert
+                    // for one epoch. As with the reconfiguration digest below,
+                    // that mismatch is the expected defer-to-next-epoch when the
+                    // key is ALREADY adopted (the prior value stays installed,
+                    // and the output-quorum byte-equality tally guards against a
+                    // genuinely divergent output); only an UNADOPTED key
+                    // contradicting the cert is the security-relevant anomaly
+                    // worth a warn.
+                    if !self.adopted_network_key_data.contains_key(key_id) {
+                        if self
+                            .warned_cert_digest_mismatches
+                            .insert((*key_id, local_dkg_digest))
+                        {
+                            warn!(
+                                ?key_id,
+                                cert_dkg_digest = ?cert_dkg_digest,
+                                local_dkg_digest = ?local_dkg_digest,
+                                "local network-key DKG output digest does not match the prior \
+                                 epoch's handoff cert and the key has no adopted value — \
+                                 skipping adoption, the key stays uninstantiated"
+                            );
+                        } else {
+                            debug!(
+                                ?key_id,
+                                "local network-key DKG output still contradicts the handoff \
+                                 cert (key unadopted) — skipping adoption"
+                            );
+                        }
                     } else {
                         debug!(
                             ?key_id,
-                            "local network-key DKG output still contradicts the handoff \
-                             cert — skipping adoption"
+                            "overlay DKG output does not match the prior epoch's cert \
+                             (expected once during the V2->V3 canonical migration) — \
+                             keeping the adopted value"
                         );
                     }
                     continue;
@@ -2299,16 +2319,47 @@ impl DWalletMPCManager {
                         if let Some(key_data) = key_data {
                             if self.epoch_store.off_chain_validator_metadata_enabled()
                                 && !key_data.network_dkg_public_output.is_empty()
-                                && let Err(e) = self.epoch_store.cache_network_dkg_output(
-                                    key_id,
-                                    &key_data.network_dkg_public_output,
-                                )
                             {
-                                warn!(
-                                    error = ?e,
-                                    ?key_id,
-                                    "failed to cache DKG output digest from adopted data"
-                                );
+                                // Mirror the CANONICAL DKG output. Once the
+                                // cert-pinned reconfiguration output is V3, the
+                                // instantiation carries a reconstructed full V3
+                                // output; mirror that in place of the V2 anchor
+                                // so the handoff digest, the overlay, and joiners
+                                // all migrate to V3 together. One-shot: after the
+                                // flip the overlay resolves V3, `reconstruct`
+                                // returns None, and this falls back to the (now
+                                // V3) anchor. Epoch-aligned because the
+                                // reconstruction comes from the cert-pinned
+                                // reconfiguration output, identical committee-wide.
+                                let canonical_dkg_output = match key
+                                    .reconstructed_full_network_dkg_output()
+                                {
+                                    Some(reconstructed_v3) => match bcs::to_bytes(reconstructed_v3)
+                                    {
+                                        Ok(bytes) => bytes,
+                                        Err(e) => {
+                                            warn!(
+                                                error = ?e,
+                                                ?key_id,
+                                                "failed to serialize reconstructed V3 network \
+                                                 DKG output for the canonical mirror; falling \
+                                                 back to the V2 anchor"
+                                            );
+                                            key_data.network_dkg_public_output.clone()
+                                        }
+                                    },
+                                    None => key_data.network_dkg_public_output.clone(),
+                                };
+                                if let Err(e) = self
+                                    .epoch_store
+                                    .cache_network_dkg_output(key_id, &canonical_dkg_output)
+                                {
+                                    warn!(
+                                        error = ?e,
+                                        ?key_id,
+                                        "failed to cache DKG output digest from adopted data"
+                                    );
+                                }
                             }
                             // Snapshot the data we just instantiated so
                             // the next poll skips this key unless a

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -2360,6 +2360,19 @@ impl DWalletMPCManager {
                                         "failed to cache DKG output digest from adopted data"
                                     );
                                 }
+                                // Surface the canonical DKG-output version for
+                                // observability of the V2->V3 migration: it
+                                // reads 3 once this validator mirrors the
+                                // reconstructed full output.
+                                let canonical_version: i64 =
+                                    if key.reconstructed_full_network_dkg_output().is_some() {
+                                        3
+                                    } else {
+                                        key.network_dkg_output().version() as i64
+                                    };
+                                self.dwallet_mpc_metrics
+                                    .network_encryption_key_canonical_dkg_output_version
+                                    .set(canonical_version);
                             }
                             // Snapshot the data we just instantiated so
                             // the next poll skips this key unless a

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -1605,11 +1605,18 @@ impl DWalletMPCManager {
         curve: DWalletCurve,
         signature_algorithm: DWalletSignatureAlgorithm,
     ) {
-        let network_dkg_output_bytes = match self
+        let network_key_identity_bytes = match self
             .network_keys
             .get_network_encryption_key_public_data(&dwallet_network_encryption_key_id)
         {
-            Ok(key_data) => key_data.network_dkg_output().as_bytes().to_vec(),
+            // Use the key's flip-invariant NetworkKeyId as the session-identifier
+            // basis; fall back to the network DKG output bytes only for a
+            // malformed key with no derivable id (deterministic, so still
+            // committee-uniform).
+            Ok(key_data) => key_data
+                .network_key_id()
+                .map(|id| id.0.to_vec())
+                .unwrap_or_else(|_| key_data.network_dkg_output().as_bytes().to_vec()),
             Err(e) => {
                 error!(
                     ?dwallet_network_encryption_key_id,
@@ -1632,7 +1639,7 @@ impl DWalletMPCManager {
             curve,
             signature_algorithm,
             dwallet_network_encryption_key_id,
-            &network_dkg_output_bytes,
+            &network_key_identity_bytes,
         );
 
         let session_identifier = request.session_identifier;
@@ -1680,11 +1687,15 @@ impl DWalletMPCManager {
             return false;
         };
         let hash_scheme_group: group::HashScheme = hash_scheme.into();
-        let network_dkg_output_bytes = match self
+        let network_key_identity_bytes = match self
             .network_keys
             .get_network_encryption_key_public_data(&dwallet_network_encryption_key_id)
         {
-            Ok(key_data) => key_data.network_dkg_output().as_bytes().to_vec(),
+            // Flip-invariant NetworkKeyId basis (see `instantiate_internal_presign_session`).
+            Ok(key_data) => key_data
+                .network_key_id()
+                .map(|id| id.0.to_vec())
+                .unwrap_or_else(|_| key_data.network_dkg_output().as_bytes().to_vec()),
             Err(e) => {
                 error!(
                     ?dwallet_network_encryption_key_id,
@@ -1778,7 +1789,7 @@ impl DWalletMPCManager {
             signature_algorithm,
             hash_scheme_group,
             dwallet_network_encryption_key_id,
-            &network_dkg_output_bytes,
+            &network_key_identity_bytes,
             message.clone(),
             wrapped_presign,
         );

--- a/crates/ika-core/src/dwallet_session_request.rs
+++ b/crates/ika-core/src/dwallet_session_request.rs
@@ -50,7 +50,7 @@ impl DWalletSessionRequest {
         curve: DWalletCurve,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
-        network_dkg_output: &[u8],
+        network_key_identity: &[u8],
     ) -> Self {
         let mut transcript = Transcript::new(b"Internal Presign session identifier preimage");
         transcript.append_u64(b"epoch", epoch);
@@ -62,7 +62,11 @@ impl DWalletSessionRequest {
             b"network encryption key id",
             dwallet_network_encryption_key_id.as_ref(),
         );
-        transcript.append_message(b"network dkg output", network_dkg_output);
+        // Bind to the key's reconfiguration- and V2->V3-flip-invariant identity
+        // (its NetworkKeyId) rather than the raw network DKG output bytes, which
+        // flip when the canonical output migrates V2->V3 — so the identifier
+        // stays stable across that migration.
+        transcript.append_message(b"network key identity", network_key_identity);
 
         // Generate a session identifier preimage in a deterministic way
         // (internally, it uses a hash function to pseudo-randomly generate it).
@@ -105,7 +109,7 @@ impl DWalletSessionRequest {
         signature_algorithm: DWalletSignatureAlgorithm,
         hash_scheme: HashScheme,
         dwallet_network_encryption_key_id: ObjectID,
-        network_dkg_output: &[u8],
+        network_key_identity: &[u8],
         message: Vec<u8>,
         presign: SerializedWrappedMPCPublicOutput,
     ) -> Self {
@@ -120,7 +124,9 @@ impl DWalletSessionRequest {
             b"network encryption key id",
             dwallet_network_encryption_key_id.as_ref(),
         );
-        transcript.append_message(b"network dkg output", network_dkg_output);
+        // See `new_internal_presign`: bind to the flip-invariant NetworkKeyId,
+        // not the migrating network DKG output bytes.
+        transcript.append_message(b"network key identity", network_key_identity);
 
         // Generate a session identifier preimage in a deterministic way
         let mut session_identifier_preimage: [u8; SessionIdentifier::LENGTH] =

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -881,8 +881,11 @@ impl HandoffItemsBuilder for MpcDataHandoffItemsBuilder {
         // This is identical across validators regardless of when each one
         // processed the output locally — unlike the old per-epoch table,
         // which a late output crossing the epoch boundary mis-filed,
-        // diverging the attestation. DKG output is stable across epochs,
-        // so the perpetual-merged getter is correct for it.
+        // diverging the attestation. The DKG output migrates at most once
+        // (V2->V3 at the first v4 reshare flips the perpetual digest mirror);
+        // the perpetual-merged getter returns whichever representation the
+        // mirror currently holds, identical across validators, so it is
+        // correct for it.
         let reconfig = to_network_key_id_keyed(
             store.get_network_reconfiguration_output_digests_for_epoch(epoch)?,
         )?;

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -450,6 +450,21 @@ macro_rules! retry_on_object_contention {
     }};
 }
 
+/// Parses a label-less prometheus gauge line (`<metric> <value>`) into a u64.
+/// Returns `None` if the metric is absent. Requires a space after the name so a
+/// prefix collision with another metric (`<metric>_other`) does not match.
+fn parse_labelless_gauge(body: &str, metric: &str) -> Option<u64> {
+    body.lines()
+        .filter(|line| !line.starts_with('#'))
+        .find_map(|line| {
+            let rest = line.strip_prefix(metric)?;
+            if !rest.starts_with(' ') {
+                return None;
+            }
+            rest.trim().parse::<f64>().ok().map(|v| v as u64)
+        })
+}
+
 impl ClusterOfProcesses {
     /// Current on-chain ika epoch (read from the system object).
     pub async fn current_epoch(&self) -> Result<u64> {
@@ -469,6 +484,33 @@ impl ClusterOfProcesses {
             .await
             .map_err(|e| anyhow::anyhow!("get_system_inner: {e}"))?;
         Ok(inner.protocol_version)
+    }
+
+    /// The minimum canonical network DKG output version reported across all
+    /// running validators' `/metrics`. Returns 0 if a running validator has not
+    /// reported the gauge yet (or is unreachable), so a poller keeps waiting
+    /// until the whole committee has migrated. The off-chain handoff carries the
+    /// migrated version; the on-chain copy stays V2, so this metric — not a Sui
+    /// read — is how the V2->V3 migration is observed.
+    pub async fn min_canonical_network_dkg_output_version(&self) -> u64 {
+        let http = reqwest::Client::new();
+        let mut min: Option<u64> = None;
+        for proc in self.validators.iter().filter(|p| p.is_running()) {
+            let url = format!("http://127.0.0.1:{}/metrics", proc.metrics_port());
+            let version = match http.get(&url).send().await {
+                Ok(resp) => match resp.text().await {
+                    Ok(body) => parse_labelless_gauge(
+                        &body,
+                        "ika_dwallet_mpc_network_encryption_key_canonical_dkg_output_version",
+                    )
+                    .unwrap_or(0),
+                    Err(_) => 0,
+                },
+                Err(_) => 0,
+            };
+            min = Some(min.map_or(version, |m| m.min(version)));
+        }
+        min.unwrap_or(0)
     }
 
     /// Block until the on-chain ika epoch counter reaches `target`.

--- a/crates/ika-upgrade-test/src/scenario.rs
+++ b/crates/ika-upgrade-test/src/scenario.rs
@@ -47,6 +47,11 @@ pub enum Step {
         buffer_bps: u64,
     },
     ExpectProtocolVersionAtLeast(u64),
+    /// Poll until every running validator reports a canonical network DKG
+    /// output version `>= at_least` (via its `/metrics`), or time out. Confirms
+    /// the off-chain handoff migrated the DKG output (e.g. 2 -> 3 after the v4
+    /// reconfiguration); the on-chain copy stays V2, so this is metric-based.
+    ExpectNetworkDkgOutputVersionAtLeast(u64),
     /// Register a brand-new validator on chain (candidate → stake → join) and
     /// spawn its process on the given binary. It enters the active committee
     /// at the next epoch boundary.
@@ -104,6 +109,9 @@ impl std::fmt::Display for Step {
             Step::SetBufferStake { buffer_bps } => write!(f, "set_buffer_stake({buffer_bps})"),
             Step::ExpectProtocolVersionAtLeast(v) => {
                 write!(f, "expect_protocol_version_at_least({v})")
+            }
+            Step::ExpectNetworkDkgOutputVersionAtLeast(v) => {
+                write!(f, "expect_network_dkg_output_version_at_least({v})")
             }
             Step::JoinValidator(spec) => write!(f, "join_validator({})", spec.label()),
             Step::JoinValidatorMirrored(spec) => {
@@ -236,6 +244,14 @@ impl Scenario {
 
     pub fn expect_protocol_version_at_least(mut self, version: u64) -> Self {
         self.steps.push(Step::ExpectProtocolVersionAtLeast(version));
+        self
+    }
+
+    /// Assert the off-chain handoff migrated the network DKG output to at least
+    /// `version` (polled across all running validators' metrics).
+    pub fn expect_network_dkg_output_version_at_least(mut self, version: u64) -> Self {
+        self.steps
+            .push(Step::ExpectNetworkDkgOutputVersionAtLeast(version));
         self
     }
 
@@ -443,6 +459,31 @@ impl Scenario {
                         expected = *version,
                         "protocol version assertion passed"
                     );
+                }
+                Step::ExpectNetworkDkgOutputVersionAtLeast(at_least) => {
+                    let c = cluster
+                        .as_ref()
+                        .context("ExpectNetworkDkgOutputVersionAtLeast before StartAll")?;
+                    let deadline = tokio::time::Instant::now() + self.epoch_timeout;
+                    loop {
+                        let got = c.min_canonical_network_dkg_output_version().await;
+                        if got >= *at_least {
+                            tracing::info!(
+                                got,
+                                expected = *at_least,
+                                "network DKG output version assertion passed \
+                                 (off-chain handoff migrated)"
+                            );
+                            break;
+                        }
+                        if tokio::time::Instant::now() >= deadline {
+                            bail!(
+                                "min canonical network DKG output version {got} < expected \
+                                 {at_least} after timeout — the off-chain handoff did not migrate"
+                            );
+                        }
+                        tokio::time::sleep(Duration::from_secs(5)).await;
+                    }
                 }
                 Step::JoinValidator(spec) => {
                     let binary = resolve(&resolver, spec).await?;

--- a/crates/ika-upgrade-test/tests/v118_churn.rs
+++ b/crates/ika-upgrade-test/tests/v118_churn.rs
@@ -126,6 +126,11 @@ async fn v118_atomic_upgrade_then_committee_churn() {
         .join_validator_mirrored(new.clone())
         .wait_for_epoch(4)
         .expect_committee_size(5)
+        // The 1.1.8-origin V2 network key migrates to the full V3 output at the
+        // first v4 reshare (epoch 3->4). Assert every member of the new 5-member
+        // committee — INCLUDING the mirrored joiner, which installed the key by
+        // the cert-pinned digest — reports the migrated V3 canonical output.
+        .expect_network_dkg_output_version_at_least(3)
         // The new 5-member committee runs a full lifecycle against the reshared
         // 1.1.8-origin network key.
         .run_workload("v4-with-joiner")

--- a/crates/ika-upgrade-test/tests/v118_upgrade.rs
+++ b/crates/ika-upgrade-test/tests/v118_upgrade.rs
@@ -207,6 +207,14 @@ async fn v118_atomic_upgrade_to_local_build() {
         // protocol). The snapshot's *window* vs `local-v4` isolates that
         // v4-math reshare from the cumulative averages.
         .wait_for_epoch(4)
+        // The deployed (1.1.8-created) network key's DKG output migrates V2->V3
+        // here. Epoch 2->3 reshared under v3 (V2 reconfiguration output); epoch
+        // 3->4 is the first reshare at v4 (`reconfiguration_message_version = 3`),
+        // producing the V3 reconfiguration output that lets each validator
+        // reconstruct the full V3 DKG output and mirror it into the off-chain
+        // handoff. Assert the migration actually happened (the on-chain copy
+        // stays V2 — this reads the validators' canonical-version metric).
+        .expect_network_dkg_output_version_at_least(3)
         .record_mpc_timings("v4-reshare")
         // Settled v4 lifecycle: pools were filled during epoch 3, the
         // boundary work is done, so this window prices v4 DKG / pool-served

--- a/dev-docs/plans/network-dkg-anchor-v2-to-v3-migration.md
+++ b/dev-docs/plans/network-dkg-anchor-v2-to-v3-migration.md
@@ -1,0 +1,165 @@
+# Making the V3 network DKG output canonical (within v4 off-chain)
+
+Status: active — 2026-06-21, design agreed (v4 + epoch-alignment),
+implementation starting, no PR yet. Consensus-critical. The in-memory V3
+reconstruction this builds on landed in `013cb1b75f`.
+
+## What this is
+
+Each network encryption key carries a `VersionedNetworkDkgOutput` (the
+`network_dkg_output` field of `NetworkEncryptionKeyPublicData`,
+`crates/dwallet-mpc-types/src/dwallet_mpc.rs:111`):
+
+- **V2** — the backward-compatible `decentralized_party::dkg::PublicOutputCore`.
+  The deployed mainnet/testnet key has a V2 anchor.
+- **V3** — the full `decentralized_party::dkg::PublicOutput` = the V2 core plus a
+  trailing `threshold_encryption_to_sharing_output`, produced only by the
+  threshold-encryption-to-sharing sub-protocol that backward-compatible
+  reconfiguration predates.
+
+A pure, RNG-free helper reconstructs V3 from (V2 DKG output, a full V3
+reconfiguration output): `reconstruct_full_network_dkg_output`
+(`crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs:721`),
+already called in `build_network_encryption_key_public_data` and stored in the
+in-memory field `NetworkEncryptionKeyPublicData::reconstructed_full_network_dkg_output`
+(committed `013cb1b75f`).
+
+**Goal:** make the V3 output the *canonical* network DKG output — what the
+cross-epoch handoff attests, what `adopt_cert_verified_keys` matches, and what
+joiners install.
+
+## Framing: within v4, not a new protocol version
+
+The handoff and `adopt_cert_verified_keys` are gated on
+`off_chain_validator_metadata_enabled()` (v4), which is **not live** on any
+deployed network, so v4 handoff behavior carries no back-compat constraint. The
+canonical-V3 behavior rides that same gate — no new protocol version, no
+`MAX_PROTOCOL_VERSION` bump.
+
+### Why the V2 anchor cannot simply stay V2
+
+The handoff digest, the overlay/instantiation source, and the adopt comparison
+all resolve through the **same** perpetual `key_id -> digest` mirror
+(`network_dkg_output_digests_by_key`, read by `get_network_dkg_output_digests`,
+`authority_per_epoch_store.rs:2545`; resolved into the overlay by
+`fetch_network_key_data_with_off_chain_blobs`, `validator_metadata.rs:1422`).
+And a joiner caches the cert-pinned blob as `network_dkg_output` via
+`cache_network_dkg_output` (`crates/ika-node/src/lib.rs:2966`) — the same write
+path continuing nodes use. So whatever the cert pins becomes `network_dkg_output`
+network-wide: if the cert pins V3, `network_dkg_output` is V3 everywhere, and so
+are the session ids hashed from it (`mpc_manager.rs:1443`/`:1518`). There is no
+way to make the cert V3 while keeping the field V2.
+
+### Why the flip must be epoch-aligned, and how
+
+`instantiate_adopted_network_keys` re-instantiates whenever the overlay's
+DKG/reconfiguration bytes move (`mpc_manager.rs:2198-2225`), not once per epoch.
+So a naive "flip when the V3 reconstruction appears" trigger would land
+mid-epoch at wall-clock-divergent times across validators, diverging both the
+session identifiers and the handoff attestation. The flip must therefore be
+driven by a signal that is identical across validators for a whole epoch.
+
+That signal is the **cert-pinned reconfiguration output**: `adopt_cert_verified_keys`
+enforces that a key's adopted reconfiguration output matches the prior epoch's
+certified reconfiguration digest (`mpc_manager.rs:897`), so at any epoch every
+validator instantiates from the same reconfiguration output. The flip decision
+("present V3") is therefore made **once, at instantiation (epoch entry), from the
+cert-pinned overlay** — V2 stored DKG output plus a V3 reconfiguration output —
+and is uniform across the committee for the epoch.
+
+## Design
+
+Three coordinated pieces, all under `off_chain_validator_metadata_enabled()`:
+
+### 1. Flip the persisted mirror at instantiation (epoch entry)
+
+When a key is instantiated with off-chain on and the result carries a
+`reconstructed_full_network_dkg_output = Some(V3)` (i.e. stored DKG output is V2
+and the cert-pinned reconfiguration output is V3), persist that V3 once via the
+existing `cache_network_dkg_output(key_id, v3_bytes)` write path. That single
+call:
+
+- adds the V3 blob to the content-addressed `mpc_artifact_blobs` store (insert
+  guarded by `Blake2b256(bytes)==digest`, `authority_perpetual_tables.rs:184`),
+  so peers — and joiners — can fetch V3 bytes under the cert-pinned V3 digest;
+- flips the single-valued `network_dkg_output_digests_by_key` mirror to the V3
+  digest (`authority_perpetual_tables.rs:53`), so `get_network_dkg_output_digests`
+  (the handoff source) and the overlay both resolve V3 from the next epoch on.
+
+It is naturally one-shot: once the overlay resolves V3, the stored DKG output is
+V3, `reconstruct` returns `None`, and the trigger no longer fires. The on-chain
+V2 output and the content-addressed V2 blob are never destroyed (zero-data-loss).
+Epoch-alignment holds because the trigger is the cert-pinned reconfiguration
+output, identical committee-wide; the handoff digest read at `EndOfPublish` is V3
+on every validator because all instantiated (and flipped) at epoch entry, a whole
+epoch earlier.
+
+### 2. Re-key session identifiers onto `NetworkKeyId`
+
+Replace the `network_dkg_output().as_bytes()` preimage at `mpc_manager.rs:1443`
+(internal-presign) and `:1518` (network-owned-address sign) with the
+`NetworkKeyId` bytes (the curve25519 NOA ed25519 pubkey, invariant across
+reconfiguration AND the V2→V3 reconstruction). This removes the flipping bytes
+from the session-id preimage, so the field change is invisible to session
+identity regardless of instantiation timing. Fallback for an unmapped key (no
+`NetworkKeyId` registered yet): keep the current `network_dkg_output` bytes —
+uniform across validators because the mapping is seeded/registered identically.
+
+### 3. Digest-gated dual-accept in adopt
+
+Within the flip epoch, after the mirror flips, a later adopt tick reads the
+overlay as V3 while the prior cert still pins V2. Make the reconfigured-branch
+comparison (`mpc_manager.rs:897`) accept when **either** the local canonical
+digest matches the prior cert (steady state) **or** the local digest differs but
+the retained V2 output (resolved by the prior cert's V2 digest from
+`mpc_artifact_blobs`, which we never delete) matches the prior cert — proving
+possession of exactly the V2 the prior committee certified, now migrated to V3.
+This keeps adoption stable across the flip without a spurious mismatch, and it
+cannot mask a genuine steady-state V3-vs-V3 mismatch (which fails both legs).
+
+## Per-consumer summary
+
+1. **Adopt** (`mpc_manager.rs:808-905`): digest-gated dual-accept; no change to
+   the raw-bytes comparison itself.
+2. **Handoff digest** (`validator_metadata.rs:866`): unchanged code — it reads
+   the mirror, which the flip writes V3. Update the stale `:873` comment.
+3. **Perpetual store**: the flip reuses `cache_network_dkg_output`; no new table.
+4. **Session ids** (`mpc_manager.rs:1443`/`:1518`): re-keyed onto `NetworkKeyId`.
+5. **Joiner** (`ika-node/src/lib.rs:2966`): unchanged — fetches V3 by the
+   cert-pinned digest once the V3 blob is persisted (piece 1).
+6. **Syncer gate** (`sui_syncer.rs:859-863`): unchanged (presence-only).
+
+No `ika-protocol-config` change.
+
+## Why no transition point wedges
+
+- **Session ids:** re-keyed onto the flip-invariant `NetworkKeyId` — timing of
+  the field flip is irrelevant.
+- **Handoff attestation:** the flip is latched at instantiation (epoch entry)
+  from the cert-pinned reconfiguration output, uniform committee-wide; by
+  `EndOfPublish` every validator's mirror is V3, so all emit the same digest.
+- **Cross-epoch adopt:** the digest-gated dual-accept bridges the one flip epoch
+  via possession of the retained V2 output.
+- **Joiner:** the persisted V3 blob lets a peer serve bytes hashing to the
+  cert-pinned V3 digest.
+
+## Open / out of scope
+
+- Pruning the retained V2 output, dropping the per-epoch reconfiguration-blob
+  dependency for instantiation, and deleting the backward-compatible V2 paths
+  are a separate far-future effort once every deployed key is V3-anchored.
+
+## Scope & tests
+
+- **Crates:** `ika-core` only — `mpc_manager.rs` (flip trigger at instantiation,
+  dual-accept, session-id re-key), `validator_metadata.rs` (comment),
+  `authority_per_epoch_store.rs`/`authority_perpetual_tables.rs` (reused). No
+  `ika-protocol-config`, `ika-node` verify-only.
+- **Tests:**
+  - Unit: the session-id preimage uses `NetworkKeyId` when mapped and falls back
+    otherwise; the dual-accept leg-2 matches a retained V2 output against a V2
+    prior cert.
+  - Cluster/sim: the **v3→v4 upgrade** path is the one that exercises case A — a
+    V2 key read from chain, v4 reconfigurations flipping it to V3, the dual-accept
+    at the flip epoch, and a **joiner** installing the V3 at/after the flip.
+    Genesis-v4 clusters exercise only case B (already V3).

--- a/dev-docs/plans/network-dkg-anchor-v2-to-v3-migration.md
+++ b/dev-docs/plans/network-dkg-anchor-v2-to-v3-migration.md
@@ -1,8 +1,11 @@
 # Making the V3 network DKG output canonical (within v4 off-chain)
 
-Status: active — 2026-06-21, design agreed (v4 + epoch-alignment),
-implementation starting, no PR yet. Consensus-critical. The in-memory V3
-reconstruction this builds on landed in `013cb1b75f`.
+Status: active — implementation complete and validated end-to-end (2026-06-28),
+PR #1758 (into `dev`, ready for review); flip to `landed` on merge.
+Consensus-critical. Builds on the in-memory V3 reconstruction (`013cb1b75f`).
+The durable behavioral contract — the `NetworkDkgOutput` item's one-time V2->V3
+migration and the adoption tolerance — now lives in
+`dev-docs/specs/handoff.md`; this plan is the intent/sequencing record.
 
 ## What this is
 
@@ -105,29 +108,42 @@ identity regardless of instantiation timing. Fallback for an unmapped key (no
 `NetworkKeyId` registered yet): keep the current `network_dkg_output` bytes —
 uniform across validators because the mapping is seeded/registered identically.
 
-### 3. Digest-gated dual-accept in adopt
+### 3. Tolerate the one-epoch DKG-digest migration in adopt
 
 Within the flip epoch, after the mirror flips, a later adopt tick reads the
-overlay as V3 while the prior cert still pins V2. Make the reconfigured-branch
-comparison (`mpc_manager.rs:897`) accept when **either** the local canonical
-digest matches the prior cert (steady state) **or** the local digest differs but
-the retained V2 output (resolved by the prior cert's V2 digest from
-`mpc_artifact_blobs`, which we never delete) matches the prior cert — proving
-possession of exactly the V2 the prior committee certified, now migrated to V3.
-This keeps adoption stable across the flip without a spurious mismatch, and it
-cannot mask a genuine steady-state V3-vs-V3 mismatch (which fails both legs).
+overlay as V3 while the prior cert still pins V2. `adopt_cert_verified_keys`
+(reconfigured branch) mirrors its existing reconfiguration-digest handling onto
+the DKG digest: when the overlay DKG digest no longer matches the prior cert but
+the key is **already adopted**, that is the expected one-epoch defer — keep the
+adopted value (debug), do not drop the key; only an **unadopted** key
+contradicting the cert warns. Softening the already-adopted case is safe because
+the output-quorum byte-equality tally remains the guard against a genuinely
+divergent output, and a wrong V3 would require either a cert-mismatching
+reconfiguration output (separately checked at the same site) or a
+non-deterministic reconstruct (impossible — it is a pure function).
+
+(The design considered a stricter "digest-gated dual-accept" that re-derives the
+prior cert's V2 digest from the retained `mpc_artifact_blobs` blob; the shipped
+tolerance is simpler, consistent with the reconfiguration-digest handling, and
+relies on the output-quorum tally for the residual guarantee.)
 
 ## Per-consumer summary
 
-1. **Adopt** (`mpc_manager.rs:808-905`): digest-gated dual-accept; no change to
-   the raw-bytes comparison itself.
-2. **Handoff digest** (`validator_metadata.rs:866`): unchanged code — it reads
-   the mirror, which the flip writes V3. Update the stale `:873` comment.
+1. **Adopt** (`mpc_manager.rs`): tolerate the one-epoch V2->V3 DKG-digest move
+   for an already-adopted key (keep its value, debug not warn), mirroring the
+   reconfiguration-digest handling; the raw-bytes comparison is unchanged.
+2. **Handoff digest** (`validator_metadata.rs`): unchanged code — it reads the
+   mirror, which the flip writes V3. (Stale "stable across epochs" comment
+   updated.)
 3. **Perpetual store**: the flip reuses `cache_network_dkg_output`; no new table.
 4. **Session ids** (`mpc_manager.rs:1443`/`:1518`): re-keyed onto `NetworkKeyId`.
-5. **Joiner** (`ika-node/src/lib.rs:2966`): unchanged — fetches V3 by the
-   cert-pinned digest once the V3 blob is persisted (piece 1).
-6. **Syncer gate** (`sui_syncer.rs:859-863`): unchanged (presence-only).
+5. **Joiner** (`ika-node/src/lib.rs`): unchanged — fetches V3 by the cert-pinned
+   digest once the V3 blob is persisted (piece 1).
+6. **Syncer gate** (`sui_syncer.rs`): unchanged (presence-only).
+7. **Observability**: `ika_dwallet_mpc_network_encryption_key_canonical_dkg_output_version`
+   (`IntGauge`) is set at each off-chain instantiation to the version mirrored
+   into the handoff — 2 before the migration, 3 after — so the migration is
+   observable (and asserted by the v118 tests).
 
 No `ika-protocol-config` change.
 
@@ -138,8 +154,9 @@ No `ika-protocol-config` change.
 - **Handoff attestation:** the flip is latched at instantiation (epoch entry)
   from the cert-pinned reconfiguration output, uniform committee-wide; by
   `EndOfPublish` every validator's mirror is V3, so all emit the same digest.
-- **Cross-epoch adopt:** the digest-gated dual-accept bridges the one flip epoch
-  via possession of the retained V2 output.
+- **Cross-epoch adopt:** the already-adopted tolerance bridges the one flip epoch
+  (the key keeps its adopted value while its overlay DKG digest moves past the
+  prior V2 cert); the output-quorum tally guards correctness.
 - **Joiner:** the persisted V3 blob lets a peer serve bytes hashing to the
   cert-pinned V3 digest.
 
@@ -151,15 +168,21 @@ No `ika-protocol-config` change.
 
 ## Scope & tests
 
-- **Crates:** `ika-core` only — `mpc_manager.rs` (flip trigger at instantiation,
-  dual-accept, session-id re-key), `validator_metadata.rs` (comment),
-  `authority_per_epoch_store.rs`/`authority_perpetual_tables.rs` (reused). No
-  `ika-protocol-config`, `ika-node` verify-only.
-- **Tests:**
-  - Unit: the session-id preimage uses `NetworkKeyId` when mapped and falls back
-    otherwise; the dual-accept leg-2 matches a retained V2 output against a V2
-    prior cert.
-  - Cluster/sim: the **v3→v4 upgrade** path is the one that exercises case A — a
-    V2 key read from chain, v4 reconfigurations flipping it to V3, the dual-accept
-    at the flip epoch, and a **joiner** installing the V3 at/after the flip.
-    Genesis-v4 clusters exercise only case B (already V3).
+- **Crates:** `ika-core` (`mpc_manager.rs` — flip trigger at instantiation,
+  adopt tolerance, session-id re-key; `dwallet_mpc_metrics.rs` — the
+  canonical-version gauge; `validator_metadata.rs` — comment;
+  `authority_per_epoch_store.rs`/`authority_perpetual_tables.rs` — reused),
+  `dwallet-mpc-types` (`reconstructed_full_network_dkg_output` field +
+  `VersionedNetworkDkgOutput::version()`), `ika-upgrade-test` (metrics scrape +
+  scenario step + the v118/v118_churn assertions). No `ika-protocol-config`;
+  `ika-node` joiner path verify-only.
+- **Tests (all green):**
+  - Unit/integration: `reconstruct_full_network_dkg_output_gating` (the version
+    gate); `already_adopted_key_survives_dkg_output_migration` (the adopt
+    tolerance); `internal_presign` (validates the session-id re-key); the
+    mainnet-v1.1.8 backward-compat suite incl. `test_v2_to_v3_reconfiguration_migration`.
+  - End-to-end on CI: the **v118 upgrade rehearsal** (literal mainnet-v1.1.8 ->
+    current build, v3->v4) and **v118 churn** (same, with a mirrored joiner added
+    to a 5-member committee) — both assert the canonical DKG-output version
+    reaches 3 across the whole committee after the flip (`got=3 expected=3` in the
+    run logs; the churn run proves it for the cert-bootstrapped joiner).

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -16,8 +16,18 @@ next epoch inherits.
   different successor committee).
 - `items` — `(HandoffItemKey, digest)` pairs, sorted strictly ascending
   by key:
-  - `NetworkDkgOutput { key_id }` — stable across the encryption key's
-    lifetime (the DKG output is a one-time deterministic computation).
+  - `NetworkDkgOutput { key_id }` — the canonical network DKG output.
+    Stable across epochs WITHIN a representation, with exactly one
+    consensus-deterministic transition over the key's lifetime: a
+    mainnet-v1.1.8-origin key's DKG output is a V2 (backward-compatible)
+    `PublicOutputCore` and migrates ONCE to the full V3
+    `decentralized_party::dkg::PublicOutput` at the first v4 reshare
+    (when the cert-pinned reconfiguration output first becomes V3, every
+    validator reconstructs the full V3 output and flips its perpetual
+    digest mirror — see `dev-docs/plans/network-dkg-anchor-v2-to-v3-migration.md`).
+    The flip is epoch-uniform because it is driven by the cert-pinned
+    reconfiguration output, identical committee-wide. A natively-v4 key
+    is V3 from the start and never migrates.
   - `NetworkReconfigurationOutput { key_id }` — this epoch's
     reconfiguration output. Its digest MUST come from the epoch-keyed
     perpetual slice (`network_reconfiguration_output_digest_by_epoch_and_key`,
@@ -118,7 +128,14 @@ next epoch inherits.
    network-key outputs are adopted into the instantiation set only if
    their digests match the prior epoch's certificate
    (`adopt_cert_verified_keys`): a reconfigured key must match BOTH its
-   stable DKG digest and its epoch-specific reconfiguration digest. A
+   DKG digest and its epoch-specific reconfiguration digest. The DKG
+   digest migrates once (V2->V3, above): at that single boundary an
+   ALREADY-ADOPTED key whose overlay DKG digest has moved past the prior
+   epoch's (V2) certificate is the expected defer — it keeps its adopted
+   value rather than being dropped, exactly as a moved reconfiguration
+   output is tolerated; only an UNADOPTED key contradicting the
+   certificate is the security-relevant anomaly (the output-quorum
+   byte-equality tally remains the guard against a divergent output). A
    certificate READ ERROR skips adoption for the tick (retry) — it must
    not be conflated with the genuinely-absent-certificate case, which
    exists only at the v3→v4 boundary and falls back to the chain copy.


### PR DESCRIPTION
> **Stacked PR** — based on `feat/network-key-id` (the NetworkKeyId PR), not `dev`. This PR's diff is the V2→V3 DKG migration only; it merges **after** the NetworkKeyId PR, after which it will be rebased onto `dev`.

## Summary

Make the full **V3** `decentralized_party::dkg::PublicOutput` (the V2 backward-compatible `PublicOutputCore` plus the trailing `threshold_encryption_to_sharing_output`) the **canonical** network DKG output — what the cross-epoch handoff attests, what `adopt_cert_verified_keys` matches, and what joiners install. A deployed (mainnet-v1.1.8-origin) key's DKG output is V2; it migrates once, deterministically, at the first v4 reshare.

Gated on the v4 off-chain regime; v4 is **not live** on any deployed network, so there are no deployed-network back-compat constraints. Builds on `NetworkKeyId` (the base PR): the migration re-keys session identifiers onto `NetworkKeyId` and operates on the `NetworkKeyId`-keyed handoff.

Design notes: [`dev-docs/plans/network-dkg-anchor-v2-to-v3-migration.md`](dev-docs/plans/network-dkg-anchor-v2-to-v3-migration.md). Durable contract: [`dev-docs/specs/handoff.md`](dev-docs/specs/handoff.md).

## How (consensus-critical — the hard part)

- A pure, RNG-free helper reconstructs the full V3 output from (V2 DKG output, a V3 reconfiguration output): `reconstruct_full_network_dkg_output`.
- **The flip is epoch-aligned**, driven by the **cert-pinned reconfiguration output** (identical committee-wide), not per-validator data-availability timing — which would split the attestation. At the first v4 reshare every validator reconstructs the same V3 and mirrors it via `cache_network_dkg_output`, flipping the perpetual digest mirror and persisting the V3 blob. After the flip the off-chain overlay resolves V3, so the handoff digest, the instantiation source, and joiner blob-fetch all move to V3 together.
- **Session identifiers re-keyed onto `NetworkKeyId`** (migration-invariant), so the field flip cannot perturb the internal-presign / NOA-sign identifiers regardless of timing.
- **Adopt tolerates the one-epoch DKG-digest move**: an already-adopted key whose overlay DKG digest has moved past the prior epoch's V2 cert keeps its adopted value (mirroring the reconfiguration-digest handling); the output-quorum byte-equality tally remains the guard against a genuinely divergent output.
- **Joiner**: the persisted V3 blob lets a peer serve bytes hashing to the cert-pinned V3 digest, so a fresh joiner installs V3 by content-address — no joiner-specific code change.
- No `ika-protocol-config` change; the on-chain V2 output is never destroyed (zero-data-loss).

## Observability

New gauge `ika_dwallet_mpc_network_encryption_key_canonical_dkg_output_version` — `2` before the migration, `3` after.

## Validation (all green)

- **Unit/integration**: `reconstruct_full_network_dkg_output_gating`; `already_adopted_key_survives_dkg_output_migration`; `internal_presign` (validates the session-id re-key); the mainnet-v1.1.8 backward-compat suite incl. `test_v2_to_v3_reconfiguration_migration`.
- **Heavy CI suites**: Integration Tests CI, Test Cluster, TS Integration Tests — all passed.
- **End-to-end upgrade rehearsals (CI)** — decisive:
  - **v118 upgrade**: boot the literal `mainnet-v1.1.8` `ika-node` binary, swap the whole network to the current build, v3→v4.
  - **v118 churn**: same, with a mirrored validator **joined** into a 5-member committee resharing the 1.1.8-origin key.
  - Both **assert the migration happened**: the canonical-version gauge reaches `3` across the whole committee after the flip (`got=3 expected=3` in the run logs). The churn run proves it for the cert-bootstrapped joiner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
