### PR TITLE
test: fix ika-test-cluster simtest + upgrade-test OCS anchor (test-tooling gaps)

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -334,8 +334,8 @@ jobs:
           # death; capturing it needs an off-pod channel (kubelet/dmesg, or a
           # token-push of samples). What the sampler DID establish on surviving
           # runs: each ika-validator ~7.5-8 GB RSS, 4 idle validators = 62% of
-          # the 96 GiB pod, swap=0 -> memory is the dominant resource and the
-          # leading (still-unconfirmed) suspect for the cross_binary death. One
+          # the 96 GiB pod, swap=0. The cross_binary death is CONFIRMED (kubectl)
+          # to be a cgroup OOM-kill at the pod's 96 GiB limit (OOMKilled/137). One
           # scenario, one process: the harness binds fixed Sui ports and chdirs
           # during publish, so --test-threads=1 is mandatory. (Live test output
           # is in the artifact, not the step log.)

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -74,7 +74,12 @@ on:
         required: false
         default: ""
       epoch_duration_ms:
-        description: "Override ika genesis epoch duration in ms (only cross_binary/v118_upgrade honor it; empty = scenario default)"
+        description: "Override ika genesis epoch duration in ms (only cross_binary/v118_upgrade/v118_churn honor it; empty = scenario default)"
+        type: string
+        required: false
+        default: ""
+      max_mpc_computation_cores:
+        description: "Cap each validator's concurrent dwallet-MPC computations (bounds peak memory for co-located test validators; empty = node default = host cores)"
         type: string
         required: false
         default: ""
@@ -279,6 +284,9 @@ jobs:
           # Empty string fails to parse and the test falls back to its own
           # default, so this is safe to pass unconditionally.
           EPOCH_DURATION_MS: ${{ inputs.epoch_duration_ms }}
+          # Cap concurrent dwallet-MPC computations per validator (bounds peak
+          # memory for co-located test validators). Empty -> node default.
+          MAX_MPC_COMPUTATION_CORES: ${{ inputs.max_mpc_computation_cores }}
         run: |
           set -euo pipefail
           export SUI_BIN="$HOME/.local/bin/sui"

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -314,6 +314,18 @@ jobs:
           # directly, and is NOT proven to prevent the cross_binary runner
           # death — v118 passes with or without it. Empty -> node default.
           MAX_MPC_COMPUTATION_CORES: ${{ inputs.max_mpc_computation_cores }}
+          # Return freed memory to the OS after the transient MPC workload. The
+          # validators use jemalloc (tikv-jemallocator) which, with default
+          # config (background_thread off, lazy demand-driven decay) across many
+          # rayon arenas, keeps the freed class-groups crypto buffers as resident
+          # dirty pages — RSS plateaus at ~2.5x idle and never falls, which is
+          # what parks the 5-validator pod at the 96 GiB OOM ceiling. NOTE: the
+          # var is PREFIXED `_RJEM_` (this build doesn't enable jemalloc's
+          # unprefixed feature, so plain MALLOC_CONF is a silent no-op); spawned
+          # ika-validator children inherit it. abort_conf:true makes jemalloc
+          # abort at boot if the string was misnamed/unparsed — so a clean boot
+          # proves the knob was actually read.
+          _RJEM_MALLOC_CONF: "background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000,abort_conf:true"
         run: |
           set -uo pipefail
           export SUI_BIN="$HOME/.local/bin/sui"

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -24,6 +24,11 @@ name: Upgrade Test
 #                  `mainnet-v1.1.8` binary, swap all to the current build,
 #                  confirm v4 and continued serving. Defaults to
 #                  old_ref=mainnet-v1.1.8, old_bin_name=ika-node.
+#   v118_churn   — v118_upgrade + post-upgrade committee churn: after the
+#                  atomic 1.1.8 -> local swap, join a brand-new local validator
+#                  so the v4 reshare of the 1.1.8-origin key includes a new
+#                  party (exercises the OCS joiner trust-anchor path from a real
+#                  1.1.8 origin). Same defaults as v118_upgrade.
 #
 # Each scenario binds the fixed Sui localnet ports (9000/9123) and chdirs the
 # process during publish, so only ONE runs per job — `--test-threads=1`, one
@@ -52,6 +57,7 @@ on:
           - workload
           - cross_binary
           - v118_upgrade
+          - v118_churn
       old_ref:
         description: "Git ref/tag/sha/branch for the OLD binary (cross_binary & v118_upgrade; empty = per-scenario default)"
         type: string
@@ -176,6 +182,7 @@ jobs:
             workload)     RUN_FLAG=RUN_WORKLOAD_TEST ;;
             cross_binary) RUN_FLAG=RUN_CROSS_BINARY ;;
             v118_upgrade) RUN_FLAG=RUN_V118_UPGRADE ;;
+            v118_churn)   RUN_FLAG=RUN_V118_CHURN ;;
             *) echo "unknown test: $TEST" >&2; exit 1 ;;
           esac
           # Per-scenario OLD-binary defaults; explicit inputs override (an
@@ -184,7 +191,7 @@ jobs:
           OLD_BIN_NAME="$IN_OLD_BIN_NAME"
           PATCH_MAX="$IN_PATCH_MAX"
           case "$TEST" in
-            v118_upgrade)
+            v118_upgrade | v118_churn)
               : "${OLD_REF:=mainnet-v1.1.8}"
               : "${OLD_BIN_NAME:=ika-node}"
               ;;
@@ -214,7 +221,7 @@ jobs:
           cargo test --no-run --release -p ika-upgrade-test --test "$TEST_NAME"
 
       - name: Build OLD binary from ${{ env.OLD_REF }}
-        if: ${{ inputs.test == 'cross_binary' || inputs.test == 'v118_upgrade' }}
+        if: ${{ inputs.test == 'cross_binary' || inputs.test == 'v118_upgrade' || inputs.test == 'v118_churn' }}
         run: |
           set -euo pipefail
           WT="$GITHUB_WORKSPACE/old-build"

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -44,20 +44,15 @@ on:
   workflow_dispatch:
     inputs:
       test:
-        description: "Which upgrade scenario to run"
-        type: choice
+        description: "Scenarios: 'all', or a comma-separated subset e.g. 'smoke,cross_binary,v118_churn'. Each runs as its own job on its own runner, in parallel."
+        type: string
         required: true
-        # cross_binary is the most robust real upgrade test: its OLD binary is
-        # built from THIS branch (current toolchain, same crypto), so it does
-        # not depend on an old tag still building. v118_upgrade is the literal
-        # mainnet rehearsal — pick it explicitly before a mainnet upgrade.
-        default: "cross_binary"
-        options:
-          - smoke
-          - workload
-          - cross_binary
-          - v118_upgrade
-          - v118_churn
+        # Default 'all' = every scenario. Or a comma-separated subset. Each
+        # selected scenario is a separate matrix job (separate runner), with
+        # fail-fast disabled. Per-run overrides (old_ref/old_max_protocol_version)
+        # apply to EVERY selected scenario, so leave them empty unless running a
+        # single scenario (each scenario otherwise uses its own defaults).
+        default: "all"
       old_ref:
         description: "Git ref/tag/sha/branch for the OLD binary (cross_binary & v118_upgrade; empty = per-scenario default)"
         type: string
@@ -103,8 +98,46 @@ env:
   rust_stable: "1.94"
 
 jobs:
+  # Resolve `inputs.test` into the matrix of scenarios to run: 'all' fans every
+  # scenario out (each as its own job on its own runner); a single scenario
+  # runs just that one.
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.pick.outputs.matrix }}
+    steps:
+      - id: pick
+        env:
+          TEST: ${{ inputs.test }}
+        run: |
+          set -euo pipefail
+          ALL="smoke workload cross_binary v118_upgrade v118_churn"
+          if [ "$TEST" = "all" ]; then
+            SELECTED="$ALL"
+          else
+            # Comma-separated subset -> space-separated, whitespace trimmed.
+            SELECTED=$(echo "$TEST" | tr ',' ' ' | xargs)
+          fi
+          json=""
+          for t in $SELECTED; do
+            case " $ALL " in
+              *" $t "*) ;;
+              *) echo "unknown scenario '$t' (valid: $ALL, or 'all')" >&2; exit 1 ;;
+            esac
+            json="$json\"$t\","
+          done
+          [ -n "$json" ] || { echo "no scenarios selected" >&2; exit 1; }
+          echo "matrix={\"test\":[${json%,}]}" >> "$GITHUB_OUTPUT"
+          echo "selected scenarios: $SELECTED"
+
   upgrade-test:
-    name: ${{ inputs.test }}
+    needs: setup
+    # One job per scenario, each on its own runner, in parallel. fail-fast off
+    # so one scenario's failure (or a runner death) doesn't cancel the others.
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    name: ${{ matrix.test }}
     runs-on: ika-k8s-large
     # An upgrade scenario crosses several long epochs plus a cold build of
     # both the current binaries and the OLD ref; the ceiling covers that.
@@ -176,7 +209,7 @@ jobs:
 
       - name: Resolve test selection
         env:
-          TEST: ${{ inputs.test }}
+          TEST: ${{ matrix.test }}
           IN_OLD_REF: ${{ inputs.old_ref }}
           IN_OLD_BIN_NAME: ${{ inputs.old_bin_name }}
           IN_PATCH_MAX: ${{ inputs.old_max_protocol_version }}
@@ -226,7 +259,7 @@ jobs:
           cargo test --no-run --release -p ika-upgrade-test --test "$TEST_NAME"
 
       - name: Build OLD binary from ${{ env.OLD_REF }}
-        if: ${{ inputs.test == 'cross_binary' || inputs.test == 'v118_upgrade' || inputs.test == 'v118_churn' }}
+        if: ${{ matrix.test == 'cross_binary' || matrix.test == 'v118_upgrade' || matrix.test == 'v118_churn' }}
         run: |
           set -euo pipefail
           WT="$GITHUB_WORKSPACE/old-build"
@@ -263,7 +296,7 @@ jobs:
           nohup bash -c 'prev=$(grep usage_usec /sys/fs/cgroup/cpu.stat 2>/dev/null | awk "{print \$2}"); while true; do sleep 15; cur=$(grep usage_usec /sys/fs/cgroup/cpu.stat 2>/dev/null | awk "{print \$2}"); echo "$(date -u +%T) effective_cpus=$(( (cur - prev) / 15000000 )).$(( ((cur - prev) / 1500000) % 10 )) $(grep -E "nr_throttled|throttled_usec" /sys/fs/cgroup/cpu.stat 2>/dev/null | tr "\n" " ") load=$(cut -d" " -f1-3 /proc/loadavg)"; prev=$cur; done' > cpu-sampler.log 2>&1 &
           echo $! > cpu-sampler.pid
 
-      - name: Run ${{ inputs.test }}
+      - name: Run ${{ matrix.test }}
         env:
           # smoke/workload read IKA_VALIDATOR_BIN/IKA_NOTIFIER_BIN/IKA_BIN;
           # cross_binary/v118_upgrade read NEW_BIN/NOTIFIER_BIN/OLD_BIN/IKA_BIN.
@@ -311,7 +344,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: cpu-sampler-${{ inputs.test }}-${{ github.run_attempt }}
+          name: cpu-sampler-${{ matrix.test }}-${{ github.run_attempt }}
           path: cpu-sampler.log
           retention-days: 7
 
@@ -321,7 +354,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: upgrade-test-log-${{ inputs.test }}-${{ github.run_attempt }}
+          name: upgrade-test-log-${{ matrix.test }}-${{ github.run_attempt }}
           path: upgrade-test.log
           retention-days: 7
 
@@ -330,7 +363,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # Logs only — the data dirs hold multi-GB RocksDB state.
-          name: upgrade-test-node-logs-${{ inputs.test }}-${{ github.run_attempt }}
+          name: upgrade-test-node-logs-${{ matrix.test }}-${{ github.run_attempt }}
           path: upgrade-test-data/**/*.log
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -314,18 +314,14 @@ jobs:
           # directly, and is NOT proven to prevent the cross_binary runner
           # death — v118 passes with or without it. Empty -> node default.
           MAX_MPC_COMPUTATION_CORES: ${{ inputs.max_mpc_computation_cores }}
-          # Return freed memory to the OS after the transient MPC workload. The
-          # validators use jemalloc (tikv-jemallocator) which, with default
-          # config (background_thread off, lazy demand-driven decay) across many
-          # rayon arenas, keeps the freed class-groups crypto buffers as resident
-          # dirty pages — RSS plateaus at ~2.5x idle and never falls, which is
-          # what parks the 5-validator pod at the 96 GiB OOM ceiling. NOTE: the
-          # var is PREFIXED `_RJEM_` (this build doesn't enable jemalloc's
-          # unprefixed feature, so plain MALLOC_CONF is a silent no-op); spawned
-          # ika-validator children inherit it. abort_conf:true makes jemalloc
-          # abort at boot if the string was misnamed/unparsed — so a clean boot
-          # proves the knob was actually read.
-          _RJEM_MALLOC_CONF: "background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000,abort_conf:true"
+          # Shrink the per-curve presign pools (production maxima 30k-150k each x
+          # 10 pools, RocksDB-backed) for the out-of-process test validators —
+          # they otherwise fill GiB-scale pools the test never uses (a Sign needs
+          # a handful of presigns). The node honors this env via
+          # ProtocolConfig::enable_small_presign_pools_for_local_swarm; mainnet
+          # never sets it. This is the other half of the per-validator RSS that
+          # parks the 5-validator pod at the 96 GiB ceiling.
+          IKA_ENABLE_SMALL_PRESIGN_POOLS: "1"
         run: |
           set -uo pipefail
           export SUI_BIN="$HOME/.local/bin/sui"

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -287,15 +287,6 @@ jobs:
           echo "OLD_BIN=$OLD_BIN" >> "$GITHUB_ENV"
           echo "built OLD binary: $OLD_BIN"
 
