### PR TITLE
perf(dwallet-mpc): offload the network-key VSS derive to rayon + two epoch-entry latency fixes

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -302,12 +302,29 @@ impl ValidatorPrivateDecryptionKeyData {
         // nothing: if the network key is pre-V3 OR any per-curve derivation
         // fails, we insert nothing into the cache and VSS sign sites then
         // `?`-propagate `WaitingForNetworkKey` like the AHE wait path.
-        if let Some(vss_cache) = derive_vss_shamir_cache_for_key(
-            &key,
-            self.party_id,
-            &self.validator_pvss_secrets_for_vss,
-            &self.validator_pvss_publics_for_vss,
-        ) {
+        //
+        // The derivation is heavy class-groups crypto (three curves), so run it
+        // off the runtime thread on rayon — mirroring the AHE decrypt above —
+        // rather than inline. On a single-threaded runtime an inline run would
+        // peg the one thread for the whole derivation, freezing this node's
+        // async (including the consensus-commit handler that feeds the MPC
+        // engine) at the epoch boundary with cores idle (see issue #1736).
+        let (vss_sender, vss_receiver) = oneshot::channel();
+        #[cfg(msim)]
+        let originating_sim_node = sui_simulator::runtime::NodeHandle::try_current();
+        let party_id = self.party_id;
+        let secrets = self.validator_pvss_secrets_for_vss.clone();
+        let publics = self.validator_pvss_publics_for_vss.clone();
+        rayon::spawn_fifo(move || {
+            #[cfg(msim)]
+            let _node_guard = originating_sim_node.as_ref().map(|n| n.enter_node());
+
+            let vss_cache = derive_vss_shamir_cache_for_key(&key, party_id, &secrets, &publics);
+            if let Err(err) = vss_sender.send(vss_cache) {
+                error!(error=?err, "failed to send VSS shamir cache");
+            }
+        });
+        if let Some(vss_cache) = vss_receiver.await.map_err(|_| DwalletMPCError::TokioRecv)? {
             self.validator_vss_shamir_cache.insert(key_id, vss_cache);
         }
 

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -75,7 +75,6 @@ use tokio::sync::watch;
 use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info, warn};
 
-const DELAY_NO_ROUNDS_SEC: u64 = 2;
 const READ_INTERVAL_MS: u64 = 20;
 const FIVE_KILO_BYTES: usize = 5 * 1024;
 
@@ -889,8 +888,14 @@ impl DWalletMPCService {
             if let Some(last_consensus_round) = last_consensus_round {
                 last_consensus_round
             } else {
-                info!("No consensus round from DB yet, retrying in {DELAY_NO_ROUNDS_SEC} seconds.");
-                tokio::time::sleep(Duration::from_secs(DELAY_NO_ROUNDS_SEC)).await;
+                // No new-epoch consensus round has committed yet (the transient
+                // window right after epoch entry). Return and let the outer
+                // loop's READ_INTERVAL_MS poll re-check, rather than sleeping
+                // here — that extra sleep added seconds of latency to every
+                // epoch-bootstrap step. Logged at debug so the fast re-check
+                // can't flood the log during a stuck boundary; the
+                // end-of-publish-gate WARN is the wedge signal there.
+                debug!("No consensus round from DB yet; awaiting the first new-epoch round.");
                 return;
             }
         } else {

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -51,6 +51,7 @@ use mpc::{MajorityVote, WeightedThresholdAccessStructure};
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 use sui_types::base_types::ObjectID;
 use tokio::sync::mpsc::Sender;
@@ -105,6 +106,13 @@ pub(crate) struct DWalletMPCManager {
     /// mapping until the epoch advances.
     pub(crate) sessions: HashMap<SessionIdentifier, DWalletSession>,
     pub(crate) epoch_id: EpochId,
+    /// Latches `local_mpc_data_ready_for_frozen_set` once it first returns true.
+    /// The frozen mpc_data input set is epoch-fixed and the manager is per-epoch,
+    /// so once every frozen-set blob is present + valid it stays so — caching the
+    /// result drops a per-tick N RocksDB reads + 2N class-groups BCS decodes (paid
+    /// for every DKG/reconfiguration session on the 20ms service loop) to a single
+    /// atomic load after convergence.
+    local_mpc_data_ready_latched: AtomicBool,
     validator_name: AuthorityPublicKeyBytes,
     pub(crate) committee: Arc<Committee>,
     pub(crate) access_structure: WeightedThresholdAccessStructure,
@@ -401,6 +409,7 @@ impl DWalletMPCManager {
         // We want to "forget" the malicious actors from the previous epoch and start from scratch.
         Ok(Self {
             sessions: HashMap::new(),
+            local_mpc_data_ready_latched: AtomicBool::new(false),
             party_id: authority_name_to_party_id_from_committee(&committee, &validator_name)?,
             epoch_id,
             access_structure,
@@ -1837,6 +1846,11 @@ impl DWalletMPCManager {
     /// is "wait until the next tick"; the rest of the network
     /// proceeds via threshold.
     fn local_mpc_data_ready_for_frozen_set(&self) -> bool {
+        // Once the gate has converged (all frozen-set blobs present + valid) it
+        // stays converged for this epoch, so skip the per-tick reads+decodes.
+        if self.local_mpc_data_ready_latched.load(Ordering::Relaxed) {
+            return true;
+        }
         if !self.epoch_store.off_chain_validator_metadata_enabled() {
             return true;
         }
@@ -1873,6 +1887,10 @@ impl DWalletMPCManager {
                 return false;
             }
         }
+        // Converged: every frozen-set blob is present + valid. Latch so later
+        // ticks short-circuit (monotonic for this epoch's fixed frozen set).
+        self.local_mpc_data_ready_latched
+            .store(true, Ordering::Relaxed);
         true
     }
 


### PR DESCRIPTION
Three fixes from the dev-branch performance audit, all on the epoch-boundary / 20 ms service-loop hot path. On a co-located localnet the validators run their entire async on **one single-threaded tokio runtime**, so any heavy inline op freezes that node's whole async (including the consensus-commit handler that feeds the MPC engine).

### 1. `network_dkg.rs` — offload the VSS Shamir derive to rayon
`decrypt_and_store_secret_key_shares` correctly offloads the AHE decrypt to rayon, then runs `derive_vss_shamir_cache_for_key` — heavy class-groups VSS derivation for three curves plus a large `bcs` decode — **inline** on the async thread. Offload it the same way (mirroring the sibling exactly: `oneshot` + `spawn_fifo` + the msim `NodeHandle` guard). Same logic, awaited before return — only *which thread* runs it changes.

### 2. `dwallet_mpc_service.rs` — drop the 2 s epoch-entry sleep
The "no consensus round yet" branch slept a fixed 2 s on top of the outer loop's 20 ms poll, adding seconds to every epoch-bootstrap step. Drop it (the 20 ms loop paces it) and demote the log to `debug` so the faster re-check can't flood a stuck boundary. Removes the now-dead `DELAY_NO_ROUNDS_SEC`.

### 3. `mpc_manager.rs` — latch the frozen-set readiness gate
`local_mpc_data_ready_for_frozen_set` re-read N RocksDB blobs + ran 2N class-groups `bcs` decodes every 20 ms tick per DKG/reconfiguration session. The frozen set is epoch-fixed and the manager per-epoch, so the gate is monotonic once converged — latch it (`AtomicBool`) so later ticks are a single atomic load.

---

**Scope note:** these are genuine slowness wins on the #1736 hot path, but they are **not** the #1736 wedge fix — that is the OCS anchor-staleness escape in #1779 (the validators never reach the reconfiguration MPC, because they read a stale committee). Landing these reduces boundary freeze/jitter; the wedge itself is #1779.

`cargo check -p ika-core` clean; the network-key DKG/reconfiguration + VSS sign paths are exercised by the Rust + TS integration suites — recommend a CI dispatch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ✅ Validated end-to-end (2026-07-01) — the #1736 wedge is fixed

The fix stack was validated on TS-integration runs (with the gate diagnostic from #1778 confirming the state):

- **Combined branch** (anchor fix + perf fixes + diagnostic), run [28473684587](https://github.com/dwallet-labs/ika/actions/runs/28473684587): **conclusion=success — all 9 files passed, advanced to epoch 6**, past the boundary that wedged *permanently* in every prior run. First green TS after 3 consecutive #1736 wedges.
- **Anchor-fix-only branch**, run [28467039473](https://github.com/dwallet-labs/ika/actions/runs/28467039473): the gate's stuck condition flipped `next_epoch_committee_exists` **false→true** — proving the validators now observe the mid-epoch committee (the anchor-staleness layer), with the run then failing at the *next* layer (`reconfiguration_completed=false`) that #1780 addresses.

The wedge is two complementary layers: **#1779** (anchor staleness) lets validators see the committee; **#1780** (inline-VSS rayon offload + latency fixes) lets the reconfiguration MPC complete. **#1780** Rust integration is green; its one cluster failure was the pre-existing wedge (a 5-boundary churn test) cleared by the stack, not a regression.

Residual (non-blocking): the green run still has transient `>60s` boundary stalls that **recover** (slow, not wedging) — tracked in #1781.
