### PR TITLE
fix(ika-upgrade-test): bound spawned-node rayon pools so co-located validators don't starve the CI runner

### DIFF
--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -265,6 +265,10 @@ impl ClusterBuilder {
             .collect();
 
         // 4. Per-validator NodeConfig on a persistent data dir, written to YAML.
+        // Bound every co-located node's crypto rayon pool to a fair share of the
+        // host so the validators + notifier don't oversubscribe the CPU (see
+        // `rayon_threads_per_node`).
+        let rayon_threads = rayon_threads_per_node(self.num_validators + 1);
         let mut validators = Vec::with_capacity(self.num_validators);
         for (i, init) in validator_init_configs.iter().enumerate() {
             let data_dir = base.join(format!("validator-{i}"));
@@ -286,6 +290,7 @@ impl ClusterBuilder {
                 self.validator_binary.clone(),
                 &node_config,
                 data_dir.clone(),
+                rayon_threads,
             )
             .await?;
             validators.push(proc);
@@ -316,6 +321,7 @@ impl ClusterBuilder {
             self.notifier_binary.clone(),
             &notifier_config,
             notifier_dir,
+            rayon_threads,
         )
         .await?;
 
@@ -573,7 +579,15 @@ impl ClusterOfProcesses {
                 self.system.ika_system_object_id,
                 self.system.ika_dwallet_coordinator_object_id,
             );
-        let proc = spawn_node(index, binary, &node_config, data_dir).await?;
+        let proc = spawn_node(
+            index,
+            binary,
+            &node_config,
+            data_dir,
+            // existing validators (`index`) + this joiner + the notifier.
+            rayon_threads_per_node(index + 2),
+        )
+        .await?;
         self.validators.push(proc);
         self.committee.push(ValidatorSlot {
             address: joiner_address,
@@ -662,6 +676,7 @@ async fn spawn_node(
     binary: PathBuf,
     node_config: &NodeConfig,
     data_dir: PathBuf,
+    rayon_threads: usize,
 ) -> Result<ValidatorProcess> {
     let config_path = data_dir.join("node-config.yaml");
     let yaml = serde_yaml::to_string(node_config).context("serialize NodeConfig")?;
@@ -681,7 +696,25 @@ async fn spawn_node(
         admin_addr,
         node_config.metrics_address.port(),
         log_path,
+        rayon_threads,
     );
     proc.start().await?;
     Ok(proc)
+}
+
+/// `RAYON_NUM_THREADS` budget for each spawned node, given how many node
+/// processes will share this host. The harness co-locates every validator
+/// (plus the notifier) on one machine, each running the real node binary built
+/// `--no-default-features` — so each one's rayon pool otherwise defaults to ALL
+/// cores (`ika-core`'s `runtime.rs`). With the parallel crypto feature active
+/// that oversubscribes the CPU by the node count, starving the async runtimes
+/// (and, on CI, the runner agent itself → "runner lost communication"). Hand
+/// each node a fair slice of ~75% of the cores, reserving the rest for the
+/// async/IO work across all the processes — the out-of-process analogue of the
+/// in-process swarm's core reserve.
+fn rayon_threads_per_node(node_count: usize) -> usize {
+    let cores = std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(4);
+    ((cores * 3 / 4) / node_count.max(1)).max(1)
 }

--- a/crates/ika-upgrade-test/src/process.rs
+++ b/crates/ika-upgrade-test/src/process.rs
@@ -36,6 +36,15 @@ pub struct ValidatorProcess {
     metrics_port: u16,
     /// Per-validator log file (child stdout+stderr).
     log_path: PathBuf,
+    /// `RAYON_NUM_THREADS` for this child's crypto pool. The harness packs
+    /// several validator processes onto one host, each running the real node
+    /// binary built `--no-default-features` (so `enforce-minimum-cpu` is off and
+    /// the node's rayon pool would otherwise grab every core — see
+    /// `ika-core`'s `runtime.rs`). With the parallel crypto feature active, N
+    /// such processes oversubscribe the CPU N× and starve the async runtimes —
+    /// on CI hard enough to kill the runner agent. Bounded to a fair per-node
+    /// slice at construction.
+    rayon_threads: usize,
     child: Option<Child>,
     http: reqwest::Client,
 }
@@ -49,6 +58,7 @@ impl ValidatorProcess {
         admin_addr: SocketAddr,
         metrics_port: u16,
         log_path: PathBuf,
+        rayon_threads: usize,
     ) -> Self {
         Self {
             index,
@@ -58,6 +68,7 @@ impl ValidatorProcess {
             admin_addr,
             metrics_port,
             log_path,
+            rayon_threads,
             child: None,
             http: reqwest::Client::new(),
         }
@@ -85,6 +96,9 @@ impl ValidatorProcess {
         let child = Command::new(&self.binary)
             .arg("--config-path")
             .arg(&self.config_path)
+            // Bound this child's crypto rayon pool so co-located validator
+            // processes don't oversubscribe the host (see `rayon_threads`).
+            .env("RAYON_NUM_THREADS", self.rayon_threads.to_string())
             .stdout(Stdio::from(log))
             .stderr(Stdio::from(stderr))
             .kill_on_drop(true)


### PR DESCRIPTION
## Symptom
The **Upgrade Test / cross_binary** run on `dev` died twice (runs [28023184063](https://github.com/dwallet-labs/ika/actions/runs/28023184063), [28026237741](https://github.com/dwallet-labs/ika/actions/runs/28026237741)) — identical signature each time: **"the self-hosted runner lost communication with the server … starves it for CPU/Memory"**, ~39 min in, no failed assertion, no artifacts. Reproduced deterministically, so not an infra flake.

## Root cause
The harness packs `num_validators` (4) validator processes **+ the notifier** onto one host, each running the real node binary built `--no-default-features` — which turns **off** `enforce-minimum-cpu`, so per [`ika-core/src/runtime.rs`](crates/ika-core/src/runtime.rs#L21) the node's global rayon pool defaults to **all cores** (no `num_threads`). That was harmless while crypto barely touched rayon — but **#1714 activated the `parallel` crypto feature in non-msim builds**, so those N unbounded pools now genuinely saturate the CPU N×, starving the async runtimes hard enough to kill the runner agent.

Corroboration that #1714's parallel crypto is the trigger: **v118_upgrade passed** on the same harness, because its OLD binary is the mainnet-1.1.8 tag (pre-`parallel`-crypto, doesn't saturate) — whereas cross_binary builds its OLD binary from the current branch (WITH parallel crypto), so *every* validator saturates.

This is the **out-of-process analogue of #1764** (which reserved cores for the *in-process* swarm); the out-of-process harness never got the equivalent bound. CI-harness/local only — production runs one validator per host and is unaffected.

## Fix
Give each spawned node a `RAYON_NUM_THREADS` budget — a fair slice of ~75% of the host's cores, reserving the rest for async/IO across the processes — set on every child `Command` in `ValidatorProcess::start` (so it also covers binary swaps and joiners). In the `--no-default-features` build, `runtime.rs` calls `build_global()` without an explicit thread count, so rayon honors `RAYON_NUM_THREADS`.

`cargo check -p ika-upgrade-test --all-targets`: clean.

## Validation
cross_binary dispatched on this branch ([28029297221](https://github.com/dwallet-labs/ika/actions/runs/28029297221)) — **in flight**. Expect it to clear the ~39-min starvation point and complete (crypto is slower under the bound but the host survives). I'll update once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)