### PR TITLE
feat(ocs): verify checkpoints against the committee before folding into the direct cache

### DIFF
--- a/crates/ika-core/src/sui_connector/ocs_metrics.rs
+++ b/crates/ika-core/src/sui_connector/ocs_metrics.rs
@@ -11,9 +11,10 @@
 use std::sync::Arc;
 
 use prometheus::{
-    HistogramVec, IntCounter, IntCounterVec, IntGauge, Registry,
-    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
-    register_int_counter_with_registry, register_int_gauge_with_registry,
+    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, Registry,
+    register_histogram_vec_with_registry, register_histogram_with_registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+    register_int_gauge_with_registry,
 };
 
 #[derive(Clone, Debug)]
@@ -39,6 +40,12 @@ pub struct OcsMetrics {
     pub pusher_pushed_total: IntCounter,
     pub pusher_skipped_irrelevant_total: IntCounter,
     pub pusher_fetch_failures_total: IntCounter,
+    /// Latency of the pre-fold committee verification the pusher runs before
+    /// folding a checkpoint into the local cache (committee BLS on the summary
+    /// + artifacts-digest binding). `_count` is the number of checkpoints
+    /// committee-verified before folding, `_sum` the total CPU time spent on
+    /// it — together they quantify the verify's cost on the fold path.
+    pub pusher_fold_verify_seconds: Histogram,
 
     // OcsVerifiedReader (consumer-side proof verification)
     pub proof_verify_total: IntCounterVec, // labels: ["kind"]
@@ -111,6 +118,13 @@ impl OcsMetrics {
             pusher_fetch_failures_total: register_int_counter_with_registry!(
                 "ika_ocs_pusher_fetch_failures_total",
                 "Number of get_full_checkpoint failures during the pusher walk",
+                registry,
+            )
+            .unwrap(),
+            pusher_fold_verify_seconds: register_histogram_with_registry!(
+                "ika_ocs_pusher_fold_verify_seconds",
+                "Latency of the sui-state-direct pusher's pre-fold committee verification (BLS on the summary + artifacts-digest binding); _count is the number of checkpoints committee-verified before folding into the cache",
+                vec![0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5],
                 registry,
             )
             .unwrap(),

--- a/crates/ika-core/src/sui_connector/ocs_verifier.rs
+++ b/crates/ika-core/src/sui_connector/ocs_verifier.rs
@@ -16,12 +16,13 @@
 //! v121 as of 2026-05.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
-use ika_sui_client::archive::SuiCheckpointArchive;
+use ika_sui_client::archive::CheckpointArchive;
 use ika_sui_client::transport::{SuiTransport, TransportError};
 
 use crate::sui_connector::committee_store::{
@@ -99,7 +100,13 @@ pub struct OcsVerifyingClient {
     /// checkpoint archive (or configured mirror), BLS-verify it against
     /// `committee[head]`, and install — trust unchanged. Tried *before* the
     /// degraded unverified fallback. `None` until wired (see `with_archive`).
-    archive: Option<Arc<SuiCheckpointArchive>>,
+    archive: Option<Arc<dyn CheckpointArchive>>,
+    /// Whether the one-time cold-bootstrap-from-archive walk has been attempted.
+    /// It runs at the start of the first ratchet, advancing the committee chain
+    /// genesis -> latest purely from the archive (BLS-verifying every summary
+    /// against the running committee); later ratchets skip it and rely on the
+    /// transport plus the per-seq archive fallback.
+    backfill_attempted: AtomicBool,
     /// Coalesces concurrent ratchet calls to one: the periodic ratchet, the
     /// boot ratchet, and the reactive (`missing_committee`) push ratchet all
     /// share this. A caller that finds a ratchet already in flight returns
@@ -121,6 +128,7 @@ impl OcsVerifyingClient {
             metrics,
             allow_unverified_committee_fallback,
             archive: None,
+            backfill_attempted: AtomicBool::new(false),
             ratchet_lock: Mutex::new(()),
         }
     }
@@ -129,7 +137,7 @@ impl OcsVerifyingClient {
     /// the upstream fullnode has pruned an end-of-epoch checkpoint. Everything
     /// fetched from it is BLS-verified before install, so the archive is an
     /// untrusted availability source — never a trust source.
-    pub fn with_archive(mut self, archive: Option<Arc<SuiCheckpointArchive>>) -> Self {
+    pub fn with_archive(mut self, archive: Option<Arc<dyn CheckpointArchive>>) -> Self {
         self.archive = archive;
         self
     }
@@ -140,6 +148,69 @@ impl OcsVerifyingClient {
 
     pub fn committees(&self) -> &Arc<CommitteeStore> {
         &self.committees
+    }
+
+    /// Cold-bootstrap the committee chain from the checkpoint `archive`: walk
+    /// `head → latest` purely from the object store. For each step it reads
+    /// epoch `head`'s end-of-epoch sequence number from the (untrusted)
+    /// `epochs.json` enumeration, fetches that checkpoint, and BLS-verifies its
+    /// summary against `committee[head]` before installing `committee[head+1]`.
+    ///
+    /// Because `head` starts at 0 (the genesis committee) and advances one
+    /// verified epoch at a time, **every** committee is verified from genesis
+    /// forward — the archive is never trusted. A forged, gapped, or reordered
+    /// `epochs.json` is caught by `install_next_from_summary`'s per-summary
+    /// signature check and its `next.epoch == head + 1` contiguity assertion
+    /// (worst case the walk stalls; it can never install a forged committee).
+    ///
+    /// Resumable: the persisted head means a re-run skips the already-installed
+    /// prefix. Past the end of the enumerated (completed) epochs it returns
+    /// `Ok` — the live tail is the transport ratchet's / follower's job.
+    async fn backfill_committee_chain_from_archive(
+        &self,
+        archive: &Arc<dyn CheckpointArchive>,
+    ) -> Result<(), OcsError> {
+        let seqs = archive
+            .enumerate_end_of_epoch_seqs()
+            .await
+            .map_err(|e| OcsError::Ika(format!("archive enumerate epochs.json: {e}")))?;
+        loop {
+            let head = self.committees.head_epoch();
+            let Some(&seq) = seqs.get(head as usize) else {
+                return Ok(());
+            };
+            let (summary, _contents) = archive
+                .fetch_checkpoint(seq)
+                .await
+                .map_err(|e| OcsError::Ika(format!("archive fetch checkpoint {seq}: {e}")))?;
+            match self.committees.install_next_from_summary(&summary) {
+                Ok(CommitteeTransition::Installed(epoch)) => {
+                    info!(epoch, seq, "cold-bootstrapped Sui committee from archive");
+                }
+                // `epochs.json[head]` is not epoch `head`'s end-of-epoch
+                // checkpoint — the enumeration is inconsistent with the verified
+                // chain (gapped/reordered), so we cannot verify past this point.
+                Ok(CommitteeTransition::NotNextTransition) => {
+                    return Err(OcsError::NotEndOfEpoch(seq));
+                }
+                Err(CommitteeTransitionError::MissingCommittee(e)) => {
+                    return Err(OcsError::MissingCommittee(e));
+                }
+                Err(
+                    CommitteeTransitionError::BadSignature { error, .. }
+                    | CommitteeTransitionError::Extract { error, .. },
+                ) => {
+                    return Err(OcsError::BadCheckpointSig(seq, error));
+                }
+                Err(CommitteeTransitionError::EpochMismatch { expected, got }) => {
+                    return Err(OcsError::RatchetEpochMismatch {
+                        requested: expected,
+                        returned: got,
+                    });
+                }
+                Err(CommitteeTransitionError::Store(e)) => return Err(e.into()),
+            }
+        }
     }
 
     /// Walk forward from the current `head_epoch` of [`CommitteeStore`] to the
@@ -163,6 +234,23 @@ impl OcsVerifyingClient {
                 return Ok(());
             }
         };
+        // Cold-bootstrap once from the archive (if configured): walk the
+        // committee chain genesis -> latest purely from the object store before
+        // the transport walk below, BLS-verifying every summary from genesis
+        // forward. Best-effort — failures (no archive, unreachable, pruned tail)
+        // log and fall through to the transport ratchet. Runs only on the first
+        // ratchet; later ratchets rely on the transport + per-seq archive
+        // fallback for the live tail.
+        if let Some(archive) = self.archive.clone() {
+            if !self.backfill_attempted.swap(true, Ordering::Relaxed) {
+                if let Err(e) = self.backfill_committee_chain_from_archive(&archive).await {
+                    warn!(
+                        error = %e,
+                        "archive cold-bootstrap incomplete; continuing with the transport ratchet"
+                    );
+                }
+            }
+        }
         // `get_current_epoch` is a relay-claimed, unverified passthrough, but
         // it only sets the loop's *target* — it can't forge progress. Every
         // step below BLS-verifies the end-of-epoch checkpoint against
@@ -527,6 +615,103 @@ mod tests {
             .unwrap(),
         );
         (dir, store)
+    }
+
+    /// A mock checkpoint archive backed by in-memory signed summaries, so the
+    /// cold-bootstrap loop is tested without a real object store.
+    struct MockArchive {
+        seqs: Vec<CheckpointSequenceNumber>,
+        checkpoints:
+            HashMap<CheckpointSequenceNumber, (CertifiedCheckpointSummary, CheckpointContents)>,
+    }
+
+    #[async_trait]
+    impl CheckpointArchive for MockArchive {
+        async fn enumerate_end_of_epoch_seqs(
+            &self,
+        ) -> Result<Vec<CheckpointSequenceNumber>, ika_sui_client::archive::ArchiveError> {
+            Ok(self.seqs.clone())
+        }
+        async fn fetch_checkpoint(
+            &self,
+            seq: CheckpointSequenceNumber,
+        ) -> Result<
+            (CertifiedCheckpointSummary, CheckpointContents),
+            ika_sui_client::archive::ArchiveError,
+        > {
+            self.checkpoints.get(&seq).cloned().ok_or_else(|| {
+                ika_sui_client::archive::ArchiveError::Fetch {
+                    url: "mock".into(),
+                    seq,
+                    source: anyhow::anyhow!("seq {seq} not in mock archive"),
+                }
+            })
+        }
+    }
+
+    /// Build a mock archive holding the end-of-epoch checkpoint of epochs
+    /// `0..epochs`, each signed by `committee[e]` and committing to
+    /// `committee[e+1]`. `seqs[e]` (the `epochs.json` index) is epoch `e`'s EOP.
+    fn archive_for_chain(base: &Committee, keys: &[AuthorityKeyPair], epochs: u64) -> MockArchive {
+        let mut seqs = Vec::new();
+        let mut checkpoints = HashMap::new();
+        for e in 0..epochs {
+            let seq = 1_000 + e;
+            let committee_e = committee_at_epoch(base, keys, e);
+            let cp = end_of_epoch_checkpoint(&committee_e, keys, seq);
+            seqs.push(seq);
+            checkpoints.insert(seq, (cp.checkpoint_summary, cp.checkpoint_contents));
+        }
+        MockArchive { seqs, checkpoints }
+    }
+
+    fn client_with_store(store: Arc<CommitteeStore>) -> OcsVerifyingClient {
+        OcsVerifyingClient::new(
+            Arc::new(RatchetMock::new(0)),
+            store,
+            OcsMetrics::new_for_testing(),
+            false,
+        )
+    }
+
+    /// Cold-bootstrap walks the whole chain from the archive, BLS-verifying each
+    /// summary against the running committee from genesis (head 0) forward; the
+    /// head advances to the last enumerated epoch.
+    #[tokio::test]
+    async fn archive_backfill_installs_the_full_chain() {
+        let (committee, keys) = Committee::new_simple_test_committee();
+        let (_dir, store) = store_with_genesis(committee.clone());
+        let archive: Arc<dyn CheckpointArchive> = Arc::new(archive_for_chain(&committee, &keys, 5));
+        let client = client_with_store(store.clone());
+        client
+            .backfill_committee_chain_from_archive(&archive)
+            .await
+            .unwrap();
+        // EOPs for epochs 0..5 -> committee[5] installed; past the list is Ok.
+        assert_eq!(store.head_epoch(), 5);
+    }
+
+    /// An UNTRUSTED `epochs.json` that omits an epoch's end-of-epoch checkpoint
+    /// is caught by the `+1` contiguity check: the walk stops with an error
+    /// rather than installing a shifted/forged committee, and the head holds at
+    /// the gap. (verify everything — the enumeration is only a hint.)
+    #[tokio::test]
+    async fn archive_backfill_rejects_a_gapped_enumeration() {
+        let (committee, keys) = Committee::new_simple_test_committee();
+        let (_dir, store) = store_with_genesis(committee.clone());
+        let mut mock = archive_for_chain(&committee, &keys, 5);
+        // Drop epoch 2's EOP so `seqs[2]` now points at epoch 3's EOP.
+        let dropped = mock.seqs.remove(2);
+        mock.checkpoints.remove(&dropped);
+        let archive: Arc<dyn CheckpointArchive> = Arc::new(mock);
+        let client = client_with_store(store.clone());
+        let err = client
+            .backfill_committee_chain_from_archive(&archive)
+            .await
+            .unwrap_err();
+        // 0,1 install; at head=2 `seqs[2]` is epoch 3's summary -> NotNextTransition.
+        assert!(matches!(err, OcsError::NotEndOfEpoch(_)), "got {err:?}");
+        assert_eq!(store.head_epoch(), 2, "head stops at the gap");
     }
 
     /// With the unverified fallback enabled, a pruned end-of-epoch checkpoint

--- a/crates/ika-core/src/sui_connector/push_worker.rs
+++ b/crates/ika-core/src/sui_connector/push_worker.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use ika_network::proof_provider::VerifiedObjectEntry;
 use ika_sui_client::transport::SuiTransport;
@@ -421,6 +421,7 @@ impl IkaCheckpointPusher {
         tree: &ModifiedObjectTree,
         folding_objects: bool,
     ) -> anyhow::Result<()> {
+        let started = Instant::now();
         self.committees
             .verify_summary(summary.clone())
             .map_err(|e| {
@@ -439,6 +440,14 @@ impl IkaCheckpointPusher {
                 );
             }
         }
+        // Record only the success path's cost: a rejection (the early returns
+        // above) is a security event surfaced by the caller's log, not a
+        // steady-state latency sample. `_count` then equals the checkpoints
+        // committee-verified before folding, `_sum` the CPU the verify added
+        // to the fold loop.
+        self.metrics
+            .pusher_fold_verify_seconds
+            .observe(started.elapsed().as_secs_f64());
         Ok(())
     }
 }

--- a/crates/ika-core/src/sui_connector/push_worker.rs
+++ b/crates/ika-core/src/sui_connector/push_worker.rs
@@ -26,12 +26,13 @@ use ika_types::messages_dwallet_mpc::IkaPackageConfig;
 use sui_light_client::proof::ocs::ModifiedObjectTree;
 use sui_types::TypeTag;
 use sui_types::base_types::ObjectID;
+use sui_types::digests::CheckpointArtifactsDigest;
 use sui_types::full_checkpoint_content::CheckpointData;
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointArtifacts, CheckpointSequenceNumber,
 };
 use sui_types::object::Object;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::authority::authority_perpetual_tables::AuthorityPerpetualTables;
 use crate::sui_connector::committee_store::{CommitteeStore, CommitteeTransition};
@@ -377,7 +378,68 @@ impl IkaCheckpointPusher {
             return Ok(None);
         }
 
+        // Verify the checkpoint against its committee BEFORE folding anything
+        // into the cache, so a direct node caches committee-attested state
+        // rather than whatever its own fullnode served.
+        let summary = &data.checkpoint_summary;
+        if let Err(e) = self.verify_before_fold(summary, &tree, !objects_with_proofs.is_empty()) {
+            error!(
+                security_critical = true,
+                seq = *summary.sequence_number(),
+                epoch = summary.epoch(),
+                error = %e,
+                "refusing to fold a checkpoint that failed committee verification — \
+                 own fullnode served state that does not verify against the committee"
+            );
+            return Err(e);
+        }
+
         Ok(Some((data.checkpoint_summary.clone(), objects_with_proofs)))
+    }
+
+    /// Verify a checkpoint against its committee BEFORE its objects are folded
+    /// into the cache, so a direct node trusts committee-attested state rather
+    /// than whatever its own fullnode served — a compromised or buggy fullnode
+    /// cannot seed the cache with forged objects. These are the same two checks
+    /// [`OcsVerifiedReader`]'s network read path performs, hoisted to fold time
+    /// (once per checkpoint, off the read hot path):
+    ///
+    ///   1. the checkpoint summary carries a valid committee quorum signature;
+    ///   2. when objects are being folded, the locally-built modified-objects
+    ///      tree root matches the committee-signed checkpoint-artifacts digest —
+    ///      binding every inclusion proof derived from that tree to
+    ///      committee-attested state (a real tree root means the proofs the
+    ///      pusher built from it are over genuine objects).
+    ///
+    /// A failure means the fullnode served state that does not verify against
+    /// the committee: the caller refuses to fold it (propagating the error, so
+    /// the cursor stays put and a transient missing-committee self-heals on the
+    /// next poll) rather than caching unverified state.
+    fn verify_before_fold(
+        &self,
+        summary: &CertifiedCheckpointSummary,
+        tree: &ModifiedObjectTree,
+        folding_objects: bool,
+    ) -> anyhow::Result<()> {
+        self.committees
+            .verify_summary(summary.clone())
+            .map_err(|e| {
+                anyhow::anyhow!("checkpoint summary failed committee verification: {e}")
+            })?;
+        if folding_objects {
+            let signed = summary.data().checkpoint_artifacts_digest().map_err(|e| {
+                anyhow::anyhow!("summary carries no checkpoint-artifacts digest: {e}")
+            })?;
+            let local = CheckpointArtifactsDigest::from_artifact_digests(vec![tree.tree_root])
+                .map_err(|e| anyhow::anyhow!("computing artifacts digest from local tree: {e}"))?;
+            if local != *signed {
+                anyhow::bail!(
+                    "checkpoint-artifacts digest mismatch — the fullnode's modified-objects \
+                     tree does not match the committee-signed digest"
+                );
+            }
+        }
+        Ok(())
     }
 }
 
