### PR TITLE
fix(crypto): keep the rayon parallel feature out of simtest (cfg(not(msim)) gating) (into #1714)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,9 +81,14 @@ crypto-bigint = { version = "0.7.0-pre.9", default-features = false, features = 
 
 mpc = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "32a27aa"}
 proof = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "32a27aa"}
-class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "32a27aa", features = ["threshold", "parallel"] }
+# NOTE: the `parallel` (rayon) feature on class_groups/twopc_mpc is enabled per
+# crate under `[target.'cfg(not(msim))'.dependencies]` (see dwallet-classgroups-types
+# and ika-core), NOT here — workspace-dependency features are inherited regardless of
+# cfg, so enabling `parallel` here would leak rayon into `cargo simtest` (cfg msim),
+# whose rayon workers have no msim node context and break determinism / panic.
+class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "32a27aa", features = ["threshold"] }
 commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "32a27aa" }
-twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "32a27aa", features = ["parallel"]}
+twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "32a27aa"}
 group = { git = "https://github.com/dwallet-labs/cryptography-private", features = ["os_rng"], rev = "32a27aa"}
 homomorphic_encryption = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "32a27aa"}
 

--- a/crates/dwallet-classgroups-types/Cargo.toml
+++ b/crates/dwallet-classgroups-types/Cargo.toml
@@ -19,6 +19,7 @@ twopc_mpc.workspace = true
 # `parallel` feature in that profile to force sequential iteration.
 [target.'cfg(not(msim))'.dependencies]
 class_groups = { workspace = true, features = ["parallel"] }
+twopc_mpc = { workspace = true, features = ["parallel"] }
 
 [dev-dependencies]
 bcs.workspace = true

--- a/crates/ika-core/Cargo.toml
+++ b/crates/ika-core/Cargo.toml
@@ -101,6 +101,7 @@ moka = { workspace = true, features = ["sync"] }
 # context and panic at the first tracing/tokio call, so we drop the
 # `parallel` feature in that profile to force sequential iteration.
 class_groups = { workspace = true, features = ["threshold", "parallel"] }
+twopc_mpc = { workspace = true, features = ["parallel"] }
 
 [features]
 test-utils = []


### PR DESCRIPTION
Targets `fast-schnorr` (#1714). Ensures `cargo simtest` (msim) does **not**
build the crypto with rayon `parallel` — rayon's real worker threads break
msim's deterministic scheduling (and have no msim node context).

## The bug

The codebase already gates `parallel` to non-msim via
`[target.'cfg(not(msim))'.dependencies]` blocks in `dwallet-classgroups-types`
and `ika-core` (their comments spell out the msim rationale). But `parallel`
was *also* enabled unconditionally in `[workspace.dependencies]`
(class_groups + twopc_mpc). **Workspace-dependency features are inherited by
every `{ workspace = true }` consumer regardless of cfg**, so the workspace
flag leaked `parallel` into the msim build, defeating the cfg gating. (Added
to the workspace base by #1756; carried forward on the crypto-pin bump.)

## The fix

Move enablement entirely into the cfg(not(msim)) blocks:
- drop `parallel` from the workspace base;
- add `twopc_mpc` next to the existing `class_groups` enablement in both
  cfg(not(msim)) blocks (twopc_mpc previously relied on the leaking workspace flag).

## Verified
- **non-msim** (production, cluster): `cargo tree` shows
  class_groups / twopc_mpc / mpc / proof / group / maurer all `parallel` —
  **unchanged**.
- **msim** (simtest): the only `parallel` enablers are now cfg(not(msim))-gated,
  so they're inactive under `--cfg msim` → crypto resolves sequential.
- Compiles; `Cargo.lock` untouched (feature-agnostic).

Complements #1764 (which bounds the in-process rayon pool for the *non-msim*
cluster); this one removes rayon from *msim* entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)