### PR TITLE
fix(clippy): make the full workspace clippy-clean under -D warnings

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -973,6 +973,10 @@ pub enum ReconfigCertStatus {
 /// together with the session identifier it uniquely identifies a single presign.
 type PresignPoolTable = DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>;
 
+/// An uncommitted presign pop: the pending write batch plus the popped
+/// presign's session identifier, blending index, and serialized value.
+type PreparedPresignPop = (DBBatch, SessionIdentifier, u16, Vec<u8>);
+
 /// AuthorityEpochTables contains tables that contain data that is only valid within an epoch.
 #[derive(DBMapUtils)]
 #[allow(clippy::type_complexity)]
@@ -1454,7 +1458,7 @@ impl AuthorityEpochTables {
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(DBBatch, SessionIdentifier, u16, Vec<u8>)>> {
+    ) -> IkaResult<Option<PreparedPresignPop>> {
         let table = self.presign_pool_table(signature_algorithm);
 
         // Get the first entry for this network encryption key ID.
@@ -2446,16 +2450,15 @@ impl AuthorityPerEpochStore {
             self.metrics
                 .dwallet_handoff_cert_epoch
                 .set(cert.attestation.epoch as i64);
-            if let Some(perpetual) = self.perpetual_tables_for_handoff.load_full() {
-                if let Err(e) =
+            if let Some(perpetual) = self.perpetual_tables_for_handoff.load_full()
+                && let Err(e) =
                     perpetual.insert_certified_handoff_attestation(cert.attestation.epoch, cert)
-                {
-                    warn!(
-                        error = ?e,
-                        epoch = cert.attestation.epoch,
-                        "failed to persist replay-minted handoff cert — cert remains in-memory only"
-                    );
-                }
+            {
+                warn!(
+                    error = ?e,
+                    epoch = cert.attestation.epoch,
+                    "failed to persist replay-minted handoff cert — cert remains in-memory only"
+                );
             }
         }
         // Drain peer V2 signatures that arrived before this

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -353,18 +353,18 @@ fn derive_vss_shamir_cache_for_key(
     use twopc_mpc::decentralized_party::{dkg as dec_dkg, reconfiguration as dec_reconf};
 
     enum DeserializedSource {
-        Reconfiguration(<dec_reconf::Party as mpc::Party>::PublicOutput),
-        NetworkDkg(<dec_dkg::Party as mpc::Party>::PublicOutput),
+        Reconfiguration(Box<<dec_reconf::Party as mpc::Party>::PublicOutput>),
+        NetworkDkg(Box<<dec_dkg::Party as mpc::Party>::PublicOutput>),
     }
 
     let source: DeserializedSource = match key.latest_network_reconfiguration_public_output() {
         Some(VersionedDecryptionKeyReconfigurationOutput::V3(bytes)) => {
-            DeserializedSource::Reconfiguration(bcs::from_bytes(&bytes).ok()?)
+            DeserializedSource::Reconfiguration(Box::new(bcs::from_bytes(&bytes).ok()?))
         }
         // Pre-V3 reconfiguration (or none yet) → fall through to network DKG output.
         _ => match key.network_dkg_output() {
             VersionedNetworkDkgOutput::V3(bytes) => {
-                DeserializedSource::NetworkDkg(bcs::from_bytes(bytes).ok()?)
+                DeserializedSource::NetworkDkg(Box::new(bcs::from_bytes(bytes).ok()?))
             }
             _ => return None,
         },
@@ -376,7 +376,7 @@ fn derive_vss_shamir_cache_for_key(
                 o.compute_secp256k1_shamir_shares_of_secret_key_share_parts(
                     party_id,
                     secrets.secp256k1_decryption_key,
-                    publics.secp256k1_encryption_key.clone(),
+                    publics.secp256k1_encryption_key,
                 ),
                 o.secp256k1_polynomial_commitments().0.clone(),
                 o.secp256k1_polynomial_commitments().1.clone(),
@@ -385,7 +385,7 @@ fn derive_vss_shamir_cache_for_key(
                 o.derive_shamir_shares_of_secp256k1_secret_key_share_parts(
                     party_id,
                     secrets.secp256k1_decryption_key,
-                    publics.secp256k1_encryption_key.clone(),
+                    publics.secp256k1_encryption_key,
                 ),
                 o.secp256k1_polynomial_commitments().0.clone(),
                 o.secp256k1_polynomial_commitments().1.clone(),
@@ -397,7 +397,7 @@ fn derive_vss_shamir_cache_for_key(
                 o.compute_curve25519_shamir_shares_of_secret_key_share_parts(
                     party_id,
                     secrets.ristretto_decryption_key,
-                    publics.ristretto_encryption_key.clone(),
+                    publics.ristretto_encryption_key,
                 ),
                 o.curve25519_polynomial_commitments().0.clone(),
                 o.curve25519_polynomial_commitments().1.clone(),
@@ -406,7 +406,7 @@ fn derive_vss_shamir_cache_for_key(
                 o.derive_shamir_shares_of_curve25519_secret_key_share_parts(
                     party_id,
                     secrets.ristretto_decryption_key,
-                    publics.ristretto_encryption_key.clone(),
+                    publics.ristretto_encryption_key,
                 ),
                 o.curve25519_polynomial_commitments().0.clone(),
                 o.curve25519_polynomial_commitments().1.clone(),
@@ -418,7 +418,7 @@ fn derive_vss_shamir_cache_for_key(
                 o.compute_ristretto_shamir_shares_of_secret_key_share_parts(
                     party_id,
                     secrets.ristretto_decryption_key,
-                    publics.ristretto_encryption_key.clone(),
+                    publics.ristretto_encryption_key,
                 ),
                 o.ristretto_polynomial_commitments().0.clone(),
                 o.ristretto_polynomial_commitments().1.clone(),
@@ -427,7 +427,7 @@ fn derive_vss_shamir_cache_for_key(
                 o.derive_shamir_shares_of_ristretto_secret_key_share_parts(
                     party_id,
                     secrets.ristretto_decryption_key,
-                    publics.ristretto_encryption_key.clone(),
+                    publics.ristretto_encryption_key,
                 ),
                 o.ristretto_polynomial_commitments().0.clone(),
                 o.ristretto_polynomial_commitments().1.clone(),
@@ -965,7 +965,17 @@ mod network_key_id_derivation_tool {
     #[tokio::test]
     async fn print_deployed_network_key_ids() {
         // (env, rpc, ika, common, twopc, system_pkg, system_obj, coordinator_obj) — from ika_sui_config.yaml
-        let envs: &[(&str, &str, &str, &str, &str, &str, &str, &str)] = &[
+        type DeployedEnv<'a> = (
+            &'a str,
+            &'a str,
+            &'a str,
+            &'a str,
+            &'a str,
+            &'a str,
+            &'a str,
+            &'a str,
+        );
+        let envs: &[DeployedEnv] = &[
             (
                 "testnet",
                 "https://fullnode.testnet.sui.io:443",

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -623,11 +623,9 @@ pub(crate) fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_re
     }
 
     match &mpc_public_output {
-        VersionedDecryptionKeyReconfigurationOutput::V1(_) => {
-            return Err(DwalletMPCError::InternalError(
-                "V1 network keys are no longer supported for instantiation.".to_string(),
-            ));
-        }
+        VersionedDecryptionKeyReconfigurationOutput::V1(_) => Err(DwalletMPCError::InternalError(
+            "V1 network keys are no longer supported for instantiation.".to_string(),
+        )),
         VersionedDecryptionKeyReconfigurationOutput::V2(public_output_bytes) => {
             // bwd-compat reconfig PublicOutput shape.
             let public_output: <bwd_compat_reconfig::Party as mpc::Party>::PublicOutput =

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
@@ -435,8 +435,7 @@ mod tests {
     fn panic_in_compute_becomes_a_failed_result() {
         let id = test_computation_id();
         let err = compute_catching_panic(id, || panic!("boom inside advance()"))
-            .err()
-            .expect("a panic must surface as a failed result, not Ok");
+            .expect_err("a panic must surface as a failed result, not Ok");
         match err {
             DwalletMPCError::MPCSessionError {
                 error,
@@ -467,8 +466,7 @@ mod tests {
                 error: "ordinary failure".to_string(),
             })
         })
-        .err()
-        .expect("the closure returned Err");
+        .expect_err("the closure returned Err");
         match err {
             DwalletMPCError::MPCSessionError { error, .. } => {
                 assert_eq!(error, "ordinary failure");

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -39,6 +39,12 @@ type TestPresignPool = Arc<
     Mutex<HashMap<(DWalletSignatureAlgorithm, ObjectID), Vec<(SessionIdentifier, u16, Vec<u8>)>>>,
 >;
 
+/// Fast Schnorr (VSS) presign private outputs, keyed by (presign session id, blending index).
+type PresignPrivateOutputs = Arc<Mutex<HashMap<(commitment::CommitmentSizedNumber, u16), Vec<u8>>>>;
+/// Assigned presigns keyed by (signature_algorithm, session_identifier, blending_index).
+type AssignedPresigns =
+    Arc<Mutex<HashMap<(DWalletSignatureAlgorithm, SessionIdentifier, u16), AssignedPresign>>>;
+
 /// A testing implementation of the `AuthorityPerEpochStoreTrait`.
 /// Records all received data for testing purposes.
 pub(crate) struct TestingAuthorityPerEpochStore {
@@ -70,11 +76,9 @@ pub(crate) struct TestingAuthorityPerEpochStore {
     /// within the blended vector produced by a presign session.
     pub(crate) used_presigns: Arc<Mutex<HashMap<(SessionIdentifier, u16), ()>>>,
     /// Fast Schnorr (VSS) presign private outputs, keyed by (presign session id, blending index).
-    pub(crate) presign_private_outputs:
-        Arc<Mutex<HashMap<(commitment::CommitmentSizedNumber, u16), Vec<u8>>>>,
+    pub(crate) presign_private_outputs: PresignPrivateOutputs,
     /// Assigned presigns keyed by (signature_algorithm, session_identifier, blending_index).
-    pub(crate) assigned_presigns:
-        Arc<Mutex<HashMap<(DWalletSignatureAlgorithm, SessionIdentifier, u16), AssignedPresign>>>,
+    pub(crate) assigned_presigns: AssignedPresigns,
     /// Configurable certified handoff attestations, keyed by epoch.
     /// Empty by default (the cert-gated adoption path then behaves as
     /// "cert absent"); tests for the cert-digest gate insert one here.
@@ -599,9 +603,10 @@ impl DWalletCheckpointServiceNotify for TestingDWalletCheckpointNotify {
 
 #[cfg(test)]
 #[allow(clippy::type_complexity)]
-pub fn create_dwallet_mpc_services(
-    size: usize,
-) -> (
+/// The per-authority services + channel handles a test harness spins up:
+/// one entry per committee member across services, senders, stores, notifies,
+/// and the NOA sign request/output channel ends.
+type DwalletMpcServiceHarness = (
     Vec<DWalletMPCService>,
     Vec<SuiDataSenders>,
     Vec<Arc<TestingSubmitToConsensus>>,
@@ -609,7 +614,9 @@ pub fn create_dwallet_mpc_services(
     Vec<Arc<TestingDWalletCheckpointNotify>>,
     Vec<Sender<NetworkOwnedAddressSignRequest>>,
     Vec<Receiver<NetworkOwnedAddressSignOutput>>,
-) {
+);
+
+pub fn create_dwallet_mpc_services(size: usize) -> DwalletMpcServiceHarness {
     let (committee, seeds, bundles) = build_committee_with_random_seeds(size);
     create_dwallet_mpc_services_with_committee_and_seeds(committee, seeds, bundles)
 }
@@ -675,15 +682,7 @@ pub fn create_dwallet_mpc_services_with_committee_and_seeds(
     committee: Committee,
     seeds: HashMap<AuthorityName, RootSeed>,
     bundles: crate::validator_metadata::OffChainCommitteeBundles,
-) -> (
-    Vec<DWalletMPCService>,
-    Vec<SuiDataSenders>,
-    Vec<Arc<TestingSubmitToConsensus>>,
-    Vec<Arc<TestingAuthorityPerEpochStore>>,
-    Vec<Arc<TestingDWalletCheckpointNotify>>,
-    Vec<Sender<NetworkOwnedAddressSignRequest>>,
-    Vec<Receiver<NetworkOwnedAddressSignOutput>>,
-) {
+) -> DwalletMpcServiceHarness {
     let dwallet_mpc_services = committee
         .names()
         .map(|authority_name| {
@@ -1146,9 +1145,8 @@ pub(crate) async fn advance_some_parties_and_wait_for_completions(
             // outer loop distributes them to all parties (regardless of running computations).
             // This check must happen BEFORE clearing so the messages are not lost.
             let check_status_update_with_data = |store: &Arc<Mutex<Vec<ConsensusTransaction>>>| {
-                store.lock().unwrap().iter().any(|msg| match &msg.kind {
-                    ConsensusTransactionKind::GlobalPresignRequest(_) => true,
-                    _ => false,
+                store.lock().unwrap().iter().any(|msg| {
+                    matches!(&msg.kind, ConsensusTransactionKind::GlobalPresignRequest(_))
                 })
             };
 

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -411,8 +411,8 @@ impl DWalletMPCManager {
             };
         let validator_pvss_publics_for_vss =
             crate::dwallet_mpc::network_dkg::ValidatorPvssEncryptionKeysForVss {
-                secp256k1_encryption_key: validator_publics.secp256k1_pvss.0.clone(),
-                ristretto_encryption_key: validator_publics.ristretto_pvss.0.clone(),
+                secp256k1_encryption_key: validator_publics.secp256k1_pvss.0,
+                ristretto_encryption_key: validator_publics.ristretto_pvss.0,
             };
 
         let validator_private_data = ValidatorPrivateDecryptionKeyData {

--- a/crates/ika-core/src/handoff_cert.rs
+++ b/crates/ika-core/src/handoff_cert.rs
@@ -140,8 +140,10 @@ impl StaticConsensusPubkeyProvider {
             keys: BTreeMap::new(),
         }
     }
+}
 
-    pub fn from_iter<I: IntoIterator<Item = (AuthorityName, Ed25519PublicKey)>>(items: I) -> Self {
+impl FromIterator<(AuthorityName, Ed25519PublicKey)> for StaticConsensusPubkeyProvider {
+    fn from_iter<I: IntoIterator<Item = (AuthorityName, Ed25519PublicKey)>>(items: I) -> Self {
         Self {
             keys: items.into_iter().collect(),
         }

--- a/crates/ika-core/src/sui_connector/metrics.rs
+++ b/crates/ika-core/src/sui_connector/metrics.rs
@@ -89,7 +89,7 @@ pub struct SuiConnectorMetrics {
 
     /// `clock.timestamp_ms - (epoch_start + epoch_duration)`, clamped to >=0.
     /// > 0 means the epoch should already have advanced; sustained values
-    /// indicate a deadlock.
+    /// > indicate a deadlock.
     pub(crate) chain_epoch_overdue_seconds: IntGauge,
 
     /// Gauge (0/1) per gating condition in `sync_dwallet_end_of_publish`.

--- a/crates/ika-core/src/sui_connector/ocs_metrics.rs
+++ b/crates/ika-core/src/sui_connector/ocs_metrics.rs
@@ -41,8 +41,8 @@ pub struct OcsMetrics {
     pub pusher_skipped_irrelevant_total: IntCounter,
     pub pusher_fetch_failures_total: IntCounter,
     /// Latency of the pre-fold committee verification the pusher runs before
-    /// folding a checkpoint into the local cache (committee BLS on the summary
-    /// + artifacts-digest binding). `_count` is the number of checkpoints
+    /// folding a checkpoint into the local cache (committee BLS on the summary +
+    /// artifacts-digest binding). `_count` is the number of checkpoints
     /// committee-verified before folding, `_sum` the total CPU time spent on
     /// it — together they quantify the verify's cost on the fold path.
     pub pusher_fold_verify_seconds: Histogram,

--- a/crates/ika-core/src/sui_connector/ocs_verifier.rs
+++ b/crates/ika-core/src/sui_connector/ocs_verifier.rs
@@ -241,15 +241,14 @@ impl OcsVerifyingClient {
         // log and fall through to the transport ratchet. Runs only on the first
         // ratchet; later ratchets rely on the transport + per-seq archive
         // fallback for the live tail.
-        if let Some(archive) = self.archive.clone() {
-            if !self.backfill_attempted.swap(true, Ordering::Relaxed) {
-                if let Err(e) = self.backfill_committee_chain_from_archive(&archive).await {
-                    warn!(
-                        error = %e,
-                        "archive cold-bootstrap incomplete; continuing with the transport ratchet"
-                    );
-                }
-            }
+        if let Some(archive) = self.archive.clone()
+            && !self.backfill_attempted.swap(true, Ordering::Relaxed)
+            && let Err(e) = self.backfill_committee_chain_from_archive(&archive).await
+        {
+            warn!(
+                error = %e,
+                "archive cold-bootstrap incomplete; continuing with the transport ratchet"
+            );
         }
         // `get_current_epoch` is a relay-claimed, unverified passthrough, but
         // it only sets the loop's *target* — it can't forge progress. Every

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -156,17 +156,17 @@ where
             ));
             // Legacy (v≤3) uncompleted-events poller. Under v4 the
             // BagEventPump emits the recovery snapshot instead.
-            if run_legacy_event_ingestion {
-                if let Some(uncompleted_requests_sender) = uncompleted_requests_sender {
-                    info!("Syncing uncompleted events");
-                    tokio::spawn(Self::sync_uncompleted_events(
-                        sui_client_clone,
-                        dwallet_coordinator_object_receiver.clone(),
-                        system_object_receiver.clone(),
-                        uncompleted_requests_sender,
-                        self.metrics.clone(),
-                    ));
-                }
+            if run_legacy_event_ingestion
+                && let Some(uncompleted_requests_sender) = uncompleted_requests_sender
+            {
+                info!("Syncing uncompleted events");
+                tokio::spawn(Self::sync_uncompleted_events(
+                    sui_client_clone,
+                    dwallet_coordinator_object_receiver.clone(),
+                    system_object_receiver.clone(),
+                    uncompleted_requests_sender,
+                    self.metrics.clone(),
+                ));
             }
         }
 
@@ -432,7 +432,7 @@ where
                 if let crate::validator_metadata::OffChainMpcDataAssembly::Complete(bundles) =
                     source.try_assemble_mpc_data(&current_members)
                     && current_epoch_mpc_keys_sender
-                        .send(Some((current_epoch, bundles)))
+                        .send(Some((current_epoch, *bundles)))
                         .is_ok()
                 {
                     current_keys_sent_for_epoch = Some(current_epoch);
@@ -673,7 +673,7 @@ where
                         quorum_threshold,
                         validity_threshold,
                     );
-                    return Ok((committee, Some(bundles)));
+                    return Ok((committee, Some(*bundles)));
                 }
                 crate::validator_metadata::OffChainMpcDataAssembly::Incomplete { missing } => {
                     if off_chain_on {

--- a/crates/ika-core/src/sui_connector/trusted_peer_updater.rs
+++ b/crates/ika-core/src/sui_connector/trusted_peer_updater.rs
@@ -67,7 +67,7 @@ pub async fn refresh_trusted_peers_loop(
                 // Keep the last good set (the watch channel still holds it, so
                 // known_peers is unaffected) and retry. Throttle the warn so an
                 // RPC outage doesn't repeat the same line every tick.
-                if consecutive_failures % 20 == 0 {
+                if consecutive_failures.is_multiple_of(20) {
                     warn!(error = %e, consecutive_failures, "trusted-peer refresh failed; keeping last set");
                 } else {
                     debug!(error = %e, "trusted-peer refresh failed");

--- a/crates/ika-core/src/sui_connector/verified_reader.rs
+++ b/crates/ika-core/src/sui_connector/verified_reader.rs
@@ -307,14 +307,14 @@ impl OcsVerifiedReader {
         // mirror path's safety bound: a stalled changeset stream that freezes
         // `currency` at `Current` still gets a forced verified re-read every
         // interval, so it can never serve a stale anchor indefinitely.
-        if !self.anchor_refresh_due(id) {
-            if let Some((hit, label)) = self.anchor_cache_hit(id) {
-                self.metrics
-                    .cache_read_total
-                    .with_label_values(&[label])
-                    .inc();
-                return Ok(hit);
-            }
+        if !self.anchor_refresh_due(id)
+            && let Some((hit, label)) = self.anchor_cache_hit(id)
+        {
+            self.metrics
+                .cache_read_total
+                .with_label_values(&[label])
+                .inc();
+            return Ok(hit);
         }
         // Refresh due, cache miss, or mirror node: take the verified network path
         // DIRECTLY (not `verified_object`, whose `try_cache_hit` would just

--- a/crates/ika-core/src/sui_connector/verified_state_cache.rs
+++ b/crates/ika-core/src/sui_connector/verified_state_cache.rs
@@ -304,10 +304,10 @@ impl VerifiedStateCache {
     /// unlike the per-object cache). `None` when pruning is disabled.
     fn eop_retention_floor(&self) -> Option<CheckpointSequenceNumber> {
         let mut floor = self.prune_floor()?;
-        if let Some(perpetual) = &self.perpetual {
-            if let Ok(Some(oldest)) = perpetual.oldest_sui_committee_summary() {
-                floor = floor.min(*oldest.sequence_number());
-            }
+        if let Some(perpetual) = &self.perpetual
+            && let Ok(Some(oldest)) = perpetual.oldest_sui_committee_summary()
+        {
+            floor = floor.min(*oldest.sequence_number());
         }
         Some(floor)
     }
@@ -338,10 +338,10 @@ impl VerifiedStateCache {
         // their committee ratchet, so they're kept back to the bootstrap anchor
         // — a deeper floor than the object cache (see `eop_retention_floor`) —
         // pruned on the same amortized schedule.
-        if let (Some(perpetual), Some(eop_floor)) = (&self.perpetual, self.eop_retention_floor()) {
-            if let Err(e) = perpetual.retain_sui_end_of_epoch_checkpoints(eop_floor) {
-                warn!(error = ?e, "failed to prune retained end-of-epoch checkpoints");
-            }
+        if let (Some(perpetual), Some(eop_floor)) = (&self.perpetual, self.eop_retention_floor())
+            && let Err(e) = perpetual.retain_sui_end_of_epoch_checkpoints(eop_floor)
+        {
+            warn!(error = ?e, "failed to prune retained end-of-epoch checkpoints");
         }
         let removed: Vec<(ObjectID, Option<ObjectID>)> = {
             let mut objects = self.objects.write();
@@ -362,12 +362,12 @@ impl VerifiedStateCache {
         {
             let mut children = self.children.write();
             for (id, parent) in &removed {
-                if let Some(parent) = parent {
-                    if let Some(set) = children.get_mut(parent) {
-                        set.remove(id);
-                        if set.is_empty() {
-                            children.remove(parent);
-                        }
+                if let Some(parent) = parent
+                    && let Some(set) = children.get_mut(parent)
+                {
+                    set.remove(id);
+                    if set.is_empty() {
+                        children.remove(parent);
                     }
                 }
             }
@@ -463,10 +463,10 @@ impl VerifiedStateCache {
         // If this object moved owners since we last cached it, evict from the
         // old parent's set.
         if prior_parent != new_parent {
-            if let Some(prev) = prior_parent {
-                if let Some(set) = self.children.write().get_mut(&prev) {
-                    set.remove(&id);
-                }
+            if let Some(prev) = prior_parent
+                && let Some(set) = self.children.write().get_mut(&prev)
+            {
+                set.remove(&id);
             }
             if let Some(p) = new_parent {
                 self.children.write().entry(p).or_default().insert(id);

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -123,10 +123,10 @@ impl StaticJoinerPubkeyProvider {
             members: BTreeMap::new(),
         }
     }
+}
 
-    pub fn from_iter<I: IntoIterator<Item = (AuthorityName, Ed25519PublicKey)>>(
-        members: I,
-    ) -> Self {
+impl FromIterator<(AuthorityName, Ed25519PublicKey)> for StaticJoinerPubkeyProvider {
+    fn from_iter<I: IntoIterator<Item = (AuthorityName, Ed25519PublicKey)>>(members: I) -> Self {
         Self {
             members: members.into_iter().collect(),
         }
@@ -958,7 +958,7 @@ pub struct OffChainCommitteeBundles {
 /// missing entry silently drops that validator's share.
 #[derive(Debug)]
 pub enum OffChainMpcDataAssembly {
-    Complete(OffChainCommitteeBundles),
+    Complete(Box<OffChainCommitteeBundles>),
     Incomplete {
         missing: Vec<AuthorityName>,
     },
@@ -1052,13 +1052,13 @@ where
         };
     }
     if missing.is_empty() {
-        OffChainMpcDataAssembly::Complete(OffChainCommitteeBundles {
+        OffChainMpcDataAssembly::Complete(Box::new(OffChainCommitteeBundles {
             class_groups,
             secp256k1_pvss,
             secp256r1_pvss,
             ristretto_pvss,
             vss_hpke,
-        })
+        }))
     } else {
         OffChainMpcDataAssembly::Incomplete { missing }
     }
@@ -1360,7 +1360,7 @@ impl OffChainCommitteeMpcDataSource for EpochStoreMpcDataSource {
             .as_ref()
             && *cached_pairs == pairs
         {
-            return OffChainMpcDataAssembly::Complete(cached_bundles.clone());
+            return OffChainMpcDataAssembly::Complete(Box::new(cached_bundles.clone()));
         }
         let perpetual = self.perpetual.clone();
         let assembly_pairs: Vec<_> = pairs.clone();
@@ -1371,7 +1371,8 @@ impl OffChainCommitteeMpcDataSource for EpochStoreMpcDataSource {
             *self
                 .assembled_cache
                 .lock()
-                .expect("assembled_cache lock poisoned") = Some((pairs.clone(), bundles.clone()));
+                .expect("assembled_cache lock poisoned") =
+                Some((pairs.clone(), (**bundles).clone()));
         }
         if let OffChainMpcDataAssembly::Incomplete { ref missing } = result {
             let blob_only_missing: Vec<_> = missing
@@ -1521,8 +1522,8 @@ mod tests {
 
         // Hard cap: oldest-first eviction once over `max`.
         let mut capped = Vec::new();
-        for i in 0..3 {
-            push_buffered_joiner_announcement(&mut capped, &signed[i], t0, ttl, 2);
+        for signed_entry in signed.iter().take(3) {
+            push_buffered_joiner_announcement(&mut capped, signed_entry, t0, ttl, 2);
         }
         assert_eq!(capped.len(), 2);
         let present: Vec<_> = capped

--- a/crates/ika-sui-client/src/archive.rs
+++ b/crates/ika-sui-client/src/archive.rs
@@ -137,7 +137,7 @@ impl CheckpointArchive for SuiCheckpointArchive {
 mod tests {
     use super::*;
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     // A unique temp dir for this test process (no external tempfile dep).
     fn temp_store_dir(tag: &str) -> PathBuf {
@@ -147,7 +147,7 @@ mod tests {
         dir
     }
 
-    fn file_url(dir: &PathBuf) -> String {
+    fn file_url(dir: &Path) -> String {
         format!("file://{}", dir.display())
     }
 

--- a/crates/ika-sui-client/src/genesis.rs
+++ b/crates/ika-sui-client/src/genesis.rs
@@ -126,14 +126,14 @@ fn verify_genesis(
 
     // Verify the blob against the binary's compiled-in 32-byte root for the
     // public chains. A swapped/forged summary is caught here.
-    if let Some(expected) = compiled_in_chain_identifier(chain) {
-        if chain_identifier != expected {
-            return Err(GenesisError::ChainMismatch {
-                chain,
-                got: chain_identifier.base58_encode(),
-                expected: expected.base58_encode(),
-            });
-        }
+    if let Some(expected) = compiled_in_chain_identifier(chain)
+        && chain_identifier != expected
+    {
+        return Err(GenesisError::ChainMismatch {
+            chain,
+            got: chain_identifier.base58_encode(),
+            expected: expected.base58_encode(),
+        });
     }
 
     // Bind committee[0] to that verified digest. The check above only pins the

--- a/crates/ika-types/src/handoff.rs
+++ b/crates/ika-types/src/handoff.rs
@@ -117,7 +117,7 @@ mod tests {
         let key_id_a = NetworkKeyId([1u8; 32]);
         let key_id_b = NetworkKeyId([2u8; 32]);
         let auth = make_authority(0);
-        let mut keys = vec![
+        let mut keys = [
             HandoffItemKey::ValidatorMpcData { validator: auth },
             HandoffItemKey::NetworkReconfigurationOutput { key_id: key_id_a },
             HandoffItemKey::NetworkDkgOutput { key_id: key_id_b },

--- a/crates/ika/src/validator_commands.rs
+++ b/crates/ika/src/validator_commands.rs
@@ -1221,8 +1221,8 @@ fn make_key_files(
     Ok(())
 }
 
-/// Generates the validator's complete MPC key material (class groups + per-curve PVSS HPKE
-/// + VSS HPKE) from a seed file if it exists, otherwise generates and saves the seed.
+/// Generates the validator's complete MPC key material (class groups + per-curve PVSS HPKE +
+/// VSS HPKE) from a seed file if it exists, otherwise generates and saves the seed.
 /// Returns both the secrets (held locally) and the public encryption-keys-and-proofs payload
 /// (published in the on-chain validator record).
 fn read_or_generate_root_seed(


### PR DESCRIPTION
## Why

CI's clippy job runs `cargo clippy --all-targets --all-features -- -D warnings`, but it always died on the **first** crate that errored — so a backlog of new-toolchain lints across the rest of the workspace was never surfaced. This makes the **entire workspace** clippy-clean, unblocking the CI clippy gate for good.

Found by running the exact CI command locally and iterating crate-by-crate (clippy checks in dependency order and aborts each crate at its first errors, so every fix unblocked the next layer: `ika-types` → `ika-sui-client` → `ika-core` → `ika`).

## What (all fixed at the source — no `#[allow]`s)

**Mechanical (via `clippy --fix`)** — `collapsible_if`, `clone_on_copy`, `needless_return`, `manual_is_multiple_of`, `err_expect`, `match_like_matches_macro`, `useless_vec`, `ptr_arg`, `needless_range_loop`, `doc_lazy_continuation`.

**`type_complexity`** — factored complex tuple/map types into `type` aliases:
- `PreparedPresignPop` (uncommitted presign pop)
- `PresignPrivateOutputs` / `AssignedPresigns` / `DwalletMpcServiceHarness` (test harness)
- `DeployedEnv` (network-key-id derivation tool)

**`large_enum_variant`** — boxed the oversized variants and unboxed at consumers:
- `DeserializedSource` (a ~10 KB MPC `PublicOutput` enum) → `Box` both variants
- `OffChainMpcDataAssembly::Complete(..)` → `Box<OffChainCommitteeBundles>` (updated construct/match sites in `validator_metadata` + `sui_syncer`)

**`should_implement_trait`** — replaced inherent `from_iter` constructors on `StaticJoinerPubkeyProvider` / `StaticConsensusPubkeyProvider` with `impl FromIterator<…>` (all `X::from_iter([...])` call sites unchanged).

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` → **clean (exit 0)** across the whole workspace.
- `cargo fmt --all` clean.
- Boxing/unboxing verified by the compiler; no behavior change (jemalloc, MPC logic untouched).

## Scope
19 files, +137/−128 — mostly `ika-core`.