### PR TITLE
fix(dwallet-mpc): don't gate non-VSS signs on the VSS Shamir cache

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/sign.rs
@@ -467,10 +467,10 @@ impl SignPublicInputByProtocol {
         hash_context: HashContext,
         access_structure: &WeightedThresholdAccessStructure,
         network_encryption_key_public_data: &NetworkEncryptionKeyPublicData,
-        // Pre-derived VSS Shamir-share + commitments cache for this network
-        // key. Empty (all-`None`) for non-VSS callers; required (and per-curve
-        // populated) for the three VSS protocols.
-        vss_shamir_cache: &crate::dwallet_mpc::network_dkg::VssShamirCachePerKey,
+        // Pre-derived VSS Shamir cache. `None` for non-VSS callers (they never
+        // use it and must NOT wait on it — it only exists for V3 keys); `Some`
+        // for the three VSS protocols, unwrapped via `require_vss_cache`.
+        vss_shamir_cache: Option<&crate::dwallet_mpc::network_dkg::VssShamirCachePerKey>,
         protocol: DWalletSignatureAlgorithm,
     ) -> DwalletMPCResult<Self> {
         let expected_decrypters =
@@ -550,7 +550,7 @@ impl SignPublicInputByProtocol {
                     hash_scheme,
                     hash_context,
                     network_encryption_key_public_data,
-                    vss_shamir_cache,
+                    require_vss_cache(vss_shamir_cache)?,
                 )?,
             )),
             DWalletSignatureAlgorithm::EdDSAVSS => Ok(SignPublicInputByProtocol::EdDSAVSS(
@@ -562,7 +562,7 @@ impl SignPublicInputByProtocol {
                     hash_scheme,
                     hash_context,
                     network_encryption_key_public_data,
-                    vss_shamir_cache,
+                    require_vss_cache(vss_shamir_cache)?,
                 )?,
             )),
             DWalletSignatureAlgorithm::SchnorrkelVSS => {
@@ -575,12 +575,27 @@ impl SignPublicInputByProtocol {
                         hash_scheme,
                         hash_context,
                         network_encryption_key_public_data,
-                        vss_shamir_cache,
+                        require_vss_cache(vss_shamir_cache)?,
                     )?,
                 ))
             }
         }
     }
+}
+
+/// Unwraps the optional VSS Shamir cache at a VSS sign builder's point of use.
+/// Callers in `session_input_from_request` pass `Some` only for the three VSS
+/// protocols (and only fetch it for them), so `None` here means an internal
+/// inconsistency — never the transient `WaitingForNetworkKey` that the non-VSS
+/// path must never hit.
+fn require_vss_cache(
+    vss_shamir_cache: Option<&crate::dwallet_mpc::network_dkg::VssShamirCachePerKey>,
+) -> DwalletMPCResult<&crate::dwallet_mpc::network_dkg::VssShamirCachePerKey> {
+    vss_shamir_cache.ok_or_else(|| {
+        DwalletMPCError::InvalidInput(
+            "Fast Schnorr (VSS) sign requires the VSS Shamir cache".to_string(),
+        )
+    })
 }
 
 // Per-curve concrete sign-public-input builders. Each pulls its
@@ -1332,7 +1347,11 @@ impl DKGAndSignPublicInputByProtocol {
         hash_context: HashContext,
         access_structure: &WeightedThresholdAccessStructure,
         network_encryption_key_public_data: &NetworkEncryptionKeyPublicData,
-        vss_shamir_cache: &crate::dwallet_mpc::network_dkg::VssShamirCachePerKey,
+        // `None` for non-VSS; `Some` for VSS protocols (unwrapped via
+        // `require_vss_cache`). The combined DKG-and-sign path is never VSS,
+        // so in practice this is always `None` here — but kept symmetric with
+        // the sign-only `try_new`.
+        vss_shamir_cache: Option<&crate::dwallet_mpc::network_dkg::VssShamirCachePerKey>,
         protocol: DWalletSignatureAlgorithm,
     ) -> DwalletMPCResult<Self> {
         let expected_decrypters =
@@ -1448,7 +1467,7 @@ impl DKGAndSignPublicInputByProtocol {
                         hash_scheme,
                         hash_context,
                         network_encryption_key_public_data,
-                        vss_shamir_cache,
+                        require_vss_cache(vss_shamir_cache)?,
                     )?,
                 ))
             }
