### PR TITLE
test: make the sign suite and v118 pre-activation probe witness what they claim

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/integration_tests/sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/sign.rs
@@ -142,11 +142,19 @@ async fn sign_flow_test() {
     );
     let (_, sign_checkpoint) =
         utils::advance_mpc_flow_until_completion(&mut test_state, consensus_round + 1).await;
-    let DWalletCheckpointMessageKind::RespondDWalletSign(_sign_output) =
+    let DWalletCheckpointMessageKind::RespondDWalletSign(sign_output) =
         sign_checkpoint.messages().clone().pop().unwrap()
     else {
         panic!("Expected DWallet sign output message");
     };
+    assert!(
+        !sign_output.rejected,
+        "the sign session must produce a signature, not a rejection"
+    );
+    assert!(
+        !sign_output.signature.is_empty(),
+        "the sign output must carry signature bytes"
+    );
 }
 
 #[tokio::test]
@@ -250,11 +258,16 @@ async fn future_sign_flow_test() {
     let (consensus_round, sign_checkpoint) =
         utils::advance_mpc_flow_until_completion(&mut test_state, consensus_round + 1).await;
     let DWalletCheckpointMessageKind::RespondDWalletPartialSignatureVerificationOutput(
-        _sign_output,
+        partial_signature_output,
     ) = sign_checkpoint.messages().clone().pop().unwrap()
     else {
         panic!("Expected DWallet future sign output message");
     };
+    assert!(
+        !partial_signature_output.rejected,
+        "the partial-signature verification must accept the centralized signature, \
+         not reject it"
+    );
     send_start_future_sign_event(
         epoch_id,
         &test_state.sui_data_senders,
@@ -272,11 +285,19 @@ async fn future_sign_flow_test() {
     );
     let (_, sign_checkpoint) =
         utils::advance_mpc_flow_until_completion(&mut test_state, consensus_round + 1).await;
-    let DWalletCheckpointMessageKind::RespondDWalletSign(_sign_output) =
+    let DWalletCheckpointMessageKind::RespondDWalletSign(sign_output) =
         sign_checkpoint.messages().clone().pop().unwrap()
     else {
         panic!("Expected DWallet future sign output message");
     };
+    assert!(
+        !sign_output.rejected,
+        "the future-sign session must produce a signature, not a rejection"
+    );
+    assert!(
+        !sign_output.signature.is_empty(),
+        "the future-sign output must carry signature bytes"
+    );
 }
 
 pub(crate) fn send_start_sign_event(
@@ -757,11 +778,19 @@ async fn external_vss_sign_flow(
     );
     let (_, sign_checkpoint) =
         utils::advance_mpc_flow_until_completion(&mut test_state, consensus_round + 1).await;
-    let DWalletCheckpointMessageKind::RespondDWalletSign(_sign_output) =
+    let DWalletCheckpointMessageKind::RespondDWalletSign(sign_output) =
         sign_checkpoint.messages().clone().pop().unwrap()
     else {
         panic!("Expected DWallet sign output message");
     };
+    assert!(
+        !sign_output.rejected,
+        "the sign session must produce a signature, not a rejection"
+    );
+    assert!(
+        !sign_output.signature.is_empty(),
+        "the sign output must carry signature bytes"
+    );
     info!(
         ?curve,
         ?signature_algorithm,

--- a/crates/ika-upgrade-test/src/scenario.rs
+++ b/crates/ika-upgrade-test/src/scenario.rs
@@ -47,6 +47,12 @@ pub enum Step {
         buffer_bps: u64,
     },
     ExpectProtocolVersionAtLeast(u64),
+    /// Instantaneous ceiling assertion: fails if the network already upgraded
+    /// past `version`. Brackets a workload that must run in a pre-upgrade
+    /// window — without the ceiling, timing drift silently erodes the window
+    /// and the workload degrades into an ordinary post-upgrade test while the
+    /// run stays green.
+    ExpectProtocolVersionAtMost(u64),
     /// Poll until every running validator reports a canonical network DKG
     /// output version `>= at_least` (via its `/metrics`), or time out. Confirms
     /// the off-chain handoff migrated the DKG output (e.g. 2 -> 3 after the v4
@@ -109,6 +115,9 @@ impl std::fmt::Display for Step {
             Step::SetBufferStake { buffer_bps } => write!(f, "set_buffer_stake({buffer_bps})"),
             Step::ExpectProtocolVersionAtLeast(v) => {
                 write!(f, "expect_protocol_version_at_least({v})")
+            }
+            Step::ExpectProtocolVersionAtMost(v) => {
+                write!(f, "expect_protocol_version_at_most({v})")
             }
             Step::ExpectNetworkDkgOutputVersionAtLeast(v) => {
                 write!(f, "expect_network_dkg_output_version_at_least({v})")
@@ -244,6 +253,14 @@ impl Scenario {
 
     pub fn expect_protocol_version_at_least(mut self, version: u64) -> Self {
         self.steps.push(Step::ExpectProtocolVersionAtLeast(version));
+        self
+    }
+
+    /// Assert the network has NOT upgraded past `version` yet. Place around a
+    /// workload that must run in a pre-upgrade window, so the window closing
+    /// early fails loudly instead of silently voiding the workload's purpose.
+    pub fn expect_protocol_version_at_most(mut self, version: u64) -> Self {
+        self.steps.push(Step::ExpectProtocolVersionAtMost(version));
         self
     }
 
@@ -458,6 +475,24 @@ impl Scenario {
                         got,
                         expected = *version,
                         "protocol version assertion passed"
+                    );
+                }
+                Step::ExpectProtocolVersionAtMost(version) => {
+                    let c = cluster
+                        .as_ref()
+                        .context("ExpectProtocolVersionAtMost before StartAll")?;
+                    let got = c.current_protocol_version().await?;
+                    if got > *version {
+                        bail!(
+                            "protocol version {got} > expected at most {version} — the \
+                             pre-upgrade window closed before/during the bracketed workload, \
+                             which therefore did not witness the pre-upgrade behavior"
+                        );
+                    }
+                    tracing::info!(
+                        got,
+                        expected_at_most = *version,
+                        "protocol version ceiling assertion passed"
                     );
                 }
                 Step::ExpectNetworkDkgOutputVersionAtLeast(at_least) => {

--- a/crates/ika-upgrade-test/tests/v118_upgrade.rs
+++ b/crates/ika-upgrade-test/tests/v118_upgrade.rs
@@ -187,7 +187,15 @@ async fn v118_atomic_upgrade_to_local_build() {
         // (`all_current_epoch_sessions_completed`) and wedge the network at
         // v3 forever, since the pool that could otherwise serve it only
         // fills at v4.
+        //
+        // Bracketed by protocol-version ceilings: the probe's whole purpose
+        // is witnessing the pre-pool fallback AT v3, and nothing else in the
+        // flow pins that — if the capability vote lands early, the probe
+        // silently degrades into an ordinary v4 pool test. The trailing
+        // ceiling is the load-bearing one (the version can flip mid-workload).
+        .expect_protocol_version_at_most(3)
         .run_workload("pre-activation-window")
+        .expect_protocol_version_at_most(3)
         .record_mpc_timings("pre-activation-window")
         // Boundary 2->3: the local binaries reshare the 1.1.8-created key
         // and the capability vote advances v3 -> v4.


### PR DESCRIPTION
Two vacuous-pass fixes from the 1.2.0 release review (findings T2 and T3 in the [review report](https://github.com/dwallet-labs/ika/pull/1787#issuecomment-4862501346)) — both gate whether green runs of the release-validation suites actually witness the properties they exist for. Land before the pre-merge validation matrix runs.

## Sign tests now assert the signature, not just the flow

The sign integration tests destructured the output and discarded it (`RespondDWalletSign(_sign_output)`) at all three sign sites plus the partial-signature site — while the create-dwallet and encrypt-share tests in the same suite assert `!rejected`. `SignOutput.rejected` is a legitimate response variant, so **a network that rejects every signature kept the sign suite green**, including the v118 workloads the release go/no-go leans on.

Now asserted at every site: `!rejected` plus non-empty signature bytes (`sign_flow_test`, `future_sign_flow_test` — both the partial-verification and completion steps — and the shared Fast-Schnorr `external_vss_sign_flow`). Cryptographic verification of the signature against the dWallet public key stays with the TS integration suite (`hash-signature-validation`), which already does it end-to-end.

## v118 pre-activation probe pinned to the window it claims to test

`v118_upgrade`'s `pre-activation-window` workload exists to witness one thing: global presigns served by the **pre-pool fallback at protocol v3** on the new binary (the #1732 network-wedge rehearsal — a pending global presign at v3 blocks `advance_epoch` forever). The scenario comment says "while the network is still at v3", but nothing enforced it: if the capability vote lands early, the probe silently degrades into an ordinary v4 pool test and the run stays green.

Added `expect_protocol_version_at_most(n)` to the scenario harness (instantaneous ceiling twin of `expect_protocol_version_at_least`) and bracketed the probe with `expect_protocol_version_at_most(3)` **before and after** — the trailing ceiling is the load-bearing one, since the version can flip mid-workload. If the window ever closes early the run now fails loudly with a message saying exactly what was not witnessed, instead of losing the rehearsal silently. (`v118_churn` has no pre-activation probe — it starts its churn post-upgrade — so only `v118_upgrade` is bracketed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