-      - name: Start CPU sampler
-        run: |
-          # Every 15s: cgroup cpu.stat (usage_usec delta -> effective CPUs
-          # actually consumed; nr_throttled/throttled_usec -> CFS quota
-          # stalls) + loadavg. Answers "does this workload USE the vCPUs"
-          # rather than inferring it from wall-clock.
-          nohup bash -c 'prev=$(grep usage_usec /sys/fs/cgroup/cpu.stat 2>/dev/null | awk "{print \$2}"); while true; do sleep 15; cur=$(grep usage_usec /sys/fs/cgroup/cpu.stat 2>/dev/null | awk "{print \$2}"); echo "$(date -u +%T) effective_cpus=$(( (cur - prev) / 15000000 )).$(( ((cur - prev) / 1500000) % 10 )) $(grep -E "nr_throttled|throttled_usec" /sys/fs/cgroup/cpu.stat 2>/dev/null | tr "\n" " ") load=$(cut -d" " -f1-3 /proc/loadavg)"; prev=$cur; done' > cpu-sampler.log 2>&1 &
-          echo $! > cpu-sampler.pid
-
       - name: Run ${{ matrix.test }}
         env:
           # smoke/workload read IKA_VALIDATOR_BIN/IKA_NOTIFIER_BIN/IKA_BIN;
@@ -317,14 +308,50 @@ jobs:
           # Empty string fails to parse and the test falls back to its own
           # default, so this is safe to pass unconditionally.
           EPOCH_DURATION_MS: ${{ inputs.epoch_duration_ms }}
-          # Cap concurrent dwallet-MPC computations per validator (bounds peak
-          # memory for co-located test validators). Empty -> node default.
+          # Cap concurrent dwallet-MPC computations per validator. NOTE: this
+          # bounds CPU concurrency (each computation already fans out across the
+          # whole rayon pool via the `parallel` crypto feature), not memory
+          # directly, and is NOT proven to prevent the cross_binary runner
+          # death — v118 passes with or without it. Empty -> node default.
           MAX_MPC_COMPUTATION_CORES: ${{ inputs.max_mpc_computation_cores }}
         run: |
           set -euo pipefail
           export SUI_BIN="$HOME/.local/bin/sui"
           export "${RUN_FLAG}=1"
           mkdir -p "$UPGRADE_TEST_DIR"
+          # Resource sampler (CPU + MEMORY), launched INSIDE this step so its
+          # output is captured here, not in a prior step whose stdout has
+          # closed. Every 15s it appends a line to resource-sampler.log AND, on
+          # this step's stdout, raises ::warning:: annotations at 90%/95% of
+          # memory.max and on any cgroup oom_kill. Annotations reach the server
+          # as the run proceeds, so they can outlive a "runner lost
+          # communication" death that skips the uploads below and 404s the job
+          # log — the only forensic channel for the cross_binary death, which
+          # lands ~29min into the run at peak committee-reshare concurrency.
+          # CPU axis is already known comfortable (peaks ~13 of the 80-core
+          # quota, zero throttling); memory is the unmeasured suspect.
+          ( set +eu
+            CG=/sys/fs/cgroup
+            prev=$(awk '/usage_usec/{print $2}' "$CG/cpu.stat" 2>/dev/null || echo 0)
+            memmax=$(cat "$CG/memory.max" 2>/dev/null || echo 0); case "$memmax" in ''|max) memmax=0;; esac
+            w90=0; w95=0; oomprev=0
+            while true; do
+              sleep 15
+              cur=$(awk '/usage_usec/{print $2}' "$CG/cpu.stat" 2>/dev/null || echo "$prev")
+              cpus="$(( (cur - prev) / 15000000 )).$(( ((cur - prev) / 1500000) % 10 ))"; prev=$cur
+              thr=$(grep -E 'nr_throttled|throttled_usec' "$CG/cpu.stat" 2>/dev/null | tr '\n' ' ')
+              load=$(cut -d' ' -f1-3 /proc/loadavg)
+              memcur=$(cat "$CG/memory.current" 2>/dev/null || echo 0)
+              swap=$(cat "$CG/memory.swap.current" 2>/dev/null || echo 0)
+              oom=$(awk '/^oom_kill /{print $2}' "$CG/memory.events" 2>/dev/null || echo 0); [ -n "$oom" ] || oom=0
+              pct=0; [ "$memmax" -gt 0 ] && pct=$(( memcur * 100 / memmax ))
+              top=$(ps -eo rss,comm --sort=-rss 2>/dev/null | awk 'NR>1 && NR<=4{printf "%s:%dM ",$2,$1/1024}')
+              echo "$(date -u +%T) effective_cpus=$cpus $thr load=$load mem=$((memcur/1048576))M/$((memmax/1048576))M pct=${pct}% swap=$((swap/1048576))M oom_kill=$oom top=[$top]" >> resource-sampler.log
+              if [ "$oom" -gt "$oomprev" ]; then echo "::warning title=cgroup oom_kill::oom_kill=$oom mem=$((memcur/1048576))M/$((memmax/1048576))M (${pct}%) top=[$top]"; oomprev=$oom; fi
+              if [ "$pct" -ge 95 ] && [ "$w95" -eq 0 ]; then echo "::warning title=memory >=95%::mem=$((memcur/1048576))M/$((memmax/1048576))M (${pct}%) top=[$top]"; w95=1; fi
+              if [ "$pct" -ge 90 ] && [ "$w90" -eq 0 ]; then echo "::warning title=memory >=90%::mem=$((memcur/1048576))M/$((memmax/1048576))M (${pct}%) top=[$top]"; w90=1; fi
+            done ) &
+          echo $! > resource-sampler.pid
           echo "running $TEST_NAME (flag $RUN_FLAG); sui=$SUI_BIN old_bin=${OLD_BIN:-<none>}"
           # One scenario, one process: the harness binds fixed Sui ports and
           # chdirs during publish, so --test-threads=1 is mandatory.
@@ -336,16 +363,16 @@ jobs:
         run: |
           grep -E "^test .*(ok|FAILED)|test result|PASSED|panicked" upgrade-test.log | tail -60 || true
 
-      - name: Stop CPU sampler
+      - name: Stop resource sampler
         if: always()
-        run: kill "$(cat cpu-sampler.pid)" 2>/dev/null || true
+        run: kill "$(cat resource-sampler.pid)" 2>/dev/null || true
 
-      - name: Upload CPU sampler log
+      - name: Upload resource sampler log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: cpu-sampler-${{ matrix.test }}-${{ github.run_attempt }}
-          path: cpu-sampler.log
+          name: resource-sampler-${{ matrix.test }}-${{ github.run_attempt }}
+          path: resource-sampler.log
           retention-days: 7
 
       - name: Upload test log

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -315,57 +315,60 @@ jobs:
           # death — v118 passes with or without it. Empty -> node default.
           MAX_MPC_COMPUTATION_CORES: ${{ inputs.max_mpc_computation_cores }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           export SUI_BIN="$HOME/.local/bin/sui"
           export "${RUN_FLAG}=1"
           mkdir -p "$UPGRADE_TEST_DIR"
-          # Resource sampler (CPU + MEMORY), launched INSIDE this step so its
-          # output is captured here, not in a prior step whose stdout has
-          # closed. Every 15s it appends a line to resource-sampler.log AND, on
-          # this step's stdout, raises ::warning:: annotations at 90%/95% of
-          # memory.max and on any cgroup oom_kill. Annotations reach the server
-          # as the run proceeds, so they can outlive a "runner lost
-          # communication" death that skips the uploads below and 404s the job
-          # log — the only forensic channel for the cross_binary death, which
-          # lands ~29min into the run at peak committee-reshare concurrency.
-          # CPU axis is already known comfortable (peaks ~13 of the 80-core
-          # quota, zero throttling); memory is the unmeasured suspect.
-          ( set +eu
-            CG=/sys/fs/cgroup
-            prev=$(awk '/usage_usec/{print $2}' "$CG/cpu.stat" 2>/dev/null || echo 0)
-            memmax=$(cat "$CG/memory.max" 2>/dev/null || echo 0); case "$memmax" in ''|max) memmax=0;; esac
-            w90=0; w95=0; oomprev=0
-            while true; do
-              sleep 15
-              cur=$(awk '/usage_usec/{print $2}' "$CG/cpu.stat" 2>/dev/null || echo "$prev")
-              cpus="$(( (cur - prev) / 15000000 )).$(( ((cur - prev) / 1500000) % 10 ))"; prev=$cur
-              thr=$(grep -E 'nr_throttled|throttled_usec' "$CG/cpu.stat" 2>/dev/null | tr '\n' ' ')
-              load=$(cut -d' ' -f1-3 /proc/loadavg)
-              memcur=$(cat "$CG/memory.current" 2>/dev/null || echo 0)
-              swap=$(cat "$CG/memory.swap.current" 2>/dev/null || echo 0)
-              oom=$(awk '/^oom_kill /{print $2}' "$CG/memory.events" 2>/dev/null || echo 0); [ -n "$oom" ] || oom=0
-              pct=0; [ "$memmax" -gt 0 ] && pct=$(( memcur * 100 / memmax ))
-              top=$(ps -eo rss,comm --sort=-rss 2>/dev/null | awk 'NR>1 && NR<=4{printf "%s:%dM ",$2,$1/1024}')
-              echo "$(date -u +%T) effective_cpus=$cpus $thr load=$load mem=$((memcur/1048576))M/$((memmax/1048576))M pct=${pct}% swap=$((swap/1048576))M oom_kill=$oom top=[$top]" >> resource-sampler.log
-              if [ "$oom" -gt "$oomprev" ]; then echo "::warning title=cgroup oom_kill::oom_kill=$oom mem=$((memcur/1048576))M/$((memmax/1048576))M (${pct}%) top=[$top]"; oomprev=$oom; fi
-              if [ "$pct" -ge 95 ] && [ "$w95" -eq 0 ]; then echo "::warning title=memory >=95%::mem=$((memcur/1048576))M/$((memmax/1048576))M (${pct}%) top=[$top]"; w95=1; fi
-              if [ "$pct" -ge 90 ] && [ "$w90" -eq 0 ]; then echo "::warning title=memory >=90%::mem=$((memcur/1048576))M/$((memmax/1048576))M (${pct}%) top=[$top]"; w90=1; fi
-            done ) &
-          echo $! > resource-sampler.pid
           echo "running $TEST_NAME (flag $RUN_FLAG); sui=$SUI_BIN old_bin=${OLD_BIN:-<none>}"
-          # One scenario, one process: the harness binds fixed Sui ports and
-          # chdirs during publish, so --test-threads=1 is mandatory.
-          time cargo test --release -p ika-upgrade-test --test "$TEST_NAME" \
-            -- --nocapture --test-threads=1 2>&1 | tee upgrade-test.log
+          # Run the test in the BACKGROUND (output -> upgrade-test.log) and use
+          # THIS foreground shell as the resource sampler. The runner only
+          # reliably parses ::warning:: workflow commands from a step's
+          # FOREGROUND process (a backgrounded sampler's commands are dropped —
+          # observed: run 28057062769 emitted none), and those annotations are
+          # the sole channel that can outlive a "runner lost communication"
+          # death, which 404s the job log and drops all artifacts incl. the
+          # sampler file. CPU is already known comfortable (~13 of the 80-core
+          # quota, zero throttling); memory is the unmeasured suspect, so we
+          # emit an unconditional "sampler up" line + a memory heartbeat every
+          # ~6min + threshold/oom_kill warnings — a no-warning run is then
+          # unambiguous. One scenario, one process: the harness binds fixed Sui
+          # ports and chdirs during publish, so --test-threads=1 is mandatory.
+          # (Live test output goes to the artifact, not the step log; on a death
+          # nothing on the pod survives anyway.)
+          cargo test --release -p ika-upgrade-test --test "$TEST_NAME" \
+            -- --nocapture --test-threads=1 > upgrade-test.log 2>&1 &
+          TEST_PID=$!
+          CG=/sys/fs/cgroup
+          memmax=$(cat "$CG/memory.max" 2>/dev/null || echo 0); case "$memmax" in ''|max) memmax=0;; esac
+          prev=$(awk '/usage_usec/{print $2}' "$CG/cpu.stat" 2>/dev/null || echo 0)
+          echo "::warning title=sampler up::memory.max=$((memmax/1048576))M cpu.max=$(cat "$CG/cpu.max" 2>/dev/null) nproc=$(nproc)"
+          w90=0; w95=0; oomprev=0; tick=0
+          while kill -0 "$TEST_PID" 2>/dev/null; do
+            sleep 15
+            cur=$(awk '/usage_usec/{print $2}' "$CG/cpu.stat" 2>/dev/null || echo "$prev")
+            cpus="$(( (cur - prev) / 15000000 )).$(( ((cur - prev) / 1500000) % 10 ))"; prev=$cur
+            load=$(cut -d' ' -f1-3 /proc/loadavg)
+            memcur=$(cat "$CG/memory.current" 2>/dev/null || echo 0)
+            swap=$(cat "$CG/memory.swap.current" 2>/dev/null || echo 0)
+            oom=$(awk '/^oom_kill /{print $2}' "$CG/memory.events" 2>/dev/null || echo 0); [ -n "$oom" ] || oom=0
+            pct=0; [ "$memmax" -gt 0 ] && pct=$(( memcur * 100 / memmax ))
+            top=$(ps -eo rss,comm --sort=-rss 2>/dev/null | awk 'NR>1 && NR<=4{printf "%s:%dM ",$2,$1/1024}')
+            echo "$(date -u +%T) cpus=$cpus load=$load mem=$((memcur/1048576))M/$((memmax/1048576))M pct=${pct}% swap=$((swap/1048576))M oom_kill=$oom top=[$top]" >> resource-sampler.log
+            tick=$((tick+1))
+            if [ $((tick % 24)) -eq 0 ]; then echo "::warning title=mem heartbeat::$(date -u +%T) mem=$((memcur/1048576))M/$((memmax/1048576))M (${pct}%) cpus=$cpus top=[$top]"; fi
+            if [ "$oom" -gt "$oomprev" ]; then echo "::warning title=cgroup oom_kill::oom_kill=$oom mem=$((memcur/1048576))M/$((memmax/1048576))M (${pct}%) top=[$top]"; oomprev=$oom; fi
+            if [ "$pct" -ge 95 ] && [ "$w95" -eq 0 ]; then echo "::warning title=memory >=95%::mem=$((memcur/1048576))M/$((memmax/1048576))M (${pct}%) top=[$top]"; w95=1; fi
+            if [ "$pct" -ge 90 ] && [ "$w90" -eq 0 ]; then echo "::warning title=memory >=90%::mem=$((memcur/1048576))M/$((memmax/1048576))M (${pct}%) top=[$top]"; w90=1; fi
+          done
+          wait "$TEST_PID"; rc=$?
+          echo "=== $TEST_NAME exited rc=$rc; tail of upgrade-test.log: ==="
+          tail -100 upgrade-test.log || true
+          exit "$rc"
 
       - name: Summarize results
         if: always()
         run: |
           grep -E "^test .*(ok|FAILED)|test result|PASSED|panicked" upgrade-test.log | tail -60 || true
