### PR TITLE
feat(dwallet-mpc): content-derived NetworkKeyId for the cross-epoch handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,4 +271,16 @@ already validated, branch names, and in-flight CI run IDs/URLs.
   the commit/round semantics ika's freeze and epoch-close logic rely on
   (leader rounds, commit boundaries) live in Sui's `consensus/core`, not
   in ika (see the upstream reference above)
-- **NOA checkpoints not live**: The NOA checkpoint system (`crates/ika-core/src/noa_checkpoints/`) is under active development and not yet deployed. No backward compatibility constraints on serialization formats or type names
+- **Currently on protocol version 3 — v4 not active yet**: the live
+  network runs protocol v3. Protocol v4 gates off-chain validator
+  metadata (`off_chain_validator_metadata_enabled()`), the cross-epoch
+  handoff (`dev-docs/specs/handoff.md`), and the deferred epoch close —
+  all implemented but NOT yet active on any deployed network. Treat
+  v4-gated paths as forward-looking: there are no deployed-network
+  backward-compatibility constraints on v4-only behavior until the
+  upgrade lands.
+- **NOA not live**: the network-owned-address (NOA) system — both NOA
+  signing AND the NOA checkpoint system (`crates/ika-core/src/noa_checkpoints/`)
+  — is under active development and not deployed at all. No backward
+  compatibility constraints on its serialization formats, type names, or
+  derived addresses.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6770,6 +6770,7 @@ dependencies = [
  "axum 0.8.8",
  "bin-version",
  "clap",
+ "dwallet-mpc-types",
  "futures",
  "hex",
  "humantime",

--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -157,6 +157,43 @@ pub struct NetworkEncryptionKeyPublicData {
     pub ristretto_network_owned_address_public_key: Vec<u8>,
 }
 
+/// Content-derived identity of a network encryption key: the curve25519
+/// network-owned-address ed25519 public key, used as the key's identity
+/// in the cross-epoch handoff (replacing the Sui `ObjectID`).
+///
+/// It is a deterministic function of the network DKG output (the NOA DKG
+/// is seeded on the class-group encryption key), so every validator
+/// derives the same value; and it is invariant across reconfiguration
+/// and the v2->v3 DKG-output reconstruction because that encryption key
+/// is invariant. Kept Sui-free (no `ObjectID`): `dwallet-mpc-types` does
+/// not depend on `sui-types`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct NetworkKeyId(pub [u8; 32]);
+
+impl NetworkKeyId {
+    pub const LENGTH: usize = 32;
+
+    /// Builds a `NetworkKeyId` from raw curve25519 NOA public-key bytes,
+    /// which must be exactly 32 bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, DwalletNetworkMPCError> {
+        let bytes: [u8; Self::LENGTH] = bytes
+            .try_into()
+            .map_err(|_| DwalletNetworkMPCError::InvalidNetworkKeyIdLength(bytes.len()))?;
+        Ok(Self(bytes))
+    }
+}
+
+impl NetworkEncryptionKeyPublicData {
+    /// This key's content-derived [`NetworkKeyId`] — its curve25519
+    /// network-owned-address ed25519 public key. curve25519 is always
+    /// computed during instantiation regardless of `supported_curves`,
+    /// so this is available for every instantiated key; a non-32-byte
+    /// value is a hard error rather than a silent fallback.
+    pub fn network_key_id(&self) -> Result<NetworkKeyId, DwalletNetworkMPCError> {
+        NetworkKeyId::from_bytes(&self.curve25519_network_owned_address_public_key)
+    }
+}
+
 #[derive(
     strum_macros::Display,
     strum_macros::EnumString,
@@ -353,6 +390,9 @@ pub enum DwalletNetworkMPCError {
 
     #[error("missing protocol public parameters for curve: {0}")]
     MissingProtocolPublicParametersForCurve(DWalletCurve),
+
+    #[error("network key id must be 32 bytes, got {0}")]
+    InvalidNetworkKeyIdLength(usize),
 }
 
 /// Opaque BCS bytes of a validator's published MPC public-key payload.

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -825,6 +825,134 @@ pub(crate) fn compute_all_network_owned_address_dkg_outputs(
     })
 }
 
+/// Derives a network key's content-derived identity material — its
+/// curve25519 network-owned-address ed25519 public key (the value used
+/// as the `NetworkKeyId`) — from the key's serialized curve25519
+/// protocol public parameters. Callers obtain those from
+/// `dwallet_mpc_centralized_party::{network_dkg_public_output,reconfiguration_public_output}_to_protocol_pp_inner`,
+/// which handle the V1/V2/V3 + reconfiguration cases (deployed keys have
+/// a V1 DKG output kept current via reconfiguration, so the params come
+/// from the reconfiguration output). The result matches what
+/// instantiation computes because both seed `compute_noa_dkg` on the
+/// curve25519 encryption-key parameters.
+pub fn derive_curve25519_network_owned_address_public_key(
+    curve25519_protocol_public_parameters: &[u8],
+) -> DwalletMPCResult<Vec<u8>> {
+    let protocol_public_parameters: twopc_mpc::curve25519::class_groups::ProtocolPublicParameters =
+        bcs::from_bytes(curve25519_protocol_public_parameters).map_err(DwalletMPCError::BcsError)?;
+    let encryption_key =
+        bcs::to_bytes(&protocol_public_parameters.encryption_scheme_public_parameters)
+            .map_err(DwalletMPCError::BcsError)?;
+    let noa = compute_noa_dkg::<Curve25519AsyncDKGProtocol>(
+        &encryption_key,
+        DWalletCurve::Curve25519,
+        &protocol_public_parameters,
+    )?;
+    Ok(noa.public_key)
+}
+
+/// One-off tool (not a unit test): fetches the deployed network key from
+/// testnet/mainnet and prints its `NetworkKeyId` (curve25519 NOA ed25519
+/// pubkey) for baking into the temporary static ObjectID->NetworkKeyId
+/// map. Run with:
+///   cargo test -p ika-core --release print_deployed_network_key_ids -- --ignored --nocapture
+#[cfg(test)]
+mod network_key_id_derivation_tool {
+    use super::derive_curve25519_network_owned_address_public_key;
+    use dwallet_mpc_centralized_party::{
+        network_dkg_public_output_to_protocol_pp_inner,
+        reconfiguration_public_output_to_protocol_pp_inner,
+    };
+    use ika_sui_client::SuiConnectorClient;
+    use ika_sui_client::metrics::SuiClientMetrics;
+    use ika_types::messages_dwallet_mpc::IkaNetworkConfig;
+    use ika_types::sui::DWalletCoordinatorInner;
+    use std::str::FromStr;
+    use sui_types::base_types::ObjectID;
+
+    #[ignore = "real-network tool; run manually to derive deployed NetworkKeyIds"]
+    #[tokio::test]
+    async fn print_deployed_network_key_ids() {
+        // (env, rpc, ika, common, twopc, system_pkg, system_obj, coordinator_obj) — from ika_sui_config.yaml
+        let envs: &[(&str, &str, &str, &str, &str, &str, &str, &str)] = &[
+            (
+                "testnet",
+                "https://fullnode.testnet.sui.io:443",
+                "0x1f26bb2f711ff82dcda4d02c77d5123089cb7f8418751474b9fb744ce031526a",
+                "0x96fc75633b6665cf84690587d1879858ff76f88c10c945e299f90bf4e0985eb0",
+                "0x6573a6c13daf26a64eb8a37d3c7a4391b353031e223072ca45b1ff9366f59293",
+                "0xde05f49e5f1ee13ed06c1e243c0a8e8fe858e1d8689476fdb7009af8ddc3c38b",
+                "0x2172c6483ccd24930834e30102e33548b201d0607fb1fdc336ba3267d910dec6",
+                "0x4d157b7415a298c56ec2cb1dcab449525fa74aec17ddba376a83a7600f2062fc",
+            ),
+            (
+                "mainnet",
+                "https://fullnode.mainnet.sui.io:443",
+                "0x7262fb2f7a3a14c888c438a3cd9b912469a58cf60f367352c46584262e8299aa",
+                "0x9e1e9f8e4e51ee2421a8e7c0c6ab3ef27c337025d15333461b72b1b813c44175",
+                "0x23b5bd96051923f800c3a2150aacdcdd8d39e1df2dce4dac69a00d2d8c7f7e77",
+                "0xd69f947d7ee6f224dd0dd31ec3ec30c0dd0f713a1de55d564e8e98910c4f9553",
+                "0x215de95d27454d102d6f82ff9c54d8071eb34d5706be85b5c73cbd8173013c80",
+                "0x5ea59bce034008a006425df777da925633ef384ce25761657ea89e2a08ec75f3",
+            ),
+        ];
+        let oid = |s: &str| ObjectID::from_str(s).unwrap();
+        for (name, rpc, ika, common, twopc, sys_pkg, sys_obj, coord) in envs {
+            let config = IkaNetworkConfig::new(
+                oid(ika),
+                oid(common),
+                oid(twopc),
+                None,
+                oid(sys_pkg),
+                oid(sys_obj),
+                oid(coord),
+            );
+            let client = SuiConnectorClient::new(rpc, SuiClientMetrics::new_for_testing(), config)
+                .await
+                .unwrap();
+            let (_, coordinator_inner) = client.must_get_dwallet_coordinator_inner().await;
+            let DWalletCoordinatorInner::V1(inner) = &coordinator_inner;
+            let epoch = inner.current_epoch;
+            let network_keys = client
+                .get_dwallet_mpc_network_keys(&coordinator_inner)
+                .await
+                .unwrap();
+            for (id, key) in &network_keys {
+                let key_data = client
+                    .get_network_encryption_key_with_full_data_by_epoch(key, epoch)
+                    .await
+                    .unwrap();
+                // curve25519 curve id = 2 (DWalletCurve::Curve25519). Deployed keys
+                // have a V1 DKG output kept current via reconfiguration, so derive
+                // the curve25519 protocol params from the reconfiguration output
+                // when present (matching the binary's instantiation path).
+                let curve25519_protocol_pp =
+                    if key_data.current_reconfiguration_public_output.is_empty() {
+                        network_dkg_public_output_to_protocol_pp_inner(
+                            2,
+                            key_data.network_dkg_public_output,
+                        )
+                        .unwrap()
+                    } else {
+                        reconfiguration_public_output_to_protocol_pp_inner(
+                            2,
+                            key_data.current_reconfiguration_public_output,
+                            key_data.network_dkg_public_output,
+                        )
+                        .unwrap()
+                    };
+                let network_key_id =
+                    derive_curve25519_network_owned_address_public_key(&curve25519_protocol_pp)
+                        .unwrap();
+                println!(
+                    "NETWORK_KEY_ID {name}: object_id={id} network_key_id=0x{}",
+                    hex::encode(network_key_id)
+                );
+            }
+        }
+    }
+}
+
 /// Builds the `NetworkEncryptionKeyPublicData` from per-curve DKG data.
 pub(crate) fn build_network_encryption_key_public_data(
     epoch: u64,

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -736,7 +736,6 @@ pub(crate) fn spawn_network_encryption_key_public_data_instantiation(
                     key_data.dkg_at_epoch,
                     &access_structure,
                     &key_data.network_dkg_public_output,
-                    key_data.id.into_bytes(),
                     &metrics,
                 )
             }
