### PR TITLE
chore(sdk): drop the phantom signature-mpc-wasm lockfile importer

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,6 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
 
-  sdk/signature-mpc-wasm/pkg: {}
-
   sdk/typescript:
     dependencies:
       '@ika.xyz/ika-wasm':


### PR DESCRIPTION
Removes the stale `sdk/signature-mpc-wasm/pkg: {}` importer from `pnpm-lock.yaml` — the package directory was deleted but the lockfile still declared an (empty) importer for it. Surgical: one importer block removed, **zero dependency version churn**.

Closes review finding **S2** (phantom lockfile importer). The companion `sdk/ika-wasm/Cargo.lock` rayon drift that S2 also flagged is already resolved on dev, so this PR is pnpm-only.

The stale entry is harmless (an empty importer), so this is pure hygiene — not release-gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)