### PR TITLE
fix(simtest): run crypto inline under msim for determinism (converge on dev's design) (into #1714)

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
@@ -28,6 +28,9 @@ use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
+// Only the non-msim path dispatches the completion via `Handle::spawn`; under
+// msim the computation runs inline (see `try_spawn_cryptographic_computation`).
+#[cfg(not(msim))]
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tracing::{debug, error, info};
@@ -85,15 +88,6 @@ pub(crate) struct CryptographicComputationsOrchestrator {
     /// from `root_seed` and reused for every VSS presign — avoids re-running
     /// the HPKE keypair generation per presign.
     vss_hpke_secret_key: group::curve25519::Scalar,
-
-    /// Under msim, the simulated node this orchestrator belongs to, captured at
-    /// construction (which runs inside the validator's node context). The rayon
-    /// worker that runs a cryptographic computation has no node context, so it uses
-    /// this handle to re-enter the node (for the compute's tracing) and to spawn the
-    /// completion task via `NodeHandle::spawn` — `Handle::spawn` would call
-    /// `NodeHandle::current().unwrap()` on the rayon worker and abort the process.
-    #[cfg(msim)]
-    sim_node: Option<sui_simulator::runtime::NodeHandle>,
 }
 
 impl CryptographicComputationsOrchestrator {
@@ -115,12 +109,6 @@ impl CryptographicComputationsOrchestrator {
             "Available CPU cores for Rayon cryptographic computations"
         );
 
-        // Capture the simulated node here: construction runs in the validator's
-        // node context (the log above succeeds via tracing), whereas `try_spawn`'s
-        // rayon-dispatching task can run outside one. No-op under non-msim.
-        #[cfg(msim)]
-        let sim_node = sui_simulator::runtime::NodeHandle::try_current();
-
         let vss_hpke_secret_key =
             dwallet_classgroups_types::ValidatorMPCSecrets::vss_hpke_secret_key_from_seed(
                 &root_seed,
@@ -134,8 +122,6 @@ impl CryptographicComputationsOrchestrator {
             completed_cryptographic_computations: HashSet::new(),
             root_seed,
             vss_hpke_secret_key,
-            #[cfg(msim)]
-            sim_node,
         })
     }
 
@@ -272,7 +258,6 @@ impl CryptographicComputationsOrchestrator {
 
             return false;
         }
-        let handle = Handle::current();
 
         let party_id = computation_request.party_id;
         let protocol_metadata: DWalletSessionRequestMetricData =
@@ -291,57 +276,72 @@ impl CryptographicComputationsOrchestrator {
         let root_seed = self.root_seed.clone();
         let vss_hpke_secret_key = self.vss_hpke_secret_key;
 
-        // Under msim, tokio APIs and tracing instrumentation require a simulated
-        // node context; rayon worker threads have none and abort at
-        // `NodeHandle::current().unwrap()`. Use the node captured at construction
-        // (`try_current()` on this rayon-dispatching task can already be outside a
-        // node). Enter it for the compute's tracing, and spawn the completion via
-        // `NodeHandle::spawn` (targets the node directly) rather than `Handle::spawn`
-        // (which calls `NodeHandle::current()`). No-op under non-msim.
+        // Under msim, run the computation INLINE in the calling task instead
+        // of on rayon. Crypto is sequential under msim anyway (the `parallel`
+        // feature is dropped in that profile), and a rayon worker has no
+        // simulated-node context: even with a captured-NodeHandle re-entry
+        // guard, msim's `Handle::spawn` re-resolves the CURRENT node at spawn
+        // time, so a computation whose node was torn down mid-compute (an
+        // epoch swap in the simulation) panics at
+        // `NodeHandle::current().unwrap()` and rayon-core aborts the whole
+        // process. Inline, the send happens in the same task context — which
+        // dies cleanly WITH the node, dropping the now-moot result.
         #[cfg(msim)]
-        let sim_node = self.sim_node.clone();
-
-        rayon::spawn_fifo(move || {
-            #[cfg(msim)]
-            let _node_guard = sim_node.as_ref().map(|n| n.enter_node());
-
+        {
             let advance_start_time = Instant::now();
-
             let computation_result = computation_request.compute(
                 computation_id,
                 root_seed,
                 vss_hpke_secret_key,
                 dwallet_mpc_metrics.clone(),
             );
-
-            let elapsed = advance_start_time.elapsed();
-            let elapsed_ms = elapsed.as_millis();
-
-            let completion_update = ComputationCompletionUpdate {
-                computation_id,
-                party_id,
-                protocol_metadata,
-                computation_result,
-                elapsed_ms,
-            };
-            let send_completion = async move {
-                if let Err(err) = computation_channel_sender.send(completion_update).await {
-                    error!(error=?err, "failed to send a computation completion update");
-                }
-            };
-
-            #[cfg(msim)]
-            match sim_node.as_ref() {
-                Some(node) => {
-                    node.spawn(send_completion);
-                }
-                None => {
-                    handle.spawn(send_completion);
-                }
+            let elapsed_ms = advance_start_time.elapsed().as_millis();
+            if let Err(err) = computation_channel_sender
+                .send(ComputationCompletionUpdate {
+                    computation_id,
+                    party_id,
+                    protocol_metadata,
+                    computation_result,
+                    elapsed_ms,
+                })
+                .await
+            {
+                error!(error=?err, "failed to send a computation completion update");
             }
-            #[cfg(not(msim))]
-            handle.spawn(send_completion);
-        });
+        }
+
+        #[cfg(not(msim))]
+        {
+            let handle = Handle::current();
+            rayon::spawn_fifo(move || {
+                let advance_start_time = Instant::now();
+
+                let computation_result = computation_request.compute(
+                    computation_id,
+                    root_seed,
+                    vss_hpke_secret_key,
+                    dwallet_mpc_metrics.clone(),
+                );
+
+                let elapsed = advance_start_time.elapsed();
+                let elapsed_ms = elapsed.as_millis();
+
+                handle.spawn(async move {
+                    if let Err(err) = computation_channel_sender
+                        .send(ComputationCompletionUpdate {
+                            computation_id,
+                            party_id,
+                            protocol_metadata,
+                            computation_result,
+                            elapsed_ms,
+                        })
+                        .await
+                    {
+                        error!(error=?err, "failed to send a computation completion update");
+                    }
+                });
+            });
+        }
 
         self.currently_running_cryptographic_computations
             .insert(computation_id);


### PR DESCRIPTION
Converges fast-schnorr's msim crypto-dispatch onto dev's #1721 design, as discussed. **Behavior under non-msim (production) is unchanged.**

## Problem

Under msim the orchestrator dispatched each cryptographic computation to `rayon::spawn_fifo`, with a captured-`NodeHandle` workaround added by the VSS-under-msim work (`9746212ef2`) to dodge a `NodeHandle::current().unwrap()` → SIGABRT. But rayon workers are **real OS threads outside msim's scheduler** (both that commit and #1765 say so), so:

- **Determinism is lost.** Completion timing is real wall-clock, delivered back into the simulation at a nondeterministic point — defeating msim's seed-reproducibility, the only reason to pick `#[sim_test]` over `#[tokio::test]`.
- **A latent abort remains.** dev's #1721 comment flags it: *"a computation whose node was torn down mid-compute (an epoch swap) panics … rayon-core aborts the whole process."* The captured-handle `spawn` still targets a node that can be dead by completion. Latent today (stable committee), live under churn/restart simtests.

## Fix

Run the computation **INLINE in the calling task under `#[cfg(msim)]`**; keep `rayon::spawn_fifo` only under `#[cfg(not(msim))]` — exactly dev's #1721 structure, with the new `vss_hpke_secret_key` param threaded through both paths.

This is free of downside under msim: **#1765 already drops the `parallel` crypto feature there**, so crypto is single-threaded regardless — inline buys determinism + crash-safety at no parallelism cost. Removes the now-unused `sim_node` field + its construction-time capture, and cfg-gates the `Handle` import to the non-msim path.

## Validation

- `cargo check -p ika-core` (non-msim): clean.
- Under msim, `cargo simtest --package ika-test-cluster -- test_swarm_reaches_epoch_2`: **1 passed** (~1132s). Slower than the rayon path (~740s) on purpose — inline crypto serializes in the msim task, which *is* the determinism being restored. Compiles clean under both cfgs (only the pre-existing unused-`Chain`-import warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)