### PR TITLE
feat(authority-name): carry consensus keys as committee data

### DIFF
--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -801,6 +801,12 @@ impl NodeConfig {
         self.protocol_key_pair().public().into()
     }
 
+    /// The node's own `AuthorityName` (committee identity): its BLS protocol
+    /// public key.
+    pub fn authority_name(&self) -> AuthorityPublicKeyBytes {
+        self.protocol_public_key()
+    }
+
     pub fn db_path(&self) -> PathBuf {
         self.db_path.join("live")
     }

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -31,13 +31,13 @@ use crate::dwallet_checkpoints::{
     PendingDWalletCheckpoint,
 };
 use crate::validator_metadata::{
-    ConsensusPubkeyProvider, HandoffAggregator, HandoffSignatureRecordOutcome,
-    HandoffSignatureVerdict, JoinerAnnouncementVerdict, JoinerPubkeyProvider,
-    MAX_PENDING_RELAYED_JOINER_ANNOUNCEMENTS, NetworkKeyBlobSource,
-    PENDING_RELAYED_JOINER_ANNOUNCEMENT_TTL, PendingRelayedJoinerAnnouncement,
-    build_handoff_attestation, hash_next_committee_pubkey_set, process_handoff_signature,
-    push_buffered_joiner_announcement, reevaluate_buffered_joiner_announcements,
-    sign_handoff_attestation, verify_handoff_signature, verify_joiner_announcement,
+    HandoffAggregator, HandoffSignatureRecordOutcome, HandoffSignatureVerdict,
+    JoinerAnnouncementVerdict, JoinerPubkeyProvider, MAX_PENDING_RELAYED_JOINER_ANNOUNCEMENTS,
+    NetworkKeyBlobSource, PENDING_RELAYED_JOINER_ANNOUNCEMENT_TTL,
+    PendingRelayedJoinerAnnouncement, build_handoff_attestation, hash_next_committee_pubkey_set,
+    process_handoff_signature, push_buffered_joiner_announcement,
+    reevaluate_buffered_joiner_announcements, sign_handoff_attestation, verify_handoff_signature,
+    verify_joiner_announcement,
 };
 
 use crate::consensus_handler::{
@@ -888,12 +888,6 @@ pub struct AuthorityPerEpochStore {
     /// which case every next-epoch joiner announcement is dropped.
     /// Current-epoch announcements are unaffected.
     joiner_pubkey_provider: ArcSwapOption<Box<dyn JoinerPubkeyProvider>>,
-
-    /// Consensus-key (Ed25519) lookup for handoff signatures; the
-    /// sui_syncer populates it from current committee + pending-set
-    /// staking-pool `consensus_pubkey_bytes`. Empty until the syncer
-    /// runs, in which case incoming handoff signatures drop.
-    consensus_pubkey_provider: ArcSwapOption<Box<dyn ConsensusPubkeyProvider>>,
 
     /// This validator's locally-computed handoff attestation for the
     /// epoch — the value every honest validator must arrive at by
@@ -1790,7 +1784,6 @@ impl AuthorityPerEpochStore {
             }),
             end_of_publish: Mutex::new(end_of_publish),
             joiner_pubkey_provider: ArcSwapOption::empty(),
-            consensus_pubkey_provider: ArcSwapOption::empty(),
             expected_handoff_attestation: ArcSwapOption::empty(),
             pending_handoff_signatures: parking_lot::Mutex::new(Vec::new()),
             pending_relayed_joiner_announcements: parking_lot::Mutex::new(Vec::new()),
@@ -1876,10 +1869,22 @@ impl AuthorityPerEpochStore {
 
     pub fn new_at_next_epoch_for_testing(&self) -> IkaResult<Arc<Self>> {
         let next_epoch = self.epoch() + 1;
+        // Carry the committee's consensus keys forward so the fabricated
+        // next committee can still verify consensus-key-signed messages.
+        let consensus_keys = self
+            .committee
+            .names()
+            .filter_map(|name| {
+                self.committee
+                    .consensus_key(name)
+                    .map(|key| (*name, key.clone()))
+            })
+            .collect();
         let next_committee = Committee::new(
             next_epoch,
             self.committee.voting_rights.to_vec(),
             self.committee.class_groups_public_keys_and_proofs.clone(),
+            consensus_keys,
             self.committee.quorum_threshold,
             self.committee.validity_threshold,
         );
@@ -2341,39 +2346,6 @@ impl AuthorityPerEpochStore {
         self.joiner_pubkey_provider.load_full()
     }
 
-    /// Install the consensus-key (Ed25519) lookup used for handoff
-    /// signature verification. Re-installable across epoch
-    /// boundaries; safe to call from non-consensus tasks.
-    pub fn install_consensus_pubkey_provider(&self, provider: Box<dyn ConsensusPubkeyProvider>) {
-        self.consensus_pubkey_provider
-            .store(Some(Arc::new(provider)));
-        // Signatures that arrived after the expected attestation installed
-        // but before this provider did were re-buffered (verification was
-        // impossible without consensus pubkeys). Replay them now that it is.
-        // If the expected attestation is still absent they simply re-buffer;
-        // each runs through full verification otherwise.
-        let drained: Vec<_> = std::mem::take(&mut *self.pending_handoff_signatures.lock());
-        if !drained.is_empty() {
-            info!(
-                pending = drained.len(),
-                epoch = self.epoch(),
-                "replaying buffered handoff signatures after consensus-pubkey provider install"
-            );
-            for msg in drained {
-                if let Err(e) = self.record_handoff_signature(&msg) {
-                    warn!(
-                        error = ?e,
-                        signer = ?msg.signer,
-                        "failed to replay buffered handoff signature after provider install"
-                    );
-                }
-            }
-            self.metrics
-                .dwallet_handoff_signatures_buffered
-                .set(self.pending_handoff_signatures.lock().len() as i64);
-        }
-    }
-
     /// Install the locally-computed expected handoff attestation
     /// for the epoch. Rebuilds the in-memory `HandoffAggregator`
     /// from any signatures already persisted in
@@ -2407,32 +2379,30 @@ impl AuthorityPerEpochStore {
         // items), those rows endorse the old bytes and must not count
         // toward the new cert. Re-verification keeps the restart path
         // correct (same attestation ⇒ rows re-verify and are kept)
-        // while dropping stale rows on a mid-epoch change. If no
-        // consensus-pubkey provider is installed yet (early startup)
-        // fall back to trusting the persist-time verification. Order
-        // doesn't matter — the aggregator is stake-weighted.
-        let provider = self.consensus_pubkey_provider.load_full();
+        // while dropping stale rows on a mid-epoch change. The committee
+        // carries every member's consensus key, so verification is always
+        // possible (no early-startup fallback needed). Order doesn't
+        // matter — the aggregator is stake-weighted.
+        let committee = self.committee();
         let tables = self.tables()?;
         let mut replayed_signatures: usize = 0;
         for entry in tables.handoff_signatures.safe_iter() {
             let (signer, signature) = entry?;
-            if let Some(provider) = provider.as_ref() {
-                let msg = ika_types::handoff::HandoffSignatureMessage {
-                    attestation: attestation.clone(),
-                    signer,
-                    signature: signature.clone(),
-                };
-                if verify_handoff_signature(&msg, &attestation, provider.as_ref().as_ref())
-                    != HandoffSignatureVerdict::Accept
-                {
-                    warn!(
-                        signer = ?signer,
-                        epoch = attestation.epoch,
-                        "persisted handoff signature no longer verifies against the \
-                         installed attestation — dropping on replay"
-                    );
-                    continue;
-                }
+            let msg = ika_types::handoff::HandoffSignatureMessage {
+                attestation: attestation.clone(),
+                signer,
+                signature: signature.clone(),
+            };
+            if verify_handoff_signature(&msg, &attestation, committee.as_ref())
+                != HandoffSignatureVerdict::Accept
+            {
+                warn!(
+                    signer = ?signer,
+                    epoch = attestation.epoch,
+                    "persisted handoff signature no longer verifies against the \
+                     installed attestation — dropping on replay"
+                );
+                continue;
             }
             aggregator.insert_verified(signer, signature);
             replayed_signatures += 1;
@@ -2875,34 +2845,6 @@ impl AuthorityPerEpochStore {
             }
             return Ok(());
         };
-        let Some(provider) = self.consensus_pubkey_provider.load_full() else {
-            // The provider installs asynchronously (a chain-fetch task), and
-            // after a restart consensus replay can deliver the committee's
-            // signatures before its first fetch completes. Dropping here
-            // would lose them permanently — peers stop re-submitting once
-            // their own vote is durable — so re-buffer instead;
-            // `install_consensus_pubkey_provider` re-drains the buffer once
-            // verification becomes possible. Same committee-membership bound
-            // as the pre-install buffer (resistance to byzantine spam).
-            if self.committee.weight(&msg.signer) == 0 {
-                debug!(
-                    signer = ?msg.signer,
-                    "non-committee handoff signature — dropping before buffer insert"
-                );
-                return Ok(());
-            }
-            debug!(
-                signer = ?msg.signer,
-                "no consensus pubkey provider installed yet — buffering handoff signature"
-            );
-            let mut pending = self.pending_handoff_signatures.lock();
-            pending.retain(|m| m.signer != msg.signer);
-            pending.push(msg.clone());
-            self.metrics
-                .dwallet_handoff_signatures_buffered
-                .set(pending.len() as i64);
-            return Ok(());
-        };
         let mut guard = self.handoff_aggregator.lock();
         let Some(aggregator) = guard.as_mut() else {
             // Aggregator wasn't initialized — should be impossible
@@ -2914,7 +2856,7 @@ impl AuthorityPerEpochStore {
         let outcome = process_handoff_signature(
             msg,
             expected.as_ref(),
-            provider.as_ref().as_ref(),
+            self.committee().as_ref(),
             aggregator,
         );
         let aggregator_signer_count = aggregator.signer_count();
@@ -5327,9 +5269,7 @@ mod tests {
     use super::*;
     use crate::authority::authority_perpetual_tables::AuthorityPerpetualTables;
     use crate::dwallet_checkpoints::DWalletCheckpointService;
-    use crate::handoff_cert::{
-        StaticConsensusPubkeyProvider, build_handoff_attestation, sign_handoff_attestation,
-    };
+    use crate::handoff_cert::{build_handoff_attestation, sign_handoff_attestation};
     use dwallet_mpc_types::dwallet_mpc::DWalletSignatureAlgorithm;
     use fastcrypto::ed25519::{Ed25519KeyPair, Ed25519PrivateKey, Ed25519Signature};
     use fastcrypto::traits::{KeyPair, ToFromBytes};
@@ -5695,9 +5635,34 @@ mod tests {
     /// this path but never persisted, so the perpetual read below returned None.
     #[tokio::test]
     async fn install_expected_handoff_attestation_persists_replay_minted_cert() {
-        let (committee, _keys) = Committee::new_simple_test_committee_of_size(4);
-        let committee = Arc::new(committee);
-        let names: Vec<AuthorityName> = committee.names().copied().collect();
+        let (base_committee, _keys) = Committee::new_simple_test_committee_of_size(4);
+        let names: Vec<AuthorityName> = base_committee.names().copied().collect();
+
+        // Deterministic Ed25519 consensus keypairs (seeded — avoids the
+        // multiple-rand-version conflict that bites direct generate() in
+        // ika-core tests), one per validator, carried ON THE COMMITTEE so the
+        // replay's signature re-verification (now committee-based, no side
+        // provider) accepts them.
+        let consensus_keypairs: Vec<Ed25519KeyPair> = (0..names.len())
+            .map(|i| {
+                let mut seed = [0u8; 32];
+                seed[0] = (i + 1) as u8;
+                Ed25519KeyPair::from(Ed25519PrivateKey::from_bytes(&seed).unwrap())
+            })
+            .collect();
+        let consensus_keys: HashMap<_, _> = names
+            .iter()
+            .copied()
+            .zip(consensus_keypairs.iter().map(|kp| kp.public().clone()))
+            .collect();
+        let committee = Arc::new(Committee::new(
+            base_committee.epoch,
+            base_committee.voting_rights.clone(),
+            HashMap::new(),
+            consensus_keys,
+            base_committee.quorum_threshold,
+            base_committee.validity_threshold,
+        ));
 
         let dir = tempfile::tempdir().unwrap();
         let epoch_start_configuration =
@@ -5713,25 +5678,6 @@ mod tests {
             IkaNetworkConfig::new_for_testing(),
         )
         .unwrap();
-
-        // Deterministic Ed25519 consensus keypairs (seeded — avoids the
-        // multiple-rand-version conflict that bites direct generate() in
-        // ika-core tests), one per validator, mapped to the committee names so
-        // the replay's signature re-verification accepts them.
-        let consensus_keypairs: Vec<Ed25519KeyPair> = (0..names.len())
-            .map(|i| {
-                let mut seed = [0u8; 32];
-                seed[0] = (i + 1) as u8;
-                Ed25519KeyPair::from(Ed25519PrivateKey::from_bytes(&seed).unwrap())
-            })
-            .collect();
-        let provider = StaticConsensusPubkeyProvider::from_iter(
-            names
-                .iter()
-                .zip(&consensus_keypairs)
-                .map(|(name, keypair)| (*name, keypair.public().clone())),
-        );
-        epoch_store.install_consensus_pubkey_provider(Box::new(provider));
 
         // Perpetual tables in their own tempdir, installed the way node startup
         // does — without this the replay-mint persist is a silent no-op.

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -2424,7 +2424,7 @@ impl DWalletMPCService {
         epoch_start_system: &EpochStartSystem,
         config: &NodeConfig,
     ) -> DwalletMPCResult<()> {
-        let authority_name = config.protocol_public_key();
+        let authority_name = config.authority_name();
         let Some(onchain_validator) = epoch_start_system
             .get_ika_validators()
             .into_iter()

--- a/crates/ika-core/src/handoff_cert.rs
+++ b/crates/ika-core/src/handoff_cert.rs
@@ -154,6 +154,15 @@ impl ConsensusPubkeyProvider for StaticConsensusPubkeyProvider {
     }
 }
 
+/// A `Committee` is itself a consensus-pubkey provider: it carries each
+/// member's consensus key, so handoff verification reads the keys straight
+/// from the committee it verifies against — no side channel to populate.
+impl ConsensusPubkeyProvider for Committee {
+    fn consensus_pubkey(&self, signer: &AuthorityName) -> Option<Ed25519PublicKey> {
+        self.consensus_key(signer).cloned()
+    }
+}
+
 /// Outcome of verifying a single `HandoffSignatureMessage`. Anything
 /// other than `Accept` is non-fatal — the caller drops the message
 /// and waits for the next one.

--- a/crates/ika-core/src/stake_aggregator.rs
+++ b/crates/ika-core/src/stake_aggregator.rs
@@ -433,6 +433,7 @@ mod quorum_after_bad_sig_eviction_tests {
             0,
             vec![(auth_high, 7), (auth_low, 3)],
             HashMap::new(),
+            /* consensus_keys */ HashMap::new(),
             /* quorum_threshold */ 7,
             /* validity_threshold */ 3,
         ));

--- a/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
+++ b/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
@@ -1,34 +1,28 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-//! Per-epoch task that installs a consensus-pubkey provider on the
-//! current `AuthorityPerEpochStore`, mapping each committee member's
+//! Per-epoch task that installs a `JoinerPubkeyProvider` on the current
+//! `AuthorityPerEpochStore`, mapping each next-epoch committee member's
 //! `AuthorityName` to its Ed25519 consensus pubkey (fetched from the
 //! members' on-chain `StakingPool.validator_info`).
 //!
-//! Two flavors share this machinery — they differ only in which
-//! committee they read and which provider slot they install into:
-//!
-//! - **Active committee** (`new_for_active_committee`): feeds
-//!   `ConsensusPubkeyProvider`, used by handoff-signature verification
-//!   (`process_handoff_signature`) to look up the current committee's
-//!   signers.
-//! - **Next-epoch committee** (`new_for_next_epoch_committee`): feeds
-//!   `JoinerPubkeyProvider`, used by the relay path
-//!   (`verify_joiner_announcement`) to verify a joiner's signature.
+//! It feeds `JoinerPubkeyProvider`, used by the relay path
+//! (`verify_joiner_announcement`) to verify a joiner's signature. Joiners
+//! aren't in the active committee yet, so — unlike handoff-signature
+//! verification, which reads consensus keys straight off the `Committee` —
+//! their keys can't come from the committee and need this side channel.
 //!
 //! The consensus pubkey is fixed at validator registration, but the
-//! *membership* (esp. the next-epoch committee) changes mid-epoch at
-//! reconfiguration, and the provider must reflect a newly-published
-//! next committee promptly — otherwise a joiner's relayed announcement
-//! is rejected as `UnregisteredJoiner` until the next poll. So the
-//! fetch cadence is modest (5s) and the task retries on transport
-//! failure rather than aborting. Without a provider installed, the
-//! corresponding verification drops every message (handoff sigs as
-//! `UnknownSigner`; relayed announcements as `UnregisteredJoiner`).
+//! next-epoch *membership* changes mid-epoch at reconfiguration, and the
+//! provider must reflect a newly-published next committee promptly —
+//! otherwise a joiner's relayed announcement is rejected as
+//! `UnregisteredJoiner` until the next poll. So the fetch cadence is
+//! modest (5s) and the task retries on transport failure rather than
+//! aborting. Without a provider installed, relayed announcements drop as
+//! `UnregisteredJoiner`.
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
-use crate::validator_metadata::{StaticConsensusPubkeyProvider, StaticJoinerPubkeyProvider};
+use crate::validator_metadata::StaticJoinerPubkeyProvider;
 use fastcrypto::ed25519::Ed25519PublicKey;
 use ika_sui_client::{SuiClient, SuiClientInner};
 use ika_types::committee::{Committee, EpochId, StakeUnit};
@@ -49,16 +43,6 @@ type MemberSelector = fn(&SystemInnerV1) -> Vec<ObjectID>;
 /// the epoch store, behind the appropriate provider slot.
 type ProviderInstaller = fn(&AuthorityPerEpochStore, Vec<(AuthorityName, Ed25519PublicKey)>);
 
-fn select_active_committee(system_inner: &SystemInnerV1) -> Vec<ObjectID> {
-    system_inner
-        .validator_set
-        .active_committee
-        .members
-        .iter()
-        .map(|m| m.validator_id)
-        .collect()
-}
-
 fn select_next_epoch_committee(system_inner: &SystemInnerV1) -> Vec<ObjectID> {
     system_inner
         .validator_set
@@ -68,57 +52,15 @@ fn select_next_epoch_committee(system_inner: &SystemInnerV1) -> Vec<ObjectID> {
         .unwrap_or_default()
 }
 
-/// Fetches the **previous** committee's `AuthorityName -> Ed25519
-/// consensus pubkey` pairs from chain.
-///
-/// Reads the prior-committee member ids from
-/// `validator_set.previous_committee` and resolves each member's
-/// `StakingPool.validator_info` by object id. Resolving by object id is
-/// what lets this recover signers that have *departed* the active set
-/// since they signed the handoff cert: their StakingPool object still
-/// exists on chain (only the active-committee membership dropped them),
-/// so a bootstrapping validator can verify their handoff signatures even
-/// though the current active-validator set no longer carries their keys.
-pub async fn fetch_previous_committee_consensus_pubkeys<C: SuiClientInner>(
-    sui_client: &SuiClient<C>,
-) -> anyhow::Result<Vec<(AuthorityName, Ed25519PublicKey)>> {
-    let (_, system_inner) = sui_client
-        .get_system_inner()
-        .await
-        .map_err(|e| anyhow::anyhow!("get_system_inner failed: {e}"))?;
-    let SystemInner::V1(system_inner) = system_inner;
-    let validator_ids: Vec<ObjectID> = system_inner
-        .validator_set
-        .previous_committee
-        .members
-        .iter()
-        .map(|m| m.validator_id)
-        .collect();
-    if validator_ids.is_empty() {
-        return Ok(Vec::new());
-    }
-    let staking_pools = sui_client.get_validators_info_by_ids(validator_ids).await?;
-    staking_pools
-        .iter()
-        .map(|pool| {
-            let verified = pool
-                .validator_info
-                .verify()
-                .map_err(|code| anyhow::anyhow!("validator info verify failed: code {code}"))?;
-            let name: AuthorityName = (&verified.protocol_pubkey).into();
-            Ok((name, verified.consensus_pubkey.clone()))
-        })
-        .collect()
-}
-
 /// Chain-reads the **previous** committee as a quorum-checkable
 /// `Committee`, for a joiner that never locally observed/persisted that
-/// epoch (so its `committee_store` has no entry for it). The source is
-/// `validator_set.previous_committee` — the same field
-/// `fetch_previous_committee_consensus_pubkeys` reads — and the membership
-/// is decoded with `read_bls_committee`. The class-groups / PVSS maps are
-/// left empty: handoff-cert verification (`verify_certified_handoff_attestation`)
-/// only needs membership, voting power, and the quorum threshold.
+/// epoch (so its `committee_store` has no entry for it). The membership
+/// is decoded with `read_bls_committee`; each member's consensus key is
+/// fetched and carried on the committee so its prior-epoch handoff
+/// signatures verify by name. The class-groups / PVSS maps are left empty:
+/// handoff-cert verification (`verify_certified_handoff_attestation`) only
+/// needs membership, voting power, the quorum threshold, and the consensus
+/// keys.
 ///
 /// `previous_committee` is implicitly the committee of `on_chain_epoch -
 /// 1`. This returns it **only** when that equals `expected_prior_epoch`,
@@ -143,14 +85,34 @@ pub async fn fetch_previous_committee<C: SuiClientInner>(
         );
     }
     let bls_committee = &system_inner.validator_set.previous_committee;
+    if bls_committee.members.is_empty() {
+        anyhow::bail!("validator_set.previous_committee is empty");
+    }
+    // Resolving by object id is what lets this recover signers that have
+    // *departed* the active set since they signed the handoff cert: their
+    // StakingPool object still exists on chain, so a bootstrapping
+    // validator can verify their handoff signatures even though the
+    // current active-validator set no longer carries their keys.
+    let validator_ids: Vec<ObjectID> = bls_committee
+        .members
+        .iter()
+        .map(|m| m.validator_id)
+        .collect();
+    let staking_pools = sui_client.get_validators_info_by_ids(validator_ids).await?;
+    let mut consensus_keys: HashMap<AuthorityName, Ed25519PublicKey> = HashMap::new();
+    for pool in &staking_pools {
+        let verified = pool
+            .validator_info
+            .verify()
+            .map_err(|code| anyhow::anyhow!("validator info verify failed: code {code}"))?;
+        let name: AuthorityName = (&verified.protocol_pubkey).into();
+        consensus_keys.insert(name, verified.consensus_pubkey.clone());
+    }
     let voting_rights: Vec<(AuthorityName, StakeUnit)> = system_inner
         .read_bls_committee(bls_committee)
         .into_iter()
         .map(|(_, (name, stake))| (name, stake))
         .collect();
-    if voting_rights.is_empty() {
-        anyhow::bail!("validator_set.previous_committee is empty");
-    }
     Ok(Committee::new(
         expected_prior_epoch,
         voting_rights,
@@ -158,18 +120,10 @@ pub async fn fetch_previous_committee<C: SuiClientInner>(
         // membership, voting power, and the quorum threshold. The off-chain
         // PVSS / VSS keys are not on `Committee` at all.
         HashMap::new(),
+        consensus_keys,
         bls_committee.quorum_threshold,
         bls_committee.validity_threshold,
     ))
-}
-
-fn install_consensus_provider(
-    epoch_store: &AuthorityPerEpochStore,
-    entries: Vec<(AuthorityName, Ed25519PublicKey)>,
-) {
-    epoch_store.install_consensus_pubkey_provider(Box::new(
-        StaticConsensusPubkeyProvider::from_iter(entries),
-    ));
 }
 
 fn install_joiner_provider(
@@ -197,23 +151,6 @@ impl<C> PubkeyProviderUpdater<C>
 where
     C: SuiClientInner + 'static,
 {
-    /// Installs a `ConsensusPubkeyProvider` from the current
-    /// (active) committee — for handoff-signature verification.
-    pub fn new_for_active_committee(
-        epoch_store: Weak<AuthorityPerEpochStore>,
-        epoch_id: EpochId,
-        sui_client: Arc<SuiClient<C>>,
-    ) -> Self {
-        Self::new(
-            epoch_store,
-            epoch_id,
-            sui_client,
-            select_active_committee,
-            install_consensus_provider,
-            "ConsensusPubkeyProvider (active committee)",
-        )
-    }
-
     /// Installs a `JoinerPubkeyProvider` from the next-epoch
     /// committee — for joiner-announcement relay verification.
     pub fn new_for_next_epoch_committee(
@@ -272,10 +209,9 @@ where
         }
         // Throttle the failure-path warn: a fullnode RPC outage would
         // otherwise repeat the identical line every poll tick for the
-        // outage's duration (two updater instances run per epoch). Warn
-        // on the first failure and every 12th thereafter (~1/minute at
-        // the 5s production cadence), debug in between, and log recovery
-        // once so the outage's end is visible.
+        // outage's duration. Warn on the first failure and every 12th
+        // thereafter (~1/minute at the 5s production cadence), debug in
+        // between, and log recovery once so the outage's end is visible.
         let mut consecutive_refresh_failures: u64 = 0;
         loop {
             // Exit once the epoch store this updater serves has been

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -657,6 +657,11 @@ where
                             .map(|(_, (name, stake))| (*name, *stake))
                             .collect(),
                         bundles.class_groups.clone(),
+                        // Empty: this assembled committee feeds only the
+                        // reconfiguration MPC input, which never reads consensus
+                        // keys. Handoff verification uses the epoch store's
+                        // committee (`get_ika_committee`), which carries them.
+                        HashMap::new(),
                         quorum_threshold,
                         validity_threshold,
                     );
@@ -803,6 +808,9 @@ where
                     .map(|(_, (name, stake))| (*name, *stake))
                     .collect(),
                 class_group_encryption_keys_and_proofs,
+                // Empty: the assembled committee feeds only the reconfiguration
+                // MPC input, which never reads consensus keys.
+                HashMap::new(),
                 quorum_threshold,
                 validity_threshold,
             ),

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -2033,6 +2033,8 @@ mod tests {
         let consensus_pubs: Vec<Ed25519PublicKey> =
             consensus_kps.iter().map(|kp| kp.public().clone()).collect();
         let voting_rights: Vec<(AuthorityName, u64)> = names.iter().map(|n| (*n, 1u64)).collect();
+        let consensus_keys: std::collections::HashMap<AuthorityName, Ed25519PublicKey> =
+            names.iter().copied().zip(consensus_pubs).collect();
         // quorum_threshold = 2f+1 over 3f+1; for size=4, f=1, q=3.
         let q = (2 * size / 3) as u64 + 1;
         let v = (size / 3) as u64 + 1;
@@ -2040,11 +2042,11 @@ mod tests {
             5,
             voting_rights,
             std::collections::HashMap::new(),
+            consensus_keys.clone(),
             q,
             v,
         ));
-        let provider =
-            StaticConsensusPubkeyProvider::from_iter(names.iter().copied().zip(consensus_pubs));
+        let provider = StaticConsensusPubkeyProvider::from_iter(consensus_keys);
         (committee, names, consensus_kps, provider)
     }
 
@@ -2137,6 +2139,7 @@ mod tests {
         let committee = Arc::new(Committee::new(
             5,
             voting_rights,
+            std::collections::HashMap::new(),
             std::collections::HashMap::new(),
             3,
             2,

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -708,7 +708,7 @@ impl IkaNode {
         let dwallet_mpc_metrics = DWalletMPCMetrics::new(&registry_service.default_registry());
 
         let epoch_store = AuthorityPerEpochStore::new(
-            config.protocol_public_key(),
+            config.authority_name(),
             committee_arc.clone(),
             &config.db_path().join("store"),
             Some(epoch_options.options),
@@ -2009,7 +2009,7 @@ impl IkaNode {
             Box::new(SubmitDWalletCheckpointToConsensus {
                 sender: consensus_adapter,
                 signer: state.secret.clone(),
-                authority: config.protocol_public_key(),
+                authority: config.authority_name(),
                 metrics: checkpoint_metrics.clone(),
             });
 
@@ -2065,7 +2065,7 @@ impl IkaNode {
             Box::new(SubmitSystemCheckpointToConsensus {
                 sender: consensus_adapter,
                 signer: state.secret.clone(),
-                authority: config.protocol_public_key(),
+                authority: config.authority_name(),
                 metrics: system_checkpoint_metrics.clone(),
             });
 
@@ -2302,16 +2302,11 @@ impl IkaNode {
                     BootstrapOutcome, BootstrapRetryConfig, CertVerifier, JoinerBootstrapVerifier,
                     P2pHandoffCertSource, warn_bootstrap_inputs_unavailable,
                 };
-                use ika_core::sui_connector::pubkey_provider_updater::{
-                    fetch_previous_committee, fetch_previous_committee_consensus_pubkeys,
-                };
+                use ika_core::sui_connector::pubkey_provider_updater::fetch_previous_committee;
                 use ika_core::validator_metadata::{
-                    StaticConsensusPubkeyProvider, next_committee_pubkey_set,
-                    verify_joiner_bootstrap_cert,
+                    next_committee_pubkey_set, verify_joiner_bootstrap_cert,
                 };
-                use ika_types::sui::epoch_start_system::{
-                    EpochStartSystemTrait, EpochStartValidatorInfoTrait,
-                };
+                use ika_types::sui::epoch_start_system::EpochStartSystemTrait;
                 let current_epoch = cur_epoch_store.epoch();
                 let prior_epoch = current_epoch - 1;
                 let self_name = cur_epoch_store.name;
@@ -2369,17 +2364,6 @@ impl IkaNode {
                 match prior_committee {
                     Some(prior_committee) => {
                         let is_joiner = !prior_committee.authority_exists(&self_name);
-                        // Consensus pubkeys are fixed at registration, so
-                        // the current epoch's active-validator set supplies
-                        // the continuing prior-committee signers' keys.
-                        // Members that have since departed the active set
-                        // are resolved from chain inside the task below.
-                        let current_consensus_pubkeys: Vec<_> = cur_epoch_store
-                            .epoch_start_state()
-                            .get_ika_validators()
-                            .into_iter()
-                            .map(|v| (v.authority_name(), v.get_consensus_pubkey()))
-                            .collect();
                         let expected_next = next_committee_pubkey_set(cur_epoch_store.committee());
                         let peer_ids: Vec<anemo::PeerId> = cur_epoch_store
                             .epoch_start_state()
@@ -2408,40 +2392,21 @@ impl IkaNode {
                         let fetch_store = cur_epoch_store.clone();
                         let cert_perpetual = perpetual.clone();
                         let fail_closed_shutdown = self.shutdown_channel_tx.clone();
-                        let bootstrap_sui_client = sui_client.clone();
                         let bootstrap_outcomes =
                             self.metrics.joiner_bootstrap_outcomes_total.clone();
                         Some(tokio::spawn(async move {
-                            // Resolve the prior committee's consensus
-                            // pubkeys for cert verification. Continuing
-                            // members come from the current active set
-                            // (already in hand); members that departed the
-                            // active set since signing are chain-read by
-                            // object id (their StakingPool persists), so a
-                            // valid cert isn't wrongly Rejected under churn.
-                            // Best-effort: on RPC failure proceed with the
-                            // current set and let the retry loop re-attempt.
-                            let mut consensus_pubkeys = current_consensus_pubkeys;
-                            match fetch_previous_committee_consensus_pubkeys(&bootstrap_sui_client)
-                                .await
-                            {
-                                Ok(prior) => consensus_pubkeys.extend(prior),
-                                Err(e) => warn!(
-                                    error = ?e,
-                                    prior_epoch,
-                                    "failed to chain-read prior-committee consensus pubkeys; \
-                                     proceeding with the current active set only"
-                                ),
-                            }
-                            let provider = Arc::new(StaticConsensusPubkeyProvider::from_iter(
-                                consensus_pubkeys,
-                            ));
+                            // The prior committee carries every member's
+                            // consensus key — continuing members and ones
+                            // that departed the active set since signing
+                            // (chain-read by object id when the committee was
+                            // built) — so it serves as the cert verifier's
+                            // consensus-pubkey provider directly.
                             let verify: CertVerifier = Arc::new(move |cert| {
                                 verify_joiner_bootstrap_cert(
                                     cert,
                                     prior_epoch,
                                     &prior_committee,
-                                    provider.as_ref(),
+                                    prior_committee.as_ref(),
                                     expected_next.iter().copied(),
                                 )
                             });
@@ -2674,25 +2639,6 @@ impl IkaNode {
                 }
             }
 
-            // Installs a `ConsensusPubkeyProvider` from the current
-            // committee's on-chain `consensus_pubkey_bytes` so the
-            // per-epoch store can verify incoming
-            // `HandoffSignatureMessage`s (otherwise every one drops
-            // as `UnknownSigner`).
-            let consensus_pubkey_updater_handle = if off_chain_metadata_enabled {
-                let updater = ika_core::sui_connector::pubkey_provider_updater::PubkeyProviderUpdater::new_for_active_committee(
-                        Arc::downgrade(&cur_epoch_store),
-                        cur_epoch_store.epoch(),
-                        sui_client.clone(),
-                    );
-                let updater = Arc::new(updater);
-                Some(tokio::spawn(async move {
-                    updater.run().await;
-                }))
-            } else {
-                None
-            };
-
             let stop_condition = self
                 .sui_connector_service
                 .run_epoch(cur_epoch_store.epoch(), run_with_range)
@@ -2735,10 +2681,6 @@ impl IkaNode {
                 Some(())
             });
             joiner_bootstrap_handle.map(|handle| {
-                handle.abort();
-                Some(())
-            });
-            consensus_pubkey_updater_handle.map(|handle| {
                 handle.abort();
                 Some(())
             });
@@ -3054,11 +2996,9 @@ impl IkaNode {
             P2pHandoffCertSource,
         };
         use ika_core::validator_metadata::{
-            StaticConsensusPubkeyProvider, next_committee_pubkey_set, verify_joiner_bootstrap_cert,
+            next_committee_pubkey_set, verify_joiner_bootstrap_cert,
         };
-        use ika_types::sui::epoch_start_system::{
-            EpochStartSystemTrait, EpochStartValidatorInfoTrait,
-        };
+        use ika_types::sui::epoch_start_system::EpochStartSystemTrait;
 
         // Build the verification closure FIRST so it can re-verify a
         // persisted cert as well as back the fetch path. The signing
@@ -3067,12 +3007,6 @@ impl IkaNode {
         // committee. Its members' consensus pubkeys are fixed at
         // registration and are in the current active validator set.
         let signing_committee = cur_epoch_store.committee().as_ref().clone();
-        let consensus_pubkeys: Vec<_> = cur_epoch_store
-            .epoch_start_state()
-            .get_ika_validators()
-            .into_iter()
-            .map(|v| (v.authority_name(), v.get_consensus_pubkey()))
-            .collect();
         // The cert pins the hash of the committee being handed into —
         // the epoch we are entering, whose committee is `new_epoch_store`'s.
         let expected_next = next_committee_pubkey_set(new_epoch_store.committee());
@@ -3082,13 +3016,14 @@ impl IkaNode {
             .into_values()
             .collect();
 
-        let provider = Arc::new(StaticConsensusPubkeyProvider::from_iter(consensus_pubkeys));
+        // The signing committee carries its members' consensus keys, so it
+        // serves as the cert verifier's consensus-pubkey provider directly.
         let verify: CertVerifier = Arc::new(move |cert| {
             verify_joiner_bootstrap_cert(
                 cert,
                 anchor_epoch,
                 &signing_committee,
-                provider.as_ref(),
+                &signing_committee,
                 expected_next.iter().copied(),
             )
         });
@@ -3537,7 +3472,7 @@ fn send_trusted_peer_change(
 ) -> Result<(), watch::error::SendError<TrustedPeerChangeEvent>> {
     sender
         .send(TrustedPeerChangeEvent {
-            new_peers: epoch_state_state.get_validator_as_p2p_peers(config.protocol_public_key()),
+            new_peers: epoch_state_state.get_validator_as_p2p_peers(config.authority_name()),
         })
         .tap_err(|err| {
             warn!(

--- a/crates/ika-test-cluster/tests/joiner.rs
+++ b/crates/ika-test-cluster/tests/joiner.rs
@@ -123,7 +123,6 @@ async fn test_joiner_lands_in_next_committee_class_groups() {
         .add_joiner_validator()
         .await
         .expect("add_joiner_validator failed");
-    let joiner_name = joiner.authority_name();
 
     cluster.wait_for_epoch(2).await;
     // Fail fast instead of hanging: an excluded joiner never enters the
@@ -139,6 +138,8 @@ async fn test_joiner_lands_in_next_committee_class_groups() {
         "joiner did not reach epoch 2 within 60s of the cluster — \
          likely excluded from the freeze (its mpc_data never propagated)",
     );
+
+    let joiner_name = joiner.authority_name();
 
     // Read the epoch-2 committee from the joiner's own node and assert
     // its class-groups material is present — i.e. the freeze captured

--- a/crates/ika-types/src/committee.rs
+++ b/crates/ika-types/src/committee.rs
@@ -88,7 +88,20 @@ pub struct Committee {
         HashMap<AuthorityName, ClassGroupsEncryptionKeyAndProof>,
     pub quorum_threshold: u64,
     pub validity_threshold: u64,
+    /// `AuthorityName -> BLS protocol pubkey`, for BLS aggregate-certificate
+    /// verification. The name is the BLS key, so this is decoded from it (a
+    /// cache).
+    // TODO(consensus-key-certs): once the network is fully on v4 and BLS
+    // aggregate certs are replaced by consensus-key-signed certs, drop
+    // `expanded_keys` / `public_key()` and the validators' BLS key entirely —
+    // `AuthorityName` can then become the consensus key.
     expanded_keys: HashMap<AuthorityName, AuthorityPublicKey>,
+    /// `AuthorityName -> consensus Ed25519 pubkey`, for verifying
+    /// consensus-key-signed messages (handoff certs today, more certs later).
+    /// Supplied at construction from chain — the BLS-derived name can't
+    /// recover it. May be empty for committees that never verify such
+    /// messages (e.g. legacy/test committees).
+    consensus_keys: HashMap<AuthorityName, NetworkPublicKey>,
     /// AuthorityName -> to PartyID (from 0).
     index_map: HashMap<AuthorityName, usize>,
 }
@@ -101,6 +114,7 @@ impl Committee {
             AuthorityName,
             ClassGroupsEncryptionKeyAndProof,
         >,
+        consensus_keys: HashMap<AuthorityName, NetworkPublicKey>,
         quorum_threshold: u64,
         validity_threshold: u64,
     ) -> Self {
@@ -114,6 +128,7 @@ impl Committee {
             voting_rights,
             class_groups_public_keys_and_proofs,
             expanded_keys,
+            consensus_keys,
             index_map,
             quorum_threshold,
             validity_threshold,
@@ -149,12 +164,17 @@ impl Committee {
             epoch,
             voting_weights.into_iter().collect(),
             HashMap::new(),
+            HashMap::new(),
             quorum_threshold,
             validity_threshold,
         )
     }
 
     // We call this if these have not yet been computed
+    /// Builds the `expanded_keys` (`AuthorityName -> BLS protocol pubkey`,
+    /// for aggregate-cert verification) and `index_map`
+    /// (`AuthorityName -> position`) caches. The name IS the BLS key, so
+    /// `expanded_keys` is decoded directly from `voting_rights`.
     pub fn load_inner(
         voting_rights: &[(AuthorityName, StakeUnit)],
     ) -> (
@@ -203,6 +223,14 @@ impl Committee {
                 self.expanded_keys.len()
             ))),
         }
+    }
+
+    /// The signer's consensus Ed25519 pubkey, if this committee carries it.
+    /// Used to verify consensus-key-signed messages (handoff certs today).
+    /// `None` means the committee wasn't built with this signer's consensus
+    /// key, so the caller treats the signature as unverifiable and drops it.
+    pub fn consensus_key(&self, authority: &AuthorityName) -> Option<&NetworkPublicKey> {
+        self.consensus_keys.get(authority)
     }
 
     /// Return a `HashMap` from **1-based** `PartyID` to `AuthorityName`.

--- a/crates/ika-types/src/sui/epoch_start_system.rs
+++ b/crates/ika-types/src/sui/epoch_start_system.rs
@@ -13,7 +13,6 @@ use anemo::PeerId;
 use anemo::types::{PeerAffinity, PeerInfo};
 use consensus_config::{Authority, Committee as ConsensusCommittee};
 use dwallet_mpc_types::dwallet_mpc::{MPCDataTrait, VersionedMPCData};
-use fastcrypto::traits::ToFromBytes;
 use ika_protocol_config::ProtocolVersion;
 use serde::{Deserialize, Serialize};
 use sui_types::base_types::{EpochId, ObjectID};
@@ -204,10 +203,25 @@ impl EpochStartSystemTrait for EpochStartSystemV1 {
             })
             .collect();
 
+        // The name is the BLS-derived label; carry each validator's consensus
+        // Ed25519 key as committee data so consensus-key-signed messages
+        // (handoff certs) can be verified by name without a side provider.
+        let consensus_keys = self
+            .active_validators
+            .iter()
+            .map(|validator| {
+                (
+                    validator.authority_name(),
+                    validator.consensus_pubkey.clone(),
+                )
+            })
+            .collect();
+
         Committee::new(
             self.epoch,
             voting_rights,
             class_groups_public_keys_and_proofs,
+            consensus_keys,
             self.quorum_threshold,
             self.validity_threshold,
         )
@@ -218,12 +232,12 @@ impl EpochStartSystemTrait for EpochStartSystemV1 {
         let mut authorities = vec![];
         for (i, (name, stake)) in ika_committee.members().enumerate() {
             let active_validator = &self.active_validators[i];
-            if name.0 != active_validator.protocol_pubkey.as_bytes() {
+            if *name != active_validator.authority_name() {
                 error!(
                     "Mismatched authority order between Ika and Mysticeti! Index {}, Mysticeti authority {:?}\nIka authority name {:?}",
                     i,
                     name,
-                    active_validator.protocol_pubkey.as_bytes()
+                    active_validator.authority_name()
                 );
             }
             authorities.push(Authority {

--- a/dev-docs/plans/authority-name-consensus-key.md
+++ b/dev-docs/plans/authority-name-consensus-key.md
@@ -1,0 +1,375 @@
+# Plan: consensus keys reachable by name (toward consensus-key-signed certs)
+
+**SHIPPED DESIGN: consensus keys are carried as `Committee` data; the
+identity (`AuthorityName`) stays the BLS key.** Jump to the
+[Redesign](#redesign-consensus-keys-are-committee-data-not-the-identity)
+section for what actually landed. Everything before it documents the
+*rejected* first approach — making `AuthorityName` itself the consensus key
+(a v4-gated flip) — and **why it was abandoned** (it wedged the v3→v4 rolling
+upgrade). Kept as design rationale for the next person who asks "why not just
+make `AuthorityName` the consensus key?"
+
+Branch: `feat/authority-name-consensus-key`.
+
+## Rejected approach (below): `AuthorityName` = consensus key, gated at v4
+
+## Goal
+
+Make a validator's `AuthorityName` (its canonical identity, used as the
+key for committees, MPC, handoff, checkpoints) be its **consensus
+Ed25519 public key** instead of its **BLS12381 protocol key**, gated by a
+protocol-config flag so the behavior turns on at protocol version 4.
+v4 is still pre-mainnet, so there is no live v4 state to preserve; but
+mainnet still crosses v3→v4 live when v4 ships, and both keys are on
+chain for every validator, so any boundary mapping is constructible.
+
+Today: `pub type AuthorityName = AuthorityPublicKeyBytes` — the BLS key,
+a `Copy` `[u8; 48]` newtype (`crates/ika-types/src/crypto.rs:66`, `:141`,
+`:154`). The Ed25519 consensus key (`NetworkPublicKey`, 32 bytes) already
+exists separately per validator (committee.rs:459;
+`epoch_start_system` `consensus_pubkey`).
+
+## Design decision: keep the fixed-size container; gate the *value*
+
+**Keep `AuthorityName = AuthorityPublicKeyBytes` (the 48-byte container).
+Under v4 it HOLDS the Ed25519 consensus key (32 bytes, zero-padded to
+48).** A runtime protocol flag cannot change a compile-time type, and one
+binary must speak both v3 (BLS-name) and v4 (Ed25519-name) during the
+rolling upgrade — a 48-byte container holds either and keeps the BCS wire
+format byte-identical (so the ~268 map-key sites, which treat the bytes
+as opaque identity, and all persisted/serialized names, are untouched).
+
+Alternatives considered and rejected:
+- **`AuthorityName = Vec<u8>`** (size-honest, BCS-variable-length): loses
+  `Copy`. `AuthorityName` is a `Copy` identity used by-value across
+  hundreds of sites and as a hash-map key on consensus/MPC hot paths;
+  `Vec<u8>` forces `.clone()` everywhere + a heap allocation per name, and
+  changes the BCS encoding for everyone (fixed 48 raw bytes →
+  ULEB-length-prefixed), breaking reads of v3-persisted data. Too costly.
+- **`enum { Bls([u8;48]), Consensus([u8;32]) }`** (stays `Copy`,
+  size-honest): also changes the BCS wire format (adds a variant tag) and
+  forces match-on-variant churn at every byte-access site.
+- **New 32-byte type:** cleanest end state, but not runtime-gatable (the
+  type is fixed at compile time) and breaks deserialization of
+  v3-persisted 48-byte names.
+
+Encoding under v4: store the 32 Ed25519 bytes canonically (first 32 bytes
+= key, last 16 = zero), enforced at construction so equality/hashing are
+consistent. The Ed25519 key is then recoverable from the name (take the
+first 32 bytes) — symmetric to how v3 recovers the BLS key from the name.
+
+## Risk map (where the BLS→Ed25519 basis is load-bearing)
+
+The 395 references are mostly noise — `AuthorityName` is used as opaque
+identity (map keys, message fields) almost everywhere, and those don't
+care about the basis. The few places that DO:
+
+### Consensus messages — basis-agnostic, NOT a problem
+Each consensus message carries a self-declared `authority: AuthorityName`
+(messages_consensus.rs:260). It is authenticated by checking that name
+equals `committee.authority_by_index(block_author)` (committee.rs:203) — a
+**positional** lookup into `voting_rights`; there is no payload signature
+to check, because the consensus layer already authenticated the block
+author via the **Ed25519 consensus key** (authority_per_epoch_store.rs:1971).
+So attribution is name-equality + index lookup; it works identically
+whether the name is BLS or Ed25519. Making the name the consensus key
+makes this *more* aligned, not less.
+
+### The actual break: BLS aggregate-signature verification
+The one place `AuthorityName` is consumed AS a BLS key. The decode is
+`TryFrom<AuthorityPublicKeyBytes> for AuthorityPublicKey`
+(crypto.rs:218), funneled through:
+- `Committee::load_inner` builds `expanded_keys: AuthorityName -> BLS pubkey`
+  by decoding each name (committee.rs:179-189),
+- `Committee::public_key()` reads it (committee.rs:211),
+- aggregate cert verification pushes `committee.public_key(authority)`
+  into the BLS `batch_verify` (crypto.rs:462 and :657) — checkpoint /
+  strong-quorum certs.
+
+Ed25519 bytes can't decode to a BLS key, so this is what breaks. `bls_checkpoints`
+is ON at v4, so BLS aggregate verification MUST keep working.
+**Fix (contained):** under v4, populate `expanded_keys` from a *separate*
+`AuthorityName -> BLS pubkey` map supplied by the on-chain read (which has
+both keys), instead of decoding the name. Every `public_key()` call site
+then works unchanged.
+
+### Name derivation from chain
+`read_bls_committee` (system_inner_v1.rs:~235) and
+`epoch_start_system::authority_name` (epoch_start_system.rs:166) derive
+the name from the BLS protocol pubkey. Under v4, derive it from the
+consensus key and populate the separate BLS map alongside.
+
+### Direct decode site
+`crypto.rs:326` (`AuthorityPublicKey::try_from(author)`) decodes a name to
+BLS in a verification path — route it through the committee BLS map under
+v4 (or gate it).
+
+### Proof-of-possession — unchanged
+BLS-signed, validated on chain (crypto.rs:74-107); it binds the Sui
+address to the BLS key and is independent of the name basis. Stays BLS.
+
+### Ordering — LOW risk under protocol gating; one rule
+Positional invariants depend on `voting_rights` order matching the
+consensus `AuthorityIndex` order: the consensus attribution above AND the
+MPC party-id derivation (`authority_index` into `voting_rights`). **Because
+the change is protocol-config-gated, every v4 validator derives the name
+identically, so ordering cannot diverge *between* validators.** And the
+basis change does not reorder `voting_rights` by itself — its order is
+on-chain position (read_bls_committee iterates the on-chain committee),
+not a sort on the name. The single rule: **do not introduce a
+name-derived sort of `voting_rights`** (it would stay consistent across
+validators but could desync from the consensus `AuthorityIndex` order).
+Audit `CommitteeWithNetworkMetadata` (committee.rs:475), which holds a
+`BTreeMap<AuthorityName, …>` (name-sorted) — confirm nothing derives
+consensus/party ordering from it; it should be network-metadata lookup
+only.
+
+## Implementation outline
+
+1. Protocol flag `consensus_key_authority_name` (name TBD) in
+   `crates/ika-protocol-config/src/lib.rs`, set true at version 4
+   (alongside the existing v4 flags).
+2. Committee carries an explicit `AuthorityName -> BLS pubkey` map. Under
+   v4, `load_inner`/construction populates `expanded_keys` from it instead
+   of decoding the name. Plumb the BLS keys in from the on-chain read.
+3. `read_bls_committee` / `epoch_start_system::authority_name`: derive the
+   name from the consensus key under v4; supply the BLS map.
+4. Gate the direct decode (crypto.rs:326) and any other
+   `AuthorityPublicKey::try_from(name)` sites found in the audit.
+5. Leave proof-of-possession, map-key uses, and consensus message
+   attribution untouched.
+
+Audit before coding: grep every `AuthorityPublicKey::try_from` /
+`::from_bytes` applied to a name, and every place that assumes the name's
+48-byte BLS shape, and confirm each is either gated or basis-agnostic.
+
+## Direction: first step toward consensus-key-signed certs
+
+This change is **step 1 of an arc** that ends with checkpoint / quorum
+certs signed by each validator's consensus Ed25519 key — a per-signer
+list, exactly like the handoff cert already does — instead of a BLS
+aggregate signature, and eventually dropping the BLS protocol key.
+
+What that means for THIS step:
+- It does the **identity** change only: `AuthorityName` becomes the
+  consensus key, gated at v4. Current BLS aggregate certs keep working.
+- The committee's separate `AuthorityName -> BLS pubkey` map (the
+  contained fix above) is a **deliberate temporary bridge** — it lets the
+  identity move to the consensus key while existing BLS certs keep
+  verifying. The follow-up cert migration removes the BLS path (and the
+  map) for the cert types it migrates.
+- Design accordingly: don't entrench *new* BLS-from-name assumptions, and
+  keep all cert verification flowing through `committee.public_key()`
+  (already the case) so swapping it for per-signer Ed25519 verification
+  later stays localized.
+
+Sequencing note (not a blocker): the cert migration does **not** strictly
+depend on this identity change — the handoff already produces
+consensus-key-signed certs while `AuthorityName` is still BLS
+(`handoff_cert.rs`; signatures use the Ed25519 consensus key). So the two
+are loosely coupled. Changing `AuthorityName` first is an alignment /
+simplification step (identity == the key that signs), worthwhile mainly
+because the end state drops BLS entirely; the cert migration could also
+proceed in parallel.
+
+## Test plan
+
+- Unit: committee construction under the flag (BLS map populated; name =
+  consensus key); `public_key()` returns the right BLS key under v4.
+- Cluster: a v4 network boots, reconfigures, and signs (checkpoint BLS
+  certs verify) with consensus-key names; the `protocol_version_transition`
+  v3→v4 path still advances.
+
+## Foundation review: refinements (after the inert foundation landed)
+
+An adversarial review of the inert foundation (the protocol flag + the
+committee BLS-map plumbing) confirmed the foundation is correct and
+validated several risk-map claims, and corrected/expanded the
+next-step site list.
+
+Validated:
+- Grace-rounds version-gating is safe — every read of
+  `end_of_publish_grace_rounds` / `mpc_data_freeze_grace_rounds` is
+  reachable only at v4 (the four sites in the EOP-close / freeze blocks).
+- `new_with_protocol_keys` is inert (zero callers); `index_map` is
+  identical across both `load_inner` paths.
+- `expanded_keys` IS serialized (no `#[serde(skip)]`, no custom
+  `Deserialize`), so the explicit BLS map survives serialization
+  round-trips — no v4 deserialize-rebuild hazard.
+- Consensus message attribution is positional (`authority_by_index`),
+  name-agnostic; `voting_rights` and the consensus committee share
+  on-chain order; `CommitteeWithNetworkMetadata` is not used for
+  ordering. Handoff / joiner signature verification already uses Ed25519
+  consensus keys via a name-keyed `ConsensusPubkeyProvider` (the
+  v4-correct pattern).
+- `staking.rs` `from_bytes` decodes the genuine BLS field, not the name.
+
+Correction to step 3 — `read_bls_committee` has NO consensus key.
+`read_bls_committee` (system_inner_v1.rs:260) iterates
+`bls_committee.members`, which carry `validator_id` + `protocol_pubkey`
+(BLS) only — the consensus Ed25519 key is NOT in `BlsCommittee`. So the
+consensus-key name CANNOT be derived there. The consensus key IS
+available one level up at `EpochStartValidatorInfoV1` (it has both
+`protocol_pubkey` and `consensus_pubkey`), so under v4 the name must be
+derived at the `epoch_start_system` level (which also builds the BLS map
+for `new_with_protocol_keys`), and `read_bls_committee` must either be
+fed the consensus key (a `validator_id -> consensus_pubkey` lookup) or be
+bypassed for committee construction under v4.
+
+Additional sites the next step must gate (beyond the original risk map):
+- `EpochStartValidatorInfoV1::authority_name()` (epoch_start_system.rs:369)
+  is a NO-ARG trait method — it structurally can't see the protocol
+  version, so the flag/version must be threaded into the name-derivation
+  path (or the basis decided by a caller that has it).
+- `NodeConfig::protocol_public_key()` (ika-config/src/node.rs:379, used at
+  ika-node/src/lib.rs:441/494/1472/1528/2968) defines the node's OWN
+  `AuthorityName` at startup as its BLS key — must flip under v4.
+- `get_consensus_committee` (epoch_start_system.rs:245) builds the
+  Mysticeti committee assuming `name == protocol_pubkey`; under v4 that
+  equality breaks (would log an error every epoch) — gate it.
+- `IkaAuthoritySignature::verify_secure` → `AuthorityPublicKey::try_from(author)`
+  (crypto.rs:326) is a second name→BLS decode path; it has no production
+  caller today, but gate or remove it so it can't be reached with a
+  consensus-key name.
+- The single decode primitive every name→BLS site funnels through is
+  `TryFrom<AuthorityPublicKeyBytes> for AuthorityPublicKey` (crypto.rs:218);
+  it is only safe when fed real BLS bytes.
+
+## read_bls_committee path (the remaining flip)
+
+`read_bls_committee` (system_inner_v1.rs:260) is sync and operates on a
+`BlsCommittee`, whose members carry only `validator_id` + BLS
+`protocol_pubkey` — no consensus key. The consensus key per `validator_id`
+is fetched from chain via `SuiClient::get_validators_info_by_ids`
+(async; each result has `consensus_pubkey`). The model already exists:
+`pubkey_provider_updater::fetch_previous_committee_consensus_pubkeys`.
+
+So the flip lives in the (async) callers, not in sync
+`read_bls_committee`:
+- `sui_syncer` builds the next-epoch committee at `read_bls_committee`
+  (:364) and constructs `Committee` at :555 (off-chain assembly) and :700
+  (chain path). Under v4: fetch `validator_id -> consensus_pubkey` for the
+  `BlsCommittee` members, derive consensus-key names
+  (`authority_name_from_consensus_key`), build the `name -> BLS pubkey`
+  map (BLS = the member's `protocol_pubkey`), and construct via
+  `Committee::new_with_protocol_keys`.
+- `pubkey_provider_updater::fetch_previous_committee` (:128) already has
+  the consensus-key fetch available; derive consensus-key names + the BLS
+  map and use `new_with_protocol_keys` (it currently `Committee::new`s
+  with empty crypto maps for handoff-cert verification).
+
+A shared async helper `(bls_committee, sui_client, consensus_key_identity)
+-> (voting_rights, Option<protocol_keys>)` keeps the two callers
+consistent (BLS names + `None` under v3; consensus-key names + the map
+under v4).
+
+## Status: flip complete (all name-minting sites)
+
+Every live site that mints or consumes `AuthorityName` now threads the
+`consensus_key_authority_name` flag:
+
+- `epoch_start_system` committee/peer/hostname builders + the
+  consensus-order check; `EpochStartValidatorInfoTrait::authority_name`
+  branches on the flag.
+- `node.rs::authority_name` and every `ika-node` self-identity site
+  (epoch-store name, network identity, both checkpoint submitters, p2p
+  self-exclusion) use `config.authority_name(flag)`.
+- `dwallet_mpc_service::verify_validator_keys`.
+- `pubkey_provider_updater`: `refresh` + `fetch_previous_committee_consensus_pubkeys`
+  (provider maps) via a shared `validator_authority_name` helper;
+  `fetch_previous_committee` (handoff-cert committee) via a v4 branch with
+  `Committee::new_with_protocol_keys`.
+- `sui_syncer`: `rekey_committee_by_consensus` re-keys the next-epoch
+  committee by consensus key (fetching validator infos in committee order,
+  length-checked) and threads the BLS map into both committee-build sites.
+- `ika-test-cluster::JoinerHandle::authority_name` takes the flag; the
+  joiner test derives it from the live committee's protocol config.
+
+Intentionally left BLS (not wedges): `lib.rs` startup log (cosmetic, flag
+unavailable there); `VerifiedValidatorInfo::ika_pubkey_bytes` (no callers,
+dead); `crypto.rs::verify_secure` decode (no production caller).
+
+### Validation: genesis runs at v4
+
+`InitiationParameters::default_protocol_version() == ProtocolVersion::MAX
+== 4`, so a fresh cluster genesis at protocol version 4 — every default
+cluster/integration test already exercises `consensus_key_authority_name
+== true` end-to-end (reconfiguration, handoff-cert verification, off-chain
+committee assembly, joiner freeze). No v4-specific test is needed; the
+existing cluster suite IS the v4 validation, and this completed flip is the
+first point where it is internally consistent enough to pass.
+
+Build/lint/unit all green: full workspace `cargo build --release`, clippy
+on the touched crates (no new warnings), `ika-protocol-config` snapshots,
+`ika-types` unit tests. Cluster-suite validation pending.
+
+## SUPERSEDED — the flip wedged the v3→v4 upgrade; redesign below
+
+Everything above describes the *flip* approach (make `AuthorityName` BE the
+consensus key at v4). The full cluster suite found it wedges the rolling
+v3→v4 upgrade: `test_protocol_version_gradual_upgrade_v3_to_v4` was the only
+failure (14/15 passed). When the protocol version crosses to v4 the name's
+basis flips BLS→consensus *mid-upgrade*, and the two committee builders
+disagree:
+
+- producing side (`sui_syncer`) keys the next committee's basis on the
+  CURRENT epoch's version — epoch N is v3 → BLS names for the epoch-N+1
+  committee;
+- consuming side (`get_ika_committee`) keys on the epoch's OWN version —
+  epoch N+1 is v4 → consensus names.
+
+So the epoch-N+1 committee assembled in epoch N doesn't match the one epoch
+N+1 builds for itself, and reconfiguration into the new epoch can't converge.
+The naive fix (assemble with `next_protocol_version`) doesn't work either:
+`next_protocol_version` is only visible on-chain *after* the off-chain
+mpc-data freeze pins the committee, so the producing side can't look ahead.
+
+### Redesign: consensus keys are Committee *data*, not the identity
+
+`AuthorityName` stays the stable BLS-derived label — it never flips, so there
+is no cross-boundary disagreement to begin with. The consensus key rides along
+as committee data:
+
+- `Committee` carries a `consensus_keys` (`AuthorityName -> Ed25519`) map
+  alongside `expanded_keys` (the BLS map, still decoded from the name), with a
+  `consensus_key()` accessor and `impl ConsensusPubkeyProvider for Committee`.
+  `new()` takes the map; `new_with_protocol_keys` is gone.
+- Build sites populate it: `get_ika_committee` and `sui_syncer` from validator
+  info, `fetch_previous_committee` from chain.
+- Handoff verification reads consensus keys from the relevant `Committee` (the
+  epoch store's current committee for live signatures; the chain-read prior
+  committee for joiner bootstrap). The async `ConsensusPubkeyProvider` side
+  channel — epoch-store field, `install_consensus_pubkey_provider`, the
+  active-committee `PubkeyProviderUpdater`, and its restart race — is removed.
+  The `JoinerPubkeyProvider` updater stays (joiners aren't committee members
+  yet, so their keys can't come from a committee).
+- The `consensus_key_authority_name` protocol flag and the consensus-key name
+  codec are removed.
+
+This is ~500 fewer lines than the flip and has no transition wedge. It does
+NOT migrate the identity off BLS — `AuthorityName` is still BLS-derived — so
+dropping the BLS key entirely is a separate future step (TODO left on
+`Committee::expanded_keys`/`public_key()`). For the stated goal
+(consensus-key-signed certs) the key only needs to be *reachable by name*,
+which it now is.
+
+Validated: `test_swarm_reaches_epoch_2` (steady-state v4 reconfig) passes;
+76 handoff/freeze unit tests + committee/handoff units + snapshots green;
+full workspace builds, no new clippy. Local cluster tests are ~9 min per
+single reconfiguration, so the v3→v4 transition is validated on CI.
+
+### One regression found and fixed: the assembled-committee consensus-key fetch
+
+The first CI run wedged `test_protocol_version_gradual_upgrade_v3_to_v4`
+(14/15 passed; it passes on `dev` in 432s, so the wedge was a regression, not
+the AuthorityName change). Cause: to populate `consensus_keys` on the
+*sui_syncer-assembled next committee*, the assembly fetched each member's
+consensus key from chain every tick. But that committee feeds only the
+reconfiguration MPC input (`session_input_from_request`), which never reads
+consensus keys — so the fetch was dead data, and its `continue`-on-error
+blocked the next-committee send during the upgrade's validator restarts
+(`get_validators_info_by_ids` / the length-check transiently fail mid-restart)
+→ reconfiguration wedged. Fix: drop the fetch, pass an empty map to the
+assembled committee. Only the committees that actually verify consensus-key
+signatures — `get_ika_committee` (active) and `fetch_previous_committee`
+(prior) — populate `consensus_keys`. Transition test then passes (418s).


### PR DESCRIPTION
## What

First step toward **consensus-key-signed certs** (eventually replacing BLS aggregate certs with per-signer Ed25519, like the handoff cert already does). A consensus key only needs to be reachable *by name*, not *be* the name — so instead of changing validator identity, this carries the key as `Committee` data.

- `Committee` gains a `consensus_keys` (`AuthorityName -> Ed25519`) map, a `consensus_key()` accessor, and `impl ConsensusPubkeyProvider for Committee`. **`AuthorityName` stays the stable BLS-derived label.**
- Populated from validator info at the committees that actually verify consensus-key signatures: `get_ika_committee` (active) and `fetch_previous_committee` (chain-read prior, for joiner bootstrap). The sui_syncer-assembled next committee leaves it empty — it feeds only the reconfiguration MPC input, which never reads consensus keys.
- Handoff verification reads consensus keys straight off the relevant `Committee` (current committee for live signatures; prior committee for bootstrap), **removing the async `ConsensusPubkeyProvider` side channel** — the epoch-store field, install path, the active-committee `PubkeyProviderUpdater`, and its restart race. The next-epoch `JoinerPubkeyProvider` stays (joiners aren't committee members yet).
- Version-gate `end_of_publish_grace_rounds` / `mpc_data_freeze_grace_rounds` to the v4 block (read only under `off_chain_validator_metadata`).

Net **~500 fewer lines** than the side-channel approach.

## Why not make `AuthorityName` itself the consensus key?

That was the first approach (a v4-gated identity flip). It **wedges the v3→v4 rolling upgrade**: the committee's lookup basis flips mid-upgrade, so the next-epoch committee assembled in the old epoch (BLS names) doesn't match the one the new epoch builds for itself (consensus names), and reconfiguration can't converge — and the next version isn't visible at the off-chain freeze, so the producing side can't look ahead. Carrying the key as data sidesteps this entirely. Full rationale + the rejected design: `dev-docs/plans/authority-name-consensus-key.md`.

## TODO (future)

`Committee` keeps the BLS key (`expanded_keys` / `public_key()`) for aggregate-cert verification. Once those are fully replaced by consensus-key-signed certs, drop the BLS key and let `AuthorityName` become the consensus key (TODO left in `committee.rs`).

## Validation

- **Full Test Cluster suite: 15/15** (incl. `test_protocol_version_gradual_upgrade_v3_to_v4`, the v3→v4 transition)
- **Integration Tests CI: green**
- 76 handoff/freeze unit tests, committee/handoff units, protocol-config snapshots, full workspace build, no new clippy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related

- #1751 — removing the BLS protocol key once checkpoint certs migrate off the BLS aggregate is tracked there. This PR sets it up (the consensus key is now carried as `Committee` data) and leaves the `TODO(consensus-key-certs)` anchor; it does **not** close the issue.
