### PR TITLE
docs(conventions): log-level + metrics discipline; fix one introduced error!→warn! (into #1714)

### DIFF
--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -755,9 +755,15 @@ where
                     match class_groups_public_key_and_proof {
                         Ok(key_and_proof) => Some((*name, key_and_proof)),
                         Err(e) => {
-                            error!(
-                                "Failed to deserialize class groups public key and proof: {}",
-                                e
+                            // Handled, recoverable anomaly: this validator is
+                            // dropped from the committee and construction
+                            // proceeds, so this is `warn!`, not `error!` — and
+                            // it re-runs every poll tick in legacy mode.
+                            warn!(
+                                authority = ?name,
+                                error = ?e,
+                                "failed to decode on-chain class-groups encryption key and proof; \
+                                 dropping this validator from the committee",
                             );
                             None
                         }

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -78,6 +78,16 @@ them has a bug — determine which before changing either.
   auditing/removing unused Rust: why the compiler can't see unused `pub`
   items, how to classify candidates in a Sui fork, and gating dependency
   removals on a build (with that build's blind spots).
+- [`conventions/metrics.md`](conventions/metrics.md) — the Prometheus
+  metric-name ratchet (`ika_` prefix, CI-enforced via
+  `scripts/check-metric-names.sh`), the counter `_total` / gauge / label
+  conventions (new protocols auto-instrument through the exhaustive
+  `[curve, signature_algorithm, key_role]` labels), and a generated name
+  inventory.
+- [`conventions/logging.md`](conventions/logging.md) — the `tracing`
+  log-level discipline: hot MPC paths are `debug!`, once-per-epoch
+  lifecycle events are `info!`; why an `info!` on the per-computation
+  path makes validator logs unreadable under load.
 
 ### learnings/ — pitfalls that cost real debugging time
 - [`learnings/pitfalls.md`](learnings/pitfalls.md) — non-obvious failure

--- a/dev-docs/conventions/logging.md
+++ b/dev-docs/conventions/logging.md
@@ -1,0 +1,68 @@
+# Log levels — the `tracing` discipline
+
+## The rule
+
+Pick the level by **how often the line fires** and **who has to read it**:
+
+- `error!` — a genuine failure: an operation that should have succeeded
+  didn't, and an operator must look. (Failed to persist a blob, failed to
+  ingest off-chain keys, a `send` on a live channel returned `Err`.)
+- `warn!` — a recoverable or expected-but-notable anomaly the node
+  handles itself: a rejected peer message, a dropped stale announcement,
+  a transient that will retry. Not a failure of *this* node. Example:
+  a per-validator on-chain key that fails to decode is logged at `warn!`
+  and the validator is dropped from the committee — construction
+  proceeds (`sui_connector/sui_syncer.rs`, `new_committee`). Logging that
+  at `error!` — on a path that re-runs every poll tick — is exactly the
+  noise this rule exists to prevent.
+- `info!` — a low-frequency lifecycle milestone: roughly **once per
+  epoch / session / reconfiguration**. Rule of thumb: if a healthy node
+  can emit it more than a handful of times per epoch, it is not `info!`.
+- `debug!` — anything on a **hot path**: per-cryptographic-computation,
+  per-MPC-round, per-consensus-message, per-session-tick. These dominate
+  log volume under load and bury the `info!`/`warn!` lines an operator
+  actually needs.
+- `trace!` — verbose inner-loop detail, off in every normal run.
+
+## Why it matters here
+
+A validator runs the entire MPC pipeline **in one process**. An `info!`
+on a per-computation path — which `CryptographicComputationsOrchestrator`
+(`dwallet_mpc/crytographic_computation/orchestrator.rs`) drives once per
+round per session — makes the log unreadable exactly when something is
+wrong. The spam-reduction pass that set this discipline demoted the
+orchestrator's per-computation *completion*, *no-available-cores*, and
+*starting-computation* lines from `info!` to `debug!` (PR #1721); a
+later `Merge dev into fast-schnorr (keep ours)` silently reverted the
+three flips and they were re-asserted in PR #1766. When in doubt about a
+line on the compute path, it is `debug!`.
+
+## Hot paths in this codebase → `debug!` (or lower)
+
+- `dwallet_mpc/crytographic_computation/orchestrator.rs` — per-computation
+  start / completion / no-available-cores lines (the recurring per-round work).
+- per-round / per-message / per-tick handlers in
+  `dwallet_mpc/mpc_manager.rs` and `dwallet_mpc/dwallet_mpc_service.rs`.
+
+## Events that ARE `info!` (verify the once-per-epoch guard)
+
+- Off-chain validator-MPC-key **ingestion** (`mpc_manager.rs`) and
+  **delivery** (`sui_connector/sui_syncer.rs`) of the agreed frozen set
+  — each guarded so it fires once per epoch (e.g. `sui_syncer` gates on
+  `current_keys_sent_for_epoch == Some(epoch)`). An `info!` here is only
+  correct *because* of that guard; the same log without a guard would be
+  spam and belongs at `debug!`.
+- Epoch open/close, reconfiguration start/finish, committee changes.
+
+## Test-subscriber trap
+
+`tracing_subscriber::fmt().init()`-style setup in tests **caps at INFO
+and ignores `RUST_LOG`**, so `debug!` evidence vanishes and a "green"
+run proves nothing about a demoted line. Use the
+`try_from_default_env().…try_init()` form — see
+[`../learnings/pitfalls.md`](../learnings/pitfalls.md).
+
+## See also
+
+- [`metrics.md`](metrics.md) — for a signal a **test or alert** must
+  assert on, prefer a scrapable metric over grepping a log string.

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -24,6 +24,40 @@ documented in the allowlist by hand — currently the epoch-store pruner
 family (`last_pruned_{consensus,authority}_db_epoch`,
 `successfully_pruned_*_dbs`, `error_pruning_*_dbs`).
 
+## Types, suffixes, and labels
+
+- **Counters** (monotonic) end in `_total` and register with
+  `register_int_counter*` — e.g. `dwallet_mpc_global_presigns_served_total`,
+  `dwallet_mpc_network_key_instantiation_failures_total`.
+- **Gauges** (a current value) are a plain noun, often `_count` / `_size`
+  / `_in_flight` — e.g. `dwallet_mpc_session_start_count`,
+  `dwallet_mpc_internal_presign_pool_size`,
+  `ika_dwallet_mpc_malicious_actors_count`. Never give a gauge `_total`.
+- **Per-protocol metrics are LABELLED, not duplicated per protocol.** The
+  MPC computation gauges are `*_vec` keyed by
+  `["curve", "signature_algorithm", "key_role"]`; the label values come
+  from `DWalletSessionRequestMetricData`
+  (`crates/ika-core/src/dwallet_session_request.rs`), whose
+  `From<&ProtocolData>` / `From<&ProtocolCryptographicData>` impls are
+  **exhaustive — no catch-all arm**. Consequence: a new signing protocol
+  that reuses the existing `ProtocolData` variants (e.g. the Fast Schnorr
+  VSS algorithms, which only add new `curve` / `signature_algorithm`
+  enum values) is instrumented **automatically** — provided its
+  curve/algorithm enum has a real `Display` so the label isn't `Unknown`.
+  Add a brand-new metric only for a genuinely new dimension (e.g.
+  `ika_dwallet_mpc_malicious_actors_count`, added by PR #1714 for a count
+  no existing label captures).
+
+## A metric vs. a log line
+
+For a signal a **test or alert** must assert on, prefer a scrapable
+metric over grepping logs (fragile, and it couples the test to a log
+string). `ika_dwallet_mpc_malicious_actors_count` — an `IntGauge` set in
+`mpc_manager.rs::record_malicious_actors` — exists precisely so the
+cross-binary malicious-detection test asserts exclusion programmatically
+instead of matching a log line. Log-level discipline itself lives in
+[`logging.md`](logging.md).
+
 ## Inventory (generated)
 
 Regenerate with: `./scripts/check-metric-names.sh --list`
@@ -139,6 +173,7 @@ highest_verified_system_checkpoint
 ika_binary_max_protocol_version
 ika_configured_max_protocol_version
 ika_current_protocol_version
+ika_dwallet_mpc_malicious_actors_count
 ika_handoff_prepare_duration_seconds
 ika_handoff_prepare_retries_total
 ika_handoff_prepare_waiting


### PR DESCRIPTION
Follows up on the #1721 log-level/metrics work: documents the convention durably **and** applies the log-level rule to the one spot #1714 introduced that violated it. Found via a file-by-file audit of #1714's entire introduced log/metric surface (adversarially verified).

## Docs

- **New — `dev-docs/conventions/logging.md`:** the `tracing` log-level discipline. Decision rule by fire-frequency + audience (`error!` genuine failure · `warn!` handled anomaly · `info!` once-per-epoch lifecycle · `debug!` hot path · `trace!` inner loop). Names the hot paths that must be `debug!` (orchestrator per-computation lines), the once-per-epoch guards that make the surviving `info!` lines correct, and the test-subscriber INFO-cap trap.
- **Extended — `dev-docs/conventions/metrics.md`:** it documented only the `ika_` name ratchet. Added the **type/suffix/label** conventions — counters `_total`, gauges plain/`_count`, and the key point that MPC metrics are *labelled* by `[curve, signature_algorithm, key_role]` via the **exhaustive** `From<&ProtocolData>`/`From<&ProtocolCryptographicData>` impls, so a new protocol (the Fast Schnorr VSS algorithms) auto-instruments with no new metric. Refreshed the generated inventory — it was missing `ika_dwallet_mpc_malicious_actors_count` (CI checks the name prefix, not inventory sync, so it slipped through).
- **`dev-docs/README.md`:** indexed `logging.md` *and* `metrics.md` (the latter was never listed).

## Fix (log-noise only — behavior unchanged)

`sui_connector/sui_syncer.rs::new_committee()` logged a per-validator on-chain class-groups **decode failure** at `error!`. That failure is **handled** (the validator is dropped via `filter_map → None`, committee construction proceeds) and the path **re-runs every poll tick** in legacy mode — so a single persistent malformed key would spam `error!` unthrottled. DEV logs the analogous failure at `warn!`; the fast-schnorr stack flipped it to `error!` and dropped the structured fields. Restored to `warn!` with `authority`/`error`.

## Audit result (the rest of #1714 is clean)

This was the **only** convention violation in #1714's introduced observability:
- the other introduced `info!` are all once-per-epoch lifecycle events (key ingestion/delivery, latched per epoch);
- the introduced `error!` are genuine failures;
- the sole new metric, `malicious_actors_count`, follows naming/type/wiring conventions and the VSS paths instrument correctly through the exhaustive label impls.

`cargo check -p ika-core` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)