### PR TITLE
fix(dwallet-mpc): handle the deployed V1 network-DKG anchor on the v3 reconfiguration path (G1)

### DIFF
--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -996,9 +996,10 @@ pub fn network_key_version_inner(
         bcs::from_bytes(&network_dkg_public_output)?;
 
     match &network_dkg_public_output {
-        VersionedNetworkDkgOutput::V1(_) => {
-            unreachable!("V1 network DKG outputs are no longer produced")
-        }
+        // A V1 anchor is genuinely version 1: the deployed mainnet/testnet
+        // keys still carry it on chain, and this is a WASM export the SDK
+        // calls with real chain bytes.
+        VersionedNetworkDkgOutput::V1(_) => Ok(1),
         VersionedNetworkDkgOutput::V2(_) => Ok(2),
         VersionedNetworkDkgOutput::V3(_) => Ok(3),
     }
@@ -1155,9 +1156,9 @@ fn protocol_public_parameters(
         bcs::from_bytes(&network_dkg_public_output)?;
 
     match &network_dkg_public_output {
-        VersionedNetworkDkgOutput::V1(_) => {
-            unreachable!("V1 network DKG outputs are no longer produced")
-        }
+        VersionedNetworkDkgOutput::V1(_) => Err(anyhow::anyhow!(
+            "deriving protocol public parameters directly from a V1 network DKG anchor              is not supported; derive from the reconfiguration output instead"
+        )),
         VersionedNetworkDkgOutput::V2(network_dkg_public_output) => {
             // bwd-compat (mainnet-v1.1.8) DKG output shape.
             let network_dkg_public_output: <twopc_mpc::decentralized_party_backward_compatible::dkg::Party as mpc::Party>::PublicOutput =
@@ -1214,7 +1215,9 @@ fn protocol_public_parameters_from_reconfiguration_output(
 
     match &reconfiguration_dkg_public_output {
         VersionedDecryptionKeyReconfigurationOutput::V1(_) => {
-            unreachable!("V1 reconfiguration outputs are no longer produced")
+            return Err(anyhow::anyhow!(
+                "V1 reconfiguration outputs are no longer supported"
+            ));
         }
         VersionedDecryptionKeyReconfigurationOutput::V2(public_output_bytes) => {
             // bwd-compat reconfig output shape.

--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -473,11 +473,13 @@ pub enum VersionedSignOutput {
 
 /// Wire-tagged network-DKG public output.
 ///
-/// - `V1` — previously-deployed shape; the raw
-///   `class_groups::dkg::PublicOutput` (no decentralized-party wrapper). Never
-///   produced anymore — mainnet has been migrated past this version — but the
-///   variant is retained so BCS variant indices of `V2` and `V3` stay stable
-///   for already-stored outputs.
+/// - `V1` — the raw `class_groups::dkg::PublicOutput` (no decentralized-party
+///   wrapper), written by a pre-1.1.8 binary. No longer PRODUCED, but the
+///   deployed mainnet/testnet anchors are still V1-tagged on chain (the anchor
+///   is written once at DKG and never rewritten — reconfiguration writes a
+///   separate field), so this variant is still READ on every reconfiguration.
+///   The variant order is also load-bearing for BCS: it keeps the `V2`/`V3`
+///   variant indices stable for already-stored outputs.
 /// - `V2` — bytes from
 ///   `twopc_mpc::decentralized_party_backward_compatible::dkg::Party::PublicOutput`,
 ///   which after the upstream `PublicOutputCore` extraction is a re-export of

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -190,9 +190,10 @@ async fn get_decryption_key_shares_from_public_output(
         let res = match shares.state() {
             NetworkDecryptionKeyPublicOutputType::NetworkDkg => {
                 match &shares.network_dkg_output() {
-                    VersionedNetworkDkgOutput::V1(_) => {
-                        unreachable!("V1 network DKG outputs are no longer produced")
-                    }
+                    VersionedNetworkDkgOutput::V1(_) => Err(DwalletMPCError::InternalError(
+                        "V1 network DKG anchors are not supported on the initial-DKG                          instantiation path (deployed keys instantiate from their                          reconfiguration output)."
+                            .to_string(),
+                    )),
                     VersionedNetworkDkgOutput::V2(public_output) => {
                         // mainnet-v1.1.8 / bwd-compat shape — decode under
                         // `bwd_compat_dkg::Party::PublicOutput`.
@@ -231,7 +232,9 @@ async fn get_decryption_key_shares_from_public_output(
                     .unwrap()
                 {
                     VersionedDecryptionKeyReconfigurationOutput::V1(_) => {
-                        unreachable!("V1 reconfiguration outputs are no longer produced")
+                        Err(DwalletMPCError::InternalError(
+                            "V1 reconfiguration outputs are no longer supported.".to_string(),
+                        ))
                     }
                     VersionedDecryptionKeyReconfigurationOutput::V2(public_output) => {
                         // bwd-compat reconfig output shape.
@@ -1278,9 +1281,10 @@ fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_dkg_public_ou
     }
 
     match &mpc_public_output {
-        VersionedNetworkDkgOutput::V1(_) => {
-            unreachable!("V1 network DKG outputs are no longer produced")
-        }
+        VersionedNetworkDkgOutput::V1(_) => Err(DwalletMPCError::InternalError(
+            "V1 network DKG anchors are not supported on this instantiation path              (deployed keys instantiate from their reconfiguration output)."
+                .to_string(),
+        )),
         VersionedNetworkDkgOutput::V2(public_output_bytes) => {
             // bwd-compat shape — decode under `bwd_compat_dkg::Party::PublicOutput`.
             let public_output: <bwd_compat_dkg::Party as mpc::Party>::PublicOutput =

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -147,9 +147,19 @@ impl ReconfigurationPartyPublicInputGenerator for ReconfigurationParty {
         }
 
         match network_dkg_public_output {
-            VersionedNetworkDkgOutput::V1(_) => {
-                unreachable!("V1 network DKG outputs are no longer produced")
-            }
+            // Deployed keys still carry a V1 anchor on chain. The main (v4)
+            // reconfiguration party does not yet reconstruct its input from a
+            // V1 anchor — that support (and the V2->V3 anchor migration for
+            // these keys) is a tracked follow-up gated behind v4 activation.
+            // Fail the session with a clear error instead of aborting the
+            // process; v4 is not active on any deployed network, so this arm
+            // is unreachable in production until that follow-up lands.
+            VersionedNetworkDkgOutput::V1(_) => Err(DwalletMPCError::InternalError(
+                "The main (v4) reconfiguration path does not yet support a V1 network \
+                 DKG anchor (deployed mainnet/testnet keys); this must be implemented \
+                 before protocol v4 activates on those networks."
+                    .to_string(),
+            )),
             // V2 and V3 DKG outputs differ only in whether the trailing Protocol-0.1
             // `threshold_encryption_to_sharing_output` is present. Decode either shape to a
             // `dkg::PublicOutputCore` and feed it into the same main constructor — covers
@@ -271,8 +281,60 @@ pub(crate) fn reconfiguration_bwd_compat_public_input(
         current_tangible_party_id_to_upcoming(current_committee, upcoming_committee);
 
     match network_dkg_public_output {
-        VersionedNetworkDkgOutput::V1(_) => {
-            unreachable!("V1 network DKG outputs are no longer produced")
+        // The deployed mainnet/testnet network keys were DKG'd by a pre-1.1.8
+        // binary, which wrote a V1-tagged anchor: the raw
+        // `class_groups::dkg::PublicOutput` (no decentralized-party wrapper).
+        // Reconfiguration never rewrites the anchor, so it is still V1 on chain
+        // and is read on every reconfiguration. 1.1.8 handled this shape here;
+        // the anchor's class-groups DKG output feeds straight into
+        // `new_from_reconfiguration_output` (its bcs layout is unchanged across
+        // the crypto bump), alongside the prior V2 reconfiguration output.
+        VersionedNetworkDkgOutput::V1(network_dkg_public_output_bytes) => {
+            match latest_reconfiguration_public_output {
+                // A V1 anchor with no prior reconfiguration output is the pre-
+                // reconfiguration genesis state of a pre-1.1.8 key — which no
+                // deployed key is in (they have all reconfigured), and which
+                // this backward-compatible path cannot bootstrap (the DKG-only
+                // constructor needs the multi-curve output shape a V1 anchor
+                // does not carry). 1.1.8 also errored here.
+                None => Err(DwalletMPCError::InternalError(
+                    "Bwd-compat reconfig with a V1 anchor requires a prior V2 \
+                     reconfiguration output; a V1 anchor with no reconfiguration \
+                     output is unsupported."
+                        .to_string(),
+                )),
+                Some(VersionedDecryptionKeyReconfigurationOutput::V2(
+                    latest_reconfiguration_public_output_bytes,
+                )) => {
+                    let public_output: <bwd_compat_reconfig::Party as mpc::Party>::PublicOutput =
+                        bcs::from_bytes(&latest_reconfiguration_public_output_bytes)?;
+                    bwd_compat_reconfig::PublicInput::new_from_reconfiguration_output(
+                        &current_access_structure,
+                        upcoming_access_structure,
+                        current_encryption_keys_per_crt_prime_and_proofs,
+                        upcoming_encryption_keys_per_crt_prime_and_proofs,
+                        current_tangible_party_id_to_upcoming,
+                        // The V1 anchor IS the class-groups DKG output the
+                        // constructor wants — decode it directly (no wrapper to
+                        // project through, unlike the V2 arm's `.into()`).
+                        bcs::from_bytes(&network_dkg_public_output_bytes)?,
+                        public_output,
+                    )
+                    .map_err(DwalletMPCError::from)
+                }
+                Some(VersionedDecryptionKeyReconfigurationOutput::V1(_)) => {
+                    Err(DwalletMPCError::InternalError(
+                        "V1 reconfiguration outputs are no longer supported.".to_string(),
+                    ))
+                }
+                Some(VersionedDecryptionKeyReconfigurationOutput::V3(_)) => {
+                    Err(DwalletMPCError::InternalError(
+                        "Bwd-compat reconfig requires a prior V2-tagged reconfiguration \
+                         output; got V3."
+                            .to_string(),
+                    ))
+                }
+            }
         }
         VersionedNetworkDkgOutput::V2(network_dkg_public_output_bytes) => {
             let bwd_compat_dkg_public_output: <twopc_mpc::decentralized_party_backward_compatible::dkg::Party as mpc::Party>::PublicOutput =
@@ -305,7 +367,9 @@ pub(crate) fn reconfiguration_bwd_compat_public_input(
                     .map_err(DwalletMPCError::from)
                 }
                 Some(VersionedDecryptionKeyReconfigurationOutput::V1(_)) => {
-                    unreachable!("V1 reconfiguration outputs are no longer produced")
+                    Err(DwalletMPCError::InternalError(
+                        "V1 reconfiguration outputs are no longer supported.".to_string(),
+                    ))
                 }
                 Some(VersionedDecryptionKeyReconfigurationOutput::V3(_)) => Err(
                     DwalletMPCError::InternalError(
@@ -517,7 +581,9 @@ pub(crate) fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_re
 
     match &mpc_public_output {
         VersionedDecryptionKeyReconfigurationOutput::V1(_) => {
-            unreachable!("V1 reconfiguration outputs are no longer produced")
+            return Err(DwalletMPCError::InternalError(
+                "V1 network keys are no longer supported for instantiation.".to_string(),
+            ));
         }
         VersionedDecryptionKeyReconfigurationOutput::V2(public_output_bytes) => {
             // bwd-compat reconfig PublicOutput shape.

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg_bwd_compat.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg_bwd_compat.rs
@@ -22,6 +22,7 @@ use crate::dwallet_mpc::integration_tests::network_dkg::{
 };
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::IntegrationTestState;
+use dwallet_mpc_types::dwallet_mpc::VersionedNetworkDkgOutput;
 use ika_protocol_config::ProtocolConfig;
 use ika_types::committee::Committee;
 use ika_types::message::DWalletCheckpointMessageKind;
@@ -374,4 +375,271 @@ async fn test_v2_to_v3_reconfiguration_migration() {
         "v2→v3 migration reconfiguration should succeed under main Party"
     );
     info!("v2→v3 migration reconfiguration completed");
+}
+
+/// Reconfiguration of a key that carries the DEPLOYED mainnet/testnet anchor
+/// shape: a **V1-tagged network DKG anchor** (a raw `class_groups::dkg::PublicOutput`)
+/// plus a **V2-tagged reconfiguration output**.
+///
+/// Regression test for the panic-abort that used to wedge every deployed
+/// network at its first reconfiguration: `reconfiguration_bwd_compat_public_input`
+/// had `VersionedNetworkDkgOutput::V1(_) => unreachable!()`, so every validator
+/// aborted the moment it read a deployed key's on-chain anchor. The fix adds a
+/// functional V1 arm that decodes the V1 inner bytes directly as the class-groups
+/// DKG output and feeds it, alongside the prior V2 reconfiguration output, to
+/// `bwd_compat_reconfig::PublicInput::new_from_reconfiguration_output`.
+///
+/// Pinned at v2 (= deployed protocol v3, `reconfiguration_message_version == 2`)
+/// for the WHOLE test, so both reconfigurations route through the bwd-compat
+/// builder.
+///
+/// Assertion level: FULL — drives the V1-anchor builder path end to end and
+/// asserts the resulting `RespondDWalletMPCNetworkReconfigurationOutput` is
+/// `!rejected` (not merely that the input builder returns `Ok`).
+#[tokio::test]
+#[cfg(test)]
+async fn test_v1_anchor_bwd_compat_reconfiguration() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let epoch_id = 1;
+
+    // Pin at v2 for the whole test — the deployed-shape path. The guard must
+    // outlive every `create_dwallet_mpc_services_*` call (each snapshots the
+    // `ProtocolConfig` onto its `DWalletMPCManager`), so keep it in scope.
+    let _override = pin_protocol_to_v2_overrides();
+
+    // Share committee + per-validator seeds + off-chain bundles across both
+    // phases so the phase-2 validators hold the same class-groups decryption
+    // keys as phase 1 — they must recover their Shamir shares from phase 1's
+    // reconfiguration output, which was dealt to these exact keys.
+    let (committee, seeds, bundles) = utils::build_committee_with_random_seeds(4);
+
+    // ── Phase 1: network DKG (→ V2 anchor), then ONE reconfiguration to the
+    //    SAME committee (epoch+1, same identities/keys) to obtain a V2-tagged
+    //    reconfiguration output that stays usable by those identities. ───────
+    let (
+        p1_dwallet_mpc_services,
+        p1_sui_data_senders,
+        p1_sent_consensus_messages_collectors,
+        p1_epoch_stores,
+        p1_notify_services,
+        p1_noa_sign_request_senders,
+        p1_noa_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services_with_committee_and_seeds(
+        committee.clone(),
+        seeds.clone(),
+        bundles.clone(),
+    );
+    let mut p1_state = IntegrationTestState {
+        dwallet_mpc_services: p1_dwallet_mpc_services,
+        sent_consensus_messages_collectors: p1_sent_consensus_messages_collectors,
+        epoch_stores: p1_epoch_stores,
+        notify_services: p1_notify_services,
+        crypto_round: 1,
+        consensus_round: 1,
+        committee: committee.clone(),
+        sui_data_senders: p1_sui_data_senders,
+        network_owned_address_sign_request_senders: p1_noa_sign_request_senders,
+        network_owned_address_sign_output_receivers: p1_noa_sign_output_receivers,
+    };
+
+    let (consensus_round, v2_network_key_bytes, key_id) =
+        create_network_key_test(&mut p1_state).await;
+    info!(
+        ?key_id,
+        bytes_len = v2_network_key_bytes.len(),
+        "Phase 1: V2-tagged network DKG anchor captured"
+    );
+
+    // Reconfigure to the SAME committee at the next epoch. At v2 the bwd-compat
+    // builder reads the (current + upcoming) class-groups keys off the committee,
+    // so only the committee is delivered (the off-chain next-epoch key channel is
+    // a v3-only input).
+    let mut p1_next_committee = (*p1_state.dwallet_mpc_services[0].committee).clone();
+    p1_next_committee.epoch = epoch_id + 1;
+    for sui_data_sender in &p1_state.sui_data_senders {
+        let _ = sui_data_sender
+            .next_epoch_committee_sender
+            .send(p1_next_committee.clone());
+    }
+    send_start_network_key_reconfiguration_event(
+        epoch_id,
+        &mut p1_state.sui_data_senders,
+        [7u8; 32],
+        7,
+        key_id,
+    );
+    let (_, p1_reconfiguration_checkpoint) =
+        utils::advance_mpc_flow_until_completion(&mut p1_state, consensus_round).await;
+    let mut v2_reconfiguration_output_bytes = vec![];
+    for message in p1_reconfiguration_checkpoint.messages() {
+        let DWalletCheckpointMessageKind::RespondDWalletMPCNetworkReconfigurationOutput(message) =
+            message
+        else {
+            continue;
+        };
+        assert!(
+            !message.rejected,
+            "phase-1 reconfiguration (to seed the prior V2 output) should not be rejected"
+        );
+        // At v2 these bytes are `bcs(VersionedDecryptionKeyReconfigurationOutput::V2(..))`
+        // — the exact shape a deployed key stores in `current_reconfiguration_public_output`.
+        v2_reconfiguration_output_bytes.extend(message.public_output.clone());
+    }
+    assert!(
+        !v2_reconfiguration_output_bytes.is_empty(),
+        "phase-1 reconfiguration output must be non-empty"
+    );
+    info!(
+        bytes_len = v2_reconfiguration_output_bytes.len(),
+        "Phase 1: V2-tagged reconfiguration output captured"
+    );
+
+    // ── Project the captured V2 anchor into the deployed V1-tagged shape ─────
+    //
+    // The deployed keys carry a V1 anchor: a raw `class_groups::dkg::PublicOutput`
+    // written once at the original (pre-1.1.8) DKG and never rewritten. We
+    // synthesize that exact shape from the V2 anchor produced above. The
+    // projection is FAITHFUL, not a hand-rolled stand-in: the V2 arm of
+    // `reconfiguration_bwd_compat_public_input` feeds the constructor
+    // `bwd_compat_dkg_public_output.into()` — the very same
+    // `From<PublicOutputCore> for class_groups::dkg::PublicOutput` conversion
+    // applied here. The fixed V1 arm decodes the V1 inner bytes straight back
+    // with `bcs::from_bytes`, so it recovers a value byte-identical to what the
+    // V2 arm hands the constructor. Both arms therefore run identical crypto ⇒
+    // the reconfiguration must not be rejected. (The class-groups DKG output's
+    // BCS layout is also stable across the crypto bump, matching the on-chain
+    // deployed bytes.)
+    let VersionedNetworkDkgOutput::V2(v2_dkg_inner) = bcs::from_bytes(&v2_network_key_bytes)
+        .expect("decode the captured versioned network anchor")
+    else {
+        panic!("phase-1 network DKG at v2 must produce a V2-tagged anchor");
+    };
+    let bwd_compat_dkg_public_output: <twopc_mpc::decentralized_party_backward_compatible::dkg::Party as mpc::Party>::PublicOutput =
+        bcs::from_bytes(&v2_dkg_inner).expect("decode the bwd-compat DKG PublicOutput");
+    let class_groups_dkg_output: class_groups::dkg::PublicOutput<
+        { twopc_mpc::secp256k1::SCALAR_LIMBS },
+        { twopc_mpc::secp256k1::class_groups::FUNDAMENTAL_DISCRIMINANT_LIMBS },
+        { twopc_mpc::secp256k1::class_groups::NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+    > = bwd_compat_dkg_public_output.into();
+    let v1_dkg_inner = bcs::to_bytes(&class_groups_dkg_output)
+        .expect("re-encode the projected class-groups DKG output");
+    let v1_anchor_bytes = bcs::to_bytes(&VersionedNetworkDkgOutput::V1(v1_dkg_inner))
+        .expect("encode the V1-tagged anchor");
+
+    // ── Phase 2: fresh services (same committee + seeds), still v2-pinned.
+    //    Inject the deployed-shape key (V1 anchor + V2 reconfig output) and
+    //    reconfigure again — this drives the fixed V1-anchor builder path. ────
+    let (
+        p2_dwallet_mpc_services,
+        p2_sui_data_senders,
+        p2_sent_consensus_messages_collectors,
+        p2_epoch_stores,
+        p2_notify_services,
+        p2_noa_sign_request_senders,
+        p2_noa_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services_with_committee_and_seeds(
+        committee.clone(),
+        seeds.clone(),
+        bundles.clone(),
+    );
+    let mut p2_state = IntegrationTestState {
+        dwallet_mpc_services: p2_dwallet_mpc_services,
+        sent_consensus_messages_collectors: p2_sent_consensus_messages_collectors,
+        epoch_stores: p2_epoch_stores,
+        notify_services: p2_notify_services,
+        crypto_round: 1,
+        consensus_round: 1,
+        committee: committee.clone(),
+        sui_data_senders: p2_sui_data_senders,
+        network_owned_address_sign_request_senders: p2_noa_sign_request_senders,
+        network_owned_address_sign_output_receivers: p2_noa_sign_output_receivers,
+    };
+
+    // Inject the deployed-shape key. A non-empty `current_reconfiguration_public_output`
+    // routes instantiation through the reconfiguration-output path
+    // (`spawn_network_encryption_key_public_data_instantiation`), which reads the
+    // V1 anchor verbatim — so a successful install already proves instantiation
+    // tolerates the V1 anchor.
+    p2_state
+        .sui_data_senders
+        .iter()
+        .for_each(|sui_data_sender| {
+            let _ = sui_data_sender
+                .network_keys_sender
+                .send(Arc::new(HashMap::from([(
+                    key_id,
+                    DWalletNetworkEncryptionKeyData {
+                        id: key_id,
+                        current_epoch: 1,
+                        dkg_at_epoch: 1,
+                        current_reconfiguration_public_output: v2_reconfiguration_output_bytes
+                            .clone(),
+                        network_dkg_public_output: v1_anchor_bytes.clone(),
+                        state: DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration,
+                    },
+                )])));
+        });
+    for service in p2_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration(vec![]).await;
+    }
+    // Fresh phase-2 services start with `last_read_consensus_round = Some(0)`, so
+    // distribute the status updates from the loop above at round 1 to keep
+    // `round_to_messages` contiguous; the reconfig flow below continues at round 2.
+    utils::send_advance_results_between_parties(
+        &p2_state.committee,
+        &mut p2_state.sent_consensus_messages_collectors,
+        &mut p2_state.epoch_stores,
+        1,
+    );
+    for service in p2_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration(vec![]).await;
+    }
+    utils::run_service_loops_until_network_key_installed(
+        &mut p2_state.dwallet_mpc_services,
+        key_id,
+    )
+    .await;
+    for (i, service) in p2_state.dwallet_mpc_services.iter().enumerate() {
+        assert!(
+            service
+                .dwallet_mpc_manager()
+                .network_keys
+                .get_network_encryption_key_public_data(&key_id)
+                .is_ok(),
+            "phase-2 validator {i} should have installed the V1-anchor deployed-shape key"
+        );
+    }
+
+    // Reconfigure the deployed-shape key. At v2 only the committee is delivered.
+    let (mut p2_next_committee, _p2_next_seeds, _p2_next_bundles) =
+        utils::build_committee_with_random_seeds(4);
+    p2_next_committee.epoch = epoch_id + 1;
+    for sui_data_sender in &p2_state.sui_data_senders {
+        let _ = sui_data_sender
+            .next_epoch_committee_sender
+            .send(p2_next_committee.clone());
+    }
+    send_start_network_key_reconfiguration_event(
+        epoch_id,
+        &mut p2_state.sui_data_senders,
+        [8u8; 32],
+        8,
+        key_id,
+    );
+    let (_, p2_reconfiguration_checkpoint) =
+        utils::advance_mpc_flow_until_completion(&mut p2_state, 2).await;
+    let DWalletCheckpointMessageKind::RespondDWalletMPCNetworkReconfigurationOutput(message) =
+        p2_reconfiguration_checkpoint
+            .messages()
+            .first()
+            .expect("Expected a reconfiguration message")
+    else {
+        error!("Expected a RespondDWalletMPCNetworkReconfigurationOutput message");
+        panic!("Test failed due to unexpected message type");
+    };
+    assert!(
+        !message.rejected,
+        "V1-anchor bwd-compat reconfiguration should not be rejected"
+    );
+    info!("V1-anchor bwd-compat reconfiguration completed");
 }

--- a/dev-docs/plans/network-dkg-anchor-v2-to-v3-migration.md
+++ b/dev-docs/plans/network-dkg-anchor-v2-to-v3-migration.md
@@ -14,7 +14,11 @@ Each network encryption key carries a `VersionedNetworkDkgOutput` (the
 `crates/dwallet-mpc-types/src/dwallet_mpc.rs:111`):
 
 - **V2** — the backward-compatible `decentralized_party::dkg::PublicOutputCore`.
-  The deployed mainnet/testnet key has a V2 anchor.
+- The deployed mainnet/testnet keys carry a **V1** anchor on chain (raw
+  `class_groups::dkg::PublicOutput`, written by a pre-1.1.8 binary and never
+  rewritten — reconfiguration writes a separate field). Their reconfiguration
+  outputs are V2. The v3 reconfiguration input builder reads (V1 anchor,
+  V2 reconfiguration output) every epoch.
 - **V3** — the full `decentralized_party::dkg::PublicOutput` = the V2 core plus a
   trailing `threshold_encryption_to_sharing_output`, produced only by the
   threshold-encryption-to-sharing sub-protocol that backward-compatible

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -19,8 +19,9 @@ next epoch inherits.
   - `NetworkDkgOutput { key_id }` — the canonical network DKG output.
     Stable across epochs WITHIN a representation, with exactly one
     consensus-deterministic transition over the key's lifetime: a
-    mainnet-v1.1.8-origin key's DKG output is a V2 (backward-compatible)
-    `PublicOutputCore` and migrates ONCE to the full V3
+    mainnet-v1.1.8-origin key's on-chain DKG anchor is V1 (the raw
+    `class_groups::dkg::PublicOutput`) and its reconfiguration outputs are
+    V2; the canonical DKG output migrates ONCE to the full V3
     `decentralized_party::dkg::PublicOutput` at the first v4 reshare
     (when the cert-pinned reconfiguration output first becomes V3, every
     validator reconstructs the full V3 output and flips its perpetual


### PR DESCRIPTION
**Release blocker G1** (finding G1 in the [review](https://github.com/dwallet-labs/ika/pull/1787#issuecomment-4862501346)): without this, a 1.2.0 binary **wedges both mainnet and testnet** — every validator panic-aborts at the first per-epoch reconfiguration, restarts, replays, and aborts again. Unrecoverable without an emergency binary.

## The bug

The deployed mainnet/testnet network keys were DKG'd by a pre-1.1.8 binary, which wrote a **V1-tagged anchor** on chain: the raw `class_groups::dkg::PublicOutput`. Reconfiguration reshares the key every epoch but writes to a *separate* field — the anchor is never rewritten, so it is **still V1 today** (verified by reading `network_dkg_public_output` from both fullnodes: first byte `0x00`). Their reconfiguration outputs are V2.

`reconfiguration_bwd_compat_public_input` (the protocol-v3 input builder) matches the **anchor's** tag first, before ever using the V2 reconfiguration output — and dev's V1 arm was `unreachable!()`. With workspace `panic=abort`, the deployed `(V1 anchor, V2 reconfiguration output)` shape kills every validator at the first reconfiguration. 1.1.8 has a working V1 arm here; it was deleted on the false premise that the deployed anchor is V2. Every existing test is green because a fresh DKG writes a V2/V3 anchor — the V1 shape only exists on the two real chains.

## The fix

Reinstate the functional V1 arm at `reconfiguration_bwd_compat_public_input`, mirroring 1.1.8: for `(V1 anchor, Some(V2 reconfiguration output))`, decode the V1 inner bytes **directly** as the class-groups DKG output (no wrapper to project through, unlike the V2 arm's `.into()`) and feed it to `bwd_compat_reconfig::PublicInput::new_from_reconfiguration_output` with the prior V2 output. No new type and no conversion — `class_groups::dkg::PublicOutput`'s bcs layout is unchanged across the `inkrypto → cryptography-private @ 32a27aa` bump. `(V1, None)` and `(V1, V3)` remain errors (as in 1.1.8).

The other `V1(_) => unreachable!()` sites are converted to proper errors rather than left as process-aborts (they are unreachable for deployed keys, but a panic on a decoded chain value is the wrong failure mode):
- `network_dkg.rs` initial-DKG instantiation paths (×3) and the reconfig-output arms — errors.
- The WASM SDK export `network_key_version` (`dwallet-mpc-centralized-party/lib.rs`) returned via `unreachable!` on real chain bytes — now correctly returns **`Ok(1)`** (a V1 anchor genuinely is version 1); the two `protocol_public_parameters*` WASM helpers return errors instead of aborting.

**v4 scope:** the main (v4) reconfiguration builder's V1 arm becomes a proper **error, not full support** — reconstructing the v4 input (and the V2→V3 anchor migration) from a V1 anchor is a tracked follow-up that must land before v4 activates on the deployed networks. v4 is not active anywhere, so this arm is unreachable in production today; the change only converts a latent panic into a clear error. **The v3 path — the actual mainnet wedge — is fully fixed.**

## Test

`test_v1_anchor_bwd_compat_reconfiguration` (network_dkg_bwd_compat.rs) drives the exact deployed shape — a **V1 anchor + V2 reconfiguration output at protocol v3** — through the reconfiguration builder and asserts it succeeds. The V1 anchor is built by the faithful projection the deployed bytes actually have: decode a v2 DKG output's inner as `PublicOutputCore`, `.into()` the class-groups `PublicOutput`, re-serialize, wrap `V1`. Against the pre-fix code this panics at the `unreachable!`, so the test genuinely discriminates the fix.

## Docs

Corrected the false "deployed anchor is V2" premise in `dev-docs/plans/network-dkg-anchor-v2-to-v3-migration.md`, `dev-docs/specs/handoff.md`, and the `VersionedNetworkDkgOutput::V1` struct doc — the deployed shape is now stated as "V1 anchor + V2 reconfiguration outputs at protocol v3", with the v4 one-time anchor migration restated from a V1 origin.

Last of the three release gates (with G2+G3 in #1797). **Requires the full cluster suite + a v118 upgrade run green before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
