### PR TITLE
fix(ika-config): old-style config keeps legacy JSON-RPC for every role

### DIFF
--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -346,16 +346,21 @@ pub struct SuiCheckpointArchiveConfig {
 /// flag can't halt running validators en masse at an upgrade boundary.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SuiTransportPlan {
-    /// Old-style config (no `sui-data-source`) on a validator: the deprecated
-    /// JSON-RPC read path — the only one that serves `query_events`, which a
-    /// validator needs for MPC event ingestion. Sui is sunsetting JSON-RPC.
+    /// Old-style config (no `sui-data-source`), any role: the deprecated
+    /// JSON-RPC path — the 1.1.8 behavior the config shape used to select.
+    /// A binary upgrade must not change a node's transport under an
+    /// unchanged config (an endpoint that serves JSON-RPC need not serve
+    /// Sui gRPC, and for a notifier that mismatch surfaces as a
+    /// network-wide epoch-advance stall); moving to gRPC is an explicit
+    /// config migration (`sui-data-source`). Also the only path serving
+    /// `query_events`, which a validator needs for MPC event ingestion.
+    /// Sui is sunsetting JSON-RPC.
     LegacyJsonRpc,
     /// `sui-state-mirrored` with no `fallback-grpc-url`: the node has no direct
     /// Sui uplink, so every read crosses the verified OCS relay.
     PeerOnlyRelay,
-    /// A direct gRPC uplink: `sui-state-direct`, `sui-state-mirrored` with a
-    /// fallback, or a notifier/fullnode on an old-style config (Sui fullnodes
-    /// serve gRPC at the same endpoint as JSON-RPC).
+    /// A direct gRPC uplink: `sui-state-direct`, or `sui-state-mirrored` with a
+    /// fallback.
     Grpc,
 }
 
@@ -400,14 +405,17 @@ pub fn select_sui_transport(
                         .to_string(),
                 );
             }
-            // A validator reads MPC events over JSON-RPC `query_events` (gRPC
-            // cannot serve them); notifiers/fullnodes run no event ingestion and
-            // read gRPC at the same fullnode endpoint.
-            Ok(if mode.is_validator() {
-                SuiTransportPlan::LegacyJsonRpc
-            } else {
-                SuiTransportPlan::Grpc
-            })
+            // Every role keeps the JSON-RPC path the same config selected on
+            // 1.1.8: a binary upgrade must not silently change a node's
+            // transport (`sui-rpc-url` endpoints are not guaranteed to serve
+            // Sui gRPC — many managed providers don't — and for the notifier,
+            // the sole submitter of checkpoints and advance_epoch, a soft
+            // gRPC failure is a network-wide epoch-advance stall). Moving to
+            // gRPC is an explicit migration: add `sui-data-source`. The
+            // JSON-RPC backend serves every role's needs, as on 1.1.8:
+            // `query_events` for validator MPC ingestion, quorum-driver
+            // submission for the notifier.
+            Ok(SuiTransportPlan::LegacyJsonRpc)
         }
         // New-style config (`sui-data-source` present): all Sui I/O over gRPC.
         Some(source) => {
@@ -1328,23 +1336,21 @@ mod tests {
         }
     }
 
-    /// An old-style validator (only `sui-rpc-url`, no anchor) keeps the
-    /// deprecated JSON-RPC path; a notifier/fullnode on the same config reads
-    /// gRPC at that endpoint.
+    /// An old-style config (only `sui-rpc-url`, no anchor) keeps the
+    /// deprecated JSON-RPC path for EVERY role — the transport a 1.1.8 node
+    /// ran on that exact config. A binary upgrade must never flip transport
+    /// under an unchanged config (the endpoint may not serve Sui gRPC, and a
+    /// notifier failing softly on gRPC stalls epoch advance network-wide);
+    /// gRPC requires explicitly configuring `sui-data-source`.
     #[test]
