### PR TITLE
feat(dwallet-mpc): support the deployed V1 network-DKG anchor on the main (v4) reconfiguration path + one-time V1->V3 anchor migration

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -1044,24 +1044,27 @@ mod network_key_id_derivation_tool {
     }
 }
 
-/// Reconstructs the full-shape (V3) network DKG output in memory from a V2
-/// (backward-compatible) DKG output and a full V3 reconfiguration output.
+/// Reconstructs the full-shape (V3) network DKG output in memory from a V1 or
+/// V2 (backward-compatible) DKG output and a full V3 reconfiguration output.
 ///
-/// The V2 DKG output is a `decentralized_party::dkg::PublicOutputCore` and
-/// lacks the trailing `threshold_encryption_to_sharing_output` that the full V3
+/// Neither pre-V3 anchor carries the trailing
+/// `threshold_encryption_to_sharing_output` that the full V3
 /// `decentralized_party::dkg::PublicOutput` carries; that field is produced
 /// only by the threshold-encryption-to-sharing sub-protocol, which the
 /// backward-compatible reconfiguration predates. Once a full V3 reconfiguration
 /// output is available it supplies that field, and the full V3 DKG output is
-/// reconstructed by combining the V2 output's reconfiguration-invariant
-/// class-group DKG output (`PublicOutputCore::class_group_dkg_output`) with the
-/// V3 reconfiguration output (`PublicOutput::new_from_reconfiguration_output`,
-/// the inverse of `class_group_dkg_output`).
+/// reconstructed by combining the anchor's reconfiguration-invariant
+/// class-group DKG output with the V3 reconfiguration output
+/// (`PublicOutput::new_from_reconfiguration_output`). A V2 anchor is a
+/// `decentralized_party::dkg::PublicOutputCore`, whose class-group DKG output
+/// `PublicOutputCore::class_group_dkg_output` projects out; a V1 anchor (the
+/// deployed mainnet/testnet shape, written by a pre-1.1.8 binary) IS the raw
+/// `class_groups::dkg::PublicOutput` and decodes directly.
 ///
-/// Returns `Some(V3)` only when `network_dkg_output` is V2 AND a V3
+/// Returns `Some(V3)` only when `network_dkg_output` is V1 or V2 AND a V3
 /// reconfiguration output is available; `None` otherwise. The reconstruction is
 /// a pure (RNG-free) function of its inputs, so every validator holding the same
