### PR TITLE
test(upgrade): legacy_config rollout rehearsal — new binary on old-style YAMLs for every role

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -29,6 +29,12 @@ name: Upgrade Test
 #                  so the v4 reshare of the 1.1.8-origin key includes a new
 #                  party (exercises the OCS joiner trust-anchor path from a real
 #                  1.1.8 origin). Same defaults as v118_upgrade.
+#   legacy_config — rollout-day config rehearsal: the current build on
+#                  old-style (1.1.8-shape) YAMLs — `sui-rpc-url` only, no
+#                  sui-data-source — for all validators AND the notifier
+#                  (the legacy JSON-RPC transport nothing else covers). Full
+#                  lifecycle at v3, the v3 -> v4 vote, lifecycle again at v4.
+#                  Current build only.
 #
 # Each scenario binds the fixed Sui localnet ports (9000/9123) and chdirs the
 # process during publish, so only ONE runs per job — `--test-threads=1`, one
@@ -116,7 +122,7 @@ jobs:
           TEST: ${{ inputs.test }}
         run: |
           set -euo pipefail
-          ALL="smoke workload cross_binary v118_upgrade v118_churn"
+          ALL="smoke workload cross_binary v118_upgrade v118_churn legacy_config"
           if [ "$TEST" = "all" ]; then
             SELECTED="$ALL"
           else
@@ -228,6 +234,7 @@ jobs:
             cross_binary) RUN_FLAG=RUN_CROSS_BINARY ;;
             v118_upgrade) RUN_FLAG=RUN_V118_UPGRADE ;;
             v118_churn)   RUN_FLAG=RUN_V118_CHURN ;;
+            legacy_config) RUN_FLAG=RUN_LEGACY_CONFIG ;;
             *) echo "unknown test: $TEST" >&2; exit 1 ;;
           esac
           # Per-scenario OLD-binary defaults; explicit inputs override (an