-    fn old_style_routes_by_role() {
-        assert_eq!(
-            select_sui_transport(None, true, false, NodeMode::Validator),
-            Ok(SuiTransportPlan::LegacyJsonRpc)
-        );
-        assert_eq!(
-            select_sui_transport(None, true, false, NodeMode::Fullnode),
-            Ok(SuiTransportPlan::Grpc)
-        );
-        assert_eq!(
-            select_sui_transport(None, true, false, NodeMode::Notifier),
-            Ok(SuiTransportPlan::Grpc)
-        );
+    fn old_style_keeps_legacy_json_rpc_for_every_role() {
+        for mode in ALL_MODES {
+            assert_eq!(
+                select_sui_transport(None, true, false, mode),
+                Ok(SuiTransportPlan::LegacyJsonRpc),
+                "mode={mode}"
+            );
+        }
     }
 
     /// A trust anchor without a `sui-data-source` section is rejected (the

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -497,9 +497,9 @@ impl IkaNode {
         let mut peer_only_stack: Option<sui_connector_setup::SuiConnectorStack> = None;
         let sui_client = if legacy_json_rpc {
             warn!(
-                "DEPRECATED: old-style config (no sui-data-source) — this validator reads Sui \
-                 over JSON-RPC, which Sui is sunsetting; migrate by adding sui-data-source plus \
-                 a trust anchor"
+                "DEPRECATED: old-style config (no sui-data-source) — this node talks to Sui \
+                 over JSON-RPC, which Sui is sunsetting; migrate by adding sui-data-source \
+                 (plus a trust anchor on validators)"
             );
             let rpc_url = config
                 .sui_connector_config

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -210,15 +210,16 @@ orthogonal to whether OCS is on. Transport is chosen by config shape:
   peer-only role. A fresh peer-only node can't dial out to reach the relay,
   so existing validators *dial it inbound* off the on-chain `pending_active_set`
   — see [`trusted-peer-discovery.md`](trusted-peer-discovery.md).
-- **Notifier / fullnode** — read gRPC at one endpoint; notifiers are the
-  only nodes that submit transactions and always use a direct uplink.
+- **Notifier / fullnode** — on a new-style config, read gRPC at one endpoint;
+  notifiers are the only nodes that submit transactions and always use a
+  direct uplink.
 
 **Config-shape gate** (evaluated at startup, `ika-node` boot):
 
 | `sui-data-source` | `sui-rpc-url` | result |
 |---|---|---|
 | absent | absent | error: no Sui endpoint |
-| absent | present | old-style: validators → legacy JSON-RPC; notifier/fullnode → gRPC at `sui-rpc-url` |
+| absent | present | old-style: legacy JSON-RPC for **every role** — the transport this exact config selected on 1.1.8. A binary upgrade must not flip a node's transport under an unchanged config (a `sui-rpc-url` endpoint need not serve Sui gRPC; a notifier failing softly on gRPC stalls epoch advance network-wide). Moving to gRPC is an explicit migration: add `sui-data-source` |
 | present | present | new-style wins; info log to drop `sui-rpc-url` |
 | present | — | new-style: gRPC + OCS; a **validator** additionally requires a Sui committee trust root |
 


### PR DESCRIPTION
Rollout-day fix from the 1.2.0 release review (finding G5 in the [review report](https://github.com/dwallet-labs/ika/pull/1787#issuecomment-4862501346)): an old-style config (`sui-rpc-url` only, no `sui-data-source`) now selects the legacy JSON-RPC transport for **every role**, not just validators.

## The problem

`select_sui_transport` routed an old-style **notifier/fullnode** to gRPC at the same URL. That means the 1.1.8 → 1.2.0 restart silently changes the notifier's Sui transport under an unchanged config — and a `sui-rpc-url` endpoint that serves JSON-RPC is not guaranteed to serve Sui gRPC (many managed providers don't expose it, or expose it on a different port). The notifier is the sole submitter of checkpoints and `advance_epoch`; a soft gRPC failure there is a network-wide epoch-advance stall on rollout day.

## The fix

Old-style config keeps the transport it selected on 1.1.8 — JSON-RPC — for all roles. Moving to gRPC is an explicit, operator-initiated config migration: add `sui-data-source`. No silent behavior change on upgrade.

Feasibility verified before the change: the notifier's submission path works over the JSON-RPC backend — `SuiBackend::JsonRpc` has a live `execute_transaction_block_with_effects` arm dispatching to the quorum-driver API (ika-sui-client `lib.rs`), which is exactly what 1.1.8's notifier ran. And the syncer already gates legacy event ingestion on `run_legacy_event_ingestion && mode.is_validator()` (`sui_syncer.rs`), so a legacy-path notifier skips event listening just like 1.1.8.

Changes:
- `select_sui_transport`: old-style → `LegacyJsonRpc` unconditionally; comment documents the invariant (a binary upgrade must never flip a node's transport under an unchanged config).
- `SuiTransportPlan` docs updated; the `old_style_routes_by_role` test becomes `old_style_keeps_legacy_json_rpc_for_every_role` (all roles asserted).
- The ika-node deprecation warning now speaks for any role.
- `dev-docs/specs/ocs-verified-sui-reads.md`: config-shape gate table row updated in the same PR, per the spec-maintenance rule.

## Coverage note / follow-up

All 15 `ika-config` transport unit tests pass. The test-harness notifiers are all new-style (`node_config_builder` always writes `sui-data-source`), so no CI flow exercises the legacy notifier path today — that's the remaining half of review finding G5: a rehearsal scenario booting the new binary from old-style YAMLs in Validator **and** Notifier modes across an epoch boundary, coming as a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