-/// V2 DKG output and the same quorum-agreed V3 reconfiguration output derives
+/// anchor and the same quorum-agreed V3 reconfiguration output derives
 /// byte-identical V3 bytes.
 fn reconstruct_full_network_dkg_output(
     network_dkg_output: &VersionedNetworkDkgOutput,
@@ -1069,20 +1072,23 @@ fn reconstruct_full_network_dkg_output(
         &VersionedDecryptionKeyReconfigurationOutput,
     >,
 ) -> DwalletMPCResult<Option<VersionedNetworkDkgOutput>> {
-    let (
-        VersionedNetworkDkgOutput::V2(dkg_public_output_core_bytes),
-        Some(VersionedDecryptionKeyReconfigurationOutput::V3(reconfiguration_output_bytes)),
-    ) = (
-        network_dkg_output,
-        latest_network_reconfiguration_public_output,
-    )
+    let Some(VersionedDecryptionKeyReconfigurationOutput::V3(reconfiguration_output_bytes)) =
+        latest_network_reconfiguration_public_output
     else {
         return Ok(None);
     };
 
-    let dkg_public_output_core: dkg::PublicOutputCore =
-        bcs::from_bytes(dkg_public_output_core_bytes)?;
-    let class_group_dkg_output = dkg_public_output_core.class_group_dkg_output();
+    let class_group_dkg_output = match network_dkg_output {
+        VersionedNetworkDkgOutput::V1(class_group_dkg_output_bytes) => {
+            bcs::from_bytes(class_group_dkg_output_bytes)?
+        }
+        VersionedNetworkDkgOutput::V2(dkg_public_output_core_bytes) => {
+            let dkg_public_output_core: dkg::PublicOutputCore =
+                bcs::from_bytes(dkg_public_output_core_bytes)?;
+            dkg_public_output_core.class_group_dkg_output()
+        }
+        VersionedNetworkDkgOutput::V3(_) => return Ok(None),
+    };
 
     let reconfiguration_output: twopc_mpc::decentralized_party::reconfiguration::PublicOutput =
         bcs::from_bytes(reconfiguration_output_bytes)?;
@@ -1306,11 +1312,13 @@ mod tests {
         VersionedDecryptionKeyReconfigurationOutput, VersionedNetworkDkgOutput,
     };
 
-    /// The reconstruction must fire ONLY for a V2 DKG output paired with a full
-    /// V3 reconfiguration output. Every other combination returns `None` without
-    /// touching the crypto decoders (so dummy bytes are fine here). The `Some`
-    /// path needs a real V2 DKG output + V3 reconfiguration output and is
-    /// exercised end-to-end by the v4 reconfiguration integration path.
+    /// The reconstruction must fire ONLY for a V1 or V2 DKG anchor paired with
+    /// a full V3 reconfiguration output. Every other combination returns `None`
+    /// without touching the crypto decoders (so dummy bytes are fine there).
+    /// The `Some` paths need real anchor + V3 reconfiguration bytes and are
+    /// exercised end-to-end by the v4 reconfiguration integration tests
+    /// (`test_v2_to_v3_reconfiguration_migration`,
+    /// `test_v1_anchor_main_reconfiguration_and_anchor_migration`).
     #[test]
     fn reconstruct_full_network_dkg_output_gating() {
         use VersionedDecryptionKeyReconfigurationOutput as Reconfiguration;
@@ -1345,14 +1353,28 @@ mod tests {
             .is_none()
         );
 
-        // V1 is never produced anymore.
+        // V1 anchor (the deployed shape) with only a V2 reconfiguration
+        // output: no threshold-encryption-to-sharing field yet, no
+        // reconstruction.
+        assert!(
+            reconstruct_full_network_dkg_output(
+                &Dkg::V1(vec![]),
+                Some(&Reconfiguration::V2(vec![])),
+            )
+            .unwrap()
+            .is_none()
+        );
+
+        // V1 anchor + V3 reconfiguration output DOES engage the
+        // reconstruction — with garbage bytes it must fail decoding rather
+        // than return `None` (a `None` here would silently skip the deployed
+        // keys' one-time anchor migration).
         assert!(
             reconstruct_full_network_dkg_output(
                 &Dkg::V1(vec![]),
                 Some(&Reconfiguration::V3(vec![])),
             )
-            .unwrap()
-            .is_none()
+            .is_err()
         );
     }
 }

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -147,19 +147,58 @@ impl ReconfigurationPartyPublicInputGenerator for ReconfigurationParty {
         }
 
         match network_dkg_public_output {
-            // Deployed keys still carry a V1 anchor on chain. The main (v4)
-            // reconfiguration party does not yet reconstruct its input from a
-            // V1 anchor — that support (and the V2->V3 anchor migration for
-            // these keys) is a tracked follow-up gated behind v4 activation.
-            // Fail the session with a clear error instead of aborting the
-            // process; v4 is not active on any deployed network, so this arm
-            // is unreachable in production until that follow-up lands.
-            VersionedNetworkDkgOutput::V1(_) => Err(DwalletMPCError::InternalError(
-                "The main (v4) reconfiguration path does not yet support a V1 network \
-                 DKG anchor (deployed mainnet/testnet keys); this must be implemented \
-                 before protocol v4 activates on those networks."
-                    .to_string(),
-            )),
+            // The deployed mainnet/testnet keys carry a V1 anchor: the raw
+            // `class_groups::dkg::PublicOutput`, written once by the original
+            // (pre-1.1.8) DKG and never rewritten. Under the main party the
+            // anchor stays V1 until the one-time canonical-anchor migration
+            // flips it to V3 (`reconstruct_full_network_dkg_output` + the
+            // canonical mirror at instantiation), so the first main
+            // reconfiguration of a deployed key runs from (V1 anchor, V2 prior
+            // output) and, during the flip epoch, (V1 anchor, V3 prior output).
+            // The V1 bytes decode directly to the `class_groups::dkg::PublicOutput`
+            // the constructor takes — the same value the V2/V3 arm reaches via
+            // `dkg_public_output_core.into()`.
+            VersionedNetworkDkgOutput::V1(network_dkg_public_output_bytes) => {
+                match latest_reconfiguration_public_output {
+                    // A V1 anchor with no prior reconfiguration output cannot
+                    // bootstrap: `new_from_dkg_output` needs the multi-curve
+                    // `PublicOutputCore`, which a V1 anchor does not carry. No
+                    // deployed key is in this state (they have all
+                    // reconfigured).
+                    None => Err(DwalletMPCError::InternalError(
+                        "Main Reconfig with a V1 network DKG anchor requires a prior V2 or \
+                         V3 reconfiguration output; a V1 anchor with no reconfiguration \
+                         output is unsupported."
+                            .to_string(),
+                    )),
+                    Some(prior) => {
+                        let prior_reconfig_core = decode_prior_reconfiguration_output_core(&prior)?;
+
+                        debug_variable_chunks(
+                            "Instantiating public input for reconfiguration v3 [prior_reconfig_core]",
+                            "prior_reconfig_core",
+                            &bcs::to_bytes(&prior_reconfig_core)?,
+                        );
+
+                        let public_input: <ReconfigurationParty as Party>::PublicInput =
+                            <twopc_mpc::decentralized_party::reconfiguration::Party as Party>::PublicInput::new_from_reconfiguration_output(
+                                &current_access_structure,
+                                upcoming_access_structure,
+                                current_encryption_keys_per_crt_prime_and_proofs.clone(),
+                                upcoming_encryption_keys_per_crt_prime_and_proofs.clone(),
+                                current_tangible_party_id_to_upcoming,
+                                bcs::from_bytes(&network_dkg_public_output_bytes)?,
+                                prior_reconfig_core,
+                                upcoming_validators_pvss_hpke_keys_by_party_id.secp256k1_pvss.clone(),
+                                upcoming_validators_pvss_hpke_keys_by_party_id.ristretto_pvss.clone(),
+                                upcoming_validators_pvss_hpke_keys_by_party_id.secp256r1_pvss.clone(),
+                            )
+                                .map_err(DwalletMPCError::from)?;
+
+                        Ok(public_input)
+                    }
+                }
+            }
             // V2 and V3 DKG outputs differ only in whether the trailing Protocol-0.1
             // `threshold_encryption_to_sharing_output` is present. Decode either shape to a
             // `dkg::PublicOutputCore` and feed it into the same main constructor — covers
@@ -201,20 +240,8 @@ impl ReconfigurationPartyPublicInputGenerator for ReconfigurationParty {
 
                         Ok(public_input)
                     }
-                    Some(prior @ (VersionedDecryptionKeyReconfigurationOutput::V2(_)
-                    | VersionedDecryptionKeyReconfigurationOutput::V3(_))) => {
-                        let prior_reconfig_core: twopc_mpc::decentralized_party::reconfiguration::PublicOutputCore =
-                            match &prior {
-                                VersionedDecryptionKeyReconfigurationOutput::V2(bytes) => {
-                                    bcs::from_bytes(bytes)?
-                                }
-                                VersionedDecryptionKeyReconfigurationOutput::V3(bytes) => {
-                                    let full: twopc_mpc::decentralized_party::reconfiguration::PublicOutput =
-                                        bcs::from_bytes(bytes)?;
-                                    full.core
-                                }
-                                VersionedDecryptionKeyReconfigurationOutput::V1(_) => unreachable!(),
-                            };
+                    Some(prior) => {
+                        let prior_reconfig_core = decode_prior_reconfiguration_output_core(&prior)?;
 
                         debug_variable_chunks(
                             "Instantiating public input for reconfiguration v3 [prior_reconfig_core]",
@@ -239,15 +266,31 @@ impl ReconfigurationPartyPublicInputGenerator for ReconfigurationParty {
 
                         Ok(public_input)
                     }
-                    Some(VersionedDecryptionKeyReconfigurationOutput::V1(_)) => Err(
-                        DwalletMPCError::InternalError(
-                            "Main Reconfig expects V2 or V3 prior reconfig output; V1 is unsupported."
-                                .to_string(),
-                        ),
-                    ),
                 }
             }
         }
+    }
+}
+
+/// Decodes a prior (V2 or V3) reconfiguration output to its
+/// `reconfiguration::PublicOutputCore` for the main reconfiguration
+/// constructors. V2 bytes are the core itself; V3 bytes are the full output,
+/// whose trailing threshold-encryption-to-sharing field the constructor
+/// re-derives. V1 outputs predate the core shape and are unsupported.
+fn decode_prior_reconfiguration_output_core(
+    prior: &VersionedDecryptionKeyReconfigurationOutput,
+) -> DwalletMPCResult<twopc_mpc::decentralized_party::reconfiguration::PublicOutputCore> {
+    match prior {
+        VersionedDecryptionKeyReconfigurationOutput::V2(bytes) => Ok(bcs::from_bytes(bytes)?),
+        VersionedDecryptionKeyReconfigurationOutput::V3(bytes) => {
+            let full: twopc_mpc::decentralized_party::reconfiguration::PublicOutput =
+                bcs::from_bytes(bytes)?;
+            Ok(full.core)
+        }
+        VersionedDecryptionKeyReconfigurationOutput::V1(_) => Err(DwalletMPCError::InternalError(
+            "Main Reconfig expects a V2 or V3 prior reconfig output; V1 is unsupported."
+                .to_string(),
+        )),
     }
 }
 

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg_bwd_compat.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg_bwd_compat.rs
@@ -22,7 +22,9 @@ use crate::dwallet_mpc::integration_tests::network_dkg::{
 };
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::IntegrationTestState;
-use dwallet_mpc_types::dwallet_mpc::VersionedNetworkDkgOutput;
+use dwallet_mpc_types::dwallet_mpc::{
+    VersionedDecryptionKeyReconfigurationOutput, VersionedNetworkDkgOutput,
+};
 use ika_protocol_config::ProtocolConfig;
 use ika_types::committee::Committee;
 use ika_types::message::DWalletCheckpointMessageKind;
@@ -642,4 +644,345 @@ async fn test_v1_anchor_bwd_compat_reconfiguration() {
         "V1-anchor bwd-compat reconfiguration should not be rejected"
     );
     info!("V1-anchor bwd-compat reconfiguration completed");
+}
+
+/// The deployed-anchor shape under the MAIN (protocol-v4) reconfiguration
+/// party, plus the one-time V1→V3 anchor migration:
+///
+/// 1. A key carrying a **V1 network DKG anchor + V2 reconfiguration output**
+///    (the deployed mainnet/testnet shape) is reconfigured at the default
+///    protocol config (`reconfiguration_message_version == 3`), driving the
+///    main builder's `(V1 anchor, Some(V2 prior))` arm — the first v4
+///    reconfiguration a deployed key will run.
+/// 2. The resulting **V3-tagged** reconfiguration output is injected back
+///    alongside the still-V1 anchor, and the instantiation must reconstruct
+///    the full V3 DKG output (`reconstructed_full_network_dkg_output`), the
+///    value the canonical-anchor mirror persists — i.e. the deployed keys'
+///    V1→V3 anchor migration fires.
+///
+/// Phase 1 runs pinned at v2 to fabricate the deployed shape (exactly like
+/// `test_v1_anchor_bwd_compat_reconfiguration`); the pin is dropped before the
+/// main-path phases. Both reconfigurations reshare to the SAME committee so
+/// every phase can reuse one committee + seed + off-chain-bundle set.
+#[tokio::test]
+#[cfg(test)]
+async fn test_v1_anchor_main_reconfiguration_and_anchor_migration() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let epoch_id = 1;
+
+    let (committee, seeds, bundles) = utils::build_committee_with_random_seeds(4);
+
+    // ── Phase 1 (pinned v2): DKG → V2 anchor, then ONE bwd-compat
+    //    reconfiguration to the SAME committee → V2 reconfiguration output. ──
+    let v2_override = pin_protocol_to_v2_overrides();
+    let (
+        p1_dwallet_mpc_services,
+        p1_sui_data_senders,
+        p1_sent_consensus_messages_collectors,
+        p1_epoch_stores,
+        p1_notify_services,
+        p1_noa_sign_request_senders,
+        p1_noa_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services_with_committee_and_seeds(
+        committee.clone(),
+        seeds.clone(),
+        bundles.clone(),
+    );
+    let mut p1_state = IntegrationTestState {
+        dwallet_mpc_services: p1_dwallet_mpc_services,
+        sent_consensus_messages_collectors: p1_sent_consensus_messages_collectors,
+        epoch_stores: p1_epoch_stores,
+        notify_services: p1_notify_services,
+        crypto_round: 1,
+        consensus_round: 1,
+        committee: committee.clone(),
+        sui_data_senders: p1_sui_data_senders,
+        network_owned_address_sign_request_senders: p1_noa_sign_request_senders,
+        network_owned_address_sign_output_receivers: p1_noa_sign_output_receivers,
+    };
+
+    let (consensus_round, v2_network_key_bytes, key_id) =
+        create_network_key_test(&mut p1_state).await;
+    info!(
+        ?key_id,
+        bytes_len = v2_network_key_bytes.len(),
+        "Phase 1: V2-tagged network DKG anchor captured"
+    );
+
+    let mut p1_next_committee = (*p1_state.dwallet_mpc_services[0].committee).clone();
+    p1_next_committee.epoch = epoch_id + 1;
+    for sui_data_sender in &p1_state.sui_data_senders {
+        let _ = sui_data_sender
+            .next_epoch_committee_sender
+            .send(p1_next_committee.clone());
+    }
+    send_start_network_key_reconfiguration_event(
+        epoch_id,
+        &mut p1_state.sui_data_senders,
+        [9u8; 32],
+        9,
+        key_id,
+    );
+    let (_, p1_reconfiguration_checkpoint) =
+        utils::advance_mpc_flow_until_completion(&mut p1_state, consensus_round).await;
+    let mut v2_reconfiguration_output_bytes = vec![];
+    for message in p1_reconfiguration_checkpoint.messages() {
+        let DWalletCheckpointMessageKind::RespondDWalletMPCNetworkReconfigurationOutput(message) =
+            message
+        else {
+            continue;
+        };
+        assert!(
+            !message.rejected,
+            "phase-1 reconfiguration (to seed the prior V2 output) should not be rejected"
+        );
+        v2_reconfiguration_output_bytes.extend(message.public_output.clone());
+    }
+    assert!(
+        !v2_reconfiguration_output_bytes.is_empty(),
+        "phase-1 reconfiguration output must be non-empty"
+    );
+
+    // Drop the v2 pin — every later phase snapshots the default (v3) config.
+    drop(v2_override);
+
+    // ── Project the V2 anchor into the deployed V1-tagged shape (same
+    //    faithful projection as `test_v1_anchor_bwd_compat_reconfiguration`:
+    //    the V1 inner bytes ARE the raw class-groups DKG output). ─────────────
+    let VersionedNetworkDkgOutput::V2(v2_dkg_inner) = bcs::from_bytes(&v2_network_key_bytes)
+        .expect("decode the captured versioned network anchor")
+    else {
+        panic!("phase-1 network DKG at v2 must produce a V2-tagged anchor");
+    };
+    let bwd_compat_dkg_public_output: <twopc_mpc::decentralized_party_backward_compatible::dkg::Party as mpc::Party>::PublicOutput =
+        bcs::from_bytes(&v2_dkg_inner).expect("decode the bwd-compat DKG PublicOutput");
+    let class_groups_dkg_output: class_groups::dkg::PublicOutput<
+        { twopc_mpc::secp256k1::SCALAR_LIMBS },
+        { twopc_mpc::secp256k1::class_groups::FUNDAMENTAL_DISCRIMINANT_LIMBS },
+        { twopc_mpc::secp256k1::class_groups::NON_FUNDAMENTAL_DISCRIMINANT_LIMBS },
+    > = bwd_compat_dkg_public_output.into();
+    let v1_dkg_inner = bcs::to_bytes(&class_groups_dkg_output)
+        .expect("re-encode the projected class-groups DKG output");
+    let v1_anchor_bytes = bcs::to_bytes(&VersionedNetworkDkgOutput::V1(v1_dkg_inner))
+        .expect("encode the V1-tagged anchor");
+
+    // ── Phase 2 (default v3): inject the deployed shape (V1 anchor + V2
+    //    reconfig output) and reconfigure under the MAIN party — the
+    //    `(V1 anchor, Some(V2 prior))` builder arm. ───────────────────────────
+    let (
+        p2_dwallet_mpc_services,
+        p2_sui_data_senders,
+        p2_sent_consensus_messages_collectors,
+        p2_epoch_stores,
+        p2_notify_services,
+        p2_noa_sign_request_senders,
+        p2_noa_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services_with_committee_and_seeds(
+        committee.clone(),
+        seeds.clone(),
+        bundles.clone(),
+    );
+    for service in &p2_dwallet_mpc_services {
+        assert!(
+            service
+                .protocol_config
+                .is_reconfiguration_message_version_v3(),
+            "Phase 2 services should run at reconfiguration_message_version == 3 (default MAX)"
+        );
+    }
+    let mut p2_state = IntegrationTestState {
+        dwallet_mpc_services: p2_dwallet_mpc_services,
+        sent_consensus_messages_collectors: p2_sent_consensus_messages_collectors,
+        epoch_stores: p2_epoch_stores,
+        notify_services: p2_notify_services,
+        crypto_round: 1,
+        consensus_round: 1,
+        committee: committee.clone(),
+        sui_data_senders: p2_sui_data_senders,
+        network_owned_address_sign_request_senders: p2_noa_sign_request_senders,
+        network_owned_address_sign_output_receivers: p2_noa_sign_output_receivers,
+    };
+
+    p2_state
+        .sui_data_senders
+        .iter()
+        .for_each(|sui_data_sender| {
+            let _ = sui_data_sender
+                .network_keys_sender
+                .send(Arc::new(HashMap::from([(
+                    key_id,
+                    DWalletNetworkEncryptionKeyData {
+                        id: key_id,
+                        current_epoch: 1,
+                        dkg_at_epoch: 1,
+                        current_reconfiguration_public_output: v2_reconfiguration_output_bytes
+                            .clone(),
+                        network_dkg_public_output: v1_anchor_bytes.clone(),
+                        state: DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration,
+                    },
+                )])));
+        });
+    for service in p2_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration(vec![]).await;
+    }
+    utils::send_advance_results_between_parties(
+        &p2_state.committee,
+        &mut p2_state.sent_consensus_messages_collectors,
+        &mut p2_state.epoch_stores,
+        1,
+    );
+    for service in p2_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration(vec![]).await;
+    }
+    utils::run_service_loops_until_network_key_installed(
+        &mut p2_state.dwallet_mpc_services,
+        key_id,
+    )
+    .await;
+
+    // Reshare to the SAME committee at the next epoch; at v3 the upcoming
+    // committee's off-chain PVSS/VSS keys travel on the next-epoch key channel.
+    let mut p2_next_committee = committee.clone();
+    p2_next_committee.epoch = epoch_id + 1;
+    for sui_data_sender in &p2_state.sui_data_senders {
+        let _ = sui_data_sender
+            .next_epoch_committee_sender
+            .send(p2_next_committee.clone());
+        let _ = sui_data_sender
+            .next_epoch_mpc_keys_sender
+            .send(Some((p2_next_committee.epoch, bundles.clone())));
+    }
+    send_start_network_key_reconfiguration_event(
+        epoch_id,
+        &mut p2_state.sui_data_senders,
+        [10u8; 32],
+        10,
+        key_id,
+    );
+    let (_, p2_reconfiguration_checkpoint) =
+        utils::advance_mpc_flow_until_completion(&mut p2_state, 2).await;
+    let mut v3_reconfiguration_output_bytes = vec![];
+    for message in p2_reconfiguration_checkpoint.messages() {
+        let DWalletCheckpointMessageKind::RespondDWalletMPCNetworkReconfigurationOutput(message) =
+            message
+        else {
+            continue;
+        };
+        assert!(
+            !message.rejected,
+            "V1-anchor main (v4) reconfiguration should not be rejected"
+        );
+        v3_reconfiguration_output_bytes.extend(message.public_output.clone());
+    }
+    assert!(
+        !v3_reconfiguration_output_bytes.is_empty(),
+        "phase-2 main reconfiguration output must be non-empty"
+    );
+    let versioned_reconfiguration_output: VersionedDecryptionKeyReconfigurationOutput =
+        bcs::from_bytes(&v3_reconfiguration_output_bytes)
+            .expect("decode the phase-2 reconfiguration output");
+    assert!(
+        matches!(
+            versioned_reconfiguration_output,
+            VersionedDecryptionKeyReconfigurationOutput::V3(_)
+        ),
+        "the main reconfiguration party must produce a V3-tagged output"
+    );
+    info!("Phase 2: V1-anchor main reconfiguration completed with a V3-tagged output");
+
+    // ── Phase 3 (default v3): inject (V1 anchor, V3 reconfig output) — the
+    //    deployed shape one epoch after the first v4 reconfiguration — and
+    //    assert instantiation reconstructs the full V3 anchor, which is what
+    //    the canonical mirror persists (the one-time V1→V3 anchor migration). ─
+    let (
+        p3_dwallet_mpc_services,
+        p3_sui_data_senders,
+        p3_sent_consensus_messages_collectors,
+        p3_epoch_stores,
+        p3_notify_services,
+        p3_noa_sign_request_senders,
+        p3_noa_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services_with_committee_and_seeds(
+        committee.clone(),
+        seeds.clone(),
+        bundles.clone(),
+    );
+    let mut p3_state = IntegrationTestState {
+        dwallet_mpc_services: p3_dwallet_mpc_services,
+        sent_consensus_messages_collectors: p3_sent_consensus_messages_collectors,
+        epoch_stores: p3_epoch_stores,
+        notify_services: p3_notify_services,
+        crypto_round: 1,
+        consensus_round: 1,
+        committee: committee.clone(),
+        sui_data_senders: p3_sui_data_senders,
+        network_owned_address_sign_request_senders: p3_noa_sign_request_senders,
+        network_owned_address_sign_output_receivers: p3_noa_sign_output_receivers,
+    };
+    p3_state
+        .sui_data_senders
+        .iter()
+        .for_each(|sui_data_sender| {
+            let _ = sui_data_sender
+                .network_keys_sender
+                .send(Arc::new(HashMap::from([(
+                    key_id,
+                    DWalletNetworkEncryptionKeyData {
+                        id: key_id,
+                        // Must equal the manager's epoch — data carrying any
+                        // other epoch is rejected before instantiation spawns
+                        // (the stale-chain-snapshot guard in `mpc_manager.rs`).
+                        current_epoch: 1,
+                        dkg_at_epoch: 1,
+                        current_reconfiguration_public_output: v3_reconfiguration_output_bytes
+                            .clone(),
+                        network_dkg_public_output: v1_anchor_bytes.clone(),
+                        state: DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration,
+                    },
+                )])));
+        });
+    for service in p3_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration(vec![]).await;
+    }
+    utils::send_advance_results_between_parties(
+        &p3_state.committee,
+        &mut p3_state.sent_consensus_messages_collectors,
+        &mut p3_state.epoch_stores,
+        1,
+    );
+    for service in p3_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration(vec![]).await;
+    }
+    utils::run_service_loops_until_network_key_installed(
+        &mut p3_state.dwallet_mpc_services,
+        key_id,
+    )
+    .await;
+    for (i, service) in p3_state.dwallet_mpc_services.iter().enumerate() {
+        let key_public_data = service
+            .dwallet_mpc_manager()
+            .network_keys
+            .get_network_encryption_key_public_data(&key_id)
+            .unwrap_or_else(|e| {
+                panic!("phase-3 validator {i} should have installed the key: {e:?}")
+            })
+            .clone();
+        assert!(
+            matches!(
+                key_public_data.network_dkg_output(),
+                VersionedNetworkDkgOutput::V1(_)
+            ),
+            "phase-3 validator {i}: the stored anchor must still be V1 (never rewritten on chain)"
+        );
+        assert!(
+            matches!(
+                key_public_data.reconstructed_full_network_dkg_output(),
+                Some(VersionedNetworkDkgOutput::V3(_))
+            ),
+            "phase-3 validator {i}: instantiation from (V1 anchor, V3 reconfiguration output) \
+             must reconstruct the full V3 DKG output — the deployed keys' one-time anchor \
+             migration"
+        );
+    }
+    info!("Phase 3: V1→V3 anchor reconstruction verified on every validator");
 }

--- a/dev-docs/plans/network-dkg-anchor-v2-to-v3-migration.md
+++ b/dev-docs/plans/network-dkg-anchor-v2-to-v3-migration.md
@@ -3,8 +3,9 @@
 Status: active — implementation complete and validated end-to-end (2026-06-28),
 PR #1758 (into `dev`, ready for review); flip to `landed` on merge.
 Consensus-critical. Builds on the in-memory V3 reconstruction (`013cb1b75f`).
-The durable behavioral contract — the `NetworkDkgOutput` item's one-time V2->V3
-migration and the adoption tolerance — now lives in
+The durable behavioral contract — the `NetworkDkgOutput` item's one-time
+pre-V3 -> V3 migration (from a V2 anchor, or from the deployed keys' V1 anchor)
+and the adoption tolerance — now lives in
 `dev-docs/specs/handoff.md`; this plan is the intent/sequencing record.
 
 ## What this is
@@ -18,13 +19,15 @@ Each network encryption key carries a `VersionedNetworkDkgOutput` (the
   `class_groups::dkg::PublicOutput`, written by a pre-1.1.8 binary and never
   rewritten — reconfiguration writes a separate field). Their reconfiguration
   outputs are V2. The v3 reconfiguration input builder reads (V1 anchor,
-  V2 reconfiguration output) every epoch.
+  V2 reconfiguration output) every epoch, and the main (v4) builder accepts the
+  same shape for the deployed keys' first v4 reconfigurations (a V1 arm that
+  decodes the anchor directly as the raw class-groups DKG output).
 - **V3** — the full `decentralized_party::dkg::PublicOutput` = the V2 core plus a
   trailing `threshold_encryption_to_sharing_output`, produced only by the
   threshold-encryption-to-sharing sub-protocol that backward-compatible
   reconfiguration predates.
 
-A pure, RNG-free helper reconstructs V3 from (V2 DKG output, a full V3
+A pure, RNG-free helper reconstructs V3 from (V1 or V2 DKG output, a full V3
 reconfiguration output): `reconstruct_full_network_dkg_output`
 (`crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs:721`),
 already called in `build_network_encryption_key_public_data` and stored in the
@@ -81,8 +84,8 @@ Three coordinated pieces, all under `off_chain_validator_metadata_enabled()`:
 ### 1. Flip the persisted mirror at instantiation (epoch entry)
 
 When a key is instantiated with off-chain on and the result carries a
-`reconstructed_full_network_dkg_output = Some(V3)` (i.e. stored DKG output is V2
-and the cert-pinned reconfiguration output is V3), persist that V3 once via the
+`reconstructed_full_network_dkg_output = Some(V3)` (i.e. stored DKG output is V1
+or V2 and the cert-pinned reconfiguration output is V3), persist that V3 once via the
 existing `cache_network_dkg_output(key_id, v3_bytes)` write path. That single
 call:
 

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -130,9 +130,9 @@ next epoch inherits.
    their digests match the prior epoch's certificate
    (`adopt_cert_verified_keys`): a reconfigured key must match BOTH its
    DKG digest and its epoch-specific reconfiguration digest. The DKG
-   digest migrates once (V2->V3, above): at that single boundary an
+   digest migrates once (V1|V2 -> V3, above): at that single boundary an
    ALREADY-ADOPTED key whose overlay DKG digest has moved past the prior
-   epoch's (V2) certificate is the expected defer — it keeps its adopted
+   epoch's (pre-V3) certificate is the expected defer — it keeps its adopted
    value rather than being dropped, exactly as a moved reconfiguration
    output is tolerated; only an UNADOPTED key contradicting the
    certificate is the security-relevant anomaly (the output-quorum


### PR DESCRIPTION
Follow-up to #1798, stacked on `fix/v1-anchor-reconfiguration` — the v4-scope work that PR explicitly deferred ("must land before v4 activates on the deployed networks"). With this, the deployed **V1 network-DKG anchor** is fully supported on the main (protocol-v4) reconfiguration path and in the one-time canonical-anchor migration the cross-epoch handoff performs, mirroring the same insight as the v3 fix: the V1 inner bytes ARE the raw `class_groups::dkg::PublicOutput` — decode them directly, no wrapper projection.

## Why (recap of the deployed shape)

The deployed mainnet/testnet keys were DKG'd by a pre-1.1.8 binary: the on-chain anchor is **V1-tagged** and is never rewritten (reconfiguration writes a separate field); their reconfiguration outputs are V2. #1798 fixed the v3 (bwd-compat) reconfiguration path — the active-network wedge — but left two v4 gaps as clear errors:

1. the main (v4) reconfiguration input builder errored on any V1 anchor, and
2. `reconstruct_full_network_dkg_output` (which feeds the handoff's one-time canonical V2→V3 anchor flip) returned `None` for a V1 anchor, so the deployed keys' anchor migration would never fire.

Timeline for a deployed key once v4 activates: the first v4 reshare runs from **(V1 anchor, V2 reconfiguration output)**; the next epoch's reshare runs from **(V1 anchor, V3 reconfiguration output)** — the flip is only observable via the handoff one epoch after the V3 output is cert-pinned; from the flip onward the anchor is V3. Both pre-flip shapes previously failed.

## The fix

- **`ReconfigurationParty::generate_public_input` (main/v4 builder)**: functional V1 arm. `(V1, Some(V2|V3 prior))` decodes the V1 bytes directly as the `class_groups::dkg::PublicOutput` the constructor takes (the V2/V3 arm reaches the same value via `PublicOutputCore::into()`) and feeds `new_from_reconfiguration_output` with the prior output's core. `(V1, None)` remains an error — `new_from_dkg_output` needs the multi-curve `PublicOutputCore` a V1 anchor doesn't carry, and no deployed key is in that state. The prior-output core decoding is extracted into `decode_prior_reconfiguration_output_core`, shared with the V2/V3 arm (whose leftover `V1 => unreachable!()` on the prior output also becomes an error through the helper).
- **`reconstruct_full_network_dkg_output`**: accepts `(V1 anchor, Some(V3 reconfiguration output))` — decode the V1 bytes directly where the V2 arm projects `PublicOutputCore::class_group_dkg_output()`. Since the handoff's canonical-mirror flip triggers purely on `reconstructed_full_network_dkg_output().is_some()`, the deployed keys' one-time **V1→V3 anchor migration** now rides the exact same mechanism as V2→V3, no `mpc_manager` change.

Parity with `main` (the production 1.1.8 line): its reconfiguration input builder handles `(V1 anchor, V2 reconfiguration output)` by decoding the V1 bytes directly into `new_from_reconfiguration_output` — this PR is that same dispatch, ported onto the v4 constructor signature (PVSS HPKE keys, `PublicOutputCore` prior).

## Tests

- `test_v1_anchor_main_reconfiguration_and_anchor_migration` (integration): fabricates the deployed shape at v2 (DKG → V2 anchor faithfully projected to V1 + one reshare → V2 reconfiguration output), then at the default (v3) protocol config drives **(V1 anchor, V2 prior)** through the main builder end-to-end and asserts the output is `!rejected` and **V3-tagged**; then re-injects **(V1 anchor, V3 reconfiguration output)** and asserts every validator's instantiation reconstructs `Some(V3)` — the value the canonical mirror persists.
- `reconstruct_full_network_dkg_output_gating` (unit): `(V1, Some(V2))` stays `None`; `(V1, Some(V3))` now ENGAGES the reconstruction (asserted via decode failure on dummy bytes — a `None` would silently skip the deployed keys' migration).

## Docs

`dev-docs/specs/handoff.md` and `dev-docs/plans/network-dkg-anchor-v2-to-v3-migration.md` updated: the one-time canonical-anchor migration is now stated as pre-V3 (V1|V2) → V3, and the main builder's V1 arm is documented as landed rather than deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