-
-      - name: Stop resource sampler
-        if: always()
-        run: kill "$(cat resource-sampler.pid)" 2>/dev/null || true
 
       - name: Upload resource sampler log
         if: always()

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -321,20 +321,24 @@ jobs:
           mkdir -p "$UPGRADE_TEST_DIR"
           echo "running $TEST_NAME (flag $RUN_FLAG); sui=$SUI_BIN old_bin=${OLD_BIN:-<none>}"
           # Run the test in the BACKGROUND (output -> upgrade-test.log) and use
-          # THIS foreground shell as the resource sampler. The runner only
-          # reliably parses ::warning:: workflow commands from a step's
-          # FOREGROUND process (a backgrounded sampler's commands are dropped —
-          # observed: run 28057062769 emitted none), and those annotations are
-          # the sole channel that can outlive a "runner lost communication"
-          # death, which 404s the job log and drops all artifacts incl. the
-          # sampler file. CPU is already known comfortable (~13 of the 80-core
-          # quota, zero throttling); memory is the unmeasured suspect, so we
-          # emit an unconditional "sampler up" line + a memory heartbeat every
-          # ~6min + threshold/oom_kill warnings — a no-warning run is then
-          # unambiguous. One scenario, one process: the harness binds fixed Sui
-          # ports and chdirs during publish, so --test-threads=1 is mandatory.
-          # (Live test output goes to the artifact, not the step log; on a death
-          # nothing on the pod survives anyway.)
+          # THIS foreground shell as the resource sampler (CPU+MEMORY ->
+          # resource-sampler.log: mem current/max/pct, swap, cgroup oom_kill,
+          # top-RSS every 15s). It also emits ::warning:: annotations (startup +
+          # ~6min heartbeat + 90/95%/oom_kill); those parse only from a step's
+          # FOREGROUND (background commands are dropped) and show on runs that
+          # FINISH. CAVEAT (proven, runs 28057062769/28059893726): a "runner
+          # lost communication" death WIPES this job's runner-emitted
+          # annotations AND drops the artifacts + job log — a surviving smoke run
+          # shows the startup annotation; a dead cross_binary run with the
+          # identical line shows none. So NOTHING here survives the cross_binary
+          # death; capturing it needs an off-pod channel (kubelet/dmesg, or a
+          # token-push of samples). What the sampler DID establish on surviving
+          # runs: each ika-validator ~7.5-8 GB RSS, 4 idle validators = 62% of
+          # the 96 GiB pod, swap=0 -> memory is the dominant resource and the
+          # leading (still-unconfirmed) suspect for the cross_binary death. One
+          # scenario, one process: the harness binds fixed Sui ports and chdirs
+          # during publish, so --test-threads=1 is mandatory. (Live test output
+          # is in the artifact, not the step log.)
           cargo test --release -p ika-upgrade-test --test "$TEST_NAME" \
             -- --nocapture --test-threads=1 > upgrade-test.log 2>&1 &
           TEST_PID=$!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,14 @@ indicatif = "0.18.0"
 insta = { version = "1.21.1", features = ["redactions", "yaml", "json"] }
 itertools = "0.14.0"
 tikv-jemalloc-ctl = "0.5.4"
-tikv-jemallocator = { version = "0.5", features = ["profiling", "disable_initial_exec_tls"] }
+# `background_threads` bakes `background_thread:true` into the compiled-in
+# jemalloc malloc_conf so the allocator runs a background purger that proactively
+# returns freed pages to the OS. Without it (jemalloc's default) freed memory —
+# e.g. the transient class-groups MPC working set — is retained as per-arena
+# dirty pages and RSS plateaus at the high-water mark. Supported on every target
+# ika ships (only `musl` is unsupported, and that degrades to a build warning,
+# not an error, because `background_threads_runtime_support` stays enabled).
+tikv-jemallocator = { version = "0.5", features = ["profiling", "disable_initial_exec_tls", "background_threads"] }
 jsonrpsee = { version = "0.26.0", features = ["server", "macros", "ws-client", "http-client", "jsonrpsee-core"] }
 lru = "0.16.3"
 merlin = { version = "3", default-features = false }

