### PR TITLE
fix(dwallet-mpc): derive NetworkKeyId on demand to break the joiner adoption deadlock

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -15,9 +15,13 @@ use commitment::CommitmentSizedNumber;
 use dwallet_classgroups_types::{
     ClassGroupsDecryptionKey, RistrettoPvssDecryptionKey, Secp256k1PvssDecryptionKey,
 };
+use dwallet_mpc_centralized_party::{
+    network_dkg_public_output_to_protocol_pp_inner,
+    reconfiguration_public_output_to_protocol_pp_inner,
+};
 use dwallet_mpc_types::dwallet_mpc::{
     DWalletCurve, NetworkDecryptionKeyPublicOutputType, NetworkEncryptionKeyPublicData,
-    SerializedWrappedMPCPublicOutput, VersionedDecryptionKeyReconfigurationOutput,
+    NetworkKeyId, SerializedWrappedMPCPublicOutput, VersionedDecryptionKeyReconfigurationOutput,
     VersionedNetworkDkgOutput,
 };
 use group::PartyID;
@@ -848,8 +852,7 @@ pub(crate) fn compute_all_network_owned_address_dkg_outputs(
 /// from the reconfiguration output). The result matches what
 /// instantiation computes because both seed `compute_noa_dkg` on the
 /// curve25519 encryption-key parameters.
-#[cfg(test)]
-pub fn derive_curve25519_network_owned_address_public_key(
+pub(crate) fn derive_curve25519_network_owned_address_public_key(
     curve25519_protocol_public_parameters: &[u8],
 ) -> DwalletMPCResult<Vec<u8>> {
     let protocol_public_parameters: twopc_mpc::curve25519::class_groups::ProtocolPublicParameters =
@@ -865,6 +868,77 @@ pub fn derive_curve25519_network_owned_address_public_key(
     Ok(noa.public_key)
 }
 
+/// Derives a network key's content-derived [`NetworkKeyId`] from its raw
+/// chain blobs and records the temporary `ObjectID` <-> `NetworkKeyId`
+/// mapping, on the rayon pool.
+///
+/// Normally the mapping registers at instantiation
+/// ([`DwalletMPCNetworkKeys::update_network_key`]), but a validator
+/// consuming a handoff cert for a key it never instantiated (a joiner on
+/// any key absent from the seeded map) needs the mapping *before*
+/// instantiation — the cert keys by `NetworkKeyId`, and cert-gated
+/// adoption is what leads to instantiation in the first place. The
+/// derivation is an expensive class-groups computation (deserialize the
+/// curve25519 protocol public parameters + the deterministic NOA DKG),
+/// so it runs off the MPC service loop; the adoption pass re-evaluates
+/// each tick and proceeds once the registration lands.
+pub(crate) fn spawn_network_key_id_registration(
+    key_id: ObjectID,
+    network_dkg_public_output: Vec<u8>,
+    current_reconfiguration_public_output: Vec<u8>,
+) {
+    // msim: rayon worker threads have no simulated-node context, so capture
+    // the originating NodeHandle and enter it before any tracing call
+    // inside the worker.
+    #[cfg(msim)]
+    let originating_sim_node = sui_simulator::runtime::NodeHandle::try_current();
+
+    rayon::spawn_fifo(move || {
+        #[cfg(msim)]
+        let _node_guard = originating_sim_node.as_ref().map(|n| n.enter_node());
+
+        // Derive from the same source instantiation would use: the
+        // reconfiguration output when present, else the DKG output. The
+        // resulting id is identical either way — resharing preserves the
+        // collective encryption key the id is derived from.
+        let curve25519_protocol_pp = if current_reconfiguration_public_output.is_empty() {
+            network_dkg_public_output_to_protocol_pp_inner(
+                DWalletCurve::Curve25519 as u32,
+                network_dkg_public_output,
+            )
+        } else {
+            reconfiguration_public_output_to_protocol_pp_inner(
+                DWalletCurve::Curve25519 as u32,
+                current_reconfiguration_public_output,
+                network_dkg_public_output,
+            )
+        };
+        let network_key_id = curve25519_protocol_pp
+            .map_err(|e| DwalletMPCError::InternalError(e.to_string()))
+            .and_then(|pp| derive_curve25519_network_owned_address_public_key(&pp))
+            .and_then(|public_key| {
+                NetworkKeyId::from_bytes(&public_key)
+                    .map_err(|e| DwalletMPCError::InternalError(e.to_string()))
+            });
+        match network_key_id {
+            Ok(network_key_id) => {
+                crate::network_key_id_mapping::register(key_id, network_key_id);
+                info!(
+                    ?key_id,
+                    ?network_key_id,
+                    "derived and registered the NetworkKeyId from locally-held key data"
+                );
+            }
+            Err(e) => error!(
+                ?key_id,
+                error = ?e,
+                "failed to derive the NetworkKeyId from locally-held key data — \
+                 cert-anchored adoption for this key stays deferred"
+            ),
+        }
+    });
+}
+
 /// One-off tool (not a unit test): fetches the deployed network key from
 /// testnet/mainnet and prints its `NetworkKeyId` (curve25519 NOA ed25519
 /// pubkey) for baking into the temporary static ObjectID->NetworkKeyId
@@ -872,8 +946,8 @@ pub fn derive_curve25519_network_owned_address_public_key(
 ///   cargo test -p ika-core --release print_deployed_network_key_ids -- --ignored --nocapture
 #[cfg(test)]
 mod network_key_id_derivation_tool {
-    use super::derive_curve25519_network_owned_address_public_key;
-    use dwallet_mpc_centralized_party::{
+    use super::{
+        derive_curve25519_network_owned_address_public_key,
         network_dkg_public_output_to_protocol_pp_inner,
         reconfiguration_public_output_to_protocol_pp_inner,
     };

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -347,3 +347,113 @@ async fn already_adopted_key_survives_dkg_output_migration() {
          mismatching overlay"
     );
 }
+
+/// A cert-referenced key whose `ObjectID` has no `NetworkKeyId` mapping
+/// (a joiner that never instantiated the key — the mapping registers at
+/// instantiation, which needs adoption first) must NOT be treated as
+/// "not pinned by the cert": pre-fix, the reconfigured branch saw
+/// `cert_dkg_digest=None`, warned a phantom mismatch, and wedged the key
+/// uninstantiated forever (the v118_churn joiner deadlock). Adoption
+/// must defer, spawn the background `NetworkKeyId` derivation exactly
+/// once, skip the pass memoization so re-evaluation happens with
+/// unchanged inputs, and proceed once the registration lands.
+#[tokio::test]
+async fn unmapped_cert_referenced_key_defers_and_spawns_derivation() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (
+        mut dwallet_mpc_services,
+        _sui_data_senders,
+        _sent_consensus_messages_collectors,
+        epoch_stores,
+        _notify_services,
+        _network_owned_address_sign_request_senders,
+        _network_owned_address_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services(1);
+    let service = dwallet_mpc_services.first_mut().unwrap();
+    let epoch_id = service.epoch;
+    let prior_epoch = epoch_id - 1;
+
+    // Deliberately NOT registered: the cert speaks NetworkKeyId, this
+    // validator only knows the ObjectID.
+    let key_id = ObjectID::random();
+    let network_key_id = NetworkKeyId([0x51; 32]);
+    let dkg_output = b"joiner network dkg public output".to_vec();
+    let reconfiguration_output = b"joiner network reconfiguration public output".to_vec();
+
+    // The prior epoch's cert pins both digests for the key (items sorted
+    // by `HandoffItemKey`: DKG < reconfiguration).
+    let attestation = HandoffAttestation {
+        epoch: prior_epoch,
+        next_committee_pubkey_set_hash: [0u8; 32],
+        items: vec![
+            (
+                HandoffItemKey::NetworkDkgOutput {
+                    key_id: network_key_id,
+                },
+                mpc_data_blob_hash(&dkg_output),
+            ),
+            (
+                HandoffItemKey::NetworkReconfigurationOutput {
+                    key_id: network_key_id,
+                },
+                mpc_data_blob_hash(&reconfiguration_output),
+            ),
+        ],
+    };
+    epoch_stores
+        .first()
+        .unwrap()
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(
+            prior_epoch,
+            CertifiedHandoffAttestation {
+                attestation,
+                signatures: vec![],
+            },
+        );
+
+    let overlay = Arc::new(HashMap::from([(
+        key_id,
+        network_key_data(
+            key_id,
+            epoch_id,
+            dkg_output.clone(),
+            reconfiguration_output.clone(),
+        ),
+    )]));
+    let manager = service.dwallet_mpc_manager_mut();
+    manager.adopt_cert_verified_keys(&overlay);
+    assert!(
+        !manager.adopted_network_key_data.contains_key(&key_id),
+        "an unmapped cert-referenced key must be deferred, not adopted"
+    );
+    assert!(
+        manager.network_key_id_derivations_spawned.contains(&key_id),
+        "the background NetworkKeyId derivation must be spawned for the unmapped key"
+    );
+
+    // Same overlay again: the deferral must have skipped the memoization
+    // (so the pass re-evaluates) and must not respawn the derivation.
+    manager.adopt_cert_verified_keys(&overlay);
+    assert_eq!(
+        manager.network_key_id_derivations_spawned.len(),
+        1,
+        "the derivation must be spawned at most once per key"
+    );
+
+    // Simulate the background derivation completing: registration alone —
+    // with the overlay bytes unchanged — must unwedge adoption on the
+    // next pass.
+    crate::network_key_id_mapping::register(key_id, network_key_id);
+    manager.adopt_cert_verified_keys(&overlay);
+    let adopted = manager
+        .adopted_network_key_data
+        .get(&key_id)
+        .expect("registration must unwedge cert-gated adoption with no overlay change");
+    assert_eq!(
+        adopted.current_reconfiguration_public_output, reconfiguration_output,
+        "the adopted data must carry the cert-pinned reconfiguration bytes"
+    );
+}

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -11,8 +11,10 @@ use crate::dwallet_mpc::mpc_session::{
     DWalletMPCSessionOutput, DWalletSession, SessionComputationType, SessionStatus,
     session_input_from_request,
 };
-use crate::dwallet_mpc::network_dkg::spawn_network_encryption_key_public_data_instantiation;
 use crate::dwallet_mpc::network_dkg::{DwalletMPCNetworkKeys, ValidatorPrivateDecryptionKeyData};
+use crate::dwallet_mpc::network_dkg::{
+    spawn_network_encryption_key_public_data_instantiation, spawn_network_key_id_registration,
+};
 use crate::dwallet_mpc::{
     ValidatorMpcKeysByPartyId, authority_name_to_party_id_from_committee,
     class_groups_keys_by_party_id, generate_access_structure_from_committee,
@@ -252,6 +254,13 @@ pub(crate) struct DWalletMPCManager {
     /// debug thereafter.
     warned_cert_digest_mismatches: HashSet<(ObjectID, [u8; 32])>,
 
+    /// Keys whose background `NetworkKeyId` derivation has been spawned by
+    /// the adoption pass, so the expensive class-groups derive runs at most
+    /// once per key per manager (i.e. per epoch). A successful derivation
+    /// registers in the process-global mapping, so later epochs resolve the
+    /// key without re-deriving.
+    pub(crate) network_key_id_derivations_spawned: HashSet<ObjectID>,
+
     /// Sessions whose protocol-cryptographic-data generation already
     /// failed and was logged. The generation re-runs every 20ms service
     /// iteration, so a stuck session would otherwise emit ~50 identical
@@ -459,6 +468,7 @@ impl DWalletMPCManager {
             pending_network_key_instantiations: HashMap::new(),
             last_cert_read_warn: None,
             warned_cert_digest_mismatches: HashSet::new(),
+            network_key_id_derivations_spawned: HashSet::new(),
             warned_cryptographic_data_generation_failures: HashSet::new(),
             last_failed_network_key_data: HashMap::new(),
             next_internal_presign_sequence_number: 1,
@@ -937,6 +947,7 @@ impl DWalletMPCManager {
             }
         }
         let off_chain_on = self.epoch_store.off_chain_validator_metadata_enabled();
+        let mut deferred_unmapped_cert_key = false;
         for (key_id, data) in overlay.iter() {
             if data.network_dkg_public_output.is_empty() {
                 continue; // nothing computed/fetched locally yet
@@ -979,10 +990,39 @@ impl DWalletMPCManager {
             let local_dkg_digest = mpc_data_blob_hash(&data.network_dkg_public_output);
             // The cert is keyed by the content-derived NetworkKeyId; translate
             // this overlay key's ObjectID via the temporary map. An unmapped
-            // key (e.g. a brand-new key not yet instantiated/registered) is
-            // treated as not-pinned-by-the-cert — correct for a fresh key,
-            // which the prior epoch's cert never references.
+            // key is ambiguous: a brand-new key the prior epoch's cert never
+            // references (genuinely not-pinned), or a key this validator
+            // simply never instantiated — the mapping registers at
+            // instantiation, instantiation needs adoption, and adoption
+            // needs the mapping to see the cert's digests. A joiner
+            // consuming the cert lands in exactly that cycle: treating its
+            // key as "not pinned" either adopts parameters the committee
+            // never agreed to (initial-DKG branch) or wedges forever on a
+            // phantom digest mismatch (reconfigured branch). When the cert
+            // references any key, break the cycle: derive this key's
+            // NetworkKeyId from the locally-held blobs on the rayon pool
+            // (an expensive class-groups computation) and defer adoption
+            // until the background derivation registers the mapping.
             let network_key_id = crate::network_key_id_mapping::network_key_id_for(key_id);
+            if network_key_id.is_none()
+                && (!dkg_digests.is_empty() || !reconfiguration_digests.is_empty())
+            {
+                if self.network_key_id_derivations_spawned.insert(*key_id) {
+                    info!(
+                        ?key_id,
+                        "handoff cert references network keys but this key's ObjectID has \
+                         no NetworkKeyId mapping (not seeded, never instantiated here) — \
+                         deriving it from the locally-held key data in the background"
+                    );
+                    spawn_network_key_id_registration(
+                        *key_id,
+                        data.network_dkg_public_output.clone(),
+                        data.current_reconfiguration_public_output.clone(),
+                    );
+                }
+                deferred_unmapped_cert_key = true;
+                continue;
+            }
             let cert_dkg_digest = network_key_id.as_ref().and_then(|id| dkg_digests.get(id));
             let cert_reconfig_digest = network_key_id
                 .as_ref()
@@ -1217,6 +1257,15 @@ impl DWalletMPCManager {
                 }
             }
             self.adopted_network_key_data.insert(*key_id, data.clone());
+        }
+        // A deferred unmapped key resolves via the background NetworkKeyId
+        // derivation, which changes nothing the memo below can see (the
+        // overlay bytes stay identical; only the process-global mapping
+        // gains an entry) — memoizing would make the deferral permanent.
+        // Skip the memo so the pass re-runs every tick until the mapping
+        // resolves.
+        if deferred_unmapped_cert_key {
+            return;
         }
         self.last_adoption_input = Some((overlay.clone(), cert.is_some()));
     }

--- a/crates/ika-core/src/network_key_id_mapping.rs
+++ b/crates/ika-core/src/network_key_id_mapping.rs
@@ -14,8 +14,15 @@
 //! planned before the on-chain request event starts carrying the
 //! `NetworkKeyId` directly. The known deployed keys are seeded as
 //! constants so the mapping is available *before* instantiation — a
-//! joiner consuming the handoff cert needs it then; tests/localnet that
-//! DKG a fresh key call [`register`] at instantiation to self-populate.
+//! joiner consuming the handoff cert needs it then. For keys outside the
+//! seed (every localnet/CI cluster's fresh DKG), [`register`] runs at
+//! instantiation, and a validator that never instantiated the key (a
+//! joiner) derives the id from its locally-held key blobs in the
+//! background when a handoff cert forces the translation — see
+//! `spawn_network_key_id_registration` in `network_dkg`. Without that
+//! path, adoption needs the mapping, the mapping registers at
+//! instantiation, and instantiation needs adoption: a deadlock that
+//! wedges the joiner's epoch entry.
 //!
 //! TODO(NetworkKeyId-from-event): delete this module once the request
 //! event carries the `NetworkKeyId`. The runtime/tables then key by

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -35,6 +35,7 @@ use tower::ServiceBuilder;
 use tracing::{debug, warn};
 use tracing::{error, info};
 
+use dwallet_mpc_types::dwallet_mpc::NetworkKeyId;
 pub use handle::IkaNodeHandle;
 use ika_archival::reader::ArchiveReaderBalancer;
 use ika_archival::writer::ArchiveWriter;
@@ -3286,7 +3287,8 @@ impl IkaNode {
             // Surface the breakdown roughly every 10s so a hang is never
             // silent on a dashboard or in the logs.
             if retries.is_multiple_of(10) {
-                let (cert_reconfiguration_items, missing_key_ids) = match &cert {
+                let (cert_reconfiguration_items, missing_key_ids, unmapped_cert_keys) = match &cert
+                {
                     Some(cert) => {
                         let total = cert
                             .attestation
@@ -3312,9 +3314,32 @@ impl IkaNode {
                                 _ => None,
                             })
                             .collect();
-                        (total, missing)
+                        // Cert keys with NO ObjectID mapping (this validator
+                        // never instantiated the key and it is not seeded)
+                        // are exactly the keys the gate can never satisfy,
+                        // yet the translation above drops them from
+                        // `missing` — report them separately so an
+                        // unmapped-key wedge no longer reads as
+                        // `missing_locally=0`. The MPC service's adoption
+                        // pass derives and registers the mapping in the
+                        // background; this state should clear on its own.
+                        let unmapped: Vec<NetworkKeyId> = cert
+                            .attestation
+                            .items
+                            .iter()
+                            .filter_map(|(item, _)| match item {
+                                HandoffItemKey::NetworkReconfigurationOutput { key_id }
+                                    if ika_core::network_key_id_mapping::object_id_for(key_id)
+                                        .is_none() =>
+                                {
+                                    Some(*key_id)
+                                }
+                                _ => None,
+                            })
+                            .collect();
+                        (total, missing, unmapped)
                     }
-                    None => (0, Vec::new()),
+                    None => (0, Vec::new(), Vec::new()),
                 };
                 warn!(
                     next_epoch,
@@ -3323,6 +3348,7 @@ impl IkaNode {
                     cert_reconfiguration_items,
                     missing_locally = missing_key_ids.len(),
                     missing_key_ids = ?missing_key_ids,
+                    unmapped_cert_keys = ?unmapped_cert_keys,
                     retries,
                     "prepare-then-start: still awaiting full verified handoff data for epoch \
                      {next_epoch}"


### PR DESCRIPTION
Fixes the joiner network-key bootstrap deadlock that failed `v118_churn` in [run 28566288225](https://github.com/dwallet-labs/ika/actions/runs/28566288225) (release-review finding V6), plus the self-masking diagnostic that hid it.

## The deadlock

The handoff cert keys network keys by content-derived `NetworkKeyId`; the runtime keys them by `ObjectID`. The temporary translation map is populated only from the hardcoded `SEED` (testnet/mainnet keys) or by `register()` **at instantiation**. A validator consuming a cert for a key it never instantiated — a joiner on any fresh-DKG network, or any validator restarted mid-epoch on a non-seeded key — has neither:

- **adoption** needs the mapping to see the cert's digests (`cert_dkg_digest=None` otherwise → phantom "digest mismatch" → skip),
- the mapping registers at **instantiation**,
- instantiation requires **adoption**.

In `v118_churn` the joiner (validator-4) spun in exactly this cycle from its epoch-4 entry until the job timed out: never instantiated, canonical-version gauge stuck at 0. `cross_binary`'s joiner passed the same flow only by racing — its first adoption pass ran *before* its cert anchored, so it took the no-cert fallback and instantiated. Any joiner scenario on a non-seeded key can flake either way on that race.

A second hazard hid behind the same gap: an unmapped key was treated as "not pinned by the cert", so on the initial-DKG branch it could be **adopted without the cert gate** — parameters the committee never agreed on, the false-malicious-conviction divergence class.

## The fix

1. **Derive-on-demand** (`mpc_manager.rs` + `network_dkg.rs`): when the cert references keys and an overlay key's `ObjectID` has no mapping, the adoption pass spawns a background derivation of the `NetworkKeyId` from the locally-held blobs (same source instantiation uses: reconfiguration output when present, else DKG output — the id is identical either way, resharing preserves the collective encryption key) on the rayon pool, and **defers** adoption for that key. The derivation registers into the process-global map; the next pass proceeds through the normal cert gate. Spawned at most once per key per manager (per epoch); a successful registration persists for the process, so later epochs never re-derive.
2. **Memoization skip**: the adoption pass memoizes on the overlay `Arc` + cert presence — but a deferred unmapped key resolves via the global mapping, which the memo cannot see. A pass that deferred skips the memo update so it re-evaluates every tick until the registration lands.
3. **Honest diagnostics** (`ika-node/src/lib.rs`): the prepare-then-start breakdown computed "missing" with `object_id_for(key_id)?` inside a `filter_map`, silently dropping exactly the unmapped keys wedging the gate — the stuck joiner logged the contradictory `missing_locally=0 missing_key_ids=[]` for 890 retries. Unmapped cert keys are now reported as a separate `unmapped_cert_keys` field.

The derivation function is the one `print_deployed_network_key_ids` already used (promoted from `#[cfg(test)]`), so the derived ids match the seeded/instantiation-computed ones by construction.

## v3 safety

The new branch triggers only when a handoff cert with items exists — certs are produced only under protocol v4 (`off_chain_validator_metadata_enabled`). At v3 and at the cert-less v3→v4 boundary the pass is byte-identical to before.

## Testing

- New regression test `unmapped_cert_referenced_key_defers_and_spawns_derivation`: cert-referenced unmapped key → deferred (not adopted), derivation spawned exactly once across repeated passes, memoization skipped, and registration alone (overlay bytes unchanged) unwedges adoption through the cert gate — the v118_churn wedge in miniature, plus proof the pass re-evaluates.
- Existing adoption regression tests unchanged (their manual `register` calls legitimately simulate previously-instantiated state).
- End-to-end proof: `v118_churn` on this branch (the failing scenario from the run above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