--- a/crates/ika-swarm-config/src/node_config_builder.rs
+++ b/crates/ika-swarm-config/src/node_config_builder.rs
@@ -59,6 +59,12 @@ pub struct ValidatorConfigBuilder {
     /// genesis-bootstraps the OCS committee chain from it (preferred over the
     /// unsafe-genesis-committee path).
     sui_genesis: Option<PathBuf>,
+    /// Emit an old-style (1.1.8-shape) Sui connector config: `sui-rpc-url`
+    /// only, no `sui-data-source` — the shape every mainnet node runs on
+    /// rollout day, which selects the deprecated JSON-RPC transport. Do not
+    /// combine with a trust anchor or a data-source override (the node
+    /// fails closed at boot on those mixed shapes).
+    legacy_sui_rpc_only: bool,
 }
 
 impl ValidatorConfigBuilder {
@@ -126,6 +132,11 @@ impl ValidatorConfigBuilder {
         self
     }
 
+    pub fn with_legacy_sui_rpc_only(mut self) -> Self {
+        self.legacy_sui_rpc_only = true;
+        self
+    }
+
     pub fn build(
         self,
         validator: &ValidatorInitializationConfig,
@@ -185,13 +196,15 @@ impl ValidatorConfigBuilder {
                 validator.consensus_key_pair.copy(),
             )),
             sui_connector_config: SuiConnectorConfig {
-                sui_rpc_url: None,
-                sui_data_source: Some(self.sui_data_source_override.clone().unwrap_or_else(|| {
-                    SuiDataSource::SuiStateDirect {
-                        url: sui_rpc_url.to_string(),
-                        serve_mirror: true,
-                    }
-                })),
+                sui_rpc_url: self.legacy_sui_rpc_only.then(|| sui_rpc_url.clone()),
+                sui_data_source: (!self.legacy_sui_rpc_only).then(|| {
+                    self.sui_data_source_override.clone().unwrap_or_else(|| {
+                        SuiDataSource::SuiStateDirect {
+                            url: sui_rpc_url.to_string(),
+                            serve_mirror: true,
+                        }
+                    })
+                }),
                 sui_state_mirror_peers: self
                     .sui_state_mirror_peers_override
                     .clone()
@@ -287,6 +300,11 @@ pub struct FullnodeConfigBuilder {
     network_key_pair: Option<KeyPairWithPath>,
     run_with_range: Option<RunWithRange>,
     disable_pruning: bool,
+    /// Emit an old-style (1.1.8-shape) Sui connector config: `sui-rpc-url`
+    /// only, no `sui-data-source` — selects the deprecated JSON-RPC
+    /// transport, the shape every mainnet notifier/fullnode runs on rollout
+    /// day.
+    legacy_sui_rpc_only: bool,
 }
 
 impl FullnodeConfigBuilder {
@@ -306,6 +324,11 @@ impl FullnodeConfigBuilder {
 
     pub fn with_disable_pruning(mut self, disable_pruning: bool) -> Self {
         self.disable_pruning = disable_pruning;
+        self
+    }
+
+    pub fn with_legacy_sui_rpc_only(mut self) -> Self {
+        self.legacy_sui_rpc_only = true;
         self
     }
 
@@ -432,12 +455,14 @@ impl FullnodeConfigBuilder {
                 .network_address
                 .unwrap_or(validator_config.network_address),
             sui_connector_config: SuiConnectorConfig {
-                sui_rpc_url: None,
+                sui_rpc_url: self.legacy_sui_rpc_only.then(|| sui_rpc_url.clone()),
                 // Fullnodes don't run the OCS verifier: direct gRPC, no
                 // mirror service, no trusted anchor.
-                sui_data_source: Some(SuiDataSource::SuiStateDirect {
-                    url: sui_rpc_url.to_string(),
-                    serve_mirror: false,
+                sui_data_source: (!self.legacy_sui_rpc_only).then(|| {
+                    SuiDataSource::SuiStateDirect {
+                        url: sui_rpc_url.to_string(),
+                        serve_mirror: false,
+                    }
                 }),
                 sui_state_mirror_peers: Vec::new(),
                 sui_unsafe_genesis_committee: None,

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -127,6 +127,11 @@ pub struct ClusterBuilder {
     /// pre-upgrade need `Empty` (the mainnet-v1.1.8 state) and apply the full
     /// config post-upgrade via [`ClusterOfProcesses::set_global_presign_config`].
     genesis_global_presign_config: GenesisGlobalPresignConfig,
+    /// Boot every validator AND the notifier from an old-style (1.1.8-shape)
+    /// config: `sui-rpc-url` only, no `sui-data-source`, no trust anchor —
+    /// the deprecated JSON-RPC transport every mainnet node runs on rollout
+    /// day. Rehearses the legacy path end-to-end on the new binary.
+    legacy_sui_config: bool,
 }
 
 impl ClusterBuilder {
@@ -141,6 +146,7 @@ impl ClusterBuilder {
             sui_binary,
             base_dir: None,
             genesis_global_presign_config: GenesisGlobalPresignConfig::Full,
+            legacy_sui_config: false,
         }
     }
 
@@ -182,6 +188,13 @@ impl ClusterBuilder {
         config: GenesisGlobalPresignConfig,
     ) -> Self {
         self.genesis_global_presign_config = config;
+        self
+    }
+
+    /// Boot the whole cluster (validators + notifier) from old-style
+    /// (1.1.8-shape) configs — `sui-rpc-url` only, the legacy JSON-RPC path.
+    pub fn with_legacy_sui_config(mut self) -> Self {
+        self.legacy_sui_config = true;
         self
     }
 
@@ -289,10 +302,20 @@ impl ClusterBuilder {
         // set refuses to boot without a Sui trust anchor. Seed every validator
         // with the Sui localnet's epoch-0 committee as the `unsafe_genesis_committee`
         // anchor (the private-net path), mirroring IkaTestClusterBuilder. Harmless
-        // pre-v4 (the field is unused on the JSON-RPC path).
-        let genesis_committee = ika_sui_client::anchor::fetch_genesis_committee(&rpc_url)
-            .await
-            .map_err(|e| anyhow::anyhow!("fetch Sui genesis committee for OCS anchor: {e}"))?;
+        // pre-v4 (the field is unused on the JSON-RPC path). A legacy-config
+        // cluster gets NO anchor at all — an old-style config with an anchor is
+        // one of the mixed shapes the node rejects at boot.
+        let genesis_committee = if self.legacy_sui_config {
+            None
+        } else {
+            Some(
+                ika_sui_client::anchor::fetch_genesis_committee(&rpc_url)
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!("fetch Sui genesis committee for OCS anchor: {e}")
+                    })?,
+            )
+        };
 
         // 4. Per-validator NodeConfig on a persistent data dir, written to YAML.
         // Bound every co-located node's crypto rayon pool to a fair share of the
@@ -311,9 +334,11 @@ impl ClusterBuilder {
         for (i, init) in validator_init_configs.iter().enumerate() {
             let data_dir = base.join(format!("validator-{i}"));
             std::fs::create_dir_all(&data_dir)?;
-            let mut builder = ValidatorConfigBuilder::new()
-                .with_config_directory(data_dir.clone())
-                .with_unsafe_genesis_committee(genesis_committee.clone());
+            let mut builder = ValidatorConfigBuilder::new().with_config_directory(data_dir.clone());
+            builder = match &genesis_committee {
+                Some(committee) => builder.with_unsafe_genesis_committee(committee.clone()),
+                None => builder.with_legacy_sui_rpc_only(),
+            };
             if let Some(cores) = max_mpc_computation_cores {
                 builder = builder.with_max_mpc_computation_cores(cores);
             }
@@ -344,20 +369,23 @@ impl ClusterBuilder {
         let notifier_dir = base.join("notifier");
         std::fs::create_dir_all(&notifier_dir)?;
         let mut notifier_rng = OsRng;
-        let notifier_config = FullnodeConfigBuilder::new()
-            .with_config_directory(notifier_dir.clone())
-            .build(
-                &mut notifier_rng,
-                &validator_init_configs,
-                rpc_url.clone(),
-                ika_package_id,
-                ika_common_package_id,
-                ika_dwallet_2pc_mpc_package_id,
-                ika_system_package_id,
-                ika_system_object_id,
-                ika_dwallet_coordinator_object_id,
-                Some(publisher_keypair.copy()),
-            );
+        let mut notifier_builder =
+            FullnodeConfigBuilder::new().with_config_directory(notifier_dir.clone());
+        if self.legacy_sui_config {
+            notifier_builder = notifier_builder.with_legacy_sui_rpc_only();
+        }
+        let notifier_config = notifier_builder.build(
+            &mut notifier_rng,
+            &validator_init_configs,
+            rpc_url.clone(),
+            ika_package_id,
+            ika_common_package_id,
+            ika_dwallet_2pc_mpc_package_id,
+            ika_system_package_id,
+            ika_system_object_id,
+            ika_dwallet_coordinator_object_id,
+            Some(publisher_keypair.copy()),
+        );
         let notifier = spawn_node(
             usize::MAX,
             self.notifier_binary.clone(),

--- a/crates/ika-upgrade-test/src/scenario.rs
+++ b/crates/ika-upgrade-test/src/scenario.rs
@@ -179,6 +179,12 @@ pub struct Scenario {
     /// these; joiners added via `join_validator_mirrored` mirror through them
     /// too. Empty (default) = every validator reads Sui directly.
     pub direct_validators: Vec<usize>,
+    /// Boot the whole cluster (validators + notifier) from old-style
+    /// (1.1.8-shape) configs: `sui-rpc-url` only, no `sui-data-source`, no
+    /// trust anchor — the deprecated JSON-RPC transport every mainnet node
+    /// runs on rollout day. Not compatible with `direct_validators` or
+    /// mirrored joiners (those require `sui-data-source`).
+    pub legacy_sui_config: bool,
 }
 
 impl Scenario {
@@ -201,7 +207,15 @@ impl Scenario {
             ika_cli: None,
             genesis_global_presign_config: GenesisGlobalPresignConfig::Full,
             direct_validators: Vec::new(),
+            legacy_sui_config: false,
         }
+    }
+
+    /// Boot the whole cluster from old-style (1.1.8-shape) configs — the
+    /// legacy JSON-RPC path for every role. See the field doc.
+    pub fn with_legacy_sui_config(mut self) -> Self {
+        self.legacy_sui_config = true;
+        self
     }
 
     /// Path to the `ika` CLI binary; required by `run_workload` steps.
@@ -394,6 +408,9 @@ impl Scenario {
                     .with_epoch_duration_ms(self.epoch_duration_ms)
                     .with_genesis_protocol_version(ProtocolVersion::MIN)
                     .with_genesis_global_presign_config(self.genesis_global_presign_config);
+                    if self.legacy_sui_config {
+                        builder = builder.with_legacy_sui_config();
+                    }
                     if let Some(dir) = &self.base_dir {
                         builder = builder.with_base_dir(dir.clone());
                     }

--- a/crates/ika-upgrade-test/tests/legacy_config.rs
+++ b/crates/ika-upgrade-test/tests/legacy_config.rs
@@ -1,0 +1,124 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Rollout-day config rehearsal: the **new binary on old-style (1.1.8-shape)
+//! configs** — `sui-rpc-url` only, no `sui-data-source`, no trust anchor —
+//! for **every role**: all four validators AND the notifier run the
+//! deprecated legacy JSON-RPC transport. That is literally what every
+//! mainnet node runs the moment its binary is swapped: operators upgrade the
+//! binary, not the YAML.
+//!
+//! No other harness covers this: every other scenario's config builder
+//! writes `sui-data-source` (gRPC) for validators and the notifier alike, so
+//! a regression confined to the legacy path — validator MPC event ingestion
+//! over JSON-RPC `query_events`, or notifier checkpoint/`advance_epoch`
+//! submission over the JSON-RPC quorum driver — would ship invisibly.
+//!
+//! What one green run proves, in order:
+//! - the new binary **boots** from an old-style YAML in Validator and
+//!   Notifier modes (config parsing + transport selection);
+//! - the genesis network DKG completes and epochs advance — i.e. the
+//!   legacy-path notifier actually submits checkpoints and `advance_epoch`
+//!   over JSON-RPC (epoch advance is impossible without it);
+//! - a full DKG → Presign → Sign lifecycle completes at protocol v3 — the
+//!   exact post-swap, pre-upgrade mainnet state;
+//! - the **capability vote advances v3 → v4 on legacy configs**, answering
+//!   an open rollout-sequencing question: operators do NOT have to migrate
+//!   to `sui-data-source` before the v4 activation vote (off-chain metadata
+//!   is p2p; the legacy event path serves MPC events at v4 the same way);
+//! - the lifecycle still completes at v4 on the legacy transport.
+//!
+//! Genesis is v3 and the vote advances to v4 mid-scenario (same structure as
+//! the `workload` scenario) — so both sides of the activation boundary run
+//! on the legacy transport.
+//!
+//! Opt-in via `RUN_LEGACY_CONFIG=1`:
+//!
+//! ```bash
+//! RUN_LEGACY_CONFIG=1 \
+//!   IKA_VALIDATOR_BIN=target/release/ika-validator \
+//!   IKA_NOTIFIER_BIN=target/release/ika-notifier \
+//!   IKA_BIN=target/release/ika \
+//!   SUI_BIN=$(which sui) \
+//!   cargo test --release -p ika-upgrade-test --test legacy_config -- --nocapture
+//! ```
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ika_upgrade_test::binary::BinarySpec;
+use ika_upgrade_test::scenario::Scenario;
+
+fn bin_from_env(var: &str, default: &str) -> PathBuf {
+    PathBuf::from(std::env::var(var).unwrap_or_else(|_| default.to_string()))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn legacy_config_full_lifecycle_across_v4_activation() {
+    if std::env::var("RUN_LEGACY_CONFIG").is_err() {
+        eprintln!("skipping: set RUN_LEGACY_CONFIG=1 to run the legacy-config rehearsal");
+        return;
+    }
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
+        .with_log_level("info")
+        .with_env()
+        .init();
+
+    let validator = BinarySpec::Path(bin_from_env(
+        "IKA_VALIDATOR_BIN",
+        "target/release/ika-validator",
+    ));
+    let notifier = bin_from_env("IKA_NOTIFIER_BIN", "target/release/ika-notifier");
+    let ika_cli = bin_from_env("IKA_BIN", "target/release/ika");
+    let sui = bin_from_env("SUI_BIN", "sui");
+    // Only used to resolve git-ref binaries; this test uses a path binary.
+    let repo = std::env::current_dir()
+        .expect("cwd")
+        .ancestors()
+        .nth(2)
+        .expect("workspace root")
+        .to_path_buf();
+    let base = PathBuf::from(
+        std::env::var("UPGRADE_TEST_DIR")
+            .unwrap_or_else(|_| "/mnt/nvme0n1p1/tmp/ika-legacy-config-test".to_string()),
+    );
+    let _ = std::fs::remove_dir_all(&base);
+
+    // 5-minute epochs: the flow runs a workload on BOTH sides of the v3→v4
+    // boundary, so each epoch needs room for a full lifecycle plus its own
+    // reconfiguration window.
+    let epoch_duration_ms = std::env::var("EPOCH_DURATION_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(300_000);
+
+    // - wait_for_epoch(2): the counter reaching 2 is the signal the genesis
+    //   network DKG finished — already proof the legacy-path notifier
+    //   submits (no epoch advances without it).
+    // - run_workload("legacy-v3"): full lifecycle in the post-swap,
+    //   pre-upgrade mainnet state (global presign served the 1.1.8 way).
+    // - set_buffer_stake(0): with n=4 the default 50% buffer requires all
+    //   four capability votes; drop to a bare quorum so the v3→v4 vote
+    //   tallies at the next boundary.
+    // - wait_for_epoch(4): crosses the upgrade boundary (4, not 3: the
+    //   v3 workload may straddle the epoch-2→3 boundary, and the vote
+    //   tallies at the first boundary after the buffer drop).
+    // - run_workload("legacy-v4"): the lifecycle keeps working at v4 on the
+    //   legacy transport.
+    Scenario::new(4, repo, sui, notifier)
+        .with_base_dir(base)
+        .with_epoch_duration_ms(epoch_duration_ms)
+        .with_epoch_timeout(Duration::from_secs(1200))
+        .with_ika_cli(ika_cli)
+        .with_legacy_sui_config()
+        .start_all(validator)
+        .wait_for_epoch(2)
+        .run_workload("legacy-v3")
+        .set_buffer_stake(0)
+        .wait_for_epoch(4)
+        .expect_protocol_version_at_least(4)
+        .run_workload("legacy-v4")
+        .run()
+        .await
+        .expect("legacy-config rehearsal: full lifecycle on the legacy JSON-RPC path, across the v4 activation");
+}


### PR DESCRIPTION
The second half of release-review finding G5 ([report](https://github.com/dwallet-labs/ika/pull/1787#issuecomment-4862501346)): a CI scenario that rehearses the **actual rollout-day shape** — the new binary booting from old-style (1.1.8-shape) YAMLs. **Depends on #1791** (this branch is based on it); mergeable once that lands.

## Why

Operators upgrade the binary, not the YAML: on rollout day every mainnet node — validators *and* the notifier — runs `sui-rpc-url`-only configs on the legacy JSON-RPC transport. No harness covered that: every existing scenario's config builder writes `sui-data-source` (gRPC) for all roles, so a regression confined to the legacy path (validator MPC event ingestion over `query_events`, or notifier checkpoint/`advance_epoch` submission over the JSON-RPC quorum driver) would ship invisibly. This is also the scenario that would have caught the transport flip #1791 fixes, had it existed.

## The scenario — `legacy_config`

`Scenario::with_legacy_sui_config()` boots all four validators **and the notifier** from old-style configs (no `sui-data-source`, no trust anchor), then:

1. `wait_for_epoch(2)` — genesis network DKG completes; epochs advancing at all is proof the legacy-path notifier submits (nothing advances without it);
2. `run_workload("legacy-v3")` — full DKG → Presign → Sign at protocol v3: the exact post-swap, pre-upgrade mainnet state;
3. buffer drop → `wait_for_epoch(4)` → `expect_protocol_version_at_least(4)` — **the v3→v4 capability vote succeeds on legacy configs**, settling a real rollout-sequencing question: operators do not need to migrate to `sui-data-source` before the v4 activation vote;
4. `run_workload("legacy-v4")` — the lifecycle keeps working at v4 on the legacy transport.

## Mechanics

- `ValidatorConfigBuilder`/`FullnodeConfigBuilder` gain `with_legacy_sui_rpc_only()`: emit `sui_rpc_url: Some(url)` + `sui_data_source: None` (the exact 1.1.8 YAML shape). All other callers unchanged.
- `ClusterBuilder::with_legacy_sui_config()` threads it to every validator and the notifier, and skips the OCS genesis-committee anchor seeding (an old-style config with an anchor is one of the mixed shapes the node rejects at boot — correctly fail-loud).
- Workflow: `legacy_config` added to the scenario matrix (`all` now fans six jobs), env gate `RUN_LEGACY_CONFIG`, no OLD binary needed (current-build-only, like `smoke`/`workload`).

## Follow-up once #1790 also lands

One-liner hardening: bracket the `legacy-v3` workload with `expect_protocol_version_at_most(3)` (the ceiling step #1790 introduces) so timing drift can't silently degrade the v3 leg into a second v4 run. In practice the window holds — at n=4 the default 50% buffer stake requires all four capability votes at the tally, which is exactly why the flow drops the buffer only *after* the v3 workload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