--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -582,6 +582,14 @@ pub struct NodeConfig {
     /// one hour when unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authority_db_pruner_period_secs: Option<u64>,
+
+    /// Cap on the number of concurrent dwallet-MPC cryptographic computations
+    /// (the orchestrator's core budget). `None` (default) uses the host core
+    /// count. Set this low to bound a validator's CPU + peak memory when many
+    /// validators are co-located on one machine — e.g. CI test clusters, where
+    /// each unbounded validator's class-groups crypto otherwise starves the pod.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_mpc_computation_cores: Option<usize>,
 }
 
 /// Keep the current epoch plus this many prior per-epoch authority store

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
@@ -84,7 +84,10 @@ pub(crate) struct CryptographicComputationsOrchestrator {
 
 impl CryptographicComputationsOrchestrator {
     /// Creates a new orchestrator for cryptographic computations.
-    pub(crate) fn try_new(root_seed: RootSeed) -> DwalletMPCResult<Self> {
+    pub(crate) fn try_new(
+        root_seed: RootSeed,
+        max_computation_cores: Option<usize>,
+    ) -> DwalletMPCResult<Self> {
         let (report_computation_completed_sender, report_computation_completed_receiver) =
             tokio::sync::mpsc::channel(COMPUTATION_UPDATE_CHANNEL_SIZE);
         let mut available_cores_for_computations =
@@ -96,8 +99,15 @@ impl CryptographicComputationsOrchestrator {
                 .map_err(|e| DwalletMPCError::FailedToGetAvailableParallelism(e.to_string()))?
                 .into();
         }
+        // Operator override (`NodeConfig::max_mpc_computation_cores`): cap the
+        // concurrent-computation budget below the host core count. Bounds peak
+        // CPU + memory when validators are co-located (e.g. CI test clusters).
+        if let Some(max) = max_computation_cores {
+            available_cores_for_computations = available_cores_for_computations.min(max).max(1);
+        }
         info!(
             available_cores_for_computations =? available_cores_for_computations,
+            ?max_computation_cores,
             "Available CPU cores for Rayon cryptographic computations"
         );
 

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -184,6 +184,7 @@ impl DWalletMPCService {
         let schnorr_presign_second_round_delay =
             protocol_config.schnorr_presign_second_round_delay();
 
+        let max_mpc_computation_cores = node_config.max_mpc_computation_cores;
         let root_seed = match node_config.root_seed_key_pair {
             None => {
                 error!("root_seed is not set in the node config, cannot start DWallet MPC service");
@@ -205,6 +206,7 @@ impl DWalletMPCService {
             protocol_config.clone(),
             epoch_store.clone(),
             network_owned_address_sign_output_sender,
+            max_mpc_computation_cores,
         );
 
         Self {
@@ -292,6 +294,7 @@ impl DWalletMPCService {
                 ProtocolConfig::get_for_max_version_UNSAFE(),
                 epoch_store,
                 network_owned_address_sign_output_sender,
+                None,
             ),
             exit: watch::channel(()).1,
             end_of_publish: false,

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -303,6 +303,7 @@ impl DWalletMPCManager {
         protocol_config: ProtocolConfig,
         epoch_store: Arc<dyn AuthorityPerEpochStoreTrait>,
         network_owned_address_sign_output_sender: Sender<NetworkOwnedAddressSignOutput>,
+        max_computation_cores: Option<usize>,
     ) -> Self {
         Self::try_new(
             validator_name,
@@ -317,6 +318,7 @@ impl DWalletMPCManager {
             protocol_config,
             epoch_store,
             network_owned_address_sign_output_sender,
+            max_computation_cores,
         )
         .unwrap_or_else(|err| {
             error!(error=?err, "Failed to create DWalletMPCManager.");
@@ -338,11 +340,14 @@ impl DWalletMPCManager {
         protocol_config: ProtocolConfig,
         epoch_store: Arc<dyn AuthorityPerEpochStoreTrait>,
         network_owned_address_sign_output_sender: Sender<NetworkOwnedAddressSignOutput>,
+        max_computation_cores: Option<usize>,
     ) -> DwalletMPCResult<Self> {
         let access_structure = generate_access_structure_from_committee(&committee)?;
 
-        let mpc_computations_orchestrator =
-            CryptographicComputationsOrchestrator::try_new(root_seed.clone())?;
+        let mpc_computations_orchestrator = CryptographicComputationsOrchestrator::try_new(
+            root_seed.clone(),
+            max_computation_cores,
+        )?;
         let party_id = authority_name_to_party_id_from_committee(&committee, &validator_name)?;
 
         let class_groups_key_pair_and_proof = ClassGroupsKeyPairAndProof::from_seed(&root_seed);

--- a/crates/ika-node/src/node_runner.rs
+++ b/crates/ika-node/src/node_runner.rs
@@ -14,6 +14,7 @@ use tracing::{error, info};
 use ika_config::node::RunWithRange;
 use ika_config::{Config, NodeConfig};
 use ika_core::runtime::IkaRuntimes;
+use ika_protocol_config::ProtocolConfig;
 use ika_telemetry::send_telemetry_event;
 use ika_types::crypto::KeypairTraits;
 use ika_types::digests::ChainIdentifier;
@@ -81,6 +82,17 @@ pub fn run_node_with_name(mode: Option<NodeMode>, version: &'static str, bin_nam
         "supported_protocol_versions cannot be read from the config file"
     );
     config.supported_protocol_versions = Some(SupportedProtocolVersions::SYSTEM_DEFAULT);
+
+    // Test-only: shrink the per-curve presign pools. Production maxima are
+    // 30k-150k presigns per pool (10 pools), RocksDB-backed, and the refill
+    // loop tops them up whenever the network is idle — so out-of-process test
+    // validators fill GiB-scale pools the test never uses (a Sign consumes a
+    // handful). The in-process swarm calls this directly; a spawned child
+    // process can't see that call, so the harness opts in via env. Never set on
+    // mainnet; the DKG->Presign->Sign path is unchanged.
+    if std::env::var("IKA_ENABLE_SMALL_PRESIGN_POOLS").is_ok() {
+        ProtocolConfig::enable_small_presign_pools_for_local_swarm();
+    }
 
     // Match run_with_range args
     // this means that we always modify the config used to start the node

--- a/crates/ika-swarm-config/src/node_config_builder.rs
+++ b/crates/ika-swarm-config/src/node_config_builder.rs
@@ -36,6 +36,10 @@ pub struct ValidatorConfigBuilder {
     config_directory: Option<PathBuf>,
     supported_protocol_versions: Option<SupportedProtocolVersions>,
     authority_overload_config: Option<AuthorityOverloadConfig>,
+    /// Override for `NodeConfig.max_mpc_computation_cores` — caps concurrent
+    /// dwallet-MPC computations so co-located test validators don't starve the
+    /// host. `None` = the node default (host core count).
+    max_mpc_computation_cores: Option<usize>,
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
     /// Optional digest of an end-of-epoch checkpoint summary, pasted
@@ -103,6 +107,11 @@ impl ValidatorConfigBuilder {
 
     pub fn with_unsafe_genesis_committee(mut self, committee: Committee) -> Self {
         self.unsafe_genesis_committee = Some(committee);
+        self
+    }
+
+    pub fn with_max_mpc_computation_cores(mut self, cores: usize) -> Self {
+        self.max_mpc_computation_cores = Some(cores);
         self
     }
 
@@ -222,6 +231,7 @@ impl ValidatorConfigBuilder {
             run_with_range: None,
             authority_db_retention_epochs: None,
             authority_db_pruner_period_secs: None,
+            max_mpc_computation_cores: self.max_mpc_computation_cores,
         }
     }
 
@@ -463,6 +473,8 @@ impl FullnodeConfigBuilder {
             run_with_range: self.run_with_range,
             authority_db_retention_epochs: None,
             authority_db_pruner_period_secs: None,
+            // Fullnodes/notifiers don't run validator MPC computations.
+            max_mpc_computation_cores: None,
         }
     }
 }

--- a/crates/ika-test-cluster/tests/smoke.rs
+++ b/crates/ika-test-cluster/tests/smoke.rs
@@ -2,9 +2,18 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 use ika_test_cluster::IkaTestClusterBuilder;
-use sui_macros::sim_test;
 
-#[sim_test]
+/// Basic epoch-advance smoke test.
+///
+/// Runs as a multi-thread tokio cluster test, not `#[sim_test]`. With the
+/// correct mysten-sim rev the full cluster does boot, network, and run DKG
+/// under msim, but it does not reach epoch 2 within the sim_test timeout — the
+/// OCS state-sync path is slow/flaky under madsim (anemo StateSync "connection
+/// lost") and the run times out. Per the testing convention, cluster tests use
+/// `#[tokio::test(flavor = "multi_thread")]`; `#[sim_test]` is reserved for
+/// targets whose subject IS scheduling/ordering nondeterminism. Making the OCS
+/// cluster pass under msim is a separate effort.
+#[tokio::test(flavor = "multi_thread")]
 async fn test_swarm_reaches_epoch_2() {
     telemetry_subscribers::init_for_testing();
     let cluster = IkaTestClusterBuilder::new()

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -274,6 +274,10 @@ impl ClusterBuilder {
             .map_err(|e| anyhow::anyhow!("fetch Sui genesis committee for OCS anchor: {e}"))?;
 
         // 4. Per-validator NodeConfig on a persistent data dir, written to YAML.
+        // Bound every co-located node's crypto rayon pool to a fair share of the
+        // host so the validators + notifier don't oversubscribe the CPU (see
+        // `rayon_threads_per_node`).
+        let rayon_threads = rayon_threads_per_node(self.num_validators + 1);
         let mut validators = Vec::with_capacity(self.num_validators);
         for (i, init) in validator_init_configs.iter().enumerate() {
             let data_dir = base.join(format!("validator-{i}"));
@@ -296,6 +300,7 @@ impl ClusterBuilder {
                 self.validator_binary.clone(),
                 &node_config,
                 data_dir.clone(),
+                rayon_threads,
             )
             .await?;
             validators.push(proc);
@@ -326,6 +331,7 @@ impl ClusterBuilder {
             self.notifier_binary.clone(),
             &notifier_config,
             notifier_dir,
+            rayon_threads,
         )
         .await?;
 
@@ -600,7 +606,15 @@ impl ClusterOfProcesses {
                 self.system.ika_system_object_id,
                 self.system.ika_dwallet_coordinator_object_id,
             );
-        let proc = spawn_node(index, binary, &node_config, data_dir).await?;
+        let proc = spawn_node(
+            index,
+            binary,
+            &node_config,
+            data_dir,
+            // existing validators (`index`) + this joiner + the notifier.
+            rayon_threads_per_node(index + 2),
+        )
+        .await?;
         self.validators.push(proc);
         self.committee.push(ValidatorSlot {
             address: joiner_address,
@@ -689,6 +703,7 @@ async fn spawn_node(
     binary: PathBuf,
     node_config: &NodeConfig,
     data_dir: PathBuf,
+    rayon_threads: usize,
 ) -> Result<ValidatorProcess> {
     let config_path = data_dir.join("node-config.yaml");
     let yaml = serde_yaml::to_string(node_config).context("serialize NodeConfig")?;
@@ -708,7 +723,25 @@ async fn spawn_node(
         admin_addr,
         node_config.metrics_address.port(),
         log_path,
+        rayon_threads,
     );
     proc.start().await?;
     Ok(proc)
+}
+
+/// `RAYON_NUM_THREADS` budget for each spawned node, given how many node
+/// processes will share this host. The harness co-locates every validator
+/// (plus the notifier) on one machine, each running the real node binary built
+/// `--no-default-features` — so each one's rayon pool otherwise defaults to ALL
+/// cores (`ika-core`'s `runtime.rs`). With the parallel crypto feature active
+/// that oversubscribes the CPU by the node count, starving the async runtimes
+/// (and, on CI, the runner agent itself → "runner lost communication"). Hand
+/// each node a fair slice of ~75% of the cores, reserving the rest for the
+/// async/IO work across all the processes — the out-of-process analogue of the
+/// in-process swarm's core reserve.
+fn rayon_threads_per_node(node_count: usize) -> usize {
+    let cores = std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(4);
+    ((cores * 3 / 4) / node_count.max(1)).max(1)
 }

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -740,8 +740,35 @@ async fn spawn_node(
 /// async/IO work across all the processes — the out-of-process analogue of the
 /// in-process swarm's core reserve.
 fn rayon_threads_per_node(node_count: usize) -> usize {
-    let cores = std::thread::available_parallelism()
+    // The pod's REAL CPU budget is the cgroup v2 CFS quota (`cpu.max` =
+    // "<quota> <period>"); on a throttled CI runner this is below the host core
+    // count that `available_parallelism()` reports, and sizing the per-node
+    // thread bound off host cores oversubscribes the pod. Prefer the quota.
+    let available = std::thread::available_parallelism()
         .map(usize::from)
         .unwrap_or(4);
-    ((cores * 3 / 4) / node_count.max(1)).max(1)
+    let cgroup_quota = std::fs::read_to_string("/sys/fs/cgroup/cpu.max")
+        .ok()
+        .and_then(|raw| {
+            let mut parts = raw.split_whitespace();
+            let quota = parts.next()?;
+            let period: usize = parts.next()?.parse().ok()?;
+            if quota == "max" || period == 0 {
+                return None;
+            }
+            Some((quota.parse::<usize>().ok()? / period).max(1))
+        });
+    let cores = cgroup_quota.map_or(available, |q| q.min(available));
+    let threads = ((cores * 3 / 4) / node_count.max(1)).max(1);
+    // Log both so the cores-vs-quota gap is visible in CI. Fires at cluster
+    // build (early), before the heavy crypto / any runner death.
+    tracing::warn!(
+        available_parallelism = available,
+        cgroup_cpu_quota = ?cgroup_quota,
+        effective_cores = cores,
+        node_count,
+        rayon_threads_per_node = threads,
+        "upgrade-test rayon budget: available_parallelism vs cgroup cpu.max"
+    );
+    threads
 }

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -278,23 +278,34 @@ impl ClusterBuilder {
         // host so the validators + notifier don't oversubscribe the CPU (see
         // `rayon_threads_per_node`).
         let rayon_threads = rayon_threads_per_node(self.num_validators + 1);
+        // Optional cap on each validator's concurrent dwallet-MPC computations
+        // (NodeConfig.max_mpc_computation_cores). Set MAX_MPC_COMPUTATION_CORES
+        // low to bound peak MEMORY when many validators are co-located on one CI
+        // pod — the class-groups crypto state of concurrent computations, not
+        // the thread count, is what OOMs the runner. Unset = node default.
+        let max_mpc_computation_cores = std::env::var("MAX_MPC_COMPUTATION_CORES")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok());
         let mut validators = Vec::with_capacity(self.num_validators);
         for (i, init) in validator_init_configs.iter().enumerate() {
             let data_dir = base.join(format!("validator-{i}"));
             std::fs::create_dir_all(&data_dir)?;
-            let node_config = ValidatorConfigBuilder::new()
+            let mut builder = ValidatorConfigBuilder::new()
                 .with_config_directory(data_dir.clone())
-                .with_unsafe_genesis_committee(genesis_committee.clone())
-                .build(
-                    init,
-                    rpc_url.clone(),
-                    ika_package_id,
-                    ika_common_package_id,
-                    ika_dwallet_2pc_mpc_package_id,
-                    ika_system_package_id,
-                    ika_system_object_id,
-                    ika_dwallet_coordinator_object_id,
-                );
+                .with_unsafe_genesis_committee(genesis_committee.clone());
+            if let Some(cores) = max_mpc_computation_cores {
+                builder = builder.with_max_mpc_computation_cores(cores);
+            }
+            let node_config = builder.build(
+                init,
+                rpc_url.clone(),
+                ika_package_id,
+                ika_common_package_id,
+                ika_dwallet_2pc_mpc_package_id,
+                ika_system_package_id,
+                ika_system_object_id,
+                ika_dwallet_coordinator_object_id,
+            );
             let proc = spawn_node(
                 i,
                 self.validator_binary.clone(),
@@ -593,19 +604,26 @@ impl ClusterOfProcesses {
             .map_err(|e| {
                 anyhow::anyhow!("fetch Sui genesis committee for joiner OCS anchor: {e}")
             })?;
-        let node_config = ValidatorConfigBuilder::new()
+        // Same MPC-computation-core cap as the genesis validators (see `build`).
+        let max_mpc_computation_cores = std::env::var("MAX_MPC_COMPUTATION_CORES")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok());
+        let mut builder = ValidatorConfigBuilder::new()
             .with_config_directory(data_dir.clone())
-            .with_unsafe_genesis_committee(genesis_committee)
-            .build(
-                &init,
-                self.rpc_url.clone(),
-                self.packages.ika_package_id,
-                self.packages.ika_common_package_id,
-                self.packages.ika_dwallet_2pc_mpc_package_id,
-                self.packages.ika_system_package_id,
-                self.system.ika_system_object_id,
-                self.system.ika_dwallet_coordinator_object_id,
-            );
+            .with_unsafe_genesis_committee(genesis_committee);
+        if let Some(cores) = max_mpc_computation_cores {
+            builder = builder.with_max_mpc_computation_cores(cores);
+        }
+        let node_config = builder.build(
+            &init,
+            self.rpc_url.clone(),
+            self.packages.ika_package_id,
+            self.packages.ika_common_package_id,
+            self.packages.ika_dwallet_2pc_mpc_package_id,
+            self.packages.ika_system_package_id,
+            self.system.ika_system_object_id,
+            self.system.ika_dwallet_coordinator_object_id,
+        );
         let proc = spawn_node(
             index,
             binary,

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -181,6 +181,14 @@ impl ClusterBuilder {
     }
 
     pub async fn build(self) -> Result<ClusterOfProcesses> {
+        let genesis_version = self
+            .genesis_protocol_version
+            .unwrap_or(ProtocolVersion::MIN);
+        tracing::info!(
+            "[flow] bringing up {} validators (genesis v{})",
+            self.num_validators,
+            genesis_version.as_u64()
+        );
         let base_dir = match &self.base_dir {
             Some(p) => {
                 std::fs::create_dir_all(p)?;
@@ -459,6 +467,7 @@ impl ClusterOfProcesses {
     /// network DKG (which runs during epoch 1) has completed — rather than
     /// polling the network-key state directly.
     pub async fn wait_for_epoch(&self, target: u64, timeout: Duration) -> Result<()> {
+        tracing::info!("[flow] waiting for epoch {target} (timeout {timeout:?})");
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
             // A failed read is treated as "not there yet" so a transient RPC
@@ -526,6 +535,7 @@ impl ClusterOfProcesses {
     ///
     /// Returns the new validator's index in `validators`.
     pub async fn add_joiner_validator(&mut self, binary: PathBuf) -> Result<usize> {
+        tracing::info!("[flow] joining new validator (candidate -> stake -> activate)");
         let index = self.validators.len();
         let mut rng = OsRng;
         let mut init = ValidatorInitializationConfigBuilder::new().build(&mut rng);

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -264,6 +264,15 @@ impl ClusterBuilder {
             })
             .collect();
 
+        // OCS verified-reads path (protocol v4): a validator with `sui-data-source`
+        // set refuses to boot without a Sui trust anchor. Seed every validator
+        // with the Sui localnet's epoch-0 committee as the `unsafe_genesis_committee`
+        // anchor (the private-net path), mirroring IkaTestClusterBuilder. Harmless
+        // pre-v4 (the field is unused on the JSON-RPC path).
+        let genesis_committee = ika_sui_client::anchor::fetch_genesis_committee(&rpc_url)
+            .await
+            .map_err(|e| anyhow::anyhow!("fetch Sui genesis committee for OCS anchor: {e}"))?;
+
         // 4. Per-validator NodeConfig on a persistent data dir, written to YAML.
         let mut validators = Vec::with_capacity(self.num_validators);
         for (i, init) in validator_init_configs.iter().enumerate() {
@@ -271,6 +280,7 @@ impl ClusterBuilder {
             std::fs::create_dir_all(&data_dir)?;
             let node_config = ValidatorConfigBuilder::new()
                 .with_config_directory(data_dir.clone())
+                .with_unsafe_genesis_committee(genesis_committee.clone())
                 .build(
                     init,
                     rpc_url.clone(),
@@ -570,8 +580,16 @@ impl ClusterOfProcesses {
 
         let data_dir = self.base.join(format!("validator-{index}"));
         std::fs::create_dir_all(&data_dir)?;
+        // Same OCS v4 trust anchor as the genesis validators (see `build`): the
+        // epoch-0 committee is immutable, so re-fetch it for the joiner.
+        let genesis_committee = ika_sui_client::anchor::fetch_genesis_committee(&self.rpc_url)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!("fetch Sui genesis committee for joiner OCS anchor: {e}")
+            })?;
         let node_config = ValidatorConfigBuilder::new()
             .with_config_directory(data_dir.clone())
+            .with_unsafe_genesis_committee(genesis_committee)
             .build(
                 &init,
                 self.rpc_url.clone(),

--- a/crates/ika-upgrade-test/src/process.rs
+++ b/crates/ika-upgrade-test/src/process.rs
@@ -36,6 +36,15 @@ pub struct ValidatorProcess {
     metrics_port: u16,
     /// Per-validator log file (child stdout+stderr).
     log_path: PathBuf,
+    /// `RAYON_NUM_THREADS` for this child's crypto pool. The harness packs
+    /// several validator processes onto one host, each running the real node
+    /// binary built `--no-default-features` (so `enforce-minimum-cpu` is off and
+    /// the node's rayon pool would otherwise grab every core — see
+    /// `ika-core`'s `runtime.rs`). With the parallel crypto feature active, N
+    /// such processes oversubscribe the CPU N× and starve the async runtimes —
+    /// on CI hard enough to kill the runner agent. Bounded to a fair per-node
+    /// slice at construction.
+    rayon_threads: usize,
     child: Option<Child>,
     http: reqwest::Client,
 }
@@ -49,6 +58,7 @@ impl ValidatorProcess {
         admin_addr: SocketAddr,
         metrics_port: u16,
         log_path: PathBuf,
+        rayon_threads: usize,
     ) -> Self {
         Self {
             index,
@@ -58,6 +68,7 @@ impl ValidatorProcess {
             admin_addr,
             metrics_port,
             log_path,
+            rayon_threads,
             child: None,
             http: reqwest::Client::new(),
         }
@@ -85,6 +96,9 @@ impl ValidatorProcess {
         let child = Command::new(&self.binary)
             .arg("--config-path")
             .arg(&self.config_path)
+            // Bound this child's crypto rayon pool so co-located validator
+            // processes don't oversubscribe the host (see `rayon_threads`).
+            .env("RAYON_NUM_THREADS", self.rayon_threads.to_string())
             .stdout(Stdio::from(log))
             .stderr(Stdio::from(stderr))
             .kill_on_drop(true)

--- a/crates/ika-upgrade-test/src/process.rs
+++ b/crates/ika-upgrade-test/src/process.rs
@@ -185,6 +185,43 @@ impl ValidatorProcess {
         .await
     }
 
+    /// Like [`set_buffer_stake`], but tolerant of the validator's local epoch
+    /// lagging the on-chain epoch right after a boundary. The admin handler
+    /// checks the requested `epoch` against the node's *local* `epoch_store`
+    /// and returns a 500 `WrongEpoch` until the node has reconfigured into
+    /// `epoch` — but the on-chain counter (what callers read to pick `epoch`)
+    /// advances first, so a POST fired the instant the counter ticks races the
+    /// node's reconfiguration. Retry across that window until the override
+    /// lands, or `timeout` elapses. Only the wrong-epoch rejection is retried;
+    /// any other error returns immediately.
+    pub async fn set_buffer_stake_when_at_epoch(
+        &self,
+        epoch: u64,
+        buffer_bps: u64,
+        timeout: Duration,
+    ) -> Result<String> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut backoff = Duration::from_millis(200);
+        loop {
+            match self.set_buffer_stake(epoch, buffer_bps).await {
+                Ok(body) => return Ok(body),
+                Err(error) => {
+                    let local_epoch_lagging = error.to_string().contains("wrong epoch");
+                    if !local_epoch_lagging || tokio::time::Instant::now() >= deadline {
+                        return Err(error);
+                    }
+                    tracing::info!(
+                        index = self.index,
+                        target_epoch = epoch,
+                        "buffer-stake override rejected; local epoch still catching up, retrying",
+                    );
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(2));
+                }
+            }
+        }
+    }
+
     pub fn is_running(&self) -> bool {
         self.child.is_some()
     }

--- a/crates/ika-upgrade-test/src/scenario.rs
+++ b/crates/ika-upgrade-test/src/scenario.rs
@@ -297,14 +297,21 @@ impl Scenario {
                 }
                 Step::SetBufferStake { buffer_bps } => {
                     let c = cluster.as_ref().context("SetBufferStake before StartAll")?;
+                    // `current_epoch` is the on-chain counter, which ticks before
+                    // validators locally reconfigure; retry the override across
+                    // that lag so it isn't rejected for a stale local epoch.
                     let epoch = c.current_epoch().await?;
                     for proc in &c.validators {
                         if proc.is_running() {
-                            proc.set_buffer_stake(epoch, *buffer_bps)
-                                .await
-                                .with_context(|| {
-                                    format!("set buffer stake on validator {}", proc.index)
-                                })?;
+                            proc.set_buffer_stake_when_at_epoch(
+                                epoch,
+                                *buffer_bps,
+                                Duration::from_secs(120),
+                            )
+                            .await
+                            .with_context(|| {
+                                format!("set buffer stake on validator {}", proc.index)
+                            })?;
                         }
                     }
                     tracing::info!(epoch, buffer_bps, "buffer stake override applied");

--- a/crates/ika-upgrade-test/src/scenario.rs
+++ b/crates/ika-upgrade-test/src/scenario.rs
@@ -81,6 +81,29 @@ pub enum Step {
     },
 }
 
+impl std::fmt::Display for Step {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Step::StartAll(spec) => write!(f, "start_all({})", spec.label()),
+            Step::WaitForEpoch(e) => write!(f, "wait_for_epoch({e})"),
+            Step::StopAndSwap { validators, to } => {
+                write!(f, "stop_and_swap({validators:?} -> {})", to.label())
+            }
+            Step::SetBufferStake { buffer_bps } => write!(f, "set_buffer_stake({buffer_bps})"),
+            Step::ExpectProtocolVersionAtLeast(v) => {
+                write!(f, "expect_protocol_version_at_least({v})")
+            }
+            Step::JoinValidator(spec) => write!(f, "join_validator({})", spec.label()),
+            Step::RemoveValidator { index } => write!(f, "remove_validator({index})"),
+            Step::StopValidator { index } => write!(f, "stop_validator({index})"),
+            Step::ExpectCommitteeSize(n) => write!(f, "expect_committee_size({n})"),
+            Step::SetGlobalPresignConfig => write!(f, "set_global_presign_config"),
+            Step::RecordMpcTimings { label } => write!(f, "record_mpc_timings({label:?})"),
+            Step::RunWorkload { label } => write!(f, "run_workload({label:?})"),
+        }
+    }
+}
+
 /// What a scenario run produced beyond pass/fail: the labeled MPC timing
 /// snapshots, in recording order. The comparison between consecutive
 /// snapshots is printed by `run` itself; tests can also inspect the raw
@@ -257,7 +280,11 @@ impl Scenario {
         let mut cluster: Option<ClusterOfProcesses> = None;
         let mut timing_snapshots: Vec<TimingSnapshot> = Vec::new();
 
-        for step in &self.steps {
+        let total = self.steps.len();
+        for (index, step) in self.steps.iter().enumerate() {
+            let step_number = index + 1;
+            let step_started = std::time::Instant::now();
+            tracing::info!("[flow {step_number}/{total}] >>> {step}");
             match step {
                 Step::StartAll(spec) => {
                     let validator_binary = resolve(&resolver, spec).await?;
@@ -393,6 +420,10 @@ impl Scenario {
                     tracing::info!(label = %label, ?outcome, "workload lifecycle completed");
                 }
             }
+            tracing::info!(
+                "[flow {step_number}/{total}] <<< {step} done in {:.1}s",
+                step_started.elapsed().as_secs_f64()
+            );
         }
         if timing_snapshots.len() >= 2 {
             println!("{}", mpc_timings::render_comparison(&timing_snapshots));

--- a/crates/ika-upgrade-test/tests/smoke.rs
+++ b/crates/ika-upgrade-test/tests/smoke.rs
@@ -52,6 +52,8 @@ async fn smoke_four_validators_reach_epoch_two() {
     );
     let _ = std::fs::remove_dir_all(&base);
 
+    tracing::info!("[flow 1/2] >>> cluster_bring_up");
+    let phase_start = std::time::Instant::now();
     let cluster = ClusterBuilder::new(validator, notifier, sui)
         .with_num_validators(4)
         .with_epoch_duration_ms(60_000)
@@ -60,6 +62,10 @@ async fn smoke_four_validators_reach_epoch_two() {
         .build()
         .await
         .expect("cluster bring-up");
+    tracing::info!(
+        "[flow 1/2] <<< cluster_bring_up done in {:.1}s",
+        phase_start.elapsed().as_secs_f64()
+    );
 
     let start_epoch = cluster.current_epoch().await.expect("read epoch");
     let start_version = cluster
@@ -72,10 +78,16 @@ async fn smoke_four_validators_reach_epoch_two() {
         "cluster up; waiting for epoch 2"
     );
 
+    tracing::info!("[flow 2/2] >>> wait_for_epoch(2)");
+    let phase_start = std::time::Instant::now();
     cluster
         .wait_for_epoch(2, Duration::from_secs(900))
         .await
         .expect("reach epoch 2");
+    tracing::info!(
+        "[flow 2/2] <<< wait_for_epoch(2) done in {:.1}s",
+        phase_start.elapsed().as_secs_f64()
+    );
 
     tracing::info!("go/no-go PASSED: out-of-process cluster reached epoch 2");
 }

--- a/crates/ika-upgrade-test/tests/v118_churn.rs
+++ b/crates/ika-upgrade-test/tests/v118_churn.rs
@@ -1,0 +1,132 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Literal mainnet-v1.1.8 upgrade rehearsal **with post-upgrade committee
+//! churn**: boot a 4-validator committee on the actual `mainnet-v1.1.8`
+//! `ika-node` binary at protocol v3, swap **all validators atomically** to the
+//! local build and confirm the upgrade to v4 — then, on the now all-local
+//! committee, **join a brand-new validator** (candidate → stake → activate) so
+//! the v4 reshare encrypts the network key (originally DKG'd by 1.1.8's crypto)
+//! to a 5-member committee that includes a party which never held it.
+//!
+//! This combines what `v118_upgrade` and `cross_binary` cover separately: the
+//! real 1.1.8 → v4 on-disk + crypto continuity (`v118_upgrade`) AND a
+//! committee-churn reshare that exercises the OCS joiner trust-anchor path
+//! (`cross_binary`'s `add_joiner_validator`, which seeds the joiner's
+//! `sui_unsafe_genesis_committee` so a v4/OCS validator boots).
+//!
+//! The churn runs **only after** the atomic swap, so every validator is the
+//! local build — there is never a mixed 1.1.8/local committee. That is
+//! required: this branch single-pins `cryptography-private`, so mixed
+//! committees can't exchange MPC messages; the swap must be atomic, and any
+//! churn must follow it. (A *rolling* 1.1.8 swap — `cross_binary` from 1.1.8 —
+//! is therefore invalid; this scenario is how to get churn from a 1.1.8
+//! origin.)
+//!
+//! Opt-in, via `RUN_V118_CHURN=1` (same binaries as `v118_upgrade`):
+//!
+//! ```bash
+//! RUN_V118_CHURN=1 \
+//!   OLD_BIN=/tmp/ika-v118/target/release/ika-node \
+//!   NEW_BIN=target/release/ika-validator \
+//!   NOTIFIER_BIN=target/release/ika-notifier \
+//!   IKA_BIN=target/release/ika \
+//!   SUI_BIN=$(which sui) \
+//!   cargo test --release -p ika-upgrade-test --test v118_churn -- --nocapture
+//! ```
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ika_swarm_config::sui_client::GenesisGlobalPresignConfig;
+use ika_upgrade_test::binary::BinarySpec;
+use ika_upgrade_test::scenario::Scenario;
+
+fn bin_from_env(var: &str, default: &str) -> PathBuf {
+    PathBuf::from(std::env::var(var).unwrap_or_else(|_| default.to_string()))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn v118_atomic_upgrade_then_committee_churn() {
+    if std::env::var("RUN_V118_CHURN").is_err() {
+        eprintln!(
+            "skipping: set RUN_V118_CHURN=1 (needs OLD_BIN/NEW_BIN/NOTIFIER_BIN/IKA_BIN/SUI_BIN)"
+        );
+        return;
+    }
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
+        .with_log_level("info")
+        .with_env()
+        .init();
+
+    let old = BinarySpec::Path(bin_from_env(
+        "OLD_BIN",
+        "/tmp/ika-v118/target/release/ika-node",
+    ));
+    let new = BinarySpec::Path(bin_from_env("NEW_BIN", "target/release/ika-validator"));
+    let notifier = bin_from_env("NOTIFIER_BIN", "target/release/ika-notifier");
+    let ika_cli = bin_from_env("IKA_BIN", "target/release/ika");
+    let sui = bin_from_env("SUI_BIN", "sui");
+    let repo = std::env::current_dir()
+        .expect("cwd")
+        .ancestors()
+        .nth(2)
+        .expect("workspace root")
+        .to_path_buf();
+
+    let base = PathBuf::from(
+        std::env::var("UPGRADE_TEST_DIR")
+            .unwrap_or_else(|_| "/mnt/nvme0n1p1/tmp/ika-v118-churn".to_string()),
+    );
+    let _ = std::fs::remove_dir_all(&base);
+
+    // Longer epochs give a loaded CI runner slack to finish each epoch's crypto
+    // before the boundary; override via `EPOCH_DURATION_MS`.
+    let epoch_duration_ms = std::env::var("EPOCH_DURATION_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(300_000);
+
+    Scenario::new(4, repo, sui, notifier)
+        .with_base_dir(base)
+        .with_epoch_duration_ms(epoch_duration_ms)
+        .with_epoch_timeout(Duration::from_secs(1200))
+        .with_ika_cli(ika_cli)
+        // Mainnet-faithful on-chain state (populated global-presign config).
+        .with_genesis_global_presign_config(GenesisGlobalPresignConfig::Full)
+        // Boot the literal 1.1.8 committee at v3; epoch 2 guarantees the genesis
+        // network DKG (1.1.8 crypto) completed before the swap.
+        .start_all(old)
+        .wait_for_epoch(2)
+        // ATOMIC swap every validator to the local build (rolling is impossible
+        // on this branch's single crypto pin). The local v4 binaries inherit
+        // and reshare the completed 1.1.8-crypto network key.
+        .stop_and_swap(&[0, 1, 2, 3], new.clone())
+        // n=4: drop the buffer to a bare quorum so the capability vote tallies.
+        .set_buffer_stake(0)
+        .wait_for_epoch(3)
+        .expect_protocol_version_at_least(4)
+        .expect_committee_size(4)
+        // The churn under test: all validators are now the local build (no mixed
+        // committee), so a brand-new local validator can join. The v4 reshare
+        // encrypts the 1.1.8-origin network key to a 5-member committee that
+        // includes a party which never held it, and the joiner boots on the OCS
+        // gRPC path — which refuses to start without a Sui trust anchor; the
+        // harness seeds it in `add_joiner_validator` (the path this scenario
+        // exists to exercise from a real 1.1.8 origin).
+        .join_validator(new.clone())
+        .wait_for_epoch(4)
+        .expect_committee_size(5)
+        // The new 5-member committee runs a full lifecycle against the reshared
+        // 1.1.8-origin network key.
+        .run_workload("v4-with-joiner")
+        .record_mpc_timings("v4-with-joiner")
+        .run()
+        .await
+        .expect("v1.1.8 -> local atomic upgrade + committee churn");
+
+    tracing::info!(
+        "v118 churn rehearsal PASSED: mainnet-v1.1.8 -> local, v3 -> v4, joiner added to a \
+         5-member committee resharing the 1.1.8-origin network key"
+    );
+}

--- a/crates/ika-upgrade-test/tests/workload.rs
+++ b/crates/ika-upgrade-test/tests/workload.rs
@@ -57,6 +57,8 @@ async fn workload_dkg_presign_sign() {
     );
     let _ = std::fs::remove_dir_all(&base);
 
+    tracing::info!("[flow 1/7] >>> cluster_bring_up");
+    let phase_start = std::time::Instant::now();
     let cluster = ClusterBuilder::new(validator, notifier, sui)
         .with_num_validators(4)
         // Genesis at v3 (MIN), never v4 — see module docs. The binary supports
@@ -74,6 +76,10 @@ async fn workload_dkg_presign_sign() {
         .build()
         .await
         .expect("cluster bring-up");
+    tracing::info!(
+        "[flow 1/7] <<< cluster_bring_up done in {:.1}s",
+        phase_start.elapsed().as_secs_f64()
+    );
 
     // Wait for epoch 2, not 1. Epoch 1 is genesis and is reached immediately,
     // *before* the network DKG runs — so the DKG output isn't on-chain yet and
@@ -81,10 +87,16 @@ async fn workload_dkg_presign_sign() {
     // 2 is itself the completion signal: reconfiguration into epoch 2 reshares
     // the genesis key, which can't happen until the genesis DKG finished. So
     // reaching epoch 2 guarantees the v3 network key is readable.
+    tracing::info!("[flow 2/7] >>> wait_for_epoch(2)");
+    let phase_start = std::time::Instant::now();
     cluster
         .wait_for_epoch(2, Duration::from_secs(900))
         .await
         .expect("reach epoch 2 (genesis network DKG + reshare done at v3)");
+    tracing::info!(
+        "[flow 2/7] <<< wait_for_epoch(2) done in {:.1}s",
+        phase_start.elapsed().as_secs_f64()
+    );
 
     // With n=4 the default 50% buffer stake rounds the capability-vote
     // threshold up to all four validators; a single lagging capability
@@ -96,18 +108,32 @@ async fn workload_dkg_presign_sign() {
     // The admin handler validates the override against the node's local epoch,
     // so POST it with a retry that waits out that reconfiguration lag rather
     // than firing once the instant the counter ticks (which loses the race).
+    tracing::info!("[flow 3/7] >>> set_buffer_stake");
+    let phase_start = std::time::Instant::now();
     let epoch = cluster.current_epoch().await.expect("read current epoch");
     for proc in &cluster.validators {
         proc.set_buffer_stake_when_at_epoch(epoch, 0, Duration::from_secs(120))
             .await
             .unwrap_or_else(|e| panic!("set buffer stake on validator {}: {e}", proc.index));
     }
+    tracing::info!(
+        "[flow 3/7] <<< set_buffer_stake done in {:.1}s",
+        phase_start.elapsed().as_secs_f64()
+    );
 
+    tracing::info!("[flow 4/7] >>> wait_for_epoch(3)");
+    let phase_start = std::time::Instant::now();
     cluster
         .wait_for_epoch(3, Duration::from_secs(600))
         .await
         .expect("reach epoch 3 (crossing the v3->v4 upgrade boundary)");
+    tracing::info!(
+        "[flow 4/7] <<< wait_for_epoch(3) done in {:.1}s",
+        phase_start.elapsed().as_secs_f64()
+    );
 
+    tracing::info!("[flow 5/7] >>> assert_protocol_version");
+    let phase_start = std::time::Instant::now();
     let protocol_version = cluster
         .current_protocol_version()
         .await
@@ -116,7 +142,13 @@ async fn workload_dkg_presign_sign() {
         protocol_version >= 4,
         "expected protocol v4 after the upgrade boundary, got v{protocol_version}"
     );
+    tracing::info!(
+        "[flow 5/7] <<< assert_protocol_version done in {:.1}s",
+        phase_start.elapsed().as_secs_f64()
+    );
 
+    tracing::info!("[flow 6/7] >>> build_workload_driver");
+    let phase_start = std::time::Instant::now();
     let driver = WorkloadDriver::new(
         ika_cli,
         cluster.rpc_url().to_string(),
@@ -126,6 +158,10 @@ async fn workload_dkg_presign_sign() {
     )
     .await
     .expect("build workload driver");
+    tracing::info!(
+        "[flow 6/7] <<< build_workload_driver done in {:.1}s",
+        phase_start.elapsed().as_secs_f64()
+    );
 
     // Debug aid: hold the cluster up and print config paths so `ika dwallet`
     // can be driven manually (fast iteration vs. ~6-min test cycles).
@@ -141,6 +177,8 @@ async fn workload_dkg_presign_sign() {
         return;
     }
 
+    tracing::info!("[flow 7/7] >>> run_dwallet_lifecycle");
+    let phase_start = std::time::Instant::now();
     let outcome = driver
         .run_dwallet_lifecycle()
         .await
@@ -149,6 +187,10 @@ async fn workload_dkg_presign_sign() {
     assert!(
         !outcome.sign_digest.is_empty(),
         "sign produced a transaction digest"
+    );
+    tracing::info!(
+        "[flow 7/7] <<< run_dwallet_lifecycle done in {:.1}s",
+        phase_start.elapsed().as_secs_f64()
     );
     tracing::info!(
         dwallet_id = %outcome.dwallet_id,

--- a/crates/ika-upgrade-test/tests/workload.rs
+++ b/crates/ika-upgrade-test/tests/workload.rs
@@ -91,9 +91,14 @@ async fn workload_dkg_presign_sign() {
     // registration then blocks the upgrade forever. Drop the buffer to a bare
     // quorum (the realistic behavior on larger committees) so the v3->v4 vote
     // tallies at the next epoch boundary.
+    // current_epoch() reads the on-chain epoch counter, which advances at the
+    // epoch-closing checkpoint *before* each validator locally reconfigures.
+    // The admin handler validates the override against the node's local epoch,
+    // so POST it with a retry that waits out that reconfiguration lag rather
+    // than firing once the instant the counter ticks (which loses the race).
     let epoch = cluster.current_epoch().await.expect("read current epoch");
     for proc in &cluster.validators {
-        proc.set_buffer_stake(epoch, 0)
+        proc.set_buffer_stake_when_at_epoch(epoch, 0, Duration::from_secs(120))
             .await
             .unwrap_or_else(|e| panic!("set buffer stake on validator {}: {e}", proc.index));
     }

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -64,9 +64,19 @@ per-push gate. The contract it verifies is
 [`../specs/cross-binary-upgrade.md`](../specs/cross-binary-upgrade.md).
 
 ```bash
-# Pick one scenario via `test`. smoke/workload need only the current build;
-# cross_binary/v118_upgrade also build an OLD binary from `old_ref` in a
-# worktree (at that ref's own toolchain) and run --test-threads=1.
+# `test` selects scenarios: 'all' (the default) fans EVERY scenario out as its
+# own matrix job on its own runner, in parallel (fail-fast off, so one
+# scenario's failure/runner-death doesn't cancel the others). Pass a
+# comma-separated subset to run several, or a single name to run one. Each
+# scenario's artifacts/logs are suffixed with its name. smoke/workload need
+# only the current build; cross_binary/v118_upgrade/v118_churn also build an OLD
+# binary from `old_ref` in a worktree (own toolchain) and run --test-threads=1.
+# NOTE: per-run overrides (old_ref/old_max_protocol_version) apply to EVERY
+# selected scenario — leave them empty unless you scope `test` to one scenario.
+
+# Everything in parallel (default), or a subset:
+gh workflow run upgrade-test.yaml --ref <branch>                       # = test=all
+gh workflow run upgrade-test.yaml --ref <branch> -f test=smoke,cross_binary,v118_churn
 
 # Plumbing go/no-go (fastest): 4 same-binary processes reach epoch 2.
 gh workflow run upgrade-test.yaml --ref <branch> -f test=smoke

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -103,9 +103,8 @@ gh workflow run upgrade-test.yaml --ref <branch> -f test=v118_upgrade
 
 # Artifacts: upgrade-test-log-<test>-<attempt> (test stdout),
 # upgrade-test-node-logs-<test>-<attempt> (per-validator *.log),
-# resource-sampler-<test>-<attempt> (15s CPU+memory samples). Plus, on a
-# runner death, the in-Run-step ::warning:: annotations (memory 90/95%,
-# oom_kill) survive on the job page when artifacts do not.
+# resource-sampler-<test>-<attempt> (15s CPU+memory samples; recovered only on
+# runs that FINISH — a runner death drops it like every other artifact).
 ```
 
 ### Scenario differences — `cross_binary` vs `v118_upgrade` (and the rest)
@@ -196,24 +195,42 @@ earlier confident claims here were wrong:**
   "the memory axis, complementary to #1770's CPU axis" was wrong — both act on
   CPU. Keep it as a cheap knob; don't rely on it to fix the death.
 
-**To actually diagnose the death:** the sampler is now memory-aware
-(`resource-sampler.log`): every 15 s it records `mem=current/max pct=… swap=…
-oom_kill=… top=[RSS by process]`, and — because it runs *inside* the Run step —
-raises `::warning::` annotations at 90 %/95 % of `memory.max` and on any cgroup
-`oom_kill`. Annotations reach the server as the run proceeds, so the last one
-before death **survives the "lost communication"** that erases everything else.
-Run `cross_binary` once and read the job's annotations: memory climbing to
-~96 GiB → OOM; flat memory while CPU pegs → starvation (already unlikely); both
-calm at the kill → external eviction. For a definitive answer, also have the
-infra owner pull the pod's **kubelet eviction events** and **`dmesg`
-OOM-killer** lines — those live on the node, not the (dead) pod.
+**What we measured, and the on-pod dead end (2026-06 follow-up):** the sampler
+is now memory-aware (`resource-sampler.log`: `mem=current/max pct=… swap=…
+oom_kill=… top=[RSS]` every 15 s). On a *surviving* `smoke` run it showed **each
+`ika-validator` ≈ 7.5–8 GB RSS** and 4 idle validators + overhead at **62 % of
+the 96 GiB pod, swap=0** — memory is the dominant resource, and `cross_binary`'s
+5–6 concurrently-resharing validators extrapolate past the ceiling, so
+**memory-OOM is the strongly-supported (but still unconfirmed) suspect**. Two
+attempts to capture it *on the pod* both failed, and the failures are the point:
 
-**Meanwhile, to get `cross_binary` green:** raise epochs for slack
-(`-f epoch_duration_ms=600000`); if memory is confirmed, use a bigger-memory
-pod or a smaller committee. `v118_upgrade`/`v118_churn` (no / one churn) and
-`smoke`/`workload` are lighter and pass. Note: artifacts **and** the live
-test-step log are lost on runner death — only the pre-test steps ("Runner
-resources", builds) and the in-Run-step `::warning::` annotations survive.
+- **Runner-emitted annotations do NOT survive a runner death.** A foreground
+  `::warning::` *is* parsed (a surviving `smoke` run shows the sampler's startup
+  line), but a death **wipes the job's runner-emitted annotations** — a dead
+  `cross_binary` run with the identical startup line shows none; only GitHub's
+  own backend-generated "lost communication" annotation remains. (Background
+  sampler commands aren't parsed at all.) So annotations, artifacts, and the job
+  log are **all** lost on death — there is **no on-pod channel** that survives.
+- **`max_mpc_computation_cores=1` + 10 min epochs still died** (run 28062374647,
+  0 artifacts). Minimizing concurrent MPC + epoch overlap should have cut any
+  *transient* MPC memory — it didn't help, which points at the **baseline
+  per-validator footprint × 5–6 validators**, not the computation transient, as
+  the pressure. The cap is the wrong lever.
+
+**So a direct read of the death needs an OFF-pod channel:** the infra owner pulls
+the pod's **kubelet events** (`OOMKilled` vs `Evicted` vs node loss) and **node
+`dmesg`** (OOM-killer line names the process + RSS) — definitive; or the sampler
+pushes samples off-pod mid-run via the runner `GITHUB_TOKEN` (e.g. to a throwaway
+branch) so they land before the death.
+
+**To get `cross_binary` green meanwhile:** the fix follows the evidence, not the
+mechanism — **a bigger-memory pod or a smaller peak committee**. The cap and
+longer epochs do *not* save it. `v118_churn` (one joiner from a real 1.1.8
+origin) already passes and covers the OCS joiner-anchor path, so `cross_binary`'s
+heavier synthetic coverage is the only thing blocked by the pod ceiling. Note:
+on a runner death, artifacts, the live step log, **and** runner-emitted
+annotations are all lost — only the pre-test step logs ("Runner resources",
+builds) survive.
 
 ## Facts that save debugging time
 
@@ -227,10 +244,12 @@ resources", builds) and the in-Run-step `::warning::` annotations survive.
   steps run when a job is cancelled (so cancelling a doomed run still
   yields artifacts), but a runner-pod death ("The self-hosted runner lost
   communication with the server", log cut off, zero artifacts) skips
-  everything — the live step log is lost too (the job-log blob 404s). The
-  only channels that survive a death are pre-test step logs and
-  **`::warning::` annotations emitted from inside the running step** (the
-  upgrade-test resource sampler exploits this for memory). That is also
+  everything — the live step log is lost too (the job-log blob 404s), and
+  even runner-emitted **`::warning::` annotations are wiped** (only GitHub's
+  own backend "lost communication" annotation remains; proven by a surviving
+  vs dead run emitting the identical startup warning). The **only** channels
+  that survive a death are pre-test step logs and anything pushed OFF the pod
+  before it dies (kubelet/dmesg on the node, or a token-push). That is also
   why failure replays stay inline in the cluster workflow.
 - **`exit code 100`** from the cluster job is nextest's tests-failed
   code (real failures, artifacts present) — distinct from runner death.

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -116,14 +116,20 @@ branch differing only in advertised protocol version, so they are
 MPC-wire-compatible and a *rolling* swap with mixed committees is valid.
 `v118_upgrade` can't do that — this branch single-pins `cryptography-private`,
 so a mixed 1.1.8/local committee can't exchange MPC messages; it must swap
-**atomically** (a coordinated full-network restart).
+**atomically** (a coordinated full-network restart). A *rolling* `cross_binary`
+from 1.1.8 is therefore invalid; to get churn from a real 1.1.8 origin you swap
+atomically first, then churn — which is exactly **`v118_churn`** (`v118_upgrade`
++ one post-swap joiner: the v4 reshare of the 1.1.8-origin network key then
+includes a party that never held it, with no mixed committee).
 
 **Which to use:** `v118_upgrade` is the pre-mainnet-upgrade rehearsal (real
-release, real on-disk + crypto continuity). `cross_binary` is the synthetic
-rolling-upgrade + **committee-churn** exercise — and the **only** scenario that
-adds a joiner validator, so it's the one that exercises the OCS
-joiner-anchor path (`add_joiner_validator`). It is also the **heaviest** (peaks
-at a 5-member committee + two full MPC lifecycles + joiners' class-groups keys).
+release, real on-disk + crypto continuity); `v118_churn` is the same plus one
+joiner. The OCS joiner-anchor path (`add_joiner_validator`) is exercised by two
+scenarios — `cross_binary` (synthetic, between two builds of this branch;
+**heaviest**: 5-member peak + two MPC lifecycles + multiple joiners) and
+`v118_churn` (a single join from a genuine 1.1.8 origin — lighter, and the more
+faithful test). All churn scenarios peak at ≥5 validators, so they hit the
+runner-resource ceiling below.
 
 ### CI runner resources & the `cross_binary` runner-death failure mode
 
@@ -152,9 +158,14 @@ oversubscription is not the killer**. The likely cause is **memory**: ~96 GiB
 shared across 5–6 class-groups validators ≈ 16 GiB each at the ceiling, with no
 swap → a hard cgroup OOM-kill. Two mitigations are in `ika-upgrade-test`: each
 spawned node's rayon pool is bounded (PR #1770), and that bound is sized by the
-CFS quota rather than host cores. **[Pending: run 28042389003 — record whether
-the quota-bounded run completes or still OOMs, and the harness-logged
-`available_parallelism` vs `cgroup cpu.max` values.]**
+CFS quota rather than host cores. **Neither resolves it** — with both in place
+the run still died the same way (runner death, 0 artifacts). That confirms
+**CPU oversubscription is not the cause; memory is** — the 96 GiB ceiling vs
+5–6 class-groups validators, not thread count. (The harness's
+`available_parallelism` value can't be captured from a dead run: the test-step
+log is lost on runner death and `gh run view --log` doesn't stream the
+in-progress step, so the surviving "Runner resources" numbers above are the
+reliable signal. Reproduced across ~8 runs on both this branch and `dev`.)
 
 **Running `cross_binary` on CI** therefore needs a bigger-memory pod (or a
 less-oversubscribed node), or a smaller committee. `v118_upgrade` (4 fixed

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -167,12 +167,24 @@ log is lost on runner death and `gh run view --log` doesn't stream the
 in-progress step, so the surviving "Runner resources" numbers above are the
 reliable signal. Reproduced across ~8 runs on both this branch and `dev`.)
 
-**Running `cross_binary` on CI** therefore needs a bigger-memory pod (or a
-less-oversubscribed node), or a smaller committee. `v118_upgrade` (4 fixed
-validators, no churn) is lighter; `smoke`/`workload` lighter still. Note:
-artifacts **and** the live test-step log are lost on runner death — only the
-pre-test steps ("Runner resources", builds, "Start CPU sampler") survive, so
-put any diagnostic you need where it runs before the test.
+**Running `cross_binary` on CI** — the direct fix for the memory ceiling is
+`-f max_mpc_computation_cores=N` (e.g. 2–4): it caps each validator's
+*concurrent* dwallet-MPC computations (`NodeConfig.max_mpc_computation_cores`,
+which sizes the orchestrator's slot count — `currently_running < available`,
+orchestrator.rs). Each in-flight class-groups computation is what holds the RAM,
+so a low N bounds peak memory across the co-located validators. This is
+**complementary to** PR #1770's per-node rayon-pool bound (`RAYON_NUM_THREADS`,
+set per child in `process.rs`): the two cap **different axes** — #1770 caps the
+rayon *worker-thread pool* (CPU oversubscription / throttling), while
+`max_mpc_computation_cores` caps *concurrent computations* (peak memory, the
+actual OOM). Neither subsumes the other — compute is `rayon::spawn_fifo`'d onto
+the global pool, so the slot count doesn't shrink the pool and the pool size
+doesn't limit how many computations queue up — keep both. Failing that: a
+bigger-memory pod, or a smaller committee. `v118_upgrade` (4 fixed validators,
+no churn) is lighter; `smoke`/`workload` lighter still. Note: artifacts **and**
+the live test-step log are lost on runner death — only the pre-test steps
+("Runner resources", builds, "Start CPU sampler") survive, so put any diagnostic
+you need where it runs before the test.
 
 ## Facts that save debugging time
 

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -103,7 +103,9 @@ gh workflow run upgrade-test.yaml --ref <branch> -f test=v118_upgrade
 
 # Artifacts: upgrade-test-log-<test>-<attempt> (test stdout),
 # upgrade-test-node-logs-<test>-<attempt> (per-validator *.log),
-# cpu-sampler-<test>-<attempt>.
+# resource-sampler-<test>-<attempt> (15s CPU+memory samples). Plus, on a
+# runner death, the in-Run-step ::warning:: annotations (memory 90/95%,
+# oom_kill) survive on the job page when artifacts do not.
 ```
 
 ### Scenario differences — `cross_binary` vs `v118_upgrade` (and the rest)
@@ -145,12 +147,12 @@ runner-resource ceiling below.
 
 `cross_binary` co-locates 5–6 `ika-validator` processes (4 → 5 with the joiner,
 + notifier), each doing class-groups DKG/presign, on one self-hosted pod — by
-far the heaviest upgrade-test. On the current `ika-k8s-large` pods this
-**starves the runner and it "loses communication"**: the job fails with **0
-artifacts** and `Run cross_binary` + all `if: always()` steps **blank**
-(distinct from a real nextest failure, which leaves artifacts + exit 100). The
-*same* death reproduces on a clean `dev` checkout, so it is the **pod, not any
-branch's code**.
+far the heaviest upgrade-test. On the current `ika-k8s-large` pods the
+**runner "loses communication" and dies**: the job fails with **0 artifacts**
+and `Run cross_binary` + all `if: always()` steps **blank** (distinct from a
+real nextest failure, which leaves artifacts + exit 100). The *same* death
+reproduces on a clean `dev` checkout, so it is the **pod, not any branch's
+code**. The mechanism is not yet proven (see the forensic findings below).
 
 What the surviving **"Runner resources"** step reports on these pods (it runs
 *before* the test, so its log survives the death):
@@ -162,39 +164,56 @@ What the surviving **"Runner resources"** step reports on these pods (it runs
 | `cgroup memory.max` | **96 GiB** |
 | swap | **0** |
 
-Host cores (96) and the CPU quota (80) differ only modestly, and
-`rayon_threads_per_node` already bounds well under 80 — so **CPU
-oversubscription is not the killer**. The likely cause is **memory**: ~96 GiB
-shared across 5–6 class-groups validators ≈ 16 GiB each at the ceiling, with no
-swap → a hard cgroup OOM-kill. Two mitigations are in `ika-upgrade-test`: each
-spawned node's rayon pool is bounded (PR #1770), and that bound is sized by the
-CFS quota rather than host cores. **Neither resolves it** — with both in place
-the run still died the same way (runner death, 0 artifacts). That confirms
-**CPU oversubscription is not the cause; memory is** — the 96 GiB ceiling vs
-5–6 class-groups validators, not thread count. (The harness's
-`available_parallelism` value can't be captured from a dead run: the test-step
-log is lost on runner death and `gh run view --log` doesn't stream the
-in-progress step, so the surviving "Runner resources" numbers above are the
-reliable signal. Reproduced across ~8 runs on both this branch and `dev`.)
+**What a 2026-06 forensic pass (run 28048024508 + 12 prior `cross_binary`
+jobs) actually established — read this before "fixing" it again. Several
+earlier confident claims here were wrong:**
 
-**Running `cross_binary` on CI** — the direct fix for the memory ceiling is
-`-f max_mpc_computation_cores=N` (e.g. 2–4): it caps each validator's
-*concurrent* dwallet-MPC computations (`NodeConfig.max_mpc_computation_cores`,
-which sizes the orchestrator's slot count — `currently_running < available`,
-orchestrator.rs). Each in-flight class-groups computation is what holds the RAM,
-so a low N bounds peak memory across the co-located validators. This is
-**complementary to** PR #1770's per-node rayon-pool bound (`RAYON_NUM_THREADS`,
-set per child in `process.rs`): the two cap **different axes** — #1770 caps the
-rayon *worker-thread pool* (CPU oversubscription / throttling), while
-`max_mpc_computation_cores` caps *concurrent computations* (peak memory, the
-actual OOM). Neither subsumes the other — compute is `rayon::spawn_fifo`'d onto
-the global pool, so the slot count doesn't shrink the pool and the pool size
-doesn't limit how many computations queue up — keep both. Failing that: a
-bigger-memory pod, or a smaller committee. `v118_upgrade` (4 fixed validators,
-no churn) is lighter; `smoke`/`workload` lighter still. Note: artifacts **and**
-the live test-step log are lost on runner death — only the pre-test steps
-("Runner resources", builds, "Start CPU sampler") survive, so put any diagnostic
-you need where it runs before the test.
+- **The death is a deterministic test phase, not an external timer.** Build /
+  setup time varies between jobs, yet the death lands at a near-constant
+  **~29 min into the *Run* step** (≈1760 s). One job with +108 s longer setup
+  still died at the same *run-relative* time — i.e. +108 s later in pod
+  wall-clock — so it tracks the scenario, not pod age. ~29 min is the
+  peak-concurrency phase (final 5→4 reshare / second MPC lifecycle, 5 resident
+  validators). This rules out a runner max-lifetime / kubelet-eviction timer.
+- **CPU starvation is refuted.** The sampler shows the heavy scenarios peak at
+  **~13 of the 80-CPU quota** with **zero in-window CFS throttling**
+  (`nr_throttled` flat). The runner agent always had schedulable CPU;
+  `rayon_threads_per_node` (#1770) already keeps threads well under quota.
+- **Memory-OOM is the leading suspect but UNPROVEN.** Until 2026-06 *nothing
+  measured memory* — the old sampler recorded CPU only, and a runner death
+  404s the job log + drops all artifacts, so no dead `cross_binary` pod's
+  memory was ever observed. 96 GiB / no swap across 5–6 class-groups
+  validators makes OOM plausible, but it is inference, not data. Don't restate
+  it as fact.
+- **`max_mpc_computation_cores` is NOT a proven fix, and is a CPU lever, not a
+  memory one.** It caps *concurrent* dwallet-MPC computations
+  (`currently_running < available`, orchestrator.rs) — but each computation
+  already fans out across the whole rayon pool (the `parallel` crypto
+  feature), so the cap bounds concurrent pool-saturating fan-outs (CPU
+  contention), not memory directly. Empirically it changes nothing observable:
+  **`v118_upgrade` passes with the cap unset (run 27954982236) and set (run
+  28048024508), and `cross_binary` dies either way.** Its earlier billing as
+  "the memory axis, complementary to #1770's CPU axis" was wrong — both act on
+  CPU. Keep it as a cheap knob; don't rely on it to fix the death.
+
+**To actually diagnose the death:** the sampler is now memory-aware
+(`resource-sampler.log`): every 15 s it records `mem=current/max pct=… swap=…
+oom_kill=… top=[RSS by process]`, and — because it runs *inside* the Run step —
+raises `::warning::` annotations at 90 %/95 % of `memory.max` and on any cgroup
+`oom_kill`. Annotations reach the server as the run proceeds, so the last one
+before death **survives the "lost communication"** that erases everything else.
+Run `cross_binary` once and read the job's annotations: memory climbing to
+~96 GiB → OOM; flat memory while CPU pegs → starvation (already unlikely); both
+calm at the kill → external eviction. For a definitive answer, also have the
+infra owner pull the pod's **kubelet eviction events** and **`dmesg`
+OOM-killer** lines — those live on the node, not the (dead) pod.
+
+**Meanwhile, to get `cross_binary` green:** raise epochs for slack
+(`-f epoch_duration_ms=600000`); if memory is confirmed, use a bigger-memory
+pod or a smaller committee. `v118_upgrade`/`v118_churn` (no / one churn) and
+`smoke`/`workload` are lighter and pass. Note: artifacts **and** the live
+test-step log are lost on runner death — only the pre-test steps ("Runner
+resources", builds) and the in-Run-step `::warning::` annotations survive.
 
 ## Facts that save debugging time
 
@@ -208,7 +227,10 @@ you need where it runs before the test.
   steps run when a job is cancelled (so cancelling a doomed run still
   yields artifacts), but a runner-pod death ("The self-hosted runner lost
   communication with the server", log cut off, zero artifacts) skips
-  everything — the live step log is the only surviving evidence. That is
+  everything — the live step log is lost too (the job-log blob 404s). The
+  only channels that survive a death are pre-test step logs and
+  **`::warning::` annotations emitted from inside the running step** (the
+  upgrade-test resource sampler exploits this for memory). That is also
   why failure replays stay inline in the cluster workflow.
 - **`exit code 100`** from the cluster job is nextest's tests-failed
   code (real failures, artifacts present) — distinct from runner death.

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -151,7 +151,8 @@ far the heaviest upgrade-test. On the current `ika-k8s-large` pods the
 and `Run cross_binary` + all `if: always()` steps **blank** (distinct from a
 real nextest failure, which leaves artifacts + exit 100). The *same* death
 reproduces on a clean `dev` checkout, so it is the **pod, not any branch's
-code**. The mechanism is not yet proven (see the forensic findings below).
+code**. The mechanism is now proven — a cgroup OOM-kill at the pod's 96 GiB
+memory limit (`OOMKilled`/137); see the findings and the fix below.
 
 What the surviving **"Runner resources"** step reports on these pods (it runs
 *before* the test, so its log survives the death):
@@ -168,22 +169,27 @@ jobs) actually established — read this before "fixing" it again. Several
 earlier confident claims here were wrong:**
 
 - **The death is a deterministic test phase, not an external timer.** Build /
-  setup time varies between jobs, yet the death lands at a near-constant
-  **~29 min into the *Run* step** (≈1760 s). One job with +108 s longer setup
-  still died at the same *run-relative* time — i.e. +108 s later in pod
-  wall-clock — so it tracks the scenario, not pod age. ~29 min is the
-  peak-concurrency phase (final 5→4 reshare / second MPC lifecycle, 5 resident
-  validators). This rules out a runner max-lifetime / kubelet-eviction timer.
+  setup time varies between jobs, yet the job is marked failed at a
+  near-constant **~29 min into the *Run* step** (≈1760 s). One job with +108 s
+  longer setup still died at the same *run-relative* time — so it tracks the
+  scenario, not pod age. Refinement from `kubectl`: the **actual OOM is ~20 min
+  into the Run step** (peak 5→4 reshare / second MPC lifecycle); GitHub's "lost
+  communication" then **lags the real kill by ~9–10 min** (its heartbeat-loss
+  timeout), which is the ~29 min figure. Rules out a max-lifetime/eviction timer.
 - **CPU starvation is refuted.** The sampler shows the heavy scenarios peak at
   **~13 of the 80-CPU quota** with **zero in-window CFS throttling**
   (`nr_throttled` flat). The runner agent always had schedulable CPU;
   `rayon_threads_per_node` (#1770) already keeps threads well under quota.
-- **Memory-OOM is the leading suspect but UNPROVEN.** Until 2026-06 *nothing
-  measured memory* — the old sampler recorded CPU only, and a runner death
-  404s the job log + drops all artifacts, so no dead `cross_binary` pod's
-  memory was ever observed. 96 GiB / no swap across 5–6 class-groups
-  validators makes OOM plausible, but it is inference, not data. Don't restate
-  it as fact.
+- **Memory-OOM is CONFIRMED (2026-06, via `kubectl`).** The runner pod ends
+  `State: Terminated, Reason: OOMKilled, Exit Code: 137` — the kernel OOM-killer
+  fired at the pod's **own 96 GiB cgroup limit** (`limits.memory=96Gi` on the
+  ARC runner). "Runner lost communication" is just the downstream symptom (the
+  OOM killed the runner container). It is **not** node pressure: the node
+  (`ika-worker-8`, 125 GiB) was at 17 %. `kubectl top` traced the climb to the
+  kill (steady ~24–36 GiB through the churn, then 24→54→56→66 GiB in the final
+  5 min). Note `top` reports `working_set`, which under-reads the cgroup
+  `memory.current` that triggers OOM, so its ~64 GiB peak is low — the
+  `OOMKilled`/137 status is ground truth that `memory.current` hit 96 GiB.
 - **`max_mpc_computation_cores` is NOT a proven fix, and is a CPU lever, not a
   memory one.** It caps *concurrent* dwallet-MPC computations
   (`currently_running < available`, orchestrator.rs) — but each computation
@@ -195,42 +201,46 @@ earlier confident claims here were wrong:**
   "the memory axis, complementary to #1770's CPU axis" was wrong — both act on
   CPU. Keep it as a cheap knob; don't rely on it to fix the death.
 
-**What we measured, and the on-pod dead end (2026-06 follow-up):** the sampler
-is now memory-aware (`resource-sampler.log`: `mem=current/max pct=… swap=…
-oom_kill=… top=[RSS]` every 15 s). On a *surviving* `smoke` run it showed **each
-`ika-validator` ≈ 7.5–8 GB RSS** and 4 idle validators + overhead at **62 % of
-the 96 GiB pod, swap=0** — memory is the dominant resource, and `cross_binary`'s
-5–6 concurrently-resharing validators extrapolate past the ceiling, so
-**memory-OOM is the strongly-supported (but still unconfirmed) suspect**. Two
-attempts to capture it *on the pod* both failed, and the failures are the point:
+**How it was confirmed — `kubectl`, not on-pod (every on-pod channel is wiped by
+the death):** the in-pod sampler measured **each `ika-validator` ≈ 7.5–8 GB RSS**
+(idle, from a surviving `smoke` run), but the death itself can't be read on the
+pod — a runner death **wipes the job's runner-emitted `::warning::` annotations**
+(a surviving `smoke` shows the sampler's startup line; a dead `cross_binary` with
+the identical line shows none — only GitHub's backend "lost communication"
+annotation remains), and drops the artifacts + job log too. The off-pod read is
+the one that works: with `kubectl` on the runners' cluster (`ika-prod-netbird` —
+NetBird must be up),
 
-- **Runner-emitted annotations do NOT survive a runner death.** A foreground
-  `::warning::` *is* parsed (a surviving `smoke` run shows the sampler's startup
-  line), but a death **wipes the job's runner-emitted annotations** — a dead
-  `cross_binary` run with the identical startup line shows none; only GitHub's
-  own backend-generated "lost communication" annotation remains. (Background
-  sampler commands aren't parsed at all.) So annotations, artifacts, and the job
-  log are **all** lost on death — there is **no on-pod channel** that survives.
-- **`max_mpc_computation_cores=1` + 10 min epochs still died** (run 28062374647,
-  0 artifacts). Minimizing concurrent MPC + epoch overlap should have cut any
-  *transient* MPC memory — it didn't help, which points at the **baseline
-  per-validator footprint × 5–6 validators**, not the computation transient, as
-  the pressure. The cap is the wrong lever.
+```bash
+# while the cross_binary job runs, find its ephemeral runner pod + node:
+kubectl get pods -n github-actions -o wide | grep ika-k8s-large
+# trace memory live (metrics-server; survives the pod death):
+kubectl top pod -n github-actions <pod>       # poll every ~20s
+# after death — the smoking gun:
+kubectl describe pod -n github-actions <pod> | grep -A3 'Last State'
+#   -> State: Terminated  Reason: OOMKilled  Exit Code: 137
+```
 
-**So a direct read of the death needs an OFF-pod channel:** the infra owner pulls
-the pod's **kubelet events** (`OOMKilled` vs `Evicted` vs node loss) and **node
-`dmesg`** (OOM-killer line names the process + RSS) — definitive; or the sampler
-pushes samples off-pod mid-run via the runner `GITHUB_TOKEN` (e.g. to a throwaway
-branch) so they land before the death.
+`OOMKilled`/137 at the pod's **96 GiB cgroup limit** is the confirmed cause; the
+node (125 GiB, 17 % used) had headroom, so it is the pod limit, not eviction.
+`max_mpc_computation_cores=1` + 10 min epochs **still OOM'd** (run 28062374647) —
+the pressure is the **baseline per-validator footprint × 5–6 validators**, not
+MPC transient, so the cap can't fix it.
 
-**To get `cross_binary` green meanwhile:** the fix follows the evidence, not the
-mechanism — **a bigger-memory pod or a smaller peak committee**. The cap and
-longer epochs do *not* save it. `v118_churn` (one joiner from a real 1.1.8
-origin) already passes and covers the OCS joiner-anchor path, so `cross_binary`'s
-heavier synthetic coverage is the only thing blocked by the pod ceiling. Note:
-on a runner death, artifacts, the live step log, **and** runner-emitted
-annotations are all lost — only the pre-test step logs ("Runner resources",
-builds) survive.
+**The fix (infra — the ARC `ika-k8s-large` `AutoscalingRunnerSet` in
+`github-actions`):** the runner template is `requests.memory=16Gi
+limits.memory=96Gi`, no `nodeSelector`, max 8 runners. cross_binary's peak demand
+is **> 96 GiB** (it died *at* the limit; true peak unmeasured). Because the
+*request* is only 16 GiB the scheduler can pack several bursting runners onto one
+125 GiB node, so **raising the limit alone risks a node-level OOM** — raise the
+*request* too (so heavy runners don't co-schedule), or pin cross_binary to the
+**377 GiB node `ika-worker-51`** (the rest are 125 GiB) via `nodeSelector` and a
+~150 GiB limit (which also reveals the true peak). Until then, `v118_churn` (one
+joiner from a real 1.1.8 origin) already passes and covers the OCS joiner-anchor
+path, so only cross_binary's heavier synthetic coverage is blocked. Note: on a
+runner death, artifacts, the live step log, **and** runner-emitted annotations
+are all lost — only pre-test step logs survive, and the live `kubectl top` /
+post-mortem `describe` above are the diagnostic channels.
 
 ## Facts that save debugging time
 

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -96,6 +96,73 @@ gh workflow run upgrade-test.yaml --ref <branch> -f test=v118_upgrade
 # cpu-sampler-<test>-<attempt>.
 ```
 
+### Scenario differences — `cross_binary` vs `v118_upgrade` (and the rest)
+
+All four scenarios genesis at **protocol v3** (a v4 *genesis* DKG is rejected
+forever — the network must upgrade *into* v4) with one notifier + a validator
+committee. They differ in the OLD binary, how it is swapped, and what
+continuity they prove:
+
+| | `smoke` | `workload` | `cross_binary` | `v118_upgrade` |
+|---|---|---|---|---|
+| OLD binary | current build | current build | **this branch pinned to `MAX_PROTOCOL_VERSION=3`** (one-line patch, current toolchain) | **the literal `mainnet-v1.1.8` `ika-node`** from the tag (old toolchain, `--no-default-features`) |
+| Binary swap | none | none | **rolling** — one at a time; mixed-binary committees exchange consensus + MPC mid-epoch | **atomic** — all validators at once |
+| Committee churn | no | no | **yes** — 4 → 3 → 5 → 4 across epochs (remove, join 2 brand-new validators, remove); a real reshare to a different party set at every boundary | **no** — fixed 4 |
+| `GlobalPresignConfig` | n/a | full | **empty** (harness arrangement → routes presign per-dWallet; exercises targeted-presign) | **populated** (mainnet-faithful → global presign; exercises the pre-activation fallback / upgrade-window deadlock guard) |
+| Proves | 4 validators reach epoch 2 | one full DKG→Presign→Sign lifecycle | wire-compat + on-disk compat + reshare/churn **between two builds of the same branch** | the **real mainnet 1.1.8 → current upgrade**: local boots against RocksDB **written by 1.1.8**, reshares a key whose DKG bytes were **produced by 1.1.8's crypto**, 1.1.8 dWallets stay usable, global-presign pre-activation fallback (no deadlock) |
+
+**Why the swap style differs:** `cross_binary`'s two binaries are the same
+branch differing only in advertised protocol version, so they are
+MPC-wire-compatible and a *rolling* swap with mixed committees is valid.
+`v118_upgrade` can't do that — this branch single-pins `cryptography-private`,
+so a mixed 1.1.8/local committee can't exchange MPC messages; it must swap
+**atomically** (a coordinated full-network restart).
+
+**Which to use:** `v118_upgrade` is the pre-mainnet-upgrade rehearsal (real
+release, real on-disk + crypto continuity). `cross_binary` is the synthetic
+rolling-upgrade + **committee-churn** exercise — and the **only** scenario that
+adds a joiner validator, so it's the one that exercises the OCS
+joiner-anchor path (`add_joiner_validator`). It is also the **heaviest** (peaks
+at a 5-member committee + two full MPC lifecycles + joiners' class-groups keys).
+
+### CI runner resources & the `cross_binary` runner-death failure mode
+
+`cross_binary` co-locates 5–6 `ika-validator` processes (4 → 5 with the joiner,
++ notifier), each doing class-groups DKG/presign, on one self-hosted pod — by
+far the heaviest upgrade-test. On the current `ika-k8s-large` pods this
+**starves the runner and it "loses communication"**: the job fails with **0
+artifacts** and `Run cross_binary` + all `if: always()` steps **blank**
+(distinct from a real nextest failure, which leaves artifacts + exit 100). The
+*same* death reproduces on a clean `dev` checkout, so it is the **pod, not any
+branch's code**.
+
+What the surviving **"Runner resources"** step reports on these pods (it runs
+*before* the test, so its log survives the death):
+
+| | value |
+|---|---|
+| `nproc` (host cores) | **96** |
+| `cgroup cpu.max` (CFS quota) | `8000000 100000` → **80 effective CPUs** |
+| `cgroup memory.max` | **96 GiB** |
+| swap | **0** |
+
+Host cores (96) and the CPU quota (80) differ only modestly, and
+`rayon_threads_per_node` already bounds well under 80 — so **CPU
+oversubscription is not the killer**. The likely cause is **memory**: ~96 GiB
+shared across 5–6 class-groups validators ≈ 16 GiB each at the ceiling, with no
+swap → a hard cgroup OOM-kill. Two mitigations are in `ika-upgrade-test`: each
+spawned node's rayon pool is bounded (PR #1770), and that bound is sized by the
+CFS quota rather than host cores. **[Pending: run 28042389003 — record whether
+the quota-bounded run completes or still OOMs, and the harness-logged
+`available_parallelism` vs `cgroup cpu.max` values.]**
+
+**Running `cross_binary` on CI** therefore needs a bigger-memory pod (or a
+less-oversubscribed node), or a smaller committee. `v118_upgrade` (4 fixed
+validators, no churn) is lighter; `smoke`/`workload` lighter still. Note:
+artifacts **and** the live test-step log are lost on runner death — only the
+pre-test steps ("Runner resources", builds, "Start CPU sampler") survive, so
+put any diagnostic you need where it runs before the test.
+
 ## Facts that save debugging time
 
 - **Concurrency groups cancel in-flight runs**: re-dispatching a workflow


### PR DESCRIPTION
## Summary

Two pre-existing test-tooling gaps on the OCS branch, surfaced while validating the Sui 1.73.2 bump's heavy gates. **Neither is caused by the bump.**

> Stacked on `feat/ocs-grpc-migration`.

## Fixes

**`ika-test-cluster` epoch-advance smoke → tokio** (`b717a07766`): the ika full cluster starts a real anemo (QUIC) network, which isn't msim-aware (`anemo::Endpoint::new` panics *"no reactor running"* under madsim), so `test_swarm_reaches_epoch_2` could never run under `#[sim_test]`. Converted to `#[tokio::test(flavor = "multi_thread")]` — the cluster-test convention (every other `ika-test-cluster` test already uses it). The companion dev-dep fix (`prometheus` + `sui-protocol-config` for the `#[sim_test]` macro) and its `Cargo.lock` sync landed on the OCS branch.

**`ika-upgrade-test` OCS anchor** (`6e67b9ba8a`): a validator with `sui-data-source` set refuses to boot at protocol v4 without a Sui trust anchor (*"no Sui trust anchor is configured"*), but the cross-binary upgrade harness never set one — so any v4 validator failed health-check at startup. Fetch the Sui localnet's epoch-0 committee and seed every validator's `unsafe_genesis_committee` anchor (mirroring `IkaTestClusterBuilder`).

## Verification

Build clean: `cargo check -p ika-test-cluster -p ika-upgrade-test --all-targets` (exit 0). Runtime verification dispatched on this branch — `test-cluster` (the converted smoke test) and `upgrade-test` cross_binary (the anchor fix lets v4 boot).

## Follow-ups (not in this PR)
- CLAUDE.md's `cargo simtest … test_swarm_reaches_epoch_2` example is now stale (that test is tokio).
- `protocol_version_transition.rs` still has a `#[sim_test]` likely also broken under anemo.
- True cluster-under-msim support is a separate, large effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
