### PR TITLE
fix(ocs): bound singleton-anchor cache staleness so a skipped update can't wedge the epoch (#1736)

### DIFF
--- a/crates/ika-core/src/sui_connector/verified_reader.rs
+++ b/crates/ika-core/src/sui_connector/verified_reader.rs
@@ -21,8 +21,9 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use sui_light_client::proof::base::{
     Proof, ProofContents, ProofContentsVerifier, ProofTarget, ProofVerifier,
 };
@@ -57,6 +58,16 @@ use tracing::warn;
 /// `ika-network`) so a legitimate full page passes, but bounds a byzantine peer
 /// that ignores its own cap and over-stuffs the response.
 const MAX_VERIFIED_PAGE_ENTRIES: usize = 1024;
+
+/// How long the singleton-anchor cache-first read may serve a snapshot before it
+/// forces a verified network re-read to re-confirm it. Bounds anchor staleness
+/// so an anchor whose update the pusher skipped (a pruned checkpoint, never
+/// re-folded for a rare singleton like the system inner) can't be served stale
+/// indefinitely and wedge the epoch (#1736). Kept well above the executor's
+/// ~120ms anchor poll so the cache absorbs the vast majority of reads — at most
+/// one network re-read per anchor per interval, far below the per-tick reach-back
+/// rate that the cache-first anchor path exists to avoid.
+const ANCHOR_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 
 #[derive(thiserror::Error, Debug)]
 pub enum ReaderError {
@@ -154,6 +165,12 @@ pub struct OcsVerifiedReader {
     /// is too stale (e.g. a stalled pusher), so `try_cache_hit` falls through
     /// to the network instead of serving frozen state. `None` disables it.
     staleness_bound: Option<u64>,
+    /// Per-singleton-anchor wall-clock of the last verified network re-read.
+    /// `verified_anchor_object` serves the cached snapshot only while the last
+    /// refresh is within `ANCHOR_REFRESH_INTERVAL`; past that it forces a network
+    /// re-read so a stale anchor (an update the pusher skipped, never re-folded)
+    /// can't be served indefinitely (#1736).
+    anchor_refreshed_at: Mutex<HashMap<ObjectID, Instant>>,
     /// Committee-signed changeset index, on a mirrored / peer-only node. When
     /// present, a verified read additionally proves *currency* against it: the
     /// inclusion proof authenticates `X@V` at its last-modifying checkpoint `M`,
@@ -184,6 +201,7 @@ impl OcsVerifiedReader {
             cache_first,
             observed_upstream_head: AtomicU64::new(0),
             staleness_bound,
+            anchor_refreshed_at: Mutex::new(HashMap::new()),
             changeset_index: None,
         }
     }
@@ -212,6 +230,18 @@ impl OcsVerifiedReader {
             self.observe_verify_latency("object_cache_hit", started);
             return Ok(hit);
         }
+        self.verified_object_over_network(id, started).await
+    }
+
+    /// The network half of [`Self::verified_object`]: pull + verify from the
+    /// provider with no cache-first short-circuit (a `NotFound` still falls back
+    /// to the cached snapshot on a direct node). [`Self::verified_anchor_object`]
+    /// calls this directly to force a refresh past `try_cache_hit`.
+    async fn verified_object_over_network(
+        &self,
+        id: ObjectID,
+        started: Instant,
+    ) -> Result<VerifiedObject, ReaderError> {
         let resp = match self.provider.verified_object(id).await {
             Ok(resp) => resp,
             // The network reach-back failed because the object's defining
@@ -263,16 +293,50 @@ impl OcsVerifiedReader {
     /// only: mirror nodes have no local verified cache (`cache_first` is false)
     /// and keep the per-read-verified path.
     async fn verified_anchor_object(&self, id: ObjectID) -> Result<VerifiedObject, ReaderError> {
-        if self.cache_first
-            && let Some(hit) = self.cache_fallback(id)
-        {
-            self.metrics
-                .cache_read_total
-                .with_label_values(&["anchor"])
-                .inc();
-            return Ok(hit);
+        // Serve the committee-verified cached snapshot, but only while it is
+        // within `ANCHOR_REFRESH_INTERVAL` of its last verified network re-read.
+        // Past that, force a network re-read (below): a rare singleton like the
+        // system inner whose update the pusher skipped past a pruned checkpoint
+        // is never re-folded, so without this bound the stale snapshot would be
+        // served forever and wedge the epoch (#1736). The interval keeps this off
+        // the hot path — the ~120ms executor polls serve cache between refreshes —
+        // so it can't relatch the per-tick reach-back feedback loop the
+        // cache-first anchor path exists to avoid.
+        if self.cache_first && !self.anchor_refresh_due(id) {
+            if let Some(hit) = self.cache_fallback(id) {
+                self.metrics
+                    .cache_read_total
+                    .with_label_values(&["anchor"])
+                    .inc();
+                return Ok(hit);
+            }
         }
-        self.verified_object(id).await
+        // Refresh due, cache miss, or mirror node: take the verified network path
+        // DIRECTLY (not `verified_object`, whose `try_cache_hit` would just
+        // re-serve the same stale snapshot — its tripwire keys off the pusher's
+        // processed head, which stays current even when one anchor update was
+        // skipped). On success, stamp the refresh so subsequent reads serve cache.
+        let result = self.verified_object_over_network(id, Instant::now()).await;
+        if result.is_ok() {
+            self.anchor_refreshed_at.lock().insert(id, Instant::now());
+        }
+        result
+    }
+
+    /// Whether the cached anchor `id` is due for a forced verified network
+    /// re-read. The first sight of an anchor starts its clock and is NOT due (so
+    /// the cache is served immediately, never reaching the network on a fresh
+    /// cache); thereafter it is due once `ANCHOR_REFRESH_INTERVAL` elapses since
+    /// the last refresh.
+    fn anchor_refresh_due(&self, id: ObjectID) -> bool {
+        let mut refreshed_at = self.anchor_refreshed_at.lock();
+        match refreshed_at.get(&id) {
+            Some(at) => at.elapsed() >= ANCHOR_REFRESH_INTERVAL,
+            None => {
+                refreshed_at.insert(id, Instant::now());
+                false
+            }
+        }
     }
 
     /// Batch counterpart of [`Self::verified_object`]: one provider
@@ -1498,6 +1562,86 @@ mod tests {
             reader.record_high_water(id, SequenceNumber::from(5u64)),
             Err(ReaderError::StaleVersion { .. })
         ));
+    }
+
+    /// The singleton-anchor read bounds its own staleness: it serves the cached
+    /// snapshot within `ANCHOR_REFRESH_INTERVAL`, but once that elapses it forces
+    /// a verified network re-read — so an anchor whose update the pusher skipped
+    /// past a pruned checkpoint (never re-folded) cannot be served stale forever
+    /// and wedge the epoch (#1736). The within-interval assertion shows the stale
+    /// snapshot IS served (the wedge condition the escape must bound); the
+    /// past-interval assertion shows the escape refreshes it.
+    #[tokio::test]
+    async fn anchor_read_refreshes_from_network_after_the_interval() {
+        let (committee, keys) = SuiCommittee::new_simple_test_committee();
+        let dir = tempfile::tempdir().unwrap();
+        let tables = Arc::new(AuthorityPerpetualTables::open(dir.path(), None));
+        let committees = Arc::new(
+            CommitteeStore::open(
+                tables,
+                Some(CommitteeBootstrap::UnsafeGenesis(committee.clone())),
+            )
+            .unwrap(),
+        );
+        let metrics = OcsMetrics::new_for_testing();
+
+        // The fullnode holds the FRESH anchor (v6@seq 50); the local cache holds a
+        // STALE snapshot (v5@seq 42) — the version whose update was never re-folded.
+        let id = ObjectID::from_single_byte(0x55);
+        let fresh = test_object(id, 6, address_owner(0x02));
+        let (net_summary, net_proof) = sign_inclusion(&committee, &keys, 50, &[&fresh], &fresh);
+        let reader = OcsVerifiedReader::new(
+            StagedProvider::object(object_response(fresh, net_summary, net_proof, 50)),
+            committees,
+            metrics.clone(),
+            None, // freshness disabled
+            Arc::new(VerifiedStateCache::new()),
+            true, // cache_first (sui-state-direct)
+            None,
+        );
+
+        let stale = test_object(id, 5, address_owner(0x02));
+        let (summary, proof) = sign_inclusion(&committee, &keys, 42, &[&stale], &stale);
+        reader.cache.absorb_entries(
+            &summary,
+            &[VerifiedObjectEntry {
+                object: stale,
+                checkpoint_seq: 42,
+                proof,
+                dynamic_field_name_type: String::new(),
+                dynamic_field_name_bcs: Vec::new(),
+            }],
+        );
+
+        // First read starts the clock and serves the cached snapshot (no network).
+        let first = reader.verified_anchor_object(id).await.unwrap();
+        assert_eq!(first.object.version(), SequenceNumber::from(5u64));
+        // A second read WITHIN the interval still serves the stale cache — exactly
+        // the indefinite-stale serving the escape must bound.
+        let within = reader.verified_anchor_object(id).await.unwrap();
+        assert_eq!(
+            within.object.version(),
+            SequenceNumber::from(5u64),
+            "within the interval the stale cache is served"
+        );
+
+        // Age the refresh clock past the interval (deterministic — no sleep).
+        {
+            let mut refreshed_at = reader.anchor_refreshed_at.lock();
+            let aged = Instant::now()
+                .checked_sub(ANCHOR_REFRESH_INTERVAL + Duration::from_secs(1))
+                .expect("monotonic clock far enough along to back-date");
+            refreshed_at.insert(id, aged);
+        }
+
+        // Now due: the read forces a verified network re-read and returns the FRESH
+        // anchor — the stale cache is no longer served.
+        let refreshed = reader.verified_anchor_object(id).await.unwrap();
+        assert_eq!(
+            refreshed.object.version(),
+            SequenceNumber::from(6u64),
+            "past the interval the anchor refreshes from the network"
+        );
     }
 
     // ===== End-to-end crypto-fixture tests =====

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -457,17 +457,27 @@ the proof.
 The two **singleton anchors** — the `System` and `DWalletCoordinator`
 inner objects (and their versioned-child inners) — are served from the
 folded cache **even when the staleness tripwire trips**.
-`verified_anchor_object` prefers the cached snapshot and reaches the
-network only on a genuine cache miss; the per-object version high-water
-still rejects a rollback, and the executor re-reads every ~120 ms so
-staleness stays bounded. The exception exists because these anchors are
-on the MPC hot path: under heavy load the pusher's processed head lags
-the live head past the tripwire bound, and a tripwire-forced reach-back
-on *every* 120 ms tick (each anchor read is the outer wrapper plus its
+`verified_anchor_object` prefers the cached snapshot but **bounds its
+staleness**: it forces a verified network re-read on a genuine cache
+miss *and* at most once per `ANCHOR_REFRESH_INTERVAL` (2 s), serving
+cache in between; the per-object version high-water still rejects a
+rollback. This bypasses the tripwire so these hot-path anchors don't
+reach back on *every* 120 ms tick: under heavy load the pusher's
+processed head lags the live head past the tripwire bound, and a
+per-tick reach-back (each anchor read is the outer wrapper plus its
 versioned-child inner — several fullnode round-trips) slows the pusher
 further and latches the tripwire, a self-reinforcing loop that collapses
-dwallet throughput. Ordinary (non-anchor) reads still fall through to
-the network when the tripwire trips. Cache-served anchors are counted
+dwallet throughput. **The TTL bound is essential, not merely an
+optimization knob:** a rare singleton like the `System` inner is updated
+only at epoch boundaries, so if the pusher *skips* its update (the
+defining checkpoint pruned before the lagging pusher folds it; the
+singleton is never modified again that epoch to re-fold it) the stale
+snapshot would be served *indefinitely* and wedge the epoch — the gate
+that drives epoch advance reads the mid-epoch committee through this
+anchor (#1736). The 2 s interval keeps the refresh well below the
+per-tick rate that latches the loop while bounding staleness to ~2 s.
+Ordinary (non-anchor) reads still fall through to the network when the
+tripwire trips. Cache-served anchors are counted
 `ika_ocs_cache_read_total{outcome="anchor"}`.
 
 The cache is authoritatively populated *only* by the node's own folder —


### PR DESCRIPTION
## The wedge

The `System` / `DWalletCoordinator` inner anchors are served **cache-first and bypass the staleness tripwire** (`verified_anchor_object`) — deliberately, to avoid the per-tick reach-back loop that collapses dwallet throughput under load. But that left **no upper bound on staleness**: a cached anchor is served as long as a snapshot is present and monotonic.

Root cause, traced from a live wedged run (28448045798) via the end-of-publish-gate diagnostic (PR #1778):

- At mid-epoch the notifier sets `next_epoch_committee` on-chain — verified: `process_mid_epoch` + `request_mid_epoch_reconfiguration` both logged "successfully", and the second is gated on the committee being `Some`.
- Yet the 4 validators' gate read `next_epoch_committee_exists=false` for **100+ minutes** and never advanced.
- Localized: the **Coordinator** anchor *did* refresh (`session_locked` flipped from the lock tx) but the **System** anchor's committee **never** updated. The System inner is a versioned child keyed by the *stable* shape version, updated only at epoch boundaries; the pusher **skipped folding that update** (its defining checkpoint pruned before the lagging pusher reached it — `get_full_checkpoint` NotFound → "advancing past"), and the singleton is never modified again that epoch to re-fold it. So the always-cache anchor read served the pre-mid-epoch snapshot **forever** → gate wedged.

This is **not** MPC / crypto / consensus / CPU — the validators never reach the reconfiguration MPC, because they don't see the committee.

## The fix

`verified_anchor_object` now forces a verified network re-read **at most once per `ANCHOR_REFRESH_INTERVAL` (2 s)** — serving cache in between. The read goes via a factored-out `verified_object_over_network` so it bypasses `try_cache_hit` (whose tripwire keys off the pusher's *processed* head and stays current even when one anchor update was skipped). 2 s is far below the per-tick rate that latches the throughput-collapse feedback loop, and bounds anchor staleness to ~2 s.

## Tests

- New `anchor_read_refreshes_from_network_after_the_interval` — **fault-injected, proven non-vacuous**: a stale-v5 cache + fresh-v6 fullnode; within the interval the stale v5 is served (the wedge), past it the read refreshes to v6. Removing the escape makes the past-interval assertion serve v5 → the test fails.
- 32/32 verified_reader tests, 95/95 sui_connector, clippy clean. Spec updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ✅ Validated end-to-end (2026-07-01) — the #1736 wedge is fixed

The fix stack was validated on TS-integration runs (with the gate diagnostic from #1778 confirming the state):

- **Combined branch** (anchor fix + perf fixes + diagnostic), run [28473684587](https://github.com/dwallet-labs/ika/actions/runs/28473684587): **conclusion=success — all 9 files passed, advanced to epoch 6**, past the boundary that wedged *permanently* in every prior run. First green TS after 3 consecutive #1736 wedges.
- **Anchor-fix-only branch**, run [28467039473](https://github.com/dwallet-labs/ika/actions/runs/28467039473): the gate's stuck condition flipped `next_epoch_committee_exists` **false→true** — proving the validators now observe the mid-epoch committee (the anchor-staleness layer), with the run then failing at the *next* layer (`reconfiguration_completed=false`) that #1780 addresses.

The wedge is two complementary layers: **#1779** (anchor staleness) lets validators see the committee; **#1780** (inline-VSS rayon offload + latency fixes) lets the reconfiguration MPC complete. **#1780** Rust integration is green; its one cluster failure was the pre-existing wedge (a 5-boundary churn test) cleared by the stack, not a regression.

Residual (non-blocking): the green run still has transient `>60s` boundary stalls that **recover** (slow, not wedging) — tracked in #1781.
