### PR TITLE
fix: restore #1721's reverted log-level + comment changes (into #1714)

### DIFF
--- a/crates/dwallet-mpc-types/src/mpc_protocol_configuration.rs
+++ b/crates/dwallet-mpc-types/src/mpc_protocol_configuration.rs
@@ -178,7 +178,9 @@ lazy_static! {
 /// Returns all supported (curve, signature_algorithms) pairs.
 ///
 /// This is the canonical source of truth, derived from
-/// [`SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES`].
+/// [`SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES`] — an
+/// ordered map (see its docs), so the output order is identical on
+/// every validator.
 pub fn supported_curve_to_signature_algorithms()
 -> Vec<(DWalletCurve, Vec<DWalletSignatureAlgorithm>)> {
     SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
@@ -178,7 +178,7 @@ impl CryptographicComputationsOrchestrator {
                     "Cryptographic computation failed"
                 );
             } else {
-                info!(
+                debug!(
                     party_id,
                     ?session_identifier,
                     ?computation_result_data,
@@ -260,7 +260,7 @@ impl CryptographicComputationsOrchestrator {
         }
 
         if !self.has_available_cores_to_perform_computation() {
-            info!(
+            debug!(
                 session_identifier=?computation_id.session_identifier,
                 mpc_round=?computation_id.mpc_round,
                 attempt_number=?computation_id.attempt_number,
@@ -278,7 +278,7 @@ impl CryptographicComputationsOrchestrator {
         let protocol_metadata: DWalletSessionRequestMetricData =
             (&computation_request.protocol_cryptographic_data).into();
 
-        info!(
+        debug!(
             party_id,
             session_identifier=?computation_id.session_identifier,
             current_round=?computation_id.mpc_round,

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -485,8 +485,14 @@ thread_local! {
     static POISON_VERSION_METHODS: AtomicBool = AtomicBool::new(false);
 }
 
-/// Set once by `enable_small_presign_pools_for_local_swarm` so a single host
-/// running the whole validator set keeps its presign pools fillable.
+/// Process-global switch, set by the local in-memory swarm / `ika start`, to
+/// shrink both the internal and network-owned-address presign pools so a single
+/// host running the whole validator set can keep them filled. The production
+/// pool sizes (thousands of presigns per curve) peg the CPU there and stall
+/// epoch advance. Unlike the thread-local `CONFIG_OVERRIDE` (which only the
+/// calling thread sees), this is honored by `get_for_version_impl` on every
+/// thread and every epoch. Off by default — only the local swarm turns it on,
+/// so testnet/mainnet binaries keep the production sizes.
 static SHRINK_PRESIGN_POOLS_FOR_LOCAL_SWARM: AtomicBool = AtomicBool::new(false);
 
 // Instantiations for each protocol version.
@@ -780,7 +786,9 @@ impl ProtocolConfig {
     /// validator set can keep both the internal and network-owned-address
     /// presign pools filled instead of pegging the CPU and stalling epoch
     /// advance. No-op (production sizes retained) when the
-    /// `IKA_DISABLE_SMALL_PRESIGN_POOLS` env var is set.
+    /// `IKA_DISABLE_SMALL_PRESIGN_POOLS` env var is set, so a local network can
+    /// still exercise production-scale pools. Validator binaries never call it,
+    /// so testnet/mainnet are unaffected.
     pub fn enable_small_presign_pools_for_local_swarm() {
         if std::env::var("IKA_DISABLE_SMALL_PRESIGN_POOLS").is_ok() {
             info!(


### PR DESCRIPTION
## Why

PR #1714's `96ffae7dfa "Merge dev into fast-schnorr (keep ours)"` is a tree-takeover merge: wherever the branch's tree differed from dev, dev's side was silently dropped. That reverted three incidental improvements landed in #1721. This restores them. **No functional change.**

## What

- **`orchestrator.rs`** — three hot-path compute logs `info!` → `debug!` (per-round completion, no-available-cores, starting-computation). They fire on *every* cryptographic computation; `debug!` keeps validator logs readable under load, matching #1721's spam reduction.
- **`mpc_protocol_configuration.rs`** — restore the dropped note on `supported_curve_to_signature_algorithms()`: the source is an ordered (BTree) map, so the emitted pair order is identical on every validator.
- **`ika-protocol-config/lib.rs`** — restore the fuller rationale on `SHRINK_PRESIGN_POOLS_FOR_LOCAL_SWARM` (process-global vs thread-local `CONFIG_OVERRIDE`, off by default) and on `enable_small_presign_pools_for_local_swarm` (the `IKA_DISABLE_SMALL_PRESIGN_POOLS` escape hatch; validator binaries never call it).

## Deliberately *not* restored

The two `<= 4` → `< 4` doc comments #1721 also touched are left as `< 4`. That is the **correct** version gate (at protocol v4 the network-encryption-key version is 3, which takes the main path) — restoring `<= 4` would re-introduce a doc bug, not fix a revert.

## Verification

`cargo check -p ika-core -p ika-protocol-config -p dwallet-mpc-types` — clean (exit 0). Log-level + comment-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)