@@ -747,7 +746,6 @@ pub(crate) fn spawn_network_encryption_key_public_data_instantiation(
                 &access_structure,
                 &key_data.current_reconfiguration_public_output,
                 &key_data.network_dkg_public_output,
-                key_data.id.into_bytes(),
                 &metrics,
             )
         };
@@ -776,29 +774,46 @@ pub(crate) struct AllCurvesNetworkOwnedAddressDkgData {
 
 /// Computes DKG outputs and public keys for all 4 curves.
 pub(crate) fn compute_all_network_owned_address_dkg_outputs(
-    network_key_id: &[u8; 32],
     secp256k1_protocol_public_parameters: &twopc_mpc::secp256k1::class_groups::ProtocolPublicParameters,
     secp256r1_protocol_public_parameters: &twopc_mpc::secp256r1::class_groups::ProtocolPublicParameters,
     ristretto_protocol_public_parameters: &twopc_mpc::ristretto::class_groups::ProtocolPublicParameters,
     curve25519_protocol_public_parameters: &twopc_mpc::curve25519::class_groups::ProtocolPublicParameters,
 ) -> DwalletMPCResult<AllCurvesNetworkOwnedAddressDkgData> {
+    // Seed each curve's NOA DKG with that curve's class-groups encryption
+    // public-key parameters (which embed the network encryption key) rather
+    // than the network key's Sui ObjectID. This makes the network-owned
+    // addresses a pure function of cryptographic key material, with no Sui
+    // dependency. The encryption key is stable across reconfiguration, so the
+    // addresses are stable too.
+    let secp256k1_encryption_key =
+        bcs::to_bytes(&secp256k1_protocol_public_parameters.encryption_scheme_public_parameters)?;
     let secp256k1 = compute_noa_dkg::<Secp256k1AsyncDKGProtocol>(
-        network_key_id,
+        &secp256k1_encryption_key,
         DWalletCurve::Secp256k1,
         secp256k1_protocol_public_parameters,
     )?;
+    let secp256r1_encryption_key =
+        bcs::to_bytes(&secp256r1_protocol_public_parameters.encryption_scheme_public_parameters)?;
     let secp256r1 = compute_noa_dkg::<Secp256r1AsyncDKGProtocol>(
-        network_key_id,
+        &secp256r1_encryption_key,
         DWalletCurve::Secp256r1,
         secp256r1_protocol_public_parameters,
     )?;
+    // curve25519 shares ristretto's scalar field and has no separate encryption
+    // key of its own; its protocol public parameters carry the same encryption
+    // key. The `curve` tag in the session id keeps the two curves' addresses
+    // distinct.
+    let curve25519_encryption_key =
+        bcs::to_bytes(&curve25519_protocol_public_parameters.encryption_scheme_public_parameters)?;
     let curve25519 = compute_noa_dkg::<Curve25519AsyncDKGProtocol>(
-        network_key_id,
+        &curve25519_encryption_key,
         DWalletCurve::Curve25519,
         curve25519_protocol_public_parameters,
     )?;
+    let ristretto_encryption_key =
+        bcs::to_bytes(&ristretto_protocol_public_parameters.encryption_scheme_public_parameters)?;
     let ristretto = compute_noa_dkg::<RistrettoAsyncDKGProtocol>(
-        network_key_id,
+        &ristretto_encryption_key,
         DWalletCurve::Ristretto,
         ristretto_protocol_public_parameters,
     )?;
@@ -900,7 +915,6 @@ fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_dkg_public_ou
     dkg_at_epoch: u64,
     access_structure: &WeightedThresholdAccessStructure,
     public_output_bytes: &SerializedWrappedMPCPublicOutput,
-    network_key_id: [u8; 32],
     metrics: &DWalletMPCMetrics,
 ) -> DwalletMPCResult<NetworkEncryptionKeyPublicData> {
     let mpc_public_output: VersionedNetworkDkgOutput =
@@ -961,7 +975,6 @@ fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_dkg_public_ou
 
             let noa_dkg_data = timed_sub_call(metrics, "noa_dkg_outputs", || {
                 compute_all_network_owned_address_dkg_outputs(
-                    &network_key_id,
                     &secp256k1_protocol_public_parameters,
                     &secp256r1_protocol_public_parameters,
                     &ristretto_protocol_public_parameters,

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -468,6 +468,19 @@ impl DwalletMPCNetworkKeys {
         access_structure: &WeightedThresholdAccessStructure,
     ) -> DwalletMPCResult<()> {
         self.network_encryption_keys.insert(key_id, key.clone());
+        // Record the temporary ObjectID <-> NetworkKeyId mapping so the
+        // handoff cert (keyed by the content-derived NetworkKeyId) can be
+        // built and consumed for this key. The NOA pubkey is already in
+        // `key`. TODO(NetworkKeyId-from-event): remove with the mapping
+        // once the request event carries the NetworkKeyId directly.
+        match key.network_key_id() {
+            Ok(network_key_id) => crate::network_key_id_mapping::register(key_id, network_key_id),
+            Err(e) => error!(
+                ?key_id,
+                error = ?e,
+                "could not derive NetworkKeyId for the temporary ObjectID mapping"
+            ),
+        }
         self.validator_private_dec_key_data
             .decrypt_and_store_secret_key_shares(key_id, key.clone(), access_structure)
             .await
@@ -835,6 +848,7 @@ pub(crate) fn compute_all_network_owned_address_dkg_outputs(
 /// from the reconfiguration output). The result matches what
 /// instantiation computes because both seed `compute_noa_dkg` on the
 /// curve25519 encryption-key parameters.
+#[cfg(test)]
 pub fn derive_curve25519_network_owned_address_public_key(
     curve25519_protocol_public_parameters: &[u8],
 ) -> DwalletMPCResult<Vec<u8>> {

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_owned_address_sign_dkg_emulation.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_owned_address_sign_dkg_emulation.rs
@@ -5,7 +5,8 @@
 //!
 //! Holds two ika-side helpers for the NOA-DKG path that have no upstream equivalent:
 //! - [`network_owned_address_sign_dkg_session_identifier`] derives a curve-specific
-//!   (sig-algo-independent) session id from `network_key_id + curve`.
+//!   (sig-algo-independent) session id from the curve's network encryption
+//!   key + curve.
 //! - [`compute_noa_dkg`] runs upstream's native
 //!   `<D as twopc_mpc::dkg::Protocol>::threshold_dkg_output(pp, session_id)`
 //!   for a single curve, extracts the public key, and wraps the output in
@@ -26,15 +27,19 @@ use merlin::Transcript;
 ///
 /// DKG is curve-specific but signature-algorithm-independent: a single DKG on a curve
 /// produces key shares usable by any signature algorithm on that curve.
+///
+/// Seeded by the curve's network **encryption key** (not the network key's
+/// Sui `ObjectID`), so the derived network-owned addresses are a pure function
+/// of cryptographic key material and carry no Sui dependency.
 pub fn network_owned_address_sign_dkg_session_identifier(
-    network_key_id: &[u8],
+    encryption_key: &[u8],
     curve: DWalletCurve,
 ) -> SessionIdentifier {
     // Use binary enum discriminant instead of string representation to prevent
     // collision if two variants ever produce the same Display output.
     let mut transcript =
         Transcript::new(b"Network Owned Address Sign DKG session identifier preimage");
-    transcript.append_message(b"network_key_id", network_key_id);
+    transcript.append_message(b"encryption_key", encryption_key);
     transcript.append_u64(b"curve", curve as u64);
 
     let mut session_identifier_preimage: [u8; SessionIdentifier::LENGTH] =
@@ -54,11 +59,11 @@ pub fn network_owned_address_sign_dkg_session_identifier(
 /// ika's NOA emulator was removed; this calls upstream's native
 /// `<D as twopc_mpc::dkg::Protocol>::threshold_dkg_output(pp, session_id)` directly
 /// to produce the decentralized-party DKG output for threshold (no centralized
-/// party) mode. The session id is derived from `network_key_id + curve`
+/// party) mode. The session id is derived from the curve's encryption key + curve
 /// (curve-specific, sig-algo independent) per
 /// [`network_owned_address_sign_dkg_session_identifier`].
 pub(crate) fn compute_noa_dkg<D>(
-    network_key_id: &[u8; 32],
+    encryption_key: &[u8],
     curve: DWalletCurve,
     protocol_public_parameters: &D::ProtocolPublicParameters,
 ) -> DwalletMPCResult<PerCurveNetworkOwnedAddressDkgData>
@@ -66,7 +71,7 @@ where
     D: twopc_mpc::dkg::Protocol,
 {
     let session_identifier =
-        network_owned_address_sign_dkg_session_identifier(network_key_id, curve);
+        network_owned_address_sign_dkg_session_identifier(encryption_key, curve);
     let session_id = CommitmentSizedNumber::from_le_slice(&session_identifier.into_bytes());
 
     let dkg_output =

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -426,7 +426,6 @@ pub(crate) fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_re
     access_structure: &WeightedThresholdAccessStructure,
     public_output_bytes: &SerializedWrappedMPCPublicOutput,
     network_dkg_public_output: &SerializedWrappedMPCPublicOutput,
-    network_key_id: [u8; 32],
     metrics: &DWalletMPCMetrics,
 ) -> DwalletMPCResult<NetworkEncryptionKeyPublicData> {
     let mpc_public_output: VersionedDecryptionKeyReconfigurationOutput =
@@ -490,7 +489,6 @@ pub(crate) fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_re
 
             let noa_dkg_data = timed_sub_call(metrics, "noa_dkg_outputs", || {
                 compute_all_network_owned_address_dkg_outputs(
-                    &network_key_id,
                     &secp256k1_protocol_public_parameters,
                     &secp256r1_protocol_public_parameters,
                     &ristretto_protocol_public_parameters,

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -31,6 +31,7 @@
 //!   already been burnt on the rayon pool).
 
 use crate::dwallet_mpc::integration_tests::utils;
+use dwallet_mpc_types::dwallet_mpc::NetworkKeyId;
 use ika_network::mpc_artifacts::mpc_data_blob_hash;
 use ika_types::handoff::{CertifiedHandoffAttestation, HandoffAttestation, HandoffItemKey};
 use ika_types::messages_dwallet_mpc::{
@@ -77,6 +78,10 @@ async fn empty_reconfiguration_overlay_is_not_adopted_when_cert_pins_reconfigura
     let prior_epoch = epoch_id - 1;
 
     let key_id = ObjectID::random();
+    // The cert is keyed by NetworkKeyId; register the mapping so adopt can
+    // translate this overlay key's ObjectID to it.
+    let network_key_id = NetworkKeyId([0x42; 32]);
+    crate::network_key_id_mapping::register(key_id, network_key_id);
     let dkg_output = b"test network dkg public output".to_vec();
     let reconfiguration_output = b"test network reconfiguration public output".to_vec();
 
@@ -88,11 +93,15 @@ async fn empty_reconfiguration_overlay_is_not_adopted_when_cert_pins_reconfigura
         next_committee_pubkey_set_hash: [0u8; 32],
         items: vec![
             (
-                HandoffItemKey::NetworkDkgOutput { key_id },
+                HandoffItemKey::NetworkDkgOutput {
+                    key_id: network_key_id,
+                },
                 mpc_data_blob_hash(&dkg_output),
             ),
             (
-                HandoffItemKey::NetworkReconfigurationOutput { key_id },
+                HandoffItemKey::NetworkReconfigurationOutput {
+                    key_id: network_key_id,
+                },
                 mpc_data_blob_hash(&reconfiguration_output),
             ),
         ],

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
@@ -79,12 +79,12 @@ async fn network_owned_address_sign_flow(
     let mut test_state = build_test_state(4);
 
     // Create a network key (required for network-owned-address signing).
-    let (consensus_round, _network_key_bytes, network_key_id) =
+    let (consensus_round, _network_key_bytes, encryption_key) =
         create_network_key_test(&mut test_state).await;
 
     info!(
         "Network key created at consensus round {}, key_id: {:?}",
-        consensus_round, network_key_id
+        consensus_round, encryption_key
     );
     test_state.consensus_round = consensus_round as usize;
 
@@ -100,7 +100,7 @@ async fn network_owned_address_sign_flow(
     let consensus_round = utils::advance_rounds_while_presign_pool_empty(
         &mut test_state,
         signature_algorithm,
-        network_key_id,
+        encryption_key,
         start_round,
     )
     .await;
@@ -108,7 +108,7 @@ async fn network_owned_address_sign_flow(
 
     // Record pool size and snapshot pool contents (session identifiers) before signing.
     let pool_size_before = test_state.epoch_stores[0]
-        .presign_pool_size(signature_algorithm, network_key_id)
+        .presign_pool_size(signature_algorithm, encryption_key)
         .expect("failed to get pool size");
     info!(
         pool_size_before,
@@ -122,7 +122,7 @@ async fn network_owned_address_sign_flow(
         .presign_pools
         .lock()
         .unwrap()
-        .get(&(signature_algorithm, network_key_id))
+        .get(&(signature_algorithm, encryption_key))
         .map(|pool| {
             pool.iter()
                 .map(|(id, blending_index, _)| (*id, *blending_index))
@@ -308,31 +308,31 @@ async fn test_network_owned_address_sign_taproot() {
 /// and that changing any single input produces a different session identifier.
 #[test]
 fn test_network_owned_address_sign_dkg_session_identifier_determinism() {
-    let network_key_id = [1u8; 32];
+    let encryption_key = [1u8; 32];
     let curve = DWalletCurve::Curve25519;
 
     // Same inputs produce same session identifier
     let session_identifier_first =
-        network_owned_address_sign_dkg_session_identifier(&network_key_id, curve);
+        network_owned_address_sign_dkg_session_identifier(&encryption_key, curve);
     let session_identifier_second =
-        network_owned_address_sign_dkg_session_identifier(&network_key_id, curve);
+        network_owned_address_sign_dkg_session_identifier(&encryption_key, curve);
     assert_eq!(
         session_identifier_first, session_identifier_second,
         "session identifiers should be deterministic for identical inputs"
     );
 
-    // Different network key ID produces different session identifier
-    let different_key_id = [2u8; 32];
+    // Different encryption key produces different session identifier
+    let different_encryption_key = [2u8; 32];
     let session_identifier_different_key =
-        network_owned_address_sign_dkg_session_identifier(&different_key_id, curve);
+        network_owned_address_sign_dkg_session_identifier(&different_encryption_key, curve);
     assert_ne!(
         session_identifier_first, session_identifier_different_key,
-        "different network key IDs should produce different session identifiers"
+        "different encryption keys should produce different session identifiers"
     );
 
     // Different curve produces different session identifiers
     let session_identifier_different_curve =
-        network_owned_address_sign_dkg_session_identifier(&network_key_id, DWalletCurve::Secp256k1);
+        network_owned_address_sign_dkg_session_identifier(&encryption_key, DWalletCurve::Secp256k1);
     assert_ne!(
         session_identifier_first, session_identifier_different_curve,
         "different curves should produce different session identifiers"
@@ -347,7 +347,7 @@ fn test_network_owned_address_sign_dkg_session_identifier_determinism() {
 
     let session_identifiers: Vec<_> = curves
         .iter()
-        .map(|c| network_owned_address_sign_dkg_session_identifier(&network_key_id, *c))
+        .map(|c| network_owned_address_sign_dkg_session_identifier(&encryption_key, *c))
         .collect();
 
     for (i, id_a) in session_identifiers.iter().enumerate() {
@@ -362,26 +362,26 @@ fn test_network_owned_address_sign_dkg_session_identifier_determinism() {
         }
     }
 
-    // Single-bit-flip edge case: flipping one bit in the network key ID must change the session identifier
-    let mut flipped_key_id = [1u8; 32];
-    flipped_key_id[0] ^= 1;
+    // Single-bit-flip edge case: flipping one bit in the encryption key must change the session identifier
+    let mut flipped_encryption_key = [1u8; 32];
+    flipped_encryption_key[0] ^= 1;
     let flipped_session_identifier = network_owned_address_sign_dkg_session_identifier(
-        &flipped_key_id,
+        &flipped_encryption_key,
         DWalletCurve::Curve25519,
     );
     assert_ne!(
         session_identifier_first, flipped_session_identifier,
-        "single-bit flip in network key ID should produce a different session identifiers"
+        "single-bit flip in encryption key should produce a different session identifiers"
     );
 
-    // Boundary edge cases: all-zeros and all-0xFF key IDs must produce different session identifiers
+    // Boundary edge cases: all-zeros and all-0xFF encryption keys must produce different session identifiers
     let zero_id =
         network_owned_address_sign_dkg_session_identifier(&[0u8; 32], DWalletCurve::Curve25519);
     let max_id =
         network_owned_address_sign_dkg_session_identifier(&[0xFFu8; 32], DWalletCurve::Curve25519);
     assert_ne!(
         zero_id, max_id,
-        "all-zeros and all-0xFF key IDs should produce different session identifiers"
+        "all-zeros and all-0xFF encryption keys should produce different session identifiers"
     );
 
     info!(
@@ -394,20 +394,26 @@ fn test_network_owned_address_sign_dkg_session_identifier_determinism() {
 /// and unique per key.
 #[test]
 fn test_dkg_session_identifier_stability() {
-    let key_id = [42u8; 32];
+    let encryption_key = [42u8; 32];
 
-    let first_call =
-        network_owned_address_sign_dkg_session_identifier(&key_id, DWalletCurve::Curve25519);
-    let second_call =
-        network_owned_address_sign_dkg_session_identifier(&key_id, DWalletCurve::Curve25519);
+    let first_call = network_owned_address_sign_dkg_session_identifier(
+        &encryption_key,
+        DWalletCurve::Curve25519,
+    );
+    let second_call = network_owned_address_sign_dkg_session_identifier(
+        &encryption_key,
+        DWalletCurve::Curve25519,
+    );
     assert_eq!(
         first_call, second_call,
         "DKG session identifiers must be byte-identical across calls"
     );
 
-    let different_key = [43u8; 32];
-    let third_call =
-        network_owned_address_sign_dkg_session_identifier(&different_key, DWalletCurve::Curve25519);
+    let different_encryption_key = [43u8; 32];
+    let third_call = network_owned_address_sign_dkg_session_identifier(
+        &different_encryption_key,
+        DWalletCurve::Curve25519,
+    );
     assert_ne!(
         first_call, third_call,
         "different keys should produce different DKG session identifiers"
@@ -436,7 +442,7 @@ async fn test_presign_pool_exhaustion_buffers_excess_sign_requests() {
     let mut test_state = build_test_state(4);
 
     // Create a network key (required for network-owned-address signing).
-    let (consensus_round, _network_key_bytes, network_key_id) =
+    let (consensus_round, _network_key_bytes, encryption_key) =
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
 
@@ -445,7 +451,7 @@ async fn test_presign_pool_exhaustion_buffers_excess_sign_requests() {
     let consensus_round = utils::advance_rounds_while_presign_pool_empty(
         &mut test_state,
         DWalletSignatureAlgorithm::EdDSA,
-        network_key_id,
+        encryption_key,
         start_round,
     )
     .await;
@@ -453,7 +459,7 @@ async fn test_presign_pool_exhaustion_buffers_excess_sign_requests() {
 
     // Record the pool size before sending sign requests.
     let pool_size_before = test_state.epoch_stores[0]
-        .presign_pool_size(DWalletSignatureAlgorithm::EdDSA, network_key_id)
+        .presign_pool_size(DWalletSignatureAlgorithm::EdDSA, encryption_key)
         .expect("failed to get pool size");
     info!(
         pool_size_before,
@@ -487,7 +493,7 @@ async fn test_presign_pool_exhaustion_buffers_excess_sign_requests() {
 
     // Assert: pool is empty (all presigns consumed).
     let pool_size_after = test_state.epoch_stores[0]
-        .presign_pool_size(DWalletSignatureAlgorithm::EdDSA, network_key_id)
+        .presign_pool_size(DWalletSignatureAlgorithm::EdDSA, encryption_key)
         .expect("failed to get pool size");
     info!(pool_size_after, "EdDSA pool size after exhaustion");
     assert_eq!(
@@ -530,7 +536,7 @@ async fn test_presign_pool_exhaustion_buffers_excess_sign_requests() {
             test_state.dwallet_mpc_services[0].pending_network_owned_address_sign_request_count();
         if round < 10 || round % 50 == 0 || pending < excess_count {
             let pool_size = test_state.epoch_stores[0]
-                .presign_pool_size(DWalletSignatureAlgorithm::EdDSA, network_key_id)
+                .presign_pool_size(DWalletSignatureAlgorithm::EdDSA, encryption_key)
                 .unwrap_or(0);
             info!(
                 round,

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -22,7 +22,7 @@ use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionReques
 use dwallet_classgroups_types::ValidatorMPCSecrets;
 use dwallet_mpc_types::dwallet_mpc::{
     DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm, NetworkEncryptionKeyPublicData,
-    VersionedPresignOutput,
+    NetworkKeyId, VersionedPresignOutput,
 };
 use dwallet_mpc_types::mpc_protocol_configuration::network_presign_pool_algorithms;
 use dwallet_rng::RootSeed;
@@ -921,8 +921,8 @@ impl DWalletMPCManager {
         {
             return;
         }
-        let mut dkg_digests: HashMap<ObjectID, [u8; 32]> = HashMap::new();
-        let mut reconfiguration_digests: HashMap<ObjectID, [u8; 32]> = HashMap::new();
+        let mut dkg_digests: HashMap<NetworkKeyId, [u8; 32]> = HashMap::new();
+        let mut reconfiguration_digests: HashMap<NetworkKeyId, [u8; 32]> = HashMap::new();
         if let Some(cert) = &cert {
             for (item, digest) in &cert.attestation.items {
                 match item {
@@ -977,6 +977,16 @@ impl DWalletMPCManager {
                 }
             }
             let local_dkg_digest = mpc_data_blob_hash(&data.network_dkg_public_output);
+            // The cert is keyed by the content-derived NetworkKeyId; translate
+            // this overlay key's ObjectID via the temporary map. An unmapped
+            // key (e.g. a brand-new key not yet instantiated/registered) is
+            // treated as not-pinned-by-the-cert — correct for a fresh key,
+            // which the prior epoch's cert never references.
+            let network_key_id = crate::network_key_id_mapping::network_key_id_for(key_id);
+            let cert_dkg_digest = network_key_id.as_ref().and_then(|id| dkg_digests.get(id));
+            let cert_reconfig_digest = network_key_id
+                .as_ref()
+                .and_then(|id| reconfiguration_digests.get(id));
             if data.current_reconfiguration_public_output.is_empty() {
                 // A cert that pins a reconfiguration digest for this key means
                 // the committee agreed this epoch runs on parameters derived
@@ -993,9 +1003,7 @@ impl DWalletMPCManager {
                 // become locally resolvable. Warn once per cert digest
                 // (deduped), debug on repeats — same pattern as the
                 // mismatch skips below.
-                if off_chain_on
-                    && let Some(cert_reconfiguration_digest) = reconfiguration_digests.get(key_id)
-                {
+                if off_chain_on && let Some(cert_reconfiguration_digest) = cert_reconfig_digest {
                     if self
                         .warned_cert_digest_mismatches
                         .insert((*key_id, *cert_reconfiguration_digest))
@@ -1020,7 +1028,7 @@ impl DWalletMPCManager {
                 }
                 // Initial-DKG state: adopt the deterministic local DKG
                 // output. Require the match only if a cert pins it.
-                if let Some(cert_dkg) = dkg_digests.get(key_id)
+                if let Some(cert_dkg) = cert_dkg_digest
                     && *cert_dkg != local_dkg_digest
                 {
                     // A locally-held DKG output contradicting the
@@ -1053,7 +1061,7 @@ impl DWalletMPCManager {
                 // the overlay carries locally-cached blobs, so anchor them
                 // against the prior epoch's cert — both the stable DKG digest
                 // and the epoch-specific reconfiguration digest must match.
-                if dkg_digests.get(key_id) != Some(&local_dkg_digest) {
+                if cert_dkg_digest != Some(&local_dkg_digest) {
                     // Same anomaly as above for a reconfigured key's
                     // stable DKG digest.
                     if self
@@ -1062,7 +1070,7 @@ impl DWalletMPCManager {
                     {
                         warn!(
                             ?key_id,
-                            cert_dkg_digest = ?dkg_digests.get(key_id),
+                            cert_dkg_digest = ?cert_dkg_digest,
                             local_dkg_digest = ?local_dkg_digest,
                             "local network-key DKG output digest does not match the prior \
                              epoch's handoff cert — skipping adoption"
@@ -1078,7 +1086,7 @@ impl DWalletMPCManager {
                 }
                 let local_reconfiguration_digest =
                     mpc_data_blob_hash(&data.current_reconfiguration_public_output);
-                if reconfiguration_digests.get(key_id) != Some(&local_reconfiguration_digest) {
+                if cert_reconfig_digest != Some(&local_reconfiguration_digest) {
                     // NOT contradiction-only: once THIS epoch's
                     // reconfiguration completes, the overlay carries the
                     // new epoch-keyed output which by design mismatches
@@ -1094,7 +1102,7 @@ impl DWalletMPCManager {
                         {
                             warn!(
                                 ?key_id,
-                                cert_reconfiguration_digest = ?reconfiguration_digests.get(key_id),
+                                cert_reconfiguration_digest = ?cert_reconfig_digest,
                                 local_reconfiguration_digest = ?local_reconfiguration_digest,
                                 "local network-key reconfiguration output digest does not \
                                  match the prior epoch's handoff cert and the key has no \

--- a/crates/ika-core/src/lib.rs
+++ b/crates/ika-core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod system_checkpoints;
 pub mod dwallet_mpc;
 pub mod epoch_tasks;
 pub mod handoff_cert;
+pub mod network_key_id_mapping;
 pub mod noa_checkpoints;
 pub mod sui_connector;
 pub mod validator_metadata;

--- a/crates/ika-core/src/network_key_id_mapping.rs
+++ b/crates/ika-core/src/network_key_id_mapping.rs
@@ -1,0 +1,127 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! TEMPORARY `ObjectID` <-> `NetworkKeyId` mapping.
+//!
+//! The cross-epoch handoff identifies a network encryption key by its
+//! content-derived [`NetworkKeyId`] (its curve25519 network-owned-address
+//! ed25519 public key), while the rest of the validator runtime and the
+//! Sui chain still identify it by `ObjectID`. This module translates
+//! between the two.
+//!
+//! It is deliberately a small static map: there is exactly one network
+//! key on testnet and one on mainnet, and no new network-key DKG is
+//! planned before the on-chain request event starts carrying the
+//! `NetworkKeyId` directly. The known deployed keys are seeded as
+//! constants so the mapping is available *before* instantiation — a
+//! joiner consuming the handoff cert needs it then; tests/localnet that
+//! DKG a fresh key call [`register`] at instantiation to self-populate.
+//!
+//! TODO(NetworkKeyId-from-event): delete this module once the request
+//! event carries the `NetworkKeyId`. The runtime/tables then key by
+//! `NetworkKeyId` directly and `ObjectID` is dropped as the key identity.
+
+use dwallet_mpc_types::dwallet_mpc::NetworkKeyId;
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+use sui_types::base_types::ObjectID;
+
+/// Deployed network keys as `(ObjectID, NetworkKeyId)` hex. Derived from
+/// chain with the `print_deployed_network_key_ids` tool (see
+/// `dwallet_mpc::...::network_dkg`).
+const SEED: &[(&str, &str)] = &[
+    // testnet
+    (
+        "0xe7c79a60931299e110297554fc02e0a0e095e96778775092c97f07a1bd1337cc",
+        "0x93e7a5e9387f8d900f378df7c39a77600a735179c50ffc7f352d150d078e072b",
+    ),
+    // mainnet
+    (
+        "0x0a9c0b88a5c729378bce1a98a8c285f1dde26f89e53d07164dba8a059dc15587",
+        "0xeecf7da51fab8228c0af7b9b4ae22fa7be7130df7c8a793fe9f95279c5d4c29f",
+    ),
+];
+
+struct Mapping {
+    object_id_to_network_key_id: HashMap<ObjectID, NetworkKeyId>,
+    network_key_id_to_object_id: HashMap<NetworkKeyId, ObjectID>,
+}
+
+fn parse_network_key_id(hex_with_prefix: &str) -> NetworkKeyId {
+    let bytes = hex::decode(hex_with_prefix.trim_start_matches("0x"))
+        .expect("seed NetworkKeyId is valid hex");
+    NetworkKeyId(bytes.try_into().expect("seed NetworkKeyId is 32 bytes"))
+}
+
+static MAPPING: LazyLock<RwLock<Mapping>> = LazyLock::new(|| {
+    let mut object_id_to_network_key_id = HashMap::new();
+    let mut network_key_id_to_object_id = HashMap::new();
+    for (object_id_hex, network_key_id_hex) in SEED {
+        let object_id = ObjectID::from_hex_literal(object_id_hex).expect("seed ObjectID is valid");
+        let network_key_id = parse_network_key_id(network_key_id_hex);
+        object_id_to_network_key_id.insert(object_id, network_key_id);
+        network_key_id_to_object_id.insert(network_key_id, object_id);
+    }
+    RwLock::new(Mapping {
+        object_id_to_network_key_id,
+        network_key_id_to_object_id,
+    })
+});
+
+/// Records an `ObjectID <-> NetworkKeyId` mapping. Called at network-key
+/// instantiation so tests/localnet (which DKG fresh keys absent from
+/// [`SEED`]) self-populate. Idempotent; the mapping is
+/// reconfiguration-invariant, so it never needs clearing.
+pub fn register(object_id: ObjectID, network_key_id: NetworkKeyId) {
+    let mut mapping = MAPPING.write();
+    mapping
+        .object_id_to_network_key_id
+        .insert(object_id, network_key_id);
+    mapping
+        .network_key_id_to_object_id
+        .insert(network_key_id, object_id);
+}
+
+/// The `NetworkKeyId` for a network key's `ObjectID`, if known.
+pub fn network_key_id_for(object_id: &ObjectID) -> Option<NetworkKeyId> {
+    MAPPING
+        .read()
+        .object_id_to_network_key_id
+        .get(object_id)
+        .copied()
+}
+
+/// The `ObjectID` for a `NetworkKeyId`, if known.
+pub fn object_id_for(network_key_id: &NetworkKeyId) -> Option<ObjectID> {
+    MAPPING
+        .read()
+        .network_key_id_to_object_id
+        .get(network_key_id)
+        .copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seeded_keys_round_trip() {
+        for (object_id_hex, network_key_id_hex) in SEED {
+            let object_id = ObjectID::from_hex_literal(object_id_hex).unwrap();
+            let network_key_id = parse_network_key_id(network_key_id_hex);
+            assert_eq!(network_key_id_for(&object_id), Some(network_key_id));
+            assert_eq!(object_id_for(&network_key_id), Some(object_id));
+        }
+    }
+
+    #[test]
+    fn register_then_look_up() {
+        let object_id = ObjectID::from_single_byte(7);
+        let network_key_id = NetworkKeyId([7u8; 32]);
+        assert_eq!(network_key_id_for(&object_id), None);
+        register(object_id, network_key_id);
+        assert_eq!(network_key_id_for(&object_id), Some(network_key_id));
+        assert_eq!(object_id_for(&network_key_id), Some(object_id));
+    }
+}

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -30,7 +30,7 @@
 //! byte-identical results.
 
 use dwallet_classgroups_types::ValidatorMPCSecrets;
-use dwallet_mpc_types::dwallet_mpc::{MPCDataV1, VersionedMPCData};
+use dwallet_mpc_types::dwallet_mpc::{MPCDataV1, NetworkKeyId, VersionedMPCData};
 use dwallet_rng::RootSeed;
 use fastcrypto::ed25519::{Ed25519KeyPair, Ed25519PublicKey, Ed25519Signature};
 use fastcrypto::traits::{Signer, VerifyingKey};
@@ -765,8 +765,8 @@ pub fn compute_effective_reconfig_input_set(
 /// finalize.
 pub fn compute_handoff_items(
     validator_mpc_data: &BTreeMap<AuthorityName, [u8; 32]>,
-    network_dkg_outputs: &BTreeMap<sui_types::base_types::ObjectID, [u8; 32]>,
-    network_reconfiguration_outputs: &BTreeMap<sui_types::base_types::ObjectID, [u8; 32]>,
+    network_dkg_outputs: &BTreeMap<NetworkKeyId, [u8; 32]>,
+    network_reconfiguration_outputs: &BTreeMap<NetworkKeyId, [u8; 32]>,
 ) -> Vec<(HandoffItemKey, [u8; 32])> {
     let mut items = Vec::with_capacity(
         validator_mpc_data.len()
@@ -795,6 +795,31 @@ pub fn compute_handoff_items(
     }
     items.sort_by(|left, right| left.0.cmp(&right.0));
     items
+}
+
+/// Translates a network-key digest map keyed by Sui `ObjectID` (the
+/// local/chain handle) to one keyed by the content-derived `NetworkKeyId`
+/// the handoff cert uses, via the temporary
+/// [`crate::network_key_id_mapping`]. Errors on any key whose
+/// `NetworkKeyId` is unknown so the caller defers signing rather than
+/// emitting an attestation that diverges from peers (the map is identical
+/// across honest validators: seeded constants + register-at-instantiation).
+fn to_network_key_id_keyed(
+    by_object_id: BTreeMap<sui_types::base_types::ObjectID, [u8; 32]>,
+) -> IkaResult<BTreeMap<NetworkKeyId, [u8; 32]>> {
+    by_object_id
+        .into_iter()
+        .map(|(object_id, digest)| {
+            crate::network_key_id_mapping::network_key_id_for(&object_id)
+                .map(|network_key_id| (network_key_id, digest))
+                .ok_or_else(|| {
+                    IkaError::Unknown(format!(
+                        "no NetworkKeyId mapping for network key {object_id} \
+                         while building handoff items"
+                    ))
+                })
+        })
+        .collect()
 }
 
 /// Per-feature contributor that produces its slice of items for the
@@ -846,7 +871,10 @@ impl HandoffItemsBuilder for MpcDataHandoffItemsBuilder {
         };
         let effective =
             store.get_effective_reconfig_input_set(next_committee_pubkeys.iter().copied())?;
-        let dkg = store.get_network_dkg_output_digests()?;
+        // Translate the locally-stored ObjectID-keyed digests into the
+        // content-derived NetworkKeyId the handoff cert is keyed by, via
+        // the temporary ObjectID<->NetworkKeyId map.
+        let dkg = to_network_key_id_keyed(store.get_network_dkg_output_digests()?)?;
         // Reconfiguration is epoch-specific: source it from the
         // epoch-keyed slice for *this handoff's* epoch, written under the
         // reconfiguration session's own (consensus-deterministic) epoch.
@@ -855,7 +883,9 @@ impl HandoffItemsBuilder for MpcDataHandoffItemsBuilder {
         // which a late output crossing the epoch boundary mis-filed,
         // diverging the attestation. DKG output is stable across epochs,
         // so the perpetual-merged getter is correct for it.
-        let reconfig = store.get_network_reconfiguration_output_digests_for_epoch(epoch)?;
+        let reconfig = to_network_key_id_keyed(
+            store.get_network_reconfiguration_output_digests_for_epoch(epoch)?,
+        )?;
         Ok(compute_handoff_items(&effective, &dkg, &reconfig))
     }
 }
@@ -1781,8 +1811,8 @@ mod tests {
     fn build_handoff_attestation_sorts_items() {
         let kp = random_committee_key_pairs_of_size(1).remove(0);
         let validator = name_of(&kp);
-        let key_id_a = ObjectID::random();
-        let key_id_b = ObjectID::random();
+        let key_id_a = NetworkKeyId([0xA1; 32]);
+        let key_id_b = NetworkKeyId([0xB2; 32]);
         // Pass items in non-canonical order; build_handoff_attestation
         // must return them sorted so all signers' bytes match.
         let items = vec![
@@ -1814,7 +1844,7 @@ mod tests {
 
     #[test]
     fn build_handoff_attestation_rejects_duplicate_keys() {
-        let key_id = ObjectID::random();
+        let key_id = NetworkKeyId([0xC3; 32]);
         let items = vec![
             (HandoffItemKey::NetworkDkgOutput { key_id }, [0x11; 32]),
             (HandoffItemKey::NetworkDkgOutput { key_id }, [0x22; 32]),
@@ -2337,8 +2367,8 @@ mod tests {
         // sources and confirm the output canonicalizes.
         let kp = random_committee_key_pairs_of_size(1).remove(0);
         let validator = name_of(&kp);
-        let key_id_a = ObjectID::random();
-        let key_id_b = ObjectID::random();
+        let key_id_a = NetworkKeyId([0x01; 32]);
+        let key_id_b = NetworkKeyId([0x02; 32]);
         let (smaller, bigger) = if key_id_a < key_id_b {
             (key_id_a, key_id_b)
         } else {
@@ -2764,8 +2794,8 @@ mod tests {
     #[test]
     fn compute_handoff_items_empty_inputs_yield_empty_list() {
         let empty: BTreeMap<AuthorityName, [u8; 32]> = BTreeMap::new();
-        let empty_obj: BTreeMap<ObjectID, [u8; 32]> = BTreeMap::new();
-        let items = compute_handoff_items(&empty, &empty_obj, &empty_obj);
+        let empty_keys: BTreeMap<NetworkKeyId, [u8; 32]> = BTreeMap::new();
+        let items = compute_handoff_items(&empty, &empty_keys, &empty_keys);
         assert!(items.is_empty());
     }
 

--- a/crates/ika-node/Cargo.toml
+++ b/crates/ika-node/Cargo.toml
@@ -31,6 +31,7 @@ path = "src/bin/ika-notifier.rs"
 
 [dependencies]
 anemo.workspace = true
+dwallet-mpc-types.workspace = true
 tikv-jemallocator = { workspace = true, optional = true }
 anemo-tower.workspace = true
 arc-swap.workspace = true

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -3366,11 +3366,13 @@ impl IkaNode {
                             .items
                             .iter()
                             .filter_map(|(item, digest)| match item {
-                                HandoffItemKey::NetworkReconfigurationOutput { key_id }
-                                    if local_reconfiguration_digests.get(key_id)
-                                        != Some(digest) =>
-                                {
-                                    Some(*key_id)
+                                HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
+                                    // Cert keys by NetworkKeyId; local digests by
+                                    // ObjectID — translate via the temporary map.
+                                    let object_id =
+                                        ika_core::network_key_id_mapping::object_id_for(key_id)?;
+                                    (local_reconfiguration_digests.get(&object_id) != Some(digest))
+                                        .then_some(object_id)
                                 }
                                 _ => None,
                             })
@@ -3458,10 +3460,20 @@ async fn install_joiner_network_key_outputs(
             HandoffItemKey::NetworkReconfigurationOutput { key_id } => (*key_id, true),
             HandoffItemKey::ValidatorMpcData { .. } => continue,
         };
+        // The cert is keyed by NetworkKeyId; the local digest tables and
+        // caches are keyed by ObjectID. Translate via the temporary map; an
+        // unmapped key is unknown to this joiner and can't be cached locally.
+        let Some(object_id) = ika_core::network_key_id_mapping::object_id_for(&key_id) else {
+            debug!(
+                ?key_id,
+                "no ObjectID mapping for cert network key; skipping"
+            );
+            continue;
+        };
         let held_locally = if is_reconfiguration {
-            local_reconfiguration_digests.get(&key_id) == Some(expected_digest)
+            local_reconfiguration_digests.get(&object_id) == Some(expected_digest)
         } else {
-            local_dkg_digests.get(&key_id) == Some(expected_digest)
+            local_dkg_digests.get(&object_id) == Some(expected_digest)
         };
         if held_locally {
             continue;
@@ -3493,7 +3505,7 @@ async fn install_joiner_network_key_outputs(
                 ?key_id,
                 "could not fetch a cert-matching network-key output from any peer this pass"
             );
-            missing_key_ids.push(key_id);
+            missing_key_ids.push(object_id);
             continue;
         };
         let cached = if is_reconfiguration {
@@ -3501,13 +3513,17 @@ async fn install_joiner_network_key_outputs(
             // epoch whose reconfiguration output the cert certifies —
             // not the joiner's wall-clock epoch, matching the producer
             // side's session-epoch keying.
-            epoch_store.cache_network_reconfiguration_output(key_id, cert.attestation.epoch, &bytes)
+            epoch_store.cache_network_reconfiguration_output(
+                object_id,
+                cert.attestation.epoch,
+                &bytes,
+            )
         } else {
-            epoch_store.cache_network_dkg_output(key_id, &bytes)
+            epoch_store.cache_network_dkg_output(object_id, &bytes)
         };
         if let Err(e) = cached {
             warn!(?key_id, error = ?e, "failed to cache fetched joiner network-key output");
-            missing_key_ids.push(key_id);
+            missing_key_ids.push(object_id);
         }
     }
     missing_key_ids
@@ -3602,7 +3618,10 @@ fn all_cert_reconfiguration_outputs_held_locally(
         .iter()
         .all(|(item, cert_digest)| match item {
             HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
-                local_reconfiguration_digests.get(key_id) == Some(cert_digest)
+                // Cert keys by NetworkKeyId; local digests by ObjectID.
+                ika_core::network_key_id_mapping::object_id_for(key_id).is_some_and(|object_id| {
+                    local_reconfiguration_digests.get(&object_id) == Some(cert_digest)
+                })
             }
             HandoffItemKey::NetworkDkgOutput { .. } | HandoffItemKey::ValidatorMpcData { .. } => {
                 true
@@ -3613,17 +3632,22 @@ fn all_cert_reconfiguration_outputs_held_locally(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dwallet_mpc_types::dwallet_mpc::NetworkKeyId;
     use ika_types::handoff::{CertifiedHandoffAttestation, HandoffAttestation, HandoffItemKey};
 
     fn key_id(index: u8) -> ObjectID {
         ObjectID::new([index; 32])
     }
 
+    fn network_key_id(index: u8) -> NetworkKeyId {
+        NetworkKeyId([index | 0x80; 32])
+    }
+
     /// Builds a cert whose only items are `NetworkReconfigurationOutput`s for
     /// the given `(key_id, digest)` pairs. Signatures are irrelevant to the
     /// readiness predicate, so they are left empty.
     fn cert_with_reconfiguration_items(
-        items: Vec<(ObjectID, [u8; 32])>,
+        items: Vec<(NetworkKeyId, [u8; 32])>,
     ) -> CertifiedHandoffAttestation {
         CertifiedHandoffAttestation {
             attestation: HandoffAttestation {
@@ -3645,9 +3669,13 @@ mod tests {
 
     #[test]
     fn all_cert_reconfiguration_outputs_held_locally_cases() {
+        // The cert is keyed by NetworkKeyId; the local slice by ObjectID.
+        // Register the mappings so the predicate can translate.
+        ika_core::network_key_id_mapping::register(key_id(0), network_key_id(0));
+        ika_core::network_key_id_mapping::register(key_id(1), network_key_id(1));
         // Cert certifies one reconfiguration output; the local slice holds a
         // matching digest → ready.
-        let cert = cert_with_reconfiguration_items(vec![(key_id(0), [1u8; 32])]);
+        let cert = cert_with_reconfiguration_items(vec![(network_key_id(0), [1u8; 32])]);
         let held = BTreeMap::from([(key_id(0), [1u8; 32])]);
         assert!(all_cert_reconfiguration_outputs_held_locally(&cert, &held));
 
@@ -3666,8 +3694,10 @@ mod tests {
 
         // Two certified outputs, only one held locally → not ready (EVERY item
         // the cert certifies must be held + matching).
-        let cert_two =
-            cert_with_reconfiguration_items(vec![(key_id(0), [1u8; 32]), (key_id(1), [2u8; 32])]);
+        let cert_two = cert_with_reconfiguration_items(vec![
+            (network_key_id(0), [1u8; 32]),
+            (network_key_id(1), [2u8; 32]),
+        ]);
         let one = BTreeMap::from([(key_id(0), [1u8; 32])]);
         assert!(!all_cert_reconfiguration_outputs_held_locally(
             &cert_two, &one
@@ -3687,7 +3717,9 @@ mod tests {
                 epoch: 7,
                 next_committee_pubkey_set_hash: [0u8; 32],
                 items: vec![(
-                    HandoffItemKey::NetworkDkgOutput { key_id: key_id(0) },
+                    HandoffItemKey::NetworkDkgOutput {
+                        key_id: network_key_id(0),
+                    },
                     [5u8; 32],
                 )],
             },

--- a/crates/ika-types/src/handoff.rs
+++ b/crates/ika-types/src/handoff.rs
@@ -16,9 +16,9 @@
 
 use crate::committee::EpochId;
 use crate::crypto::AuthorityName;
+use dwallet_mpc_types::dwallet_mpc::NetworkKeyId;
 use fastcrypto::ed25519::Ed25519Signature;
 use serde::{Deserialize, Serialize};
-use sui_types::base_types::ObjectID;
 
 /// Identifies a single piece of state covered by a `HandoffAttestation`.
 ///
@@ -29,11 +29,13 @@ use sui_types::base_types::ObjectID;
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum HandoffItemKey {
     /// Network DKG public output for a specific encryption key. Stable
-    /// across an encryption key's lifetime.
-    NetworkDkgOutput { key_id: ObjectID },
+    /// across an encryption key's lifetime. `key_id` is the key's
+    /// content-derived [`NetworkKeyId`] (its curve25519 NOA ed25519
+    /// public key), not the Sui `ObjectID`.
+    NetworkDkgOutput { key_id: NetworkKeyId },
     /// Network reconfiguration public output for a specific encryption
     /// key, produced this epoch.
-    NetworkReconfigurationOutput { key_id: ObjectID },
+    NetworkReconfigurationOutput { key_id: NetworkKeyId },
     /// MPC class-groups public material of a committee member, pinned
     /// to the exact version that was consumed as input by this epoch's
     /// MPC sessions.
@@ -99,7 +101,6 @@ pub struct CertifiedHandoffAttestation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sui_types::base_types::ObjectID;
 
     fn make_authority(byte: u8) -> AuthorityName {
         // BLS12381 min_pk public keys are 48 bytes. The fake bytes
@@ -113,8 +114,8 @@ mod tests {
         // Variant order in the enum defines the canonical sort key
         // for items; freeze it so reordering the enum is caught
         // here.
-        let key_id_a = ObjectID::random();
-        let key_id_b = ObjectID::random();
+        let key_id_a = NetworkKeyId([1u8; 32]);
+        let key_id_b = NetworkKeyId([2u8; 32]);
         let auth = make_authority(0);
         let mut keys = vec![
             HandoffItemKey::ValidatorMpcData { validator: auth },
@@ -144,7 +145,7 @@ mod tests {
     /// upgrade — never silently.
     #[test]
     fn handoff_item_key_bcs_variant_tags_are_frozen() {
-        let key_id = ObjectID::from_bytes([0x11; ObjectID::LENGTH]).unwrap();
+        let key_id = NetworkKeyId([0x11; 32]);
         let validator = AuthorityName::new([0x22; 48]);
 
         let dkg_bytes =
@@ -170,7 +171,7 @@ mod tests {
 
     #[test]
     fn handoff_attestation_bcs_roundtrip_preserves_sorted_items() {
-        let key_id = ObjectID::random();
+        let key_id = NetworkKeyId([0x55; 32]);
         let auth = make_authority(1);
         let attestation = HandoffAttestation {
             epoch: 7,


### PR DESCRIPTION
## Summary

Make the network encryption key's identity in the cross-epoch handoff a **content-derived `NetworkKeyId`** — its curve25519 network-owned-address ed25519 public key, used directly (`[u8; 32]`) — instead of the Sui `ObjectID`. The handoff certificate, the cross-epoch trust artifact, no longer depends on Sui-assigned identifiers.

Gated on the v4 off-chain regime; v4 is **not live** on any deployed network, so there are no deployed-network back-compat constraints.

## What & why

- **NOA sign-DKG session id seeded on the encryption key** (not the `ObjectID`) — breaks the circularity that blocked using the NOA pubkey as the identity, so the NOA pubkey is Sui-independent and reconfiguration-invariant, and can serve as the identity.
- **`NetworkKeyId([u8; 32])`** type + `derive_curve25519_network_owned_address_public_key`, with an ignored real-network tool that prints a deployed key's `ObjectID → NetworkKeyId`.
- `HandoffItemKey` and the epoch-keyed digest tables key by `NetworkKeyId`.
- A **temporary** static `ObjectID ↔ NetworkKeyId` map (`TODO(NetworkKeyId-from-event)`), seeded with the derived testnet/mainnet constants + `register()` at network-key instantiation — bridges until the on-chain request event carries the `NetworkKeyId` directly, at which point the map is deleted. One key per network; no new DKG planned before then.
- Wiring: build (`compute_handoff_items` / `MpcDataHandoffItemsBuilder` translate `ObjectID → NetworkKeyId`), consume (`adopt_cert_verified_keys` keys its digest maps by `NetworkKeyId`), joiner/barrier in `ika-node` (`NetworkKeyId → ObjectID` for caching).

`NetworkKeyId` is content-derived, reconfiguration-invariant, and (relevant to the stacked follow-up) invariant across the V2→V3 DKG-output migration — the class-group encryption key it derives from is invariant.

## Stacked follow-up

The **V2→V3 canonical network DKG migration** builds on this (it re-keys session identifiers onto `NetworkKeyId` and operates on the `NetworkKeyId`-keyed handoff) and is in **#1758**, stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