@@ -1467,7 +1486,7 @@ impl DKGAndSignPublicInputByProtocol {
                         hash_scheme,
                         hash_context,
                         network_encryption_key_public_data,
-                        vss_shamir_cache,
+                        require_vss_cache(vss_shamir_cache)?,
                     )?,
                 ))
             }
@@ -1486,7 +1505,7 @@ impl DKGAndSignPublicInputByProtocol {
                         hash_scheme,
                         hash_context,
                         network_encryption_key_public_data,
-                        vss_shamir_cache,
+                        require_vss_cache(vss_shamir_cache)?,
                     )?,
                 ))
             }

--- a/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
@@ -132,16 +132,23 @@ pub(crate) fn session_input_from_request(
                 &data.centralized_public_key_share_and_proof,
                 BytesCentralizedPartyKeyShareVerification::from(data.user_secret_key_share.clone()),
             )?;
-            // Mirror the AHE "no decryption key shares" wait path: a missing
-            // cache means the network key hasn't been ingested yet (the cache
-            // is populated atomically with the AHE shares in
-            // `decrypt_and_store_secret_key_shares`). Propagate the
-            // `WaitingForNetworkKey` error so the session isn't processed
-            // until the key arrives — same shape as
-            // `get_network_encryption_key_public_data` above.
-            let vss_shamir_cache = network_keys
-                .vss_shamir_cache(dwallet_network_encryption_key_id)?
-                .clone();
+            // The VSS Shamir cache is consumed ONLY by the Fast Schnorr (VSS)
+            // protocols, so fetch (and wait on) it only for those. It is derived
+            // exclusively from a V3 DKG/reconfiguration output, so at a pre-V3
+            // network key it is never populated — requiring it unconditionally
+            // would permanently block EVERY non-VSS sign (ECDSA/EdDSA/Schnorrkel/
+            // Taproot, and the DKG-and-sign path) with `WaitingForNetworkKey`.
+            // Non-VSS signs are already gated by `get_network_encryption_key_public_data`
+            // above; they pass `None` and the non-VSS builders ignore it.
+            let vss_shamir_cache = if data.signature_algorithm.is_vss() {
+                Some(
+                    network_keys
+                        .vss_shamir_cache(dwallet_network_encryption_key_id)?
+                        .clone(),
+                )
+            } else {
+                None
+            };
             Ok((
                 PublicInput::DWalletDKGAndSign(DKGAndSignPublicInputByProtocol::try_new(
                     request.session_identifier,
@@ -153,7 +160,7 @@ pub(crate) fn session_input_from_request(
                     data.hash_context.clone(),
                     access_structure,
                     encryption_key_public_data,
-                    &vss_shamir_cache,
+                    vss_shamir_cache.as_ref(),
                     data.signature_algorithm,
                 )?),
                 None,
@@ -342,16 +349,23 @@ pub(crate) fn session_input_from_request(
             message_centralized_signature,
             ..
         } => {
-            // Mirror the AHE "no decryption key shares" wait path: a missing
-            // cache means the network key hasn't been ingested yet (the cache
-            // is populated atomically with the AHE shares in
-            // `decrypt_and_store_secret_key_shares`). Propagate the
-            // `WaitingForNetworkKey` error so the session isn't processed
-            // until the key arrives — same shape as
-            // `get_network_encryption_key_public_data` above.
-            let vss_shamir_cache = network_keys
-                .vss_shamir_cache(dwallet_network_encryption_key_id)?
-                .clone();
+            // The VSS Shamir cache is consumed ONLY by the Fast Schnorr (VSS)
+            // protocols, so fetch (and wait on) it only for those. It is derived
+            // exclusively from a V3 DKG/reconfiguration output, so at a pre-V3
+            // network key it is never populated — requiring it unconditionally
+            // would permanently block EVERY non-VSS sign (ECDSA/EdDSA/Schnorrkel/
+            // Taproot, and the DKG-and-sign path) with `WaitingForNetworkKey`.
+            // Non-VSS signs are already gated by `get_network_encryption_key_public_data`
+            // above; they pass `None` and the non-VSS builders ignore it.
+            let vss_shamir_cache = if data.signature_algorithm.is_vss() {
+                Some(
+                    network_keys
+                        .vss_shamir_cache(dwallet_network_encryption_key_id)?
+                        .clone(),
+                )
+            } else {
+                None
+            };
             Ok((
                 PublicInput::Sign(SignPublicInputByProtocol::try_new(
                     request.session_identifier,
@@ -365,7 +379,7 @@ pub(crate) fn session_input_from_request(
                     network_keys.get_network_encryption_key_public_data(
                         dwallet_network_encryption_key_id,
                     )?,
-                    &vss_shamir_cache,
+                    vss_shamir_cache.as_ref(),
                     data.signature_algorithm,
                 )?),
                 None,
@@ -388,16 +402,23 @@ pub(crate) fn session_input_from_request(
                 encryption_key_public_data.network_owned_address_dkg_output(data.curve);
 
             let stored_dkg_output_bytes = stored_dkg_output_bytes.to_vec();
-            // Mirror the AHE "no decryption key shares" wait path: a missing
-            // cache means the network key hasn't been ingested yet (the cache
-            // is populated atomically with the AHE shares in
-            // `decrypt_and_store_secret_key_shares`). Propagate the
-            // `WaitingForNetworkKey` error so the session isn't processed
-            // until the key arrives — same shape as
-            // `get_network_encryption_key_public_data` above.
-            let vss_shamir_cache = network_keys
-                .vss_shamir_cache(dwallet_network_encryption_key_id)?
-                .clone();
+            // The VSS Shamir cache is consumed ONLY by the Fast Schnorr (VSS)
+            // protocols, so fetch (and wait on) it only for those. It is derived
+            // exclusively from a V3 DKG/reconfiguration output, so at a pre-V3
+            // network key it is never populated — requiring it unconditionally
+            // would permanently block EVERY non-VSS sign (ECDSA/EdDSA/Schnorrkel/
+            // Taproot, and the DKG-and-sign path) with `WaitingForNetworkKey`.
+            // Non-VSS signs are already gated by `get_network_encryption_key_public_data`
+            // above; they pass `None` and the non-VSS builders ignore it.
+            let vss_shamir_cache = if data.signature_algorithm.is_vss() {
+                Some(
+                    network_keys
+                        .vss_shamir_cache(dwallet_network_encryption_key_id)?
+                        .clone(),
+                )
+            } else {
+                None
+            };
             Ok((
                 PublicInput::Sign(SignPublicInputByProtocol::try_new(
                     request.session_identifier,
@@ -409,7 +430,7 @@ pub(crate) fn session_input_from_request(
                     data.hash_context.clone(),
                     access_structure,
                     encryption_key_public_data,
-                    &vss_shamir_cache,
+                    vss_shamir_cache.as_ref(),
                     data.signature_algorithm,
                 )?),
                 None,


### PR DESCRIPTION
## Problem

At protocol **v3** (`network_encryption_key_version = 2`, pre-fast-schnorr keys) **every sign was permanently stuck** on `WaitingForNetworkKey` — including ECDSA/EdDSA/Schnorrkel/Taproot. Signing was completely broken at v3.

## Root cause

The `Sign`, `NetworkOwnedAddressSign`, and `DWalletDKGAndSign` arms of `session_input_from_request` fetched `vss_shamir_cache(key_id)?` **unconditionally**. That cache is derived only from a **V3** DKG/reconfiguration output (`derive_vss_shamir_cache_for_key` returns `None` otherwise), so at a pre-V3 key it is never populated — and the `?` turned a permanent "no cache" into a permanent wait. But the cache is consumed **only** by the three Fast Schnorr (VSS) protocols (`TaprootVSS`/`EdDSAVSS`/`SchnorrkelVSS`); the non-VSS sign builders never touch it.

## Fix

Make the cache optional end-to-end:
- `session_input_from_request` fetches (and waits on) it **only when `signature_algorithm.is_vss()`**, passing `None` otherwise.
- The two `try_new`s (`SignPublicInputByProtocol`, `DKGAndSignPublicInputByProtocol`) take `Option<&VssShamirCachePerKey>` and unwrap it at the VSS builders via a new `require_vss_cache` helper.

Non-VSS signs remain gated by `get_network_encryption_key_public_data` (present at v3), restoring the pre-fast-schnorr ECDSA gating. The branch is on the request's signature algorithm, so it's deterministic across validators. Diff is scoped to `mpc_session/input.rs` + `mpc_computations/sign.rs`.

## Validation

- **v3 localnet** `transfer-dwallet`: **7/7** (previously 79 min of sign-completion timeouts; 0 sign rejections, epoch advances normally).
- **v4 integration** `sign` + `network_owned_address_sign` + `create_dwallet`: **18/18** — the VSS path is unaffected.

## Not included

No in-repo regression test yet: the integration harness runs at v4, and constructing a v3-key-without-VSS-cache state to assert "a non-VSS sign doesn't wait" needs harness work. Validated end-to-end instead (v3 localnet + v4 integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)