@@ -417,15 +479,18 @@ fn type_touches_ika(t: &TypeTag, ika: &HashSet<ObjectID>) -> bool {
 mod tests {
     use super::*;
     use async_trait::async_trait;
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     use ika_sui_client::transport::{DynamicFieldPage, ExecutedTransaction, TransportError};
-    use sui_types::base_types::{SequenceNumber, TransactionDigest};
+    use sui_types::base_types::{ObjectDigest, SequenceNumber, TransactionDigest};
     use sui_types::committee::{Committee, ProtocolVersion};
     use sui_types::crypto::AuthorityKeyPair;
     use sui_types::digests::CheckpointDigest;
     use sui_types::gas::GasCostSummary;
-    use sui_types::messages_checkpoint::{CheckpointContents, CheckpointSummary, EndOfEpochData};
+    use sui_types::messages_checkpoint::{
+        CheckpointCommitment, CheckpointContents, CheckpointSummary, EndOfEpochData,
+    };
+    use sui_types::object::Owner;
 
     use crate::sui_connector::committee_store::CommitteeBootstrap;
     use crate::sui_connector::verified_state_cache::{
@@ -909,6 +974,163 @@ mod tests {
         assert_eq!(
             perpetual.get_sui_pusher_last_seq().unwrap(),
             Some(latest_seq)
+        );
+    }
+
+    /// A non-end-of-epoch, committee-signed summary at `seq` carrying exactly
+    /// `commitment` (used to plant a correct or a deliberately-wrong
+    /// checkpoint-artifacts digest).
+    fn signed_summary_with_commitment(
+        committee: &Committee,
+        keys: &[AuthorityKeyPair],
+        seq: CheckpointSequenceNumber,
+        commitment: CheckpointCommitment,
+    ) -> CertifiedCheckpointSummary {
+        let contents = CheckpointContents::new_with_digests_only_for_tests(vec![]);
+        let summary = CheckpointSummary {
+            epoch: committee.epoch(),
+            sequence_number: seq,
+            network_total_transactions: 0,
+            content_digest: *contents.digest(),
+            previous_digest: None,
+            epoch_rolling_gas_cost_summary: GasCostSummary::default(),
+            timestamp_ms: 0,
+            checkpoint_commitments: vec![commitment],
+            end_of_epoch_data: None,
+            version_specific_data: Vec::new(),
+        };
+        CertifiedCheckpointSummary::new_from_keypairs_for_testing(summary, keys, committee)
+    }
+
+    /// The modified-objects tree over a single object plus its
+    /// `CheckpointArtifactsDigest`, mirroring what the pusher builds from a
+    /// fetched checkpoint.
+    fn tree_and_digest_over(object: &Object) -> (ModifiedObjectTree, CheckpointArtifactsDigest) {
+        let (id, version, digest) = object.compute_object_reference();
+        let states: BTreeMap<ObjectID, (SequenceNumber, ObjectDigest)> =
+            std::iter::once((id, (version, digest))).collect();
+        let artifacts = CheckpointArtifacts::from_object_states(states);
+        let tree = ModifiedObjectTree::new(&artifacts).unwrap();
+        let artifacts_digest = artifacts.digest().unwrap();
+        (tree, artifacts_digest)
+    }
+
+    /// A direct node must never fold state its own fullnode failed to prove
+    /// against the committee. A foldable (end-of-epoch) checkpoint whose summary
+    /// is signed by the WRONG committee is rejected at fold time: `advance()`
+    /// surfaces the error, the committee head does not move, and nothing is
+    /// cached. Without the fold-time committee check a compromised fullnode
+    /// could seed the cache with forged state that cache-first reads serve
+    /// unverified. (The honest counterpart is
+    /// `pusher_eagerly_captures_end_of_epoch_committee`, which folds the same
+    /// shape when it IS correctly signed.)
+    #[tokio::test]
+    async fn pusher_refuses_to_fold_a_checkpoint_that_fails_committee_verification() {
+        let (committee, _keys) = Committee::new_simple_test_committee_of_size(4);
+        // A different committee at the same epoch (0): its authorities are not
+        // in the store's committee[0], so any summary it signs fails
+        // verification. A different size guarantees a disjoint authority set
+        // (the test-committee constructor is deterministic per size).
+        let (foreign_committee, foreign_keys) = Committee::new_simple_test_committee_of_size(7);
+
+        let dir = tempfile::tempdir().unwrap();
+        let perpetual = Arc::new(AuthorityPerpetualTables::open(dir.path(), None));
+        let committees = Arc::new(
+            CommitteeStore::open(
+                perpetual.clone(),
+                Some(CommitteeBootstrap::UnsafeGenesis(committee.clone())),
+            )
+            .unwrap(),
+        );
+        assert_eq!(committees.head_epoch(), 0);
+
+        // An end-of-epoch checkpoint at epoch 0 signed by the foreign committee.
+        let forged = end_of_epoch_checkpoint(&foreign_committee, &foreign_keys, 100);
+        let latest = forged.checkpoint_summary.clone();
+        let cache: SharedVerifiedStateCache = Arc::new(VerifiedStateCache::new());
+        let transport: Arc<dyn SuiTransport> = Arc::new(MockTransport {
+            latest,
+            checkpoints: HashMap::from([(100u64, forged)]),
+            eoe_seqs: HashMap::new(),
+        });
+        perpetual.put_sui_pusher_last_seq(99).unwrap();
+
+        let mut pusher = pusher_over_with_cache(
+            perpetual.clone(),
+            committees.clone(),
+            transport,
+            cache.clone(),
+            OcsMetrics::new_for_testing(),
+        )
+        .await;
+
+        // The fold-time committee check rejects it: advance() returns the error
+        // rather than caching unverified state.
+        assert!(
+            pusher.advance().await.is_err(),
+            "a checkpoint that fails committee verification must not be folded"
+        );
+        // The committee head never advanced past the unverifiable transition,
+        // the cursor stayed put (the error halts it before the cursor write), so
+        // a later honest checkpoint at the same seq is reprocessed, and nothing
+        // was cached.
+        assert_eq!(committees.head_epoch(), 0);
+        assert_eq!(perpetual.get_sui_pusher_last_seq().unwrap(), Some(99));
+        assert!(cache.is_empty());
+    }
+
+    /// The second fold-time check: even with a valid committee signature, the
+    /// locally-built modified-objects tree must match the committee-signed
+    /// checkpoint-artifacts digest before any object is folded — otherwise a
+    /// fullnode could serve a genuine summary alongside a forged object tree.
+    /// An honest summary (committing to THIS tree's digest) is accepted; one
+    /// committing to a different tree's digest is rejected.
+    #[tokio::test]
+    async fn fold_verify_rejects_an_artifacts_digest_that_does_not_match_the_tree() {
+        let (committee, keys) = Committee::new_simple_test_committee();
+        let dir = tempfile::tempdir().unwrap();
+        let perpetual = Arc::new(AuthorityPerpetualTables::open(dir.path(), None));
+        let committees = Arc::new(
+            CommitteeStore::open(
+                perpetual.clone(),
+                Some(CommitteeBootstrap::UnsafeGenesis(committee.clone())),
+            )
+            .unwrap(),
+        );
+        let transport: Arc<dyn SuiTransport> = Arc::new(MockTransport {
+            latest: end_of_epoch_checkpoint(&committee, &keys, 1).checkpoint_summary,
+            checkpoints: HashMap::new(),
+            eoe_seqs: HashMap::new(),
+        });
+        let pusher = pusher_over(perpetual, committees, transport).await;
+
+        // The tree the pusher would build for this checkpoint, and its digest.
+        let object = Object::with_id_owner_version_for_testing(
+            ObjectID::random(),
+            SequenceNumber::from(1),
+            Owner::AddressOwner(ObjectID::random().into()),
+        );
+        let (tree, artifacts_digest) = tree_and_digest_over(&object);
+
+        // Honest: the summary commits to THIS tree's artifacts digest → folds.
+        let honest = signed_summary_with_commitment(&committee, &keys, 1, artifacts_digest.into());
+        assert!(
+            pusher.verify_before_fold(&honest, &tree, true).is_ok(),
+            "a summary committing to the matching tree digest must fold"
+        );
+
+        // Forged: a valid signature, but the summary commits to a DIFFERENT
+        // tree's digest, so the binding to THIS tree fails → rejected.
+        let other = Object::with_id_owner_version_for_testing(
+            ObjectID::random(),
+            SequenceNumber::from(7),
+            Owner::AddressOwner(ObjectID::random().into()),
+        );
+        let (_other_tree, wrong_digest) = tree_and_digest_over(&other);
+        let forged = signed_summary_with_commitment(&committee, &keys, 1, wrong_digest.into());
+        assert!(
+            pusher.verify_before_fold(&forged, &tree, true).is_err(),
+            "a summary whose committed digest does not match the folded tree must be rejected"
         );
     }
 }

--- a/crates/ika-core/src/sui_connector/setup.rs
+++ b/crates/ika-core/src/sui_connector/setup.rs
@@ -335,12 +335,13 @@ pub async fn build_sui_connector_stack(
     // Verified-fallback end-of-epoch checkpoint archive (object store). Used by
     // the ratchet when the upstream fullnode has pruned an end-of-epoch
     // checkpoint; every byte is BLS-verified, so the archive is untrusted.
-    let archive = cfg.sui_checkpoint_archive.as_ref().map(|a| {
-        Arc::new(ika_sui_client::archive::SuiCheckpointArchive::new(
-            a.url.clone(),
-            a.options.clone(),
-        ))
-    });
+    let archive: Option<Arc<dyn ika_sui_client::archive::CheckpointArchive>> =
+        cfg.sui_checkpoint_archive.as_ref().map(|a| {
+            Arc::new(ika_sui_client::archive::SuiCheckpointArchive::new(
+                a.url.clone(),
+                a.options.clone(),
+            )) as Arc<dyn ika_sui_client::archive::CheckpointArchive>
+        });
     let ratchet = Arc::new(
         OcsVerifyingClient::new(
             raw_for_ratchet,

--- a/crates/ika-sui-client/src/archive.rs
+++ b/crates/ika-sui-client/src/archive.rs
@@ -30,6 +30,7 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use object_store::ObjectStore;
 use sui_storage::object_store::util::{build_object_store, end_of_epoch_data, fetch_checkpoint};
 use sui_types::messages_checkpoint::{
@@ -52,6 +53,27 @@ pub enum ArchiveError {
         #[source]
         source: anyhow::Error,
     },
+}
+
+/// Read-only source of Sui end-of-epoch checkpoints over an object store. A
+/// trait so the committee ratchet / cold-bootstrap can be unit-tested with an
+/// in-memory archive. Everything returned is UNVERIFIED — the caller BLS-verifies
+/// each summary against the committee chain (rooted at the genesis committee).
+#[async_trait]
+pub trait CheckpointArchive: Send + Sync {
+    /// Enumerate the end-of-epoch checkpoint sequence numbers (`epochs.json`).
+    /// An untrusted hint for *where* the end-of-epoch checkpoints are; the
+    /// caller verifies each fetched checkpoint cryptographically.
+    async fn enumerate_end_of_epoch_seqs(
+        &self,
+    ) -> Result<Vec<CheckpointSequenceNumber>, ArchiveError>;
+
+    /// Fetch a checkpoint by sequence number, returning its (still-unverified)
+    /// certified summary and contents.
+    async fn fetch_checkpoint(
+        &self,
+        seq: CheckpointSequenceNumber,
+    ) -> Result<(CertifiedCheckpointSummary, CheckpointContents), ArchiveError>;
 }
 
 /// A read-only client over a Sui checkpoint object store.
@@ -80,13 +102,11 @@ impl SuiCheckpointArchive {
     pub fn url(&self) -> &str {
         &self.url
     }
+}
 
-    /// Enumerate the end-of-epoch checkpoint sequence numbers from `epochs.json`.
-    ///
-    /// UNTRUSTED: a hint for where the end-of-epoch checkpoints live. The caller
-    /// verifies each fetched checkpoint cryptographically; this list cannot be
-    /// trusted to be complete or correctly ordered.
-    pub async fn enumerate_end_of_epoch_seqs(
+#[async_trait]
+impl CheckpointArchive for SuiCheckpointArchive {
+    async fn enumerate_end_of_epoch_seqs(
         &self,
     ) -> Result<Vec<CheckpointSequenceNumber>, ArchiveError> {
         end_of_epoch_data(&self.url, self.options.clone())
@@ -97,10 +117,7 @@ impl SuiCheckpointArchive {
             })
     }
 
-    /// Fetch a checkpoint by sequence number, returning its (still-unverified)
-    /// certified summary and contents. The caller MUST BLS-verify the summary
-    /// against the committee chain before trusting any of it.
-    pub async fn fetch_checkpoint(
+    async fn fetch_checkpoint(
         &self,
         seq: CheckpointSequenceNumber,
     ) -> Result<(CertifiedCheckpointSummary, CheckpointContents), ArchiveError> {

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -448,22 +448,32 @@ verification asymmetry:
 ```
   DIRECT validator                          PEER-ONLY validator
   ────────────────                          ───────────────────
-  fold once (own gRPC) → verify → cache     (no fold, no cache-first)
+  fold once → committee-verify → cache      (no fold, no cache-first)
   cache HIT  → serve, NO re-verify  ◄── asymmetry ──►  EVERY read → verify
   cache MISS / stale → fetch + verify        (committee BLS + Merkle + currency)
-  trust root: own gRPC uplink               trust root: committee signature
+  trust root: committee (verified at fold)   trust root: committee (verified per read)
   ── both: committee ratchet BLS-verified; per-object high-water on every read ──
 ```
+
+The asymmetry is *when* the committee proof runs, not *whether* it does:
+a direct node verifies once at fold time and reuses that result on cache
+hits; a peer-only node verifies on every read. Neither trusts a fullnode's
+word — the trust root on both sides is the Sui committee.
 
 Direct validators run a checkpoint folder (`IkaCheckpointPusher`) that
 folds every Ika-modified object of every checkpoint, in order, into a
 local verified state cache — building each object's inclusion proof from
-the checkpoint's `ModifiedObjectTree`. Direct nodes then serve verified
-reads **cache-first** (with the staleness tripwire above falling through
-to the network when the cache lags). Because the folder reads from the
-node's own authoritative Sui access and folds in order, a cache hit is
-the object's current state up to the poll lag, and may skip re-running
-the proof.
+the checkpoint's `ModifiedObjectTree`. Before anything is folded, the
+folder verifies the checkpoint against its committee (`verify_before_fold`
+→ the shared `verify_summary` chokepoint for the committee BLS, then the
+`checkpoint_artifacts_digest` binding when objects are being folded), so a
+compromised or buggy *own* fullnode cannot seed the cache with forged
+state. A verify failure is refused, not cached: the error propagates and
+the fold cursor stays put, so a transient missing committee self-heals on
+the next poll while a bad signature halts the fold loudly
+(`security_critical`). Because the cache is therefore committee-attested
+and folded in order, a cache hit is the object's current state up to the
+poll lag, and safely skips re-running the proof.
 
 The two **singleton anchors** — the `System` and `DWalletCoordinator`
 inner objects (and their versioned-child inners) — are served from the
@@ -534,6 +544,11 @@ over the relay and re-verifying it per read.
 8. Cached state is committee-verified before it enters the cache; the
    cache never holds unverified state, and on a direct node it is folded
    only from the node's own authoritative Sui access, never from peers.
+   The direct-side folder enforces this at fold time
+   (`verify_before_fold`): the committee BLS on the summary plus the
+   artifacts-digest binding run before `absorb_entries`, so a direct
+   node's own fullnode is not in its trust boundary — serving forged state
+   is refused, not cached.
 9. On mirrored/peer-only nodes a verified read additionally passes a
    committee-attested **currency** gate: an authentic-but-superseded object
    is rejected — a read anchored before the object's latest folded


### PR DESCRIPTION
## Why

A `sui-state-direct` validator serves OCS reads **cache-first**, and that cache is populated by `IkaCheckpointPusher` folding its **own fullnode's** checkpoints. Before this change, `build_entries` folded the fullnode's `CheckpointData` — summary, modified-objects tree, and inclusion proofs — into the cache with **no committee verification**.

So a direct node's cache-served reads — including the always-cached `System` / `DWalletCoordinator` singleton anchors on the MPC hot path — were rooted in its **own fullnode, not the Sui committee**. A compromised or buggy fullnode could seed the cache with forged state that cache-first reads served undetected; only mirrored/peer-only nodes (which verify every read) were protected.

This violated spec invariant 8 (*"cached state is committee-verified before it enters the cache"*) and the documented promise that `verify_summary` is the single chokepoint the direct-side folder shares with the reader — both were intent the code didn't enforce.

## What

`verify_before_fold`, run once per checkpoint at **fold time** (off the read hot path) before `absorb_entries`:

1. **Committee BLS** on the summary, via the shared `verify_summary` chokepoint (reader and folder can't drift apart).
2. **Artifacts-digest binding** (when objects are folded): the locally-built `tree_root` must reproduce the committee-signed `checkpoint_artifacts_digest` — a real root means every inclusion proof the pusher derived from that tree is over genuine state.

A verify failure is **refused, not cached**: the error propagates so the fold cursor stays put — a transient missing committee self-heals on the next poll, a bad signature halts the fold loudly (`security_critical`). **The direct trust root is now the committee, matching the peer-only path.**

Cost is one BLS verify per ika-touching checkpoint — *not* per read — so zero read-path latency added.

## Tests

Fault-injected per the test-testing rule (each proven to trip when its check is neutered, then restored):
- a foldable checkpoint signed by a **foreign committee** is refused end-to-end through `advance()` (head doesn't move, cursor stays, cache empty);
- a summary committing to a **mismatched artifacts digest** is rejected by `verify_before_fold`.

7/7 push_worker tests + 98/98 `sui_connector` tests green; clippy clean.

## Notes

- **Spec** (`ocs-verified-sui-reads.md`): cache-fast-path trust root flips from `own gRPC uplink` → `committee (verified at fold)`; invariant 8 cites the enforcing mechanism. Spec already declared this behavior; the code was the lagging side — now they agree.
- **Cargo.lock**: locks the cold-bootstrap archive deps (`object_store`/`sui-storage`/`sui-config`) the parent branch added to `ika-sui-client/Cargo.toml` but left out of the lock, so this branch builds `--locked`. Worth fixing on the parent PR too.
- Stacked on `feat/ocs-archive-cold-bootstrap` — review/merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)