### PR TITLE
fix: make the documented simtest command compile + label presign-pool metric with Display (into #1714)

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -1516,8 +1516,8 @@ impl DWalletMPCManager {
                 } else {
                     "other"
                 };
-                let curve_label = format!("{curve:?}");
-                let signature_algorithm_label = format!("{signature_algorithm:?}");
+                let curve_label = curve.to_string();
+                let signature_algorithm_label = signature_algorithm.to_string();
                 self.dwallet_mpc_metrics
                     .internal_presign_pool_size
                     .with_label_values(&[

--- a/crates/ika-test-cluster/Cargo.toml
+++ b/crates/ika-test-cluster/Cargo.toml
@@ -42,3 +42,13 @@ sui-simulator.workspace = true
 sui-macros.workspace = true
 telemetry-subscribers.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
+
+# `#[sim_test]` expands (under cfg(msim)) to sui-macros' `init_static_initializers`,
+# whose generated static-init thread references `sui_protocol_config` and
+# `prometheus` directly (everything else it uses is re-exported through
+# `sui-simulator`). They must be linkable deps of the test crate or the msim
+# build of these tests fails: `unresolved import sui_protocol_config` /
+# `unlinked crate prometheus`.
+[target.'cfg(msim)'.dev-dependencies]
+sui-protocol-config.workspace = true
+prometheus.workspace = true


### PR DESCRIPTION
Two small, independent fixes you asked for.

## 1. `ika-test-cluster` doesn't compile under msim

`#[sim_test]` expands (under `cfg(msim)`) to sui-macros' `init_static_initializers`, whose generated static-init thread references `sui_protocol_config` and `prometheus` **directly** (everything else it uses comes via `sui-simulator`). `ika-test-cluster` declared neither, so the command CLAUDE.md documents —

```
MSIM_DISABLE_WATCHDOG=1 cargo simtest --package ika-test-cluster -- test_swarm_reaches_epoch_2
```

— failed to compile its `#[sim_test]` targets (`smoke.rs`, `protocol_version_transition.rs`) with `unresolved import sui_protocol_config` / `unlinked crate prometheus`. **Pre-existing** (identical on dev, from #1713). Added both as **`cfg(msim)` dev-dependencies** (msim-only — under non-msim `#[sim_test]` is just `#[tokio::test]`).

**Verified end-to-end:** the previously-broken command now compiles and `test_swarm_reaches_epoch_2` **passes** (`1 passed`, ~740s under msim).

## 2. `internal_presign_pool_size` metric used Debug labels

The gauge set in `DWalletMPCManager` built its `[curve, signature_algorithm, key_role]` labels with `format!("{curve:?}")` (Debug), while every sibling metric derives the same labels from `DWalletSessionRequestMetricData` via strum `.to_string()` (Display). Switched to `.to_string()` so it can't drift onto a separate time series.

**No value change today** — every `DWalletCurve`/`DWalletSignatureAlgorithm` strum `to_string` equals its variant name (`Secp256k1`, `Taproot`, `TaprootVSS`, …), so Debug == Display for these enums. Consistency insurance, matching `dev-docs/conventions/metrics.md`. `cargo check -p ika-core` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)