### PR TITLE
fix(dwallet-mpc): gate v3 wire behavior for the 1.1.8 rolling upgrade (G2+G3)

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations.rs
@@ -142,7 +142,9 @@ impl ProtocolCryptographicData {
                     access_structure,
                     consensus_round,
                     schnorr_presign_second_round_delay,
-                    protocol_config.schnorr_presign_third_round_delay(),
+                    protocol_config
+                        .schnorr_presign_third_round_delay_as_option()
+                        .unwrap_or(0),
                     serialized_messages_by_consensus_round,
                 )?;
 
@@ -167,7 +169,9 @@ impl ProtocolCryptographicData {
                     access_structure,
                     consensus_round,
                     schnorr_presign_second_round_delay,
-                    protocol_config.schnorr_presign_third_round_delay(),
+                    protocol_config
+                        .schnorr_presign_third_round_delay_as_option()
+                        .unwrap_or(0),
                     serialized_messages_by_consensus_round,
                 )?;
 

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/presign.rs
@@ -80,6 +80,18 @@ pub(crate) enum PresignAdvanceRequestByProtocol {
     ),
 }
 
+/// Builds the per-MPC-round consensus-delay map, OMITTING zero-valued
+/// entries. A zero delay must produce the exact map 1.1.8 passed (no entry
+/// at all, `HashMap::new()`), not an explicit `(round, 0)` — the map crosses
+/// into the crypto crate's `ready_to_advance`, and byte-identical v3
+/// behavior must not depend on how that side treats an explicit zero.
+fn round_delays<const N: usize>(entries: [(u64, u64); N]) -> HashMap<u64, u64> {
+    entries
+        .into_iter()
+        .filter(|(_, delay)| *delay > 0)
+        .collect()
+}
+
 impl PresignAdvanceRequestByProtocol {
     pub fn try_new(
         protocol: &DWalletSignatureAlgorithm,
@@ -112,7 +124,7 @@ impl PresignAdvanceRequestByProtocol {
                     party_id,
                     access_structure,
                     consensus_round,
-                    HashMap::from([(2, schnorr_presign_second_round_delay)]),
+                    round_delays([(2, schnorr_presign_second_round_delay)]),
                     &serialized_messages_by_consensus_round,
                 )?;
 
@@ -125,7 +137,7 @@ impl PresignAdvanceRequestByProtocol {
                     party_id,
                     access_structure,
                     consensus_round,
-                    HashMap::from([(2, schnorr_presign_second_round_delay)]),
+                    round_delays([(2, schnorr_presign_second_round_delay)]),
                     &serialized_messages_by_consensus_round,
                 )?;
 
@@ -138,7 +150,7 @@ impl PresignAdvanceRequestByProtocol {
                     party_id,
                     access_structure,
                     consensus_round,
-                    HashMap::from([(2, schnorr_presign_second_round_delay)]),
+                    round_delays([(2, schnorr_presign_second_round_delay)]),
                     &serialized_messages_by_consensus_round,
                 )?;
 
@@ -166,7 +178,7 @@ impl PresignAdvanceRequestByProtocol {
                     party_id,
                     access_structure,
                     consensus_round,
-                    HashMap::from([
+                    round_delays([
                         (2, schnorr_presign_second_round_delay),
                         (3, schnorr_presign_third_round_delay),
                     ]),
@@ -182,7 +194,7 @@ impl PresignAdvanceRequestByProtocol {
                     party_id,
                     access_structure,
                     consensus_round,
-                    HashMap::from([
+                    round_delays([
                         (2, schnorr_presign_second_round_delay),
                         (3, schnorr_presign_third_round_delay),
                     ]),
@@ -198,7 +210,7 @@ impl PresignAdvanceRequestByProtocol {
                     party_id,
                     access_structure,
                     consensus_round,
-                    HashMap::from([
+                    round_delays([
                         (2, schnorr_presign_second_round_delay),
                         (3, schnorr_presign_third_round_delay),
                     ]),

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -181,8 +181,12 @@ impl DWalletMPCService {
         let decryption_key_reconfiguration_third_round_delay =
             protocol_config.decryption_key_reconfiguration_third_round_delay();
 
-        let schnorr_presign_second_round_delay =
-            protocol_config.schnorr_presign_second_round_delay();
+        // None below protocol v4 — external Schnorr presigns at v3 must
+        // advance exactly like 1.1.8 (no delay); 0 entries are omitted from
+        // the delay map entirely.
+        let schnorr_presign_second_round_delay = protocol_config
+            .schnorr_presign_second_round_delay_as_option()
+            .unwrap_or(0);
 
         let max_mpc_computation_cores = node_config.max_mpc_computation_cores;
         let root_seed = match node_config.root_seed_key_pair {
@@ -653,7 +657,16 @@ impl DWalletMPCService {
 
         // Check if there's anything new to send.
         let has_unsent_requests = !unsent_presign_requests.is_empty();
-        let idle_status_changed = self.last_sent_idle_status != Some(is_idle);
+        // Wire gate for the rolling-upgrade window: `IdleStatusUpdate` is a
+        // consensus transaction kind introduced with internal presign
+        // sessions. A 1.1.8 peer cannot decode it — its `verify_batch`
+        // rejects the WHOLE block containing one, and its replay path panics
+        // on an undecodable sequenced transaction — so it must never reach
+        // the wire while the network runs a protocol version whose peers may
+        // predate the kind. Same flag that gates the DB write and read
+        // streams for these updates.
+        let idle_status_changed = self.protocol_config.internal_presign_sessions_enabled()
+            && self.last_sent_idle_status != Some(is_idle);
         let observation_changed = sui_chain_observation != self.last_sent_sui_chain_observation;
         let has_noa_observations = !self.buffered_noa_observations.is_empty();
 

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/idle_status_voting.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/idle_status_voting.rs
@@ -7,6 +7,7 @@ use crate::dwallet_mpc::integration_tests::utils::{
 };
 use dwallet_mpc_types::dwallet_mpc::{DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm};
 use ika_protocol_config::ProtocolConfig;
+use ika_types::messages_consensus::ConsensusTransactionKind;
 use tracing::info;
 
 /// Creates a protocol config override guard tuned for the idle-status lifecycle test.
@@ -649,4 +650,70 @@ async fn test_split_idle_status_vote_does_not_reach_consensus() {
     );
 
     info!("Test passed: 2-2 split idle status vote does not reach consensus");
+}
+
+/// The wire gate for the rolling 1.1.8-upgrade window: below the
+/// internal-presign activation (protocol v3 — the live mainnet state) the
+/// service must NEVER submit an `IdleStatusUpdate` consensus transaction.
+/// A 1.1.8 peer cannot decode that kind: its `verify_batch` rejects the
+/// whole block containing one, and its replay path panics on an
+/// undecodable sequenced transaction — one emission during the restart
+/// window is a consensus-layer interop break, regardless of the feature
+/// being unused. Without the gate this fails on the FIRST iteration:
+/// `last_sent_idle_status` starts `None`, so the ungated service submits
+/// an update immediately after start.
+#[tokio::test]
+#[cfg(test)]
+async fn test_no_idle_status_update_emitted_below_activation() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_version, mut config| {
+        config.set_internal_presign_sessions_for_testing(false);
+        config
+    });
+
+    let mut test_state = build_test_state(4);
+    let (consensus_round, _network_key_bytes, _network_key_id) =
+        create_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+
+    for _round in 0..10 {
+        for service in test_state.dwallet_mpc_services.iter_mut() {
+            service.run_service_loop_iteration(vec![]).await;
+        }
+        // Wire-level assertion, checked BEFORE this round's messages are
+        // drained for distribution: nothing submitted may be an
+        // IdleStatusUpdate.
+        for (validator, collector) in test_state
+            .sent_consensus_messages_collectors
+            .iter()
+            .enumerate()
+        {
+            let submitted = collector.submitted_messages.lock().unwrap();
+            assert!(
+                !submitted.iter().any(|message| matches!(
+                    &message.kind,
+                    ConsensusTransactionKind::IdleStatusUpdate(_)
+                )),
+                "validator {validator} submitted an IdleStatusUpdate below the \
+                 internal-presign activation — a 1.1.8 peer cannot decode it"
+            );
+        }
+        utils::send_advance_results_between_parties(
+            &test_state.committee,
+            &mut test_state.sent_consensus_messages_collectors,
+            &mut test_state.epoch_stores,
+            test_state.consensus_round as u64,
+        );
+        test_state.consensus_round += 1;
+    }
+
+    // And none may have reached any epoch store.
+    for (validator, epoch_store) in test_state.epoch_stores.iter().enumerate() {
+        let updates = epoch_store.round_to_idle_status_updates.lock().unwrap();
+        let total: usize = updates.values().map(|round| round.len()).sum();
+        assert_eq!(
+            total, 0,
+            "validator {validator} received IdleStatusUpdates below the activation"
+        );
+    }
 }

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -640,8 +640,13 @@ impl ProtocolConfig {
             consensus_gc_depth: Some(60),
             // The delay is measured in consensus rounds.
             decryption_key_reconfiguration_third_round_delay: Some(10),
-            schnorr_presign_second_round_delay: Some(8),
-            schnorr_presign_third_round_delay: Some(8),
+            // None below v4: external Schnorr-family presigns are servable at
+            // v3, where 1.1.8 applies no round delay — a base-config value
+            // would make upgraded validators advance round 2 later than 1.1.8
+            // peers on the SAME session during the rolling window, splitting
+            // the output quorum. The delays activate with the v4 arm below.
+            schnorr_presign_second_round_delay: None,
+            schnorr_presign_third_round_delay: None,
             network_dkg_third_round_delay: Some(10),
             network_encryption_key_version: Some(1),
             reconfiguration_message_version: Some(1),
@@ -732,6 +737,9 @@ impl ProtocolConfig {
                     cfg.feature_flags.fast_schnorr_supported = true;
                     cfg.network_encryption_key_version = Some(3);
                     cfg.reconfiguration_message_version = Some(3);
+                    // The delay is measured in consensus rounds.
+                    cfg.schnorr_presign_second_round_delay = Some(8);
+                    cfg.schnorr_presign_third_round_delay = Some(8);
                 }
                 // 5 => {
                 //     cfg.feature_flags.noa_checkpoints = true;
@@ -1107,6 +1115,10 @@ impl ProtocolConfig {
 
     pub fn set_enforce_checkpoint_timestamp_monotonicity_for_testing(&mut self, val: bool) {
         self.feature_flags.enforce_checkpoint_timestamp_monotonicity = val;
+    }
+
+    pub fn set_internal_presign_sessions_for_testing(&mut self, val: bool) {
+        self.feature_flags.internal_presign_sessions = val;
     }
 }
 

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Mainnet_version_3.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Mainnet_version_3.snap
@@ -22,8 +22,6 @@ consensus_max_num_transactions_in_block: 512
 consensus_max_transactions_in_block_bytes: 315218930
 consensus_gc_depth: 60
 decryption_key_reconfiguration_third_round_delay: 10
-schnorr_presign_second_round_delay: 8
-schnorr_presign_third_round_delay: 8
 network_dkg_third_round_delay: 10
 network_encryption_key_version: 2
 reconfiguration_message_version: 2

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Testnet_version_3.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Testnet_version_3.snap
@@ -22,8 +22,6 @@ consensus_max_num_transactions_in_block: 512
 consensus_max_transactions_in_block_bytes: 315218930
 consensus_gc_depth: 60
 decryption_key_reconfiguration_third_round_delay: 10
-schnorr_presign_second_round_delay: 8
-schnorr_presign_third_round_delay: 8
 network_dkg_third_round_delay: 10
 network_encryption_key_version: 2
 reconfiguration_message_version: 2

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__version_3.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__version_3.snap
@@ -22,8 +22,6 @@ consensus_max_num_transactions_in_block: 512
 consensus_max_transactions_in_block_bytes: 315218930
 consensus_gc_depth: 60
 decryption_key_reconfiguration_third_round_delay: 10
-schnorr_presign_second_round_delay: 8
-schnorr_presign_third_round_delay: 8
 network_dkg_third_round_delay: 10
 network_encryption_key_version: 2
 reconfiguration_message_version: 2


### PR DESCRIPTION
Two protocol-v3 interop fixes for the 1.1.8 → 1.2.0 rolling upgrade (findings G2 and G3 in the [release review](https://github.com/dwallet-labs/ika/pull/1787#issuecomment-4862501346)). Both share one root cause: a value/message that must not exist on the v3 wire is live at v3.

## G2 — gate the `IdleStatusUpdate` consensus emission

`send_status_update_to_consensus` emitted `IdleStatusUpdate` whenever the idle flag changed, with **no protocol gate**. `last_sent_idle_status` starts `None`, so the first service-loop iteration after every restart submits the transaction — at v3, unconditionally. A 1.1.8 peer cannot decode that consensus-transaction kind: its `verify_batch` rejects the **whole block** containing one, and its replay path **panics** on an undecodable sequenced transaction. During the rolling restart that is a consensus-layer interop break, regardless of the feature being unused at v3.

Fix: gate the emission on `internal_presign_sessions_enabled()` — the same flag that already gates this feature's DB write and read streams (`authority_per_epoch_store.rs`, `dwallet_mpc_service.rs`); this one wire emission was the single missed site.

## G3 — move the Schnorr presign round delay out of the base config

`schnorr_presign_second_round_delay: Some(8)` lived in the **base** protocol config, visible at v3. It is applied by signature algorithm, not session type — so it hit plain **Taproot / Schnorrkel / EdDSA external presigns**, which are user-requestable and served at v3 today. 1.1.8 has no such parameter (zero delay). During the mixed window an upgraded validator would advance round 2 of the *same* presign session 8 consensus rounds later than a 1.1.8 peer → divergent message sets → byte-divergent outputs → output-quorum split (this codebase's false-malicious / stall failure class). It is also a v3 latency change even post-swap.

Fix: `None` in the base config for both the second- and third-round delays; `Some(8)` in the `4 =>` arm (the pool — the delays' actual purpose — is v4-only). Consumers read `*_as_option().unwrap_or(0)`. The delay map is now built by a `round_delays()` helper that **omits zero-valued entries**, so a v3 presign passes `HashMap::new()` to the crypto layer — byte-identical to 1.1.8, not an explicit `(round, 0)`.

## Snapshots

`Mainnet/Testnet/version _3` snapshots drop both delay lines; `_4` snapshots keep `8`. This is the intended, reviewable effect of the gating — v3's protocol-config shape moves back toward 1.1.8.

## Testing

- New `test_no_idle_status_update_emitted_below_activation` (idle_status_voting.rs): with `internal_presign_sessions=false`, runs 10 service-loop iterations across 4 validators and asserts **no** `IdleStatusUpdate` is ever submitted to consensus nor reaches any epoch store. **Fault-injected per the test-testing rule**: reverting the G2 gate makes it fail on the first iteration (ungated emission fires immediately because `last_sent_idle_status` starts `None`), confirming it guards the real property; reverted.
- `ika-protocol-config` snapshot tests updated and green; existing idle-status suite (3 tests) still green; clippy clean.

Gates the 1.2.0 release together with G1 (the V1-anchor fix, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
