### PR TITLE
fix(dwallet-mpc): make a wedged epoch-close gate loud at the default log level

### DIFF
--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -1121,6 +1121,14 @@ where
         end_of_publish_sender: Sender<Option<u64>>,
         noa_checkpoints_finalized: Arc<dyn Fn() -> bool + Send + Sync>,
     ) {
+        // Consecutive ticks the end-of-publish gate has stayed unsatisfied. A
+        // healthy epoch boundary clears it in 1-2 ticks; a wedged reconfiguration
+        // (the #1736 genuine-laggard variant: an epoch's network-key
+        // reconfiguration output, or the tail of locked sessions, never reaching
+        // on-chain quorum) stays stuck indefinitely. This drives the WARN
+        // escalation below so the stall is loud — and names the blocking
+        // condition — at the default log level instead of silent.
+        let mut consecutive_unsatisfied: u64 = 0;
         loop {
             time::sleep(Duration::from_secs(10)).await;
 
@@ -1175,6 +1183,7 @@ where
                 && all_noa_checkpoints_finalized
                 && no_pricing_calculation_votes;
             if !ready_to_end_publish {
+                consecutive_unsatisfied += 1;
                 // The epoch cannot end-of-publish (and therefore cannot
                 // advance) until every condition below holds. Logging the
                 // breakdown each tick pinpoints a stuck reconfiguration —
@@ -1191,8 +1200,34 @@ where
                     no_pricing_calculation_votes,
                     "end-of-publish gate not yet satisfied; epoch cannot advance",
                 );
-            } else if let Err(err) = end_of_publish_sender.send(Some(system_inner_v1.epoch)) {
-                error!(error=?err, "failed to send end of publish epoch to the channel");
+                // Once the gate has stayed unsatisfied well past a normal
+                // boundary drain, escalate to WARN (and re-warn at the same
+                // cadence) so a wedged epoch is visible at the default log
+                // level — the false condition(s) below name what is blocking
+                // it, with no debug-level logging to perturb the boundary
+                // timing this race is sensitive to.
+                const STALE_GATE_WARN_TICKS: u64 = 6; // 6 * 10s = 60s; healthy clears < 30s
+                if consecutive_unsatisfied.is_multiple_of(STALE_GATE_WARN_TICKS) {
+                    warn!(
+                        epoch = system_inner_v1.epoch,
+                        stuck_secs = consecutive_unsatisfied * 10,
+                        session_locked,
+                        all_epoch_sessions_finished,
+                        all_immediate_sessions_completed,
+                        next_epoch_committee_exists,
+                        all_network_encryption_keys_reconfiguration_completed,
+                        all_noa_checkpoints_finalized,
+                        no_pricing_calculation_votes,
+                        "end-of-publish gate STUCK: epoch cannot advance; the false \
+                         condition(s) above are blocking it (a persistent \
+                         reconfiguration/session-output stall — see issue #1736)",
+                    );
+                }
+            } else {
+                consecutive_unsatisfied = 0;
+                if let Err(err) = end_of_publish_sender.send(Some(system_inner_v1.epoch)) {
+                    error!(error=?err, "failed to send end of publish epoch to the channel");
+                }
             }
         }
     }

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -1183,12 +1183,9 @@ where
                 && all_noa_checkpoints_finalized
                 && no_pricing_calculation_votes;
             if !ready_to_end_publish {
-                consecutive_unsatisfied += 1;
-                // The epoch cannot end-of-publish (and therefore cannot
-                // advance) until every condition below holds. Logging the
-                // breakdown each tick pinpoints a stuck reconfiguration —
-                // e.g. a restarted validator that left a system session
-                // started-but-not-completed.
+                // The breakdown each tick (debug) pinpoints a stuck
+                // reconfiguration — e.g. a restarted validator that left a
+                // system session started-but-not-completed.
                 debug!(
                     epoch = system_inner_v1.epoch,
                     session_locked,
@@ -1200,28 +1197,37 @@ where
                     no_pricing_calculation_votes,
                     "end-of-publish gate not yet satisfied; epoch cannot advance",
                 );
-                // Once the gate has stayed unsatisfied well past a normal
-                // boundary drain, escalate to WARN (and re-warn at the same
-                // cadence) so a wedged epoch is visible at the default log
-                // level — the false condition(s) below name what is blocking
-                // it, with no debug-level logging to perturb the boundary
-                // timing this race is sensitive to.
-                const STALE_GATE_WARN_TICKS: u64 = 6; // 6 * 10s = 60s; healthy clears < 30s
-                if consecutive_unsatisfied.is_multiple_of(STALE_GATE_WARN_TICKS) {
-                    warn!(
-                        epoch = system_inner_v1.epoch,
-                        stuck_secs = consecutive_unsatisfied * 10,
-                        session_locked,
-                        all_epoch_sessions_finished,
-                        all_immediate_sessions_completed,
-                        next_epoch_committee_exists,
-                        all_network_encryption_keys_reconfiguration_completed,
-                        all_noa_checkpoints_finalized,
-                        no_pricing_calculation_votes,
-                        "end-of-publish gate STUCK: epoch cannot advance; the false \
-                         condition(s) above are blocking it (a persistent \
-                         reconfiguration/session-output stall — see issue #1736)",
-                    );
+                // Escalate to WARN only once the epoch has COMMITTED to closing
+                // (the last user-initiated session is locked) yet the gate still
+                // won't satisfy. Before the lock the gate is legitimately
+                // unsatisfied for most of the epoch, so counting that would be
+                // pure noise; a post-lock stall is the actual wedge — "locked but
+                // can't close" (the #1736 signature) — and the false condition(s)
+                // below name what is blocking advance, at the default log level,
+                // with no debug-level logging to perturb the boundary timing this
+                // race is sensitive to.
+                if session_locked {
+                    consecutive_unsatisfied += 1;
+                    const STALE_GATE_WARN_TICKS: u64 = 6; // 6 * 10s = 60s post-lock
+                    if consecutive_unsatisfied.is_multiple_of(STALE_GATE_WARN_TICKS) {
+                        warn!(
+                            epoch = system_inner_v1.epoch,
+                            stuck_secs = consecutive_unsatisfied * 10,
+                            all_epoch_sessions_finished,
+                            all_immediate_sessions_completed,
+                            next_epoch_committee_exists,
+                            all_network_encryption_keys_reconfiguration_completed,
+                            all_noa_checkpoints_finalized,
+                            no_pricing_calculation_votes,
+                            "end-of-publish gate STUCK after the epoch locked to close: the \
+                             false condition(s) above are blocking advance (a persistent \
+                             reconfiguration/session-output stall — see issue #1736)",
+                        );
+                    }
+                } else {
+                    // Not committed to closing yet (normal mid-epoch) — don't
+                    // accumulate a stall against the gate.
+                    consecutive_unsatisfied = 0;
                 }
             } else {
                 consecutive_unsatisfied = 0;


### PR DESCRIPTION
## Why

The end-of-publish gate (`sync_dwallet_end_of_publish`) is the single chokepoint that decides whether an epoch can advance — it requires every session drained, the network-key **reconfiguration output reaching on-chain quorum**, the next committee present, etc. When the #1736 genuine-laggard variant wedges an epoch, this gate stays unsatisfied forever.

But the breakdown of *which* condition is stuck was only logged at `debug`, so at the default `warn,ika=info` level the wedge was **completely silent** (the forensic of run 28386601258 showed 0 ERROR / 0 WARN at the gate) — which is exactly what made #1736 so hard to diagnose.

## What

Track consecutive unsatisfied ticks; once the gate has been stuck past a normal boundary drain (60s — healthy boundaries clear in 1–2 of the 10s ticks), escalate the breakdown to `warn!` and re-warn at that cadence. The wedge now self-describes its blocking condition at the default log level, e.g.:

```
end-of-publish gate STUCK: epoch cannot advance; the false condition(s) above are blocking it
  epoch=5 stuck_secs=120 ... all_network_encryption_keys_reconfiguration_completed=false ...
```

Crucially this uses **no debug-level logging** — debug runs perturb the boundary timing this race is sensitive to (the observer-effect wall that has blocked log-based diagnosis of #1736). A `warn` that fires only once already-stuck does not.

## Context (corrected #1736 mechanism)

A code-grounded investigation confirmed the genuine (≥2-non-producer) variant wedges **inside the closing epoch** at the on-chain session-output-quorum gate — *upstream* of, and never reaching, the next-epoch handoff-cert barrier. #1761's `decide_v4_epoch_close` is inside `if has_quorum {`, so it is **structurally inert** when EndOfPublish quorum never forms. This gate (`ready_to_end_publish`) is the precise point that stays false.

This PR does not fix the wedge — it makes the next occurrence **diagnosable** (which condition is stuck → which subsystem to fix), which prior debug-based attempts could not capture without changing the result.

## Safety

Logging-only: the `end_of_publish_sender.send()` path and all gate logic are unchanged. `cargo check -p ika-core` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ✅ Validated end-to-end (2026-07-01) — the #1736 wedge is fixed

The fix stack was validated on TS-integration runs (with the gate diagnostic from #1778 confirming the state):

- **Combined branch** (anchor fix + perf fixes + diagnostic), run [28473684587](https://github.com/dwallet-labs/ika/actions/runs/28473684587): **conclusion=success — all 9 files passed, advanced to epoch 6**, past the boundary that wedged *permanently* in every prior run. First green TS after 3 consecutive #1736 wedges.
- **Anchor-fix-only branch**, run [28467039473](https://github.com/dwallet-labs/ika/actions/runs/28467039473): the gate's stuck condition flipped `next_epoch_committee_exists` **false→true** — proving the validators now observe the mid-epoch committee (the anchor-staleness layer), with the run then failing at the *next* layer (`reconfiguration_completed=false`) that #1780 addresses.

The wedge is two complementary layers: **#1779** (anchor staleness) lets validators see the committee; **#1780** (inline-VSS rayon offload + latency fixes) lets the reconfiguration MPC complete. **#1780** Rust integration is green; its one cluster failure was the pre-existing wedge (a 5-boundary churn test) cleared by the stack, not a regression.

Residual (non-blocking): the green run still has transient `>60s` boundary stalls that **recover** (slow, not wedging) — tracked in #1781.
