### PR TITLE
docs(playbook): map the #1736 epoch-entry wedge to the gate diagnostic

### DIFF
--- a/dev-docs/playbooks/mpc-stall-postmortem.md
+++ b/dev-docs/playbooks/mpc-stall-postmortem.md
@@ -52,18 +52,52 @@ results sent into a dead handle). Per-validator attribution: re-run with
 sit Active means computations are not SPAWNING — different class than
 hanging.
 
-## 3. Epoch-entry key gap (the stale-mpc_data race, issue #1736)
+## 3. Epoch-entry wedge — "locked but can't close" (issue #1736)
+
+The epoch committed to closing (the last user session is locked) but
+never advances. Start at the end-of-publish gate, which names the
+blocker directly:
 
 ```bash
-grep "Adopted network key epoch does not match" $L | sed -E 's/^([^ ]+).*name=(k#[a-f0-9]{8}).*/\1 \2/'
-grep "Updating network key" $L | sed -E 's/^([^ ]+).*name=(k#[a-f0-9]{8}).*/\1 \2/' | tail -8
+grep "end-of-publish gate STUCK" $L | tail -3              # post-lock stall, re-warned every 60s
+grep "end-of-publish gate not yet satisfied" $L | tail -1  # same per-condition breakdown at debug
 ```
 
-Historically: exactly ONE rejection warn per epoch boundary is routine —
-that validator's presign sessions may be silently dead all epoch
-(invisible at 3-of-4 quorum). TWO at one boundary = quorum death for
-internal presigns = pool starvation = the wedge. Check whether sessions
-created during a validator's key gap ever compute afterwards.
+The gate prints every advance condition as a bool; the `false` one is
+the wedge. (The warn fires only *after* the session lock — pre-lock the
+gate is legitimately unsatisfied for most of the epoch, so it isn't
+counted.) The three roots seen for #1736, keyed by which field is false:
+
+- **`next_epoch_committee_exists=false` — stale System committee anchor.**
+  The notifier writes `next_epoch_committee` on-chain mid-epoch, but each
+  validator reads the `System` inner through the always-cache anchor
+  path, which historically had no staleness bound and served the
+  pre-write snapshot forever, so the new committee was never observed and
+  reconfiguration never started. Fixed by bounding the anchor cache: it
+  forces a verified network re-read on a miss *and* at most once per
+  `ANCHOR_REFRESH_INTERVAL` (2 s) — see `verified_anchor_object` in
+  `sui_connector/verified_reader.rs` and the cache-fast-path section of
+  `../specs/ocs-verified-sui-reads.md`. Confirm by reading the on-chain
+  `next_epoch_committee` (it is set) while the gate still reports it
+  absent.
+- **`all_network_encryption_keys_reconfiguration_completed=false` —
+  reconfiguration MPC stalled.** The network-key reconfiguration never
+  finishes. One cause was a synchronous VSS-cache derive
+  (`derive_vss_shamir_cache_for_key`) running inline on the async runtime
+  and starving every other task on that thread; it is now offloaded to
+  rayon (`network_dkg.rs`). When this field is false, trace the
+  reconfiguration session (check 6) and watch CPU (check 2) — a frozen
+  single thread reads as "Active but zero CPU".
+- **network-key adoption gap (the original stale-mpc_data variant).**
+  ```bash
+  grep "Adopted network key epoch does not match" $L | sed -E 's/^([^ ]+).*name=(k#[a-f0-9]{8}).*/\1 \2/'
+  grep "Updating network key" $L | sed -E 's/^([^ ]+).*name=(k#[a-f0-9]{8}).*/\1 \2/' | tail -8
+  ```
+  Exactly ONE rejection warn per epoch boundary is routine — that
+  validator's presign sessions may be silently dead all epoch (invisible
+  at 3-of-4 quorum). TWO at one boundary = quorum death for internal
+  presigns = pool starvation = the wedge. Check whether sessions created
+  during a validator's key gap ever compute afterwards.
 
 ## 4. Chain counters — the over/undershoot discriminator
 

--- a/dev-docs/playbooks/mpc-stall-postmortem.md
+++ b/dev-docs/playbooks/mpc-stall-postmortem.md
@@ -66,7 +66,8 @@ grep "end-of-publish gate not yet satisfied" $L | tail -1  # same per-condition 
 The gate prints every advance condition as a bool; the `false` one is
 the wedge. (The warn fires only *after* the session lock — pre-lock the
 gate is legitimately unsatisfied for most of the epoch, so it isn't
-counted.) The three roots seen for #1736, keyed by which field is false:
+counted.) The roots seen for #1736, keyed by which field is false
+(first three fixed, the last still open):
 
 - **`next_epoch_committee_exists=false` — stale System committee anchor.**
   The notifier writes `next_epoch_committee` on-chain mid-epoch, but each
@@ -98,6 +99,26 @@ counted.) The three roots seen for #1736, keyed by which field is false:
   at 3-of-4 quorum). TWO at one boundary = quorum death for internal
   presigns = pool starvation = the wedge. Check whether sessions created
   during a validator's key gap ever compute afterwards.
+- **`all_epoch_sessions_finished=false` — a locked user session that is
+  never re-pulled (the still-OPEN core of #1736).** All other gate
+  conditions read true; the epoch locked its last user session and simply
+  waits for a session that never computes. A session held at the lock
+  boundary logs a "holding … re-pulled next epoch otherwise" line with
+  its `session_sequence_number`, then never reappears — the promised
+  next-epoch re-pull does not fire.
+  ```bash
+  grep -E "holding .*re-pulled next epoch" $L | tail -3   # the held session + its seq
+  # then confirm that seq never returns (no completion, no re-pull):
+  grep "session_sequence_number=<SEQ>" $L
+  ```
+  A second, correlated signature at every epoch entry: a burst of
+  `FailedToAdvanceMPC(InvalidParameters)` in `compute_presign` round 1
+  with `should_never_happen=true`, VSS algorithms only, never retried to
+  quorum — the internal-presign refill sessions created inside the
+  epoch-entry key gap. Unlike the three roots above (all fixed), this one
+  has no fix yet; the healthy-vs-wedged discriminator and the standing
+  evidence are on issue #1736. Diagnosis needs a FAILING instrumented run
+  (most runs are healthy) — the captured one is CI run 28577745311.
 
 ## 4. Chain counters — the over/undershoot discriminator
 


### PR DESCRIPTION
## Summary

Updates the MPC-stall post-mortem playbook's #1736 section. It only covered the
network-key adoption-gap variant and predated both the end-of-publish **gate
STUCK diagnostic** (from #1778) and the two roots fixed in the #1736 stack
(#1779 anchor-staleness escape, #1780 VSS rayon offload).

Rewrites section 3 to lead with the gate breakdown — the `false` advance
condition names the wedge — and keys the three known roots off it:

- `next_epoch_committee_exists = false` → stale System committee anchor (bounded
  by `ANCHOR_REFRESH_INTERVAL` in `verified_reader.rs`).
- `all_network_encryption_keys_reconfiguration_completed = false` →
  reconfiguration MPC stalled (inline VSS derive offloaded to rayon in
  `network_dkg.rs`).
- network-key adoption gap (the original stale-`mpc_data` variant, kept).

Docs-only; the diagnostic + both fixes are already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)