### PR TITLE
OCS: compile in per-chain ika on-chain identity (genesis-rooted)

### DIFF
--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -194,6 +194,91 @@ impl fmt::Display for SuiChainIdentifier {
     }
 }
 
+/// ika's on-chain identity (Move package + object IDs) for a public chain.
+/// Deployment constants: the object IDs are immutable, and the package IDs are
+/// the exact values the node config expects — the dwallet base id is the
+/// **original v1** with the upgrade in `_v2` (event filtering accepts both),
+/// and the system id is the **current/latest**. Sourced from
+/// `deployed_contracts/{mainnet,testnet}/address.yaml` (NOT `ika_sui_config.yaml`,
+/// which flattens packages to their latest under the base name).
+#[derive(Clone, Copy, Debug)]
+pub struct IkaOnChainIdentity {
+    pub ika_package_id: ObjectID,
+    pub ika_common_package_id: ObjectID,
+    pub ika_dwallet_2pc_mpc_package_id: ObjectID,
+    pub ika_dwallet_2pc_mpc_package_id_v2: ObjectID,
+    pub ika_system_package_id: ObjectID,
+    pub ika_system_object_id: ObjectID,
+    pub ika_dwallet_coordinator_object_id: ObjectID,
+}
+
+/// The binary's compiled-in ika on-chain identity for a public chain, keyed off
+/// `sui_chain_identifier` (which the verified genesis blob authenticates).
+/// `None` on `Devnet`/`Custom` (localnet), where the IDs are freshly generated
+/// each genesis and must be supplied via config.
+pub fn compiled_in_ika_identity(chain: SuiChainIdentifier) -> Option<IkaOnChainIdentity> {
+    fn oid(literal: &str) -> ObjectID {
+        ObjectID::from_hex_literal(literal).expect("compiled-in ika object id literal is valid")
+    }
+    match chain {
+        SuiChainIdentifier::Mainnet => Some(IkaOnChainIdentity {
+            ika_package_id: oid(
+                "0x7262fb2f7a3a14c888c438a3cd9b912469a58cf60f367352c46584262e8299aa",
+            ),
+            ika_common_package_id: oid(
+                "0x9e1e9f8e4e51ee2421a8e7c0c6ab3ef27c337025d15333461b72b1b813c44175",
+            ),
+            ika_dwallet_2pc_mpc_package_id: oid(
+                "0xdd24c62739923fbf582f49ef190b4a007f981ca6eb209ca94f3a8eaf7c611317",
+            ),
+            ika_dwallet_2pc_mpc_package_id_v2: oid(
+                "0x23b5bd96051923f800c3a2150aacdcdd8d39e1df2dce4dac69a00d2d8c7f7e77",
+            ),
+            ika_system_package_id: oid(
+                "0xd69f947d7ee6f224dd0dd31ec3ec30c0dd0f713a1de55d564e8e98910c4f9553",
+            ),
+            ika_system_object_id: oid(
+                "0x215de95d27454d102d6f82ff9c54d8071eb34d5706be85b5c73cbd8173013c80",
+            ),
+            ika_dwallet_coordinator_object_id: oid(
+                "0x5ea59bce034008a006425df777da925633ef384ce25761657ea89e2a08ec75f3",
+            ),
+        }),
+        SuiChainIdentifier::Testnet => Some(IkaOnChainIdentity {
+            ika_package_id: oid(
+                "0x1f26bb2f711ff82dcda4d02c77d5123089cb7f8418751474b9fb744ce031526a",
+            ),
+            ika_common_package_id: oid(
+                "0x96fc75633b6665cf84690587d1879858ff76f88c10c945e299f90bf4e0985eb0",
+            ),
+            ika_dwallet_2pc_mpc_package_id: oid(
+                "0xf02f5960c94fce1899a3795b5d11fd076bc70a8d0e20a2b19923d990ed490730",
+            ),
+            ika_dwallet_2pc_mpc_package_id_v2: oid(
+                "0x6573a6c13daf26a64eb8a37d3c7a4391b353031e223072ca45b1ff9366f59293",
+            ),
+            ika_system_package_id: oid(
+                "0xde05f49e5f1ee13ed06c1e243c0a8e8fe858e1d8689476fdb7009af8ddc3c38b",
+            ),
+            ika_system_object_id: oid(
+                "0x2172c6483ccd24930834e30102e33548b201d0607fb1fdc336ba3267d910dec6",
+            ),
+            ika_dwallet_coordinator_object_id: oid(
+                "0x4d157b7415a298c56ec2cb1dcab449525fa74aec17ddba376a83a7600f2062fc",
+            ),
+        }),
+        SuiChainIdentifier::Devnet | SuiChainIdentifier::Custom => None,
+    }
+}
+
+/// serde default for the on-chain id fields: a ZERO sentinel meaning "unset",
+/// filled from [`compiled_in_ika_identity`] at startup (see
+/// [`SuiConnectorConfig::resolve_ika_on_chain_identity`]). `0x0` is never a real
+/// package/object id, so it is a safe "not provided" marker.
+fn unset_object_id() -> ObjectID {
+    ObjectID::ZERO
+}
+
 /// Where this validator gets Sui state from.
 ///
 /// `SuiStateDirect` runs against a Sui fullnode reachable over gRPC, and
@@ -445,19 +530,28 @@ pub struct SuiConnectorConfig {
     pub auto_reanchor_on_format_change: bool,
     /// The expected sui chain identifier connecting to.
     pub sui_chain_identifier: SuiChainIdentifier,
-    /// The move package ID of ika (IKA) on sui.
+    /// The move package ID of ika (IKA) on sui. Omit on mainnet/testnet to use
+    /// the compiled-in default (see [`compiled_in_ika_identity`]); required on
+    /// localnet/Custom.
+    #[serde(default = "unset_object_id")]
     pub ika_package_id: ObjectID,
     /// The move package id of `ika_common` on sui.
+    #[serde(default = "unset_object_id")]
     pub ika_common_package_id: ObjectID,
-    /// The move package id of ika_dwallet_2pc_mpc on sui.
+    /// The move package id of ika_dwallet_2pc_mpc on sui — the **original v1**
+    /// (the upgrade is `ika_dwallet_2pc_mpc_package_id_v2`).
+    #[serde(default = "unset_object_id")]
     pub ika_dwallet_2pc_mpc_package_id: ObjectID,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ika_dwallet_2pc_mpc_package_id_v2: Option<ObjectID>,
-    /// The move package ID of `ika_system` on sui.
+    /// The move package ID of `ika_system` on sui (the **current/latest**).
+    #[serde(default = "unset_object_id")]
     pub ika_system_package_id: ObjectID,
     /// The object ID of the Ika system on sui.
+    #[serde(default = "unset_object_id")]
     pub ika_system_object_id: ObjectID,
     /// The object id of ika_dwallet_coordinator on sui.
+    #[serde(default = "unset_object_id")]
     pub ika_dwallet_coordinator_object_id: ObjectID,
 
     /// How many checkpoints of OCS-verified state the direct-node cache retains
@@ -497,6 +591,61 @@ impl SuiConnectorConfig {
     pub fn verified_cache_retention_checkpoints(&self) -> u64 {
         self.verified_cache_retention_checkpoints
             .unwrap_or(DEFAULT_VERIFIED_CACHE_RETENTION_CHECKPOINTS)
+    }
+
+    /// Fill any unset (ZERO) on-chain id field from the binary's compiled-in
+    /// per-chain ika identity (keyed off `sui_chain_identifier`). A
+    /// config-supplied (non-ZERO) value always wins, so every id is overridable
+    /// per field. On localnet (`Custom`/`Devnet`) there is no compiled-in
+    /// identity, so every id must be supplied explicitly; an id still ZERO after
+    /// resolution is a hard error. Subsumes the old per-chain dwallet-`_v2`
+    /// hardcode in `ika-node`.
+    pub fn resolve_ika_on_chain_identity(&mut self) -> anyhow::Result<()> {
+        if let Some(id) = compiled_in_ika_identity(self.sui_chain_identifier) {
+            fn fill(field: &mut ObjectID, default: ObjectID) {
+                if *field == ObjectID::ZERO {
+                    *field = default;
+                }
+            }
+            fill(&mut self.ika_package_id, id.ika_package_id);
+            fill(&mut self.ika_common_package_id, id.ika_common_package_id);
+            fill(
+                &mut self.ika_dwallet_2pc_mpc_package_id,
+                id.ika_dwallet_2pc_mpc_package_id,
+            );
+            fill(&mut self.ika_system_package_id, id.ika_system_package_id);
+            fill(&mut self.ika_system_object_id, id.ika_system_object_id);
+            fill(
+                &mut self.ika_dwallet_coordinator_object_id,
+                id.ika_dwallet_coordinator_object_id,
+            );
+            if self.ika_dwallet_2pc_mpc_package_id_v2.is_none() {
+                self.ika_dwallet_2pc_mpc_package_id_v2 = Some(id.ika_dwallet_2pc_mpc_package_id_v2);
+            }
+        }
+        for (name, value) in [
+            ("ika_package_id", self.ika_package_id),
+            ("ika_common_package_id", self.ika_common_package_id),
+            (
+                "ika_dwallet_2pc_mpc_package_id",
+                self.ika_dwallet_2pc_mpc_package_id,
+            ),
+            ("ika_system_package_id", self.ika_system_package_id),
+            ("ika_system_object_id", self.ika_system_object_id),
+            (
+                "ika_dwallet_coordinator_object_id",
+                self.ika_dwallet_coordinator_object_id,
+            ),
+        ] {
+            if value == ObjectID::ZERO {
+                anyhow::bail!(
+                    "sui_connector_config.{name} is unset and chain {} has no compiled-in \
+                     default; set it explicitly (required on localnet / Custom)",
+                    self.sui_chain_identifier
+                );
+            }
+        }
+        Ok(())
     }
 }
 
@@ -1067,6 +1216,94 @@ mod tests {
     }
 
     const ALL_MODES: [NodeMode; 3] = [NodeMode::Validator, NodeMode::Fullnode, NodeMode::Notifier];
+
+    // ---- compiled-in on-chain ika identity resolution ----
+
+    fn config_for_chain(chain: SuiChainIdentifier) -> SuiConnectorConfig {
+        SuiConnectorConfig {
+            sui_rpc_url: None,
+            sui_data_source: Some(direct()),
+            sui_state_mirror_peers: vec![],
+            sui_unsafe_genesis_committee: None,
+            sui_genesis: None,
+            sui_checkpoint_archive: None,
+            allow_unverified_committee_fallback: false,
+            auto_reanchor_on_format_change: false,
+            sui_chain_identifier: chain,
+            ika_package_id: ObjectID::ZERO,
+            ika_common_package_id: ObjectID::ZERO,
+            ika_dwallet_2pc_mpc_package_id: ObjectID::ZERO,
+            ika_dwallet_2pc_mpc_package_id_v2: None,
+            ika_system_package_id: ObjectID::ZERO,
+            ika_system_object_id: ObjectID::ZERO,
+            ika_dwallet_coordinator_object_id: ObjectID::ZERO,
+            verified_cache_retention_checkpoints: None,
+            notifier_client_key_pair: None,
+            sui_ika_system_module_last_processed_event_id_override: None,
+        }
+    }
+
+    #[test]
+    fn resolves_compiled_in_ids_for_public_chains() {
+        for chain in [SuiChainIdentifier::Mainnet, SuiChainIdentifier::Testnet] {
+            let mut cfg = config_for_chain(chain);
+            cfg.resolve_ika_on_chain_identity().unwrap();
+            let id = compiled_in_ika_identity(chain).unwrap();
+            assert_eq!(cfg.ika_package_id, id.ika_package_id);
+            assert_eq!(cfg.ika_common_package_id, id.ika_common_package_id);
+            assert_eq!(
+                cfg.ika_dwallet_2pc_mpc_package_id,
+                id.ika_dwallet_2pc_mpc_package_id
+            );
+            assert_eq!(
+                cfg.ika_dwallet_2pc_mpc_package_id_v2,
+                Some(id.ika_dwallet_2pc_mpc_package_id_v2)
+            );
+            assert_eq!(cfg.ika_system_package_id, id.ika_system_package_id);
+            assert_eq!(cfg.ika_system_object_id, id.ika_system_object_id);
+            assert_eq!(
+                cfg.ika_dwallet_coordinator_object_id,
+                id.ika_dwallet_coordinator_object_id
+            );
+            // The dwallet base id is v1 — distinct from the v2 upgrade.
+            assert_ne!(
+                cfg.ika_dwallet_2pc_mpc_package_id, id.ika_dwallet_2pc_mpc_package_id_v2,
+                "{chain}: base id must be v1, not the v2 upgrade"
+            );
+        }
+    }
+
+    #[test]
+    fn config_supplied_id_overrides_compiled_in() {
+        let mut cfg = config_for_chain(SuiChainIdentifier::Mainnet);
+        let custom = ObjectID::from_hex_literal("0x1234").unwrap();
+        cfg.ika_system_object_id = custom;
+        cfg.resolve_ika_on_chain_identity().unwrap();
+        assert_eq!(cfg.ika_system_object_id, custom, "explicit value must win");
+        // Other unset fields still get the compiled-in default.
+        let id = compiled_in_ika_identity(SuiChainIdentifier::Mainnet).unwrap();
+        assert_eq!(cfg.ika_package_id, id.ika_package_id);
+    }
+
+    #[test]
+    fn localnet_custom_requires_explicit_ids() {
+        let mut cfg = config_for_chain(SuiChainIdentifier::Custom);
+        let err = cfg.resolve_ika_on_chain_identity().unwrap_err();
+        assert!(err.to_string().contains("no compiled-in default"), "{err}");
+    }
+
+    #[test]
+    fn v2_kept_when_config_supplies_it() {
+        let mut cfg = config_for_chain(SuiChainIdentifier::Testnet);
+        let custom_v2 = ObjectID::from_hex_literal("0xabcd").unwrap();
+        cfg.ika_dwallet_2pc_mpc_package_id_v2 = Some(custom_v2);
+        cfg.resolve_ika_on_chain_identity().unwrap();
+        assert_eq!(
+            cfg.ika_dwallet_2pc_mpc_package_id_v2,
+            Some(custom_v2),
+            "explicit v2 must win"
+        );
+    }
 
     // ---- old-style config (no `sui-data-source`) ----
 

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -270,7 +270,7 @@ impl IkaNode {
     /// Start the node in a specific mode with validation.
     /// This method validates that the configuration matches the expected mode.
     pub async fn start_with_mode(
-        mut config: NodeConfig,
+        config: NodeConfig,
         registry_service: RegistryService,
         _software_version: &'static str,
         mode: NodeMode,

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -306,10 +306,34 @@ impl IkaNode {
 
         let sui_client_metrics = SuiClientMetrics::new(&registry_service.default_registry());
 
+        // Genesis-root the chain before resolving the on-chain identity: when a
+        // Sui genesis blob is configured, load + verify it and DERIVE the chain
+        // from its checkpoint digest, then require the declared
+        // `sui_chain_identifier` to match. This roots the compiled-in ika
+        // identity (resolved next) in the cryptographically-verified genesis,
+        // not the operator's declared chain, and fails fast on a mismatch — e.g.
+        // a config that declares `Custom` but supplies a real mainnet/testnet
+        // genesis blob (which the load-and-verify alone would accept).
+        if let Some(genesis_path) = config.sui_connector_config.sui_genesis.clone() {
+            let boot = ika_sui_client::genesis::load_and_verify_sui_genesis(
+                &genesis_path,
+                config.sui_connector_config.sui_chain_identifier,
+            )
+            .map_err(|e| anyhow!("verify Sui genesis blob {}: {e}", genesis_path.display()))?;
+            let derived = boot.chain();
+            if derived != config.sui_connector_config.sui_chain_identifier {
+                anyhow::bail!(
+                    "configured sui_chain_identifier is {} but the genesis blob is for {}",
+                    config.sui_connector_config.sui_chain_identifier,
+                    derived
+                );
+            }
+        }
+
         // Fill any omitted on-chain ika ids (packages + objects) from the
-        // binary's compiled-in per-chain identity, keyed off the configured Sui
-        // chain; explicit config values always win. Subsumes the old per-chain
-        // dwallet-v2 hardcode.
+        // binary's compiled-in per-chain identity, keyed off the now
+        // genesis-verified Sui chain; explicit config values always win.
+        // Subsumes the old per-chain dwallet-v2 hardcode.
         config
             .sui_connector_config
             .resolve_ika_on_chain_identity()?;

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -270,7 +270,7 @@ impl IkaNode {
     /// Start the node in a specific mode with validation.
     /// This method validates that the configuration matches the expected mode.
     pub async fn start_with_mode(
-        config: NodeConfig,
+        mut config: NodeConfig,
         registry_service: RegistryService,
         _software_version: &'static str,
         mode: NodeMode,
@@ -306,33 +306,13 @@ impl IkaNode {
 
         let sui_client_metrics = SuiClientMetrics::new(&registry_service.default_registry());
 
-        let mut ika_dwallet_2pc_mpc_package_id_v2 = config
+        // Fill any omitted on-chain ika ids (packages + objects) from the
+        // binary's compiled-in per-chain identity, keyed off the configured Sui
+        // chain; explicit config values always win. Subsumes the old per-chain
+        // dwallet-v2 hardcode.
+        config
             .sui_connector_config
-            .ika_dwallet_2pc_mpc_package_id_v2;
-
-        // Testnet V2
-        if ika_dwallet_2pc_mpc_package_id_v2.is_none()
-            && config.sui_connector_config.ika_dwallet_2pc_mpc_package_id
-                == ObjectID::from_str(
-                    "0xf02f5960c94fce1899a3795b5d11fd076bc70a8d0e20a2b19923d990ed490730",
-                )?
-        {
-            ika_dwallet_2pc_mpc_package_id_v2 = Some(ObjectID::from_str(
-                "0x6573a6c13daf26a64eb8a37d3c7a4391b353031e223072ca45b1ff9366f59293",
-            )?)
-        }
-
-        // Mainnet V2
-        if ika_dwallet_2pc_mpc_package_id_v2.is_none()
-            && config.sui_connector_config.ika_dwallet_2pc_mpc_package_id
-                == ObjectID::from_str(
-                    "0xdd24c62739923fbf582f49ef190b4a007f981ca6eb209ca94f3a8eaf7c611317",
-                )?
-        {
-            ika_dwallet_2pc_mpc_package_id_v2 = Some(ObjectID::from_str(
-                "0x23b5bd96051923f800c3a2150aacdcdd8d39e1df2dce4dac69a00d2d8c7f7e77",
-            )?)
-        }
+            .resolve_ika_on_chain_identity()?;
 
         let ika_network_config = IkaNetworkConfig {
             packages: IkaPackageConfig {
@@ -341,7 +321,9 @@ impl IkaNode {
                 ika_dwallet_2pc_mpc_package_id: config
                     .sui_connector_config
                     .ika_dwallet_2pc_mpc_package_id,
-                ika_dwallet_2pc_mpc_package_id_v2,
+                ika_dwallet_2pc_mpc_package_id_v2: config
+                    .sui_connector_config
+                    .ika_dwallet_2pc_mpc_package_id_v2,
                 ika_system_package_id: config.sui_connector_config.ika_system_package_id,
             },
             objects: IkaObjectsConfig {

--- a/crates/ika-sui-client/src/genesis.rs
+++ b/crates/ika-sui-client/src/genesis.rs
@@ -238,6 +238,29 @@ pub fn compiled_in_chain_identifier(chain: SuiChainIdentifier) -> Option<ChainId
     }
 }
 
+/// The inverse of [`compiled_in_chain_identifier`]: derive which chain a genesis
+/// checkpoint digest belongs to by matching it against the compiled-in
+/// mainnet/testnet identifiers. `Custom` if it matches neither (localnet /
+/// private net). This is how a node learns its chain from the *verified* genesis
+/// blob rather than from the operator-declared config.
+pub fn chain_of_chain_identifier(id: ChainIdentifier) -> SuiChainIdentifier {
+    if id == get_mainnet_chain_identifier() {
+        SuiChainIdentifier::Mainnet
+    } else if id == get_testnet_chain_identifier() {
+        SuiChainIdentifier::Testnet
+    } else {
+        SuiChainIdentifier::Custom
+    }
+}
+
+impl SuiGenesisBootstrap {
+    /// The chain this genesis blob belongs to, derived from its verified
+    /// checkpoint digest (see [`chain_of_chain_identifier`]).
+    pub fn chain(&self) -> SuiChainIdentifier {
+        chain_of_chain_identifier(self.chain_identifier)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -396,6 +419,22 @@ mod tests {
         assert_eq!(
             compiled_in_chain_identifier(SuiChainIdentifier::Custom),
             None
+        );
+    }
+
+    #[test]
+    fn chain_is_derived_from_the_genesis_digest() {
+        // The test fixture is a local (Custom) chain, not mainnet/testnet.
+        let boot = load_and_verify_sui_genesis(FIXTURE, SuiChainIdentifier::Custom).unwrap();
+        assert_eq!(boot.chain(), SuiChainIdentifier::Custom);
+        // The compiled-in constants map back to their chains.
+        assert_eq!(
+            chain_of_chain_identifier(get_mainnet_chain_identifier()),
+            SuiChainIdentifier::Mainnet
+        );
+        assert_eq!(
+            chain_of_chain_identifier(get_testnet_chain_identifier()),
+            SuiChainIdentifier::Testnet
         );
     }
 }


### PR DESCRIPTION
> Stacked on #1774 (base is `feat/ocs-genesis-anchor-removal`). Diff shows only
> this branch's changes; will retarget to `dev` once #1774 merges.

## Summary

Once the Sui chain is known (authenticated by the genesis blob from #1774), the
ika package + object IDs for mainnet/testnet are deployment constants. This
compiles them into the binary so a node only configures them for localnet or to
override — and **genesis-roots the chain** those IDs are picked for.

## What changes

- `compiled_in_ika_identity(chain)` with the mainnet/testnet IDs from
  `deployed_contracts/{net}/address.yaml` (dwallet base = **v1** + `_v2` = v2;
  system = **latest**; objects immutable). Deliberately **not** from
  `ika_sui_config.yaml`, which flattens packages to v2 under the base name —
  wrong for the node config schema, and would break v1-era event filtering. (See
  the in-code note so it can't be "fixed" into the wrong source later.)
- The 6 required ID fields `#[serde(default)]` to a ZERO sentinel;
  `SuiConnectorConfig::resolve_ika_on_chain_identity()` fills any unset one from
  the per-chain constant — **config-supplied values always win**. This subsumes
  and replaces the ad-hoc per-chain dwallet-`_v2` hardcode in `ika-node`.
- **Genesis-rooting:** before resolving, if a genesis blob is configured, derive
  the chain from its checkpoint digest (`chain_of_chain_identifier`) and assert
  it matches the declared `sui_chain_identifier`. So the IDs are rooted in the
  cryptographically-verified genesis, not the operator's declaration — and a
  `Custom`-declared config that points at a real mainnet/testnet genesis blob is
  rejected (the plain loader skips the digest check for `Custom`).

## Verification

- 10 unit tests: resolution fills mainnet/testnet, override-wins,
  custom-requires-explicit, dwallet-base-is-v1, chain-derived-from-digest.
- All four heavy CI suites green (TS via re-run past the pre-existing #1736 flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
**Supersedes #1775**, which GitHub auto-closed when #1774's base branch was
deleted on merge. Rebased onto `dev` (now carrying #1774's genesis re-root).
Also drops a vestigial `mut` on `start_with_mode`'s `config` param (its
mutations hit the shadowed clone) that failed CI's `-D warnings` build.
