### PR TITLE
fix(dwallet-mpc): expire never-completing internal-presign top-up batches instead of starving the pool for the epoch

### DIFF
--- a/.github/workflows/simtest.yaml
+++ b/.github/workflows/simtest.yaml
@@ -106,4 +106,8 @@ jobs:
           MSIM_TEST_SEED: ${{ inputs.seed }}
           MSIM_TEST_NUM: ${{ inputs.test_num }}
         run: |
-          cargo simtest --package ${{ inputs.package }} -- ${{ inputs.test_filter }}
+          # --no-tests=pass is a nextest option, so it must come BEFORE the
+          # `--` separator: the workspace currently has zero #[sim_test]
+          # targets by convention, and without it nextest exits 4
+          # ("no tests to run") on every dispatch.
+          cargo simtest --package ${{ inputs.package }} --no-tests=pass -- ${{ inputs.test_filter }}

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -124,6 +124,14 @@ pub struct VssRistrettoShamirCache {
 /// `WaitingForNetworkKey`, same as the AHE wait path).
 #[derive(Clone, Debug)]
 pub struct VssShamirCachePerKey {
+    /// The epoch of the key data this cache was derived from. The cache map
+    /// is keyed by ObjectID only, so across an epoch switch a stale entry
+    /// (previous epoch's shares) sits under the current key id until this
+    /// validator's re-derivation lands; readers must treat an epoch mismatch
+    /// exactly like a missing entry (see `vss_shamir_cache`), or VSS
+    /// computations mix the new epoch's public parameters with the old
+    /// epoch's shares and fail round one with `InvalidParameters`.
+    pub derived_for_epoch: u64,
     pub secp256k1: VssSecp256k1ShamirCache,
     pub curve25519: VssCurve25519ShamirCache,
     pub ristretto: VssRistrettoShamirCache,
@@ -439,6 +447,7 @@ fn derive_vss_shamir_cache_for_key(
     let (ristretto_first, ristretto_second) = ristretto_shares.ok()?;
 
     Some(VssShamirCachePerKey {
+        derived_for_epoch: key.epoch(),
         secp256k1: VssSecp256k1ShamirCache {
             secret_key_share_first_part: secp256k1_first,
             secret_key_share_second_part: secp256k1_second,
@@ -513,10 +522,23 @@ impl DwalletMPCNetworkKeys {
         &self,
         key_id: &ObjectID,
     ) -> DwalletMPCResult<&VssShamirCachePerKey> {
-        self.validator_private_dec_key_data
+        let cache = self
+            .validator_private_dec_key_data
             .validator_vss_shamir_cache
             .get(key_id)
-            .ok_or(DwalletMPCError::WaitingForNetworkKey(*key_id))
+            .ok_or(DwalletMPCError::WaitingForNetworkKey(*key_id))?;
+        // A cache derived from a previous epoch's key data mixed with the
+        // current epoch's public parameters fails MPC round one with
+        // `InvalidParameters` (the per-validator epoch-entry failure window
+        // of issue #1736: the re-derivation is heavy class-groups work that
+        // lands seconds to minutes after the key update, per validator).
+        // Treat a stale entry exactly like a missing one — the computation
+        // parks and retries once this validator's re-derivation lands.
+        let current_key_epoch = self.get_network_encryption_key_public_data(key_id)?.epoch();
+        if cache.derived_for_epoch != current_key_epoch {
+            return Err(DwalletMPCError::WaitingForNetworkKey(*key_id));
+        }
+        Ok(cache)
     }
 
     pub fn key_public_data_exists(&self, key_id: &ObjectID) -> bool {

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/presign.rs
@@ -278,6 +278,23 @@ impl PresignPublicInputByProtocol {
         dwallet_dkg_output: Option<MPCPublicOutput>,
         validator_mpc_keys_by_party_id: &ValidatorMpcKeysByPartyId,
     ) -> DwalletMPCResult<Self> {
+        // The manager starts each epoch with EMPTY off-chain key maps; the
+        // epoch's consensus-agreed set arrives via `ingest_offchain_mpc_keys`
+        // shortly after entry. A VSS presign input built in that gap deals to
+        // an empty party set and fails MPC round one with
+        // `InvalidParameters` (the per-validator epoch-entry failure window
+        // of issue #1736). Fail the attempt as not-ready instead of building
+        // a structurally empty input: the session's fate is then a clean
+        // per-validator miss absorbed by quorum redundancy, and a fully-dead
+        // refill batch is retried by the internal-presign stale-batch expiry
+        // once the key set lands.
+        if protocol.is_vss()
+            && validator_mpc_keys_by_party_id
+                .vss_hpke_verified_party_encryption_key_values
+                .is_empty()
+        {
+            return Err(DwalletMPCError::NetworkDecryptionKeyNotReady);
+        }
         let input = match protocol {
             DWalletSignatureAlgorithm::ECDSASecp256k1 => {
                 let protocol_public_parameters =

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -1381,7 +1381,17 @@ impl DWalletMPCService {
                         Ok(Some((_presign_session_id, _presign_blending_index, presign))) => {
                             match bcs::to_bytes(&VersionedPresignOutput::V2(presign)) {
                                 Ok(presign) => {
-                                    debug!(
+                                    // Info on purpose: a pool-served presign
+                                    // session completes without ever running
+                                    // MPC, so this is the ONLY line tying its
+                                    // session identifier and sequence number
+                                    // to a completion — at debug, such
+                                    // sessions are untraceable in production
+                                    // logs (each held/served session's fate
+                                    // was invisible in the issue #1736
+                                    // forensics). Volume: once per served
+                                    // presign.
+                                    info!(
                                         request_session_id =? request.session_identifier,
                                         presign_id =? request.presign_id,
                                         session_sequence_number =? request.session_sequence_number,

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -3,11 +3,13 @@ use crate::dwallet_mpc::NetworkOwnedAddressSignRequest;
 use crate::dwallet_mpc::integration_tests::network_dkg::create_network_key_test;
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::{
-    TEST_NETWORK_OWNED_ADDRESS_SIGN_PRESIGN_SESSIONS_TO_INSTANTIATE,
+    IntegrationTestState, TEST_NETWORK_OWNED_ADDRESS_SIGN_PRESIGN_SESSIONS_TO_INSTANTIATE,
     TEST_PRESIGN_CONSENSUS_ROUND_DELAY, TEST_PRESIGN_POOL_MAXIMUM_SIZE,
-    TEST_PRESIGN_POOL_MINIMUM_SIZE, build_test_state, create_test_protocol_config_guard,
+    TEST_PRESIGN_POOL_MINIMUM_SIZE, apply_test_presign_pool_overrides, build_test_state,
+    create_test_protocol_config_guard,
 };
 use dwallet_mpc_types::dwallet_mpc::{DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm};
+use ika_protocol_config::ProtocolConfig;
 use tracing::info;
 
 /// All signature algorithms that have internal presign pools.
@@ -27,6 +29,205 @@ const ALL_ALGORITHMS: &[(DWalletCurve, DWalletSignatureAlgorithm)] = &[
     ),
     (DWalletCurve::Secp256k1, DWalletSignatureAlgorithm::Taproot),
 ];
+
+/// Consensus rounds after which an in-flight top-up batch is presumed dead in
+/// [`test_internal_presign_stale_batch_expiry`] — small so the test reaches
+/// the expiry within a handful of service-loop iterations.
+const TEST_STALE_BATCH_EXPIRY_ROUNDS: u64 = 12;
+
+/// Reads the (instantiated, completed) internal-presign counters of one
+/// service for one (curve, algorithm) pair.
+fn presign_batch_counters(
+    test_state: &IntegrationTestState,
+    service_index: usize,
+    curve: DWalletCurve,
+    algorithm: DWalletSignatureAlgorithm,
+) -> (u64, u64) {
+    let manager = test_state.dwallet_mpc_services[service_index].dwallet_mpc_manager();
+    (
+        manager
+            .instantiated_internal_presign_sessions
+            .get(&(curve, algorithm))
+            .copied()
+            .unwrap_or(0),
+        manager
+            .completed_internal_presign_sessions
+            .get(&(curve, algorithm))
+            .copied()
+            .unwrap_or(0),
+    )
+}
+
+/// Runs one consensus round across all services, first discarding every
+/// pending consensus message so nothing the validators produced is ever
+/// delivered — the round advances, but every in-flight MPC session is dead.
+/// Waits for rayon computations BEFORE discarding so a slow computation
+/// cannot deposit its message after the discard and leak into the next
+/// delivery.
+async fn run_one_round_discarding_all_messages(test_state: &mut IntegrationTestState) {
+    utils::wait_for_computations(test_state).await;
+    for collector in &test_state.sent_consensus_messages_collectors {
+        collector.submitted_messages.lock().unwrap().clear();
+    }
+    utils::send_advance_results_between_parties(
+        &test_state.committee,
+        &mut test_state.sent_consensus_messages_collectors,
+        &mut test_state.epoch_stores,
+        test_state.consensus_round as u64,
+    );
+    test_state.consensus_round += 1;
+    for service in test_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration(vec![]).await;
+    }
+}
+
+/// Runs one consensus round across all services with normal message delivery.
+async fn run_one_round_delivering_messages(test_state: &mut IntegrationTestState) {
+    utils::send_advance_results_between_parties(
+        &test_state.committee,
+        &mut test_state.sent_consensus_messages_collectors,
+        &mut test_state.epoch_stores,
+        test_state.consensus_round as u64,
+    );
+    test_state.consensus_round += 1;
+    for service in test_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration(vec![]).await;
+    }
+    utils::wait_for_computations(test_state).await;
+}
+
+/// Test the stale-batch expiry of the internal-presign top-up guard.
+///
+/// A top-up batch whose sessions die without ever reaching an output quorum
+/// (in production: internal-presign refill sessions failing their first
+/// computation round on every validator at epoch entry) never advances the
+/// completion counter, and the in-flight guard would block that pool's
+/// top-up for the rest of the epoch — the pool starves. The expiry presumes
+/// such a batch dead after `internal_presign_stale_batch_expiry_rounds`
+/// consensus rounds, reconciles the counters, and lets the pool top up again.
+///
+/// Simulates the dead batch by discarding ALL consensus messages once the
+/// first batch instantiates (rounds keep flowing; no MPC message or output
+/// is ever delivered), then asserts:
+/// - the guard stays closed (no new instantiation) before the expiry;
+/// - after the expiry the counters reconcile and a new batch fires;
+/// - with delivery restored, the retried batch completes and the starved
+///   pool actually fills;
+/// - all four validators agree on the counters throughout (the top-up
+///   decision derives the deterministic session identifiers every validator
+///   computes independently, so it must be committee-uniform).
+#[tokio::test]
+#[cfg(test)]
+async fn test_internal_presign_stale_batch_expiry() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    // One guard carrying the standard small pools PLUS the small expiry:
+    // `apply_overrides_for_testing` replaces the previous override closure,
+    // so the standard guard and an expiry-only guard would not compose.
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_version, mut config| {
+        apply_test_presign_pool_overrides(&mut config);
+        config.set_internal_presign_stale_batch_expiry_rounds_for_testing(
+            TEST_STALE_BATCH_EXPIRY_ROUNDS,
+        );
+        config
+    });
+
+    let mut test_state = build_test_state(4);
+    let (consensus_round, _network_key_bytes, network_key_id) =
+        create_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+
+    // Track EdDSA: its presign protocol is single-round, so it is the batch
+    // most likely to complete by accident — proving IT stays dead under the
+    // discard covers the slower protocols a fortiori.
+    let (curve, algorithm) = (DWalletCurve::Curve25519, DWalletSignatureAlgorithm::EdDSA);
+    let batch_size = TEST_NETWORK_OWNED_ADDRESS_SIGN_PRESIGN_SESSIONS_TO_INSTANTIATE;
+
+    // === Phase 1: discard from the start; run until the first batch fires ===
+    // Discarding from the very first round means the batch is dead from
+    // birth — its computations run, but their messages are never delivered.
+    let mut batch_seen = false;
+    for _ in 0..12 {
+        run_one_round_discarding_all_messages(&mut test_state).await;
+        let (instantiated, completed) = presign_batch_counters(&test_state, 0, curve, algorithm);
+        if instantiated > 0 {
+            assert_eq!(instantiated, batch_size, "exactly one batch should fire");
+            assert_eq!(completed, 0, "the dead batch must never complete");
+            batch_seen = true;
+            break;
+        }
+    }
+    assert!(batch_seen, "the first top-up batch never instantiated");
+
+    // === Phase 2: the guard must hold while the batch is within the expiry ===
+    // The batch fired at most one round before detection; asserting over
+    // expiry-minus-three rounds keeps the window strictly inside the expiry
+    // regardless of that lag.
+    for round_offset in 0..(TEST_STALE_BATCH_EXPIRY_ROUNDS - 3) {
+        run_one_round_discarding_all_messages(&mut test_state).await;
+        let (instantiated, completed) = presign_batch_counters(&test_state, 0, curve, algorithm);
+        assert_eq!(
+            (instantiated, completed),
+            (batch_size, 0),
+            "guard must block new top-ups while the dead batch is within the \
+             expiry window (round offset {round_offset})"
+        );
+    }
+
+    // === Phase 3: past the expiry, the counters reconcile and a new batch fires ===
+    let mut refired = false;
+    for _ in 0..(TEST_STALE_BATCH_EXPIRY_ROUNDS + 10) {
+        run_one_round_discarding_all_messages(&mut test_state).await;
+        let (instantiated, _) = presign_batch_counters(&test_state, 0, curve, algorithm);
+        if instantiated > batch_size {
+            refired = true;
+            break;
+        }
+    }
+    assert!(
+        refired,
+        "the pool must top up again after the stale-batch expiry"
+    );
+    for service_index in 0..test_state.dwallet_mpc_services.len() {
+        let (instantiated, completed) =
+            presign_batch_counters(&test_state, service_index, curve, algorithm);
+        assert_eq!(
+            (instantiated, completed),
+            (batch_size * 2, batch_size),
+            "service {service_index}: expiry must reconcile the dead batch \
+             (completed := instantiated) before the new batch fires"
+        );
+    }
+
+    // === Phase 4: with delivery restored, the retried batch heals the pool ===
+    let mut pool_size = 0;
+    for _ in 0..30 {
+        run_one_round_delivering_messages(&mut test_state).await;
+        pool_size = test_state.epoch_stores[0]
+            .presign_pool_size(algorithm, network_key_id)
+            .unwrap_or(0);
+        let (instantiated, completed) = presign_batch_counters(&test_state, 0, curve, algorithm);
+        if pool_size > 0 && instantiated == completed {
+            break;
+        }
+    }
+    assert!(
+        pool_size > 0,
+        "the retried batch must complete and refill the starved pool"
+    );
+
+    // Final cross-service consistency: instantiation is consensus-driven, so
+    // every validator must hold identical counters.
+    let reference = presign_batch_counters(&test_state, 0, curve, algorithm);
+    for service_index in 1..test_state.dwallet_mpc_services.len() {
+        assert_eq!(
+            presign_batch_counters(&test_state, service_index, curve, algorithm),
+            reference,
+            "service {service_index}: counters diverged from service 0"
+        );
+    }
+
+    info!("Test completed: stale-batch expiry releases a starved pool and the retry heals it");
+}
 
 /// Test that internal presign sessions are instantiated at exactly the correct consensus
 /// rounds based on the production logic in `mpc_manager.rs:instantiate_internal_presign_sessions`.

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -1319,8 +1319,20 @@ pub(crate) const TEST_NETWORK_OWNED_ADDRESS_SIGN_PRESIGN_SESSIONS_TO_INSTANTIATE
 #[cfg(test)]
 pub(crate) fn create_test_protocol_config_guard() -> OverrideGuard {
     ProtocolConfig::apply_overrides_for_testing(|_version, mut config| {
-        config.set_idle_session_count_threshold_for_testing(TEST_IDLE_SESSION_COUNT_THRESHOLD);
+        apply_test_presign_pool_overrides(&mut config);
+        config
+    })
+}
 
+/// The shared override set behind [`create_test_protocol_config_guard`],
+/// callable from tests that need these small pools PLUS extra overrides in a
+/// single guard — `ProtocolConfig::apply_overrides_for_testing` replaces any
+/// previously installed override closure, so two guards do not compose.
+#[cfg(test)]
+pub(crate) fn apply_test_presign_pool_overrides(config: &mut ProtocolConfig) {
+    config.set_idle_session_count_threshold_for_testing(TEST_IDLE_SESSION_COUNT_THRESHOLD);
+
+    {
         // Per-algorithm presign pool settings
         config.set_internal_secp256k1_ecdsa_presign_pool_minimum_size_for_testing(
             TEST_PRESIGN_POOL_MINIMUM_SIZE,
@@ -1456,9 +1468,7 @@ pub(crate) fn create_test_protocol_config_guard() -> OverrideGuard {
         config.set_network_owned_address_taproot_presign_sessions_to_instantiate_for_testing(
             TEST_NETWORK_OWNED_ADDRESS_SIGN_PRESIGN_SESSIONS_TO_INSTANTIATE,
         );
-
-        config
-    })
+    }
 }
 
 /// Creates an `IntegrationTestState` from the output of `create_dwallet_mpc_services`.

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -88,7 +88,9 @@ fn compute_chain_context<C: CounterpartyChain>(
     if let Some(context) =
         C::context_from_observations(&observations, current_context.as_ref(), access_structure)
     {
-        info!(
+        // The agreement recomputes every consensus round per chain; at info
+        // this line alone was ~9K lines/min (half the log) on a localnet.
+        debug!(
             consensus_round,
             chain = %C::KIND,
             "Chain context agreed upon"

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -298,6 +298,17 @@ pub(crate) struct DWalletMPCManager {
     pub(crate) completed_internal_presign_sessions:
         HashMap<(DWalletCurve, DWalletSignatureAlgorithm), u64>,
 
+    /// Consensus round at which the most recent internal-presign top-up batch
+    /// was instantiated, per (curve, signature_algorithm). Drives the
+    /// stale-batch expiry in `instantiate_internal_presign_sessions`: a batch
+    /// that never reaches an output quorum (e.g. every validator's
+    /// computation failed locally) would otherwise block its pool's top-up
+    /// for the rest of the epoch, starving the pool.
+    /// Consensus-safe: written only with consensus-agreed round numbers, so
+    /// all honest parties maintain identical values.
+    internal_presign_batch_instantiated_at_round:
+        HashMap<(DWalletCurve, DWalletSignatureAlgorithm), u64>,
+
     /// The epoch store for persisting presign pools to disk.
     pub(crate) epoch_store: Arc<dyn AuthorityPerEpochStoreTrait>,
 
@@ -490,6 +501,7 @@ impl DWalletMPCManager {
             next_internal_presign_sequence_number: 1,
             instantiated_internal_presign_sessions: HashMap::new(),
             completed_internal_presign_sessions: HashMap::new(),
+            internal_presign_batch_instantiated_at_round: HashMap::new(),
             epoch_store,
             network_owned_address_sign_output_sender,
             sui_chain_observations_by_party: HashMap::new(),
@@ -1670,7 +1682,43 @@ impl DWalletMPCManager {
                     .copied()
                     .unwrap_or(0);
                 if instantiated != completed {
-                    continue;
+                    // A batch that dies without ever reaching an output quorum
+                    // (e.g. every validator's round-one computation failed
+                    // locally) never advances `completed`, so without an
+                    // expiry it blocks this pool's top-up for the rest of the
+                    // epoch and the pool starves. Presume such a batch dead
+                    // after a bounded number of consensus rounds and forgive
+                    // it by reconciling the counters; a presumed-dead batch
+                    // that completes late is absorbed by the saturating
+                    // increment in `record_internal_presign_output`.
+                    // Consensus-safe: the decision reads only consensus-agreed
+                    // inputs (round numbers and the shared counters), so every
+                    // validator expires the same batch at the same round.
+                    let Some(expiry_rounds) = self
+                        .protocol_config
+                        .internal_presign_stale_batch_expiry_rounds_as_option()
+                    else {
+                        continue;
+                    };
+                    let batch_round = self
+                        .internal_presign_batch_instantiated_at_round
+                        .get(&(curve, signature_algorithm))
+                        .copied()
+                        .unwrap_or(0);
+                    if consensus_round.saturating_sub(batch_round) < expiry_rounds {
+                        continue;
+                    }
+                    warn!(
+                        ?curve,
+                        ?signature_algorithm,
+                        instantiated,
+                        completed,
+                        batch_round,
+                        consensus_round,
+                        "internal presign top-up batch never completed; presuming it dead and releasing the pool for new top-ups"
+                    );
+                    self.completed_internal_presign_sessions
+                        .insert((curve, signature_algorithm), instantiated);
                 }
 
                 if (number_of_consensus_rounds.is_multiple_of(consensus_round_delay)
@@ -1689,6 +1737,8 @@ impl DWalletMPCManager {
                             .entry((curve, signature_algorithm))
                             .or_insert(0) += 1;
                     }
+                    self.internal_presign_batch_instantiated_at_round
+                        .insert((curve, signature_algorithm), consensus_round);
                     pools_filled.push(format!(
                         "{curve:?}/{signature_algorithm:?}={current_pool_size}(min{minimal_pool_size})+{sessions_to_instantiate}"
                     ));
@@ -2821,10 +2871,23 @@ impl DWalletMPCManager {
                         );
                     }
                 }
-                *self
+                // Saturating at `instantiated`: a batch presumed dead by the
+                // stale-batch expiry already had its slot reconciled, so a
+                // late completion must not push `completed` past
+                // `instantiated` — the top-up skip compares them for
+                // equality and would block the pool permanently.
+                let instantiated = self
+                    .instantiated_internal_presign_sessions
+                    .get(&(curve, signature_algorithm))
+                    .copied()
+                    .unwrap_or(0);
+                let completed = self
                     .completed_internal_presign_sessions
                     .entry((curve, signature_algorithm))
-                    .or_insert(0) += 1;
+                    .or_insert(0);
+                if *completed < instantiated {
+                    *completed += 1;
+                }
             }
             DWalletInternalMPCOutputKind::NetworkOwnedAddressSign {
                 output,

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -1240,9 +1240,18 @@ where
                 coordinator.dwallet_network_encryption_keys.size
                     == coordinator.epoch_dwallet_network_encryption_keys_reconfiguration_completed;
             let all_noa_checkpoints_finalized = noa_checkpoints_finalized();
+            // The lock flag belongs to the coordinator's OWN epoch. Right
+            // after an epoch advance the syncer can observe the system
+            // object's bumped epoch while this coordinator snapshot still
+            // predates the coordinator's advance — its lock flag is then the
+            // PREVIOUS epoch's close-lock, and counting it produced spurious
+            // "gate STUCK" warns for the first minutes of every epoch. Treat
+            // the gate as post-lock only when both objects agree on the
+            // epoch.
             let session_locked = coordinator
                 .sessions_manager
-                .locked_last_user_initiated_session_to_complete_in_current_epoch;
+                .locked_last_user_initiated_session_to_complete_in_current_epoch
+                && coordinator.current_epoch == system_inner_v1.epoch;
             let no_pricing_calculation_votes = coordinator
                 .pricing_and_fee_management
                 .calculation_votes

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -375,6 +375,17 @@ pub struct ProtocolConfig {
     internal_eddsa_presign_pool_maximum_size: Option<u64>,
     internal_schnorrkel_substrate_presign_pool_maximum_size: Option<u64>,
     internal_taproot_presign_pool_maximum_size: Option<u64>,
+
+    /// Consensus rounds after which an incomplete internal-presign top-up
+    /// batch is presumed dead and stops blocking its pool's top-up. A batch
+    /// that dies without ever reaching an output quorum (its completion
+    /// counter only advances on quorum) would otherwise block that pool's
+    /// top-up for the rest of the epoch and starve the pool. `None` disables
+    /// the expiry (the pre-existing block-forever behavior). Version-gated
+    /// because the top-up decision must be identical across the committee:
+    /// it derives the deterministic session identifiers every validator
+    /// computes independently.
+    internal_presign_stale_batch_expiry_rounds: Option<u64>,
 }
 
 // feature flags
@@ -707,6 +718,9 @@ impl ProtocolConfig {
             internal_eddsa_presign_pool_maximum_size: Some(30000),
             internal_schnorrkel_substrate_presign_pool_maximum_size: Some(30000),
             internal_taproot_presign_pool_maximum_size: Some(30000),
+
+            // Set at v4 (see the version match below).
+            internal_presign_stale_batch_expiry_rounds: None,
         };
 
         cfg.feature_flags.mysticeti_num_leaders_per_round = Some(1);
@@ -735,6 +749,12 @@ impl ProtocolConfig {
                     cfg.feature_flags.bls_checkpoints = true;
                     cfg.feature_flags.off_chain_validator_metadata = true;
                     cfg.feature_flags.fast_schnorr_supported = true;
+                    // ~2.5 minutes at the ~20 rounds/s observed under loaded
+                    // CI consensus — far beyond an honest batch's completion
+                    // time. Erring short merely risks a one-batch pool
+                    // overshoot; erring long only delays the refill of a
+                    // starved pool.
+                    cfg.internal_presign_stale_batch_expiry_rounds = Some(3000);
                     cfg.network_encryption_key_version = Some(3);
                     cfg.reconfiguration_message_version = Some(3);
                     // The delay is measured in consensus rounds.

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Mainnet_version_4.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Mainnet_version_4.snap
@@ -73,3 +73,4 @@ internal_secp256r1_ecdsa_presign_pool_maximum_size: 30000
 internal_eddsa_presign_pool_maximum_size: 30000
 internal_schnorrkel_substrate_presign_pool_maximum_size: 30000
 internal_taproot_presign_pool_maximum_size: 30000
+internal_presign_stale_batch_expiry_rounds: 3000

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Testnet_version_4.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Testnet_version_4.snap
@@ -73,3 +73,4 @@ internal_secp256r1_ecdsa_presign_pool_maximum_size: 30000
 internal_eddsa_presign_pool_maximum_size: 30000
 internal_schnorrkel_substrate_presign_pool_maximum_size: 30000
 internal_taproot_presign_pool_maximum_size: 30000
+internal_presign_stale_batch_expiry_rounds: 3000

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__version_4.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__version_4.snap
@@ -73,3 +73,4 @@ internal_secp256r1_ecdsa_presign_pool_maximum_size: 30000
 internal_eddsa_presign_pool_maximum_size: 30000
 internal_schnorrkel_substrate_presign_pool_maximum_size: 30000
 internal_taproot_presign_pool_maximum_size: 30000
+internal_presign_stale_batch_expiry_rounds: 3000

--- a/crates/ika-types/src/committee.rs
+++ b/crates/ika-types/src/committee.rs
@@ -404,14 +404,39 @@ fn verify_vss_hpke_keys_by_party_id(
         })
         .collect();
     match parse_and_uc_verify_encryption_keys(&by_party_id) {
-        Ok(verified) => verified
-            .into_iter()
-            .map(|(pid, ek)| {
-                use group::GroupElement as _;
-                (pid, ek.value())
-            })
-            .collect(),
-        Err(_) => HashMap::new(),
+        Ok(verified) => {
+            if verified.len() < by_party_id.len() {
+                tracing::warn!(
+                    raw = raw.len(),
+                    mapped = by_party_id.len(),
+                    verified = verified.len(),
+                    "some validators' VSS HPKE keys failed UC verification and were dropped \
+                     from the epoch's verified set"
+                );
+            }
+            verified
+                .into_iter()
+                .map(|(pid, ek)| {
+                    use group::GroupElement as _;
+                    (pid, ek.value())
+                })
+                .collect()
+        }
+        Err(e) => {
+            // An empty verified set means EVERY VSS (Fast Schnorr) session
+            // this epoch is rejected as not-ready — an epoch-long VSS
+            // outage. This error was previously swallowed silently, leaving
+            // the outage with no attributable cause in the logs.
+            tracing::error!(
+                error = ?e,
+                raw = raw.len(),
+                mapped = by_party_id.len(),
+                "VSS HPKE UC verification failed for the whole bundle — the epoch's verified \
+                 VSS key set is EMPTY and every VSS session this epoch will be rejected as \
+                 not-ready"
+            );
+            HashMap::new()
+        }
     }
 }
 


### PR DESCRIPTION
## The bug

The internal-presign top-up guard skips a pool while `instantiated != completed` for its `(curve, signature_algorithm)`. `completed` only advances when a session's output reaches consensus quorum — there is no path that advances it for a batch that **dies**. One dead batch therefore blocks that pool's top-up for the rest of the epoch, and since the per-epoch manager resets the counters, the cycle repeats at every entry.

This is not theoretical: at **every epoch entry from epoch 2 on**, all VSS (Fast Schnorr) refill batches fail round-one with `InvalidParameters` on **all four validators** — reproduced deterministically on an idle localnet (debug logs archived) and present in every analyzed CI TS-suite run. Root cause of the batch deaths is the issue #1736 "double-fetch": the entry key adoption installs a stale mpc_data overlay, and the corrected overlay only arrives ~2 minutes later (the syncer's re-instantiation of the *same key with changed content* is visible in the logs at entry+2min, and VSS refills succeed immediately after it). Combined with the counter leak, a ~2-minute poisoned window became **full-epoch VSS pool starvation**, which under the heavy TS suite starves in-target sessions and pins the epoch close (`all_epoch_sessions_finished=false`) — the `all-combinations-future-sign` wedge.

## The fix

- New protocol-config value `internal_presign_stale_batch_expiry_rounds`: `None` ≤ v3 (the pre-existing block-forever behavior), `Some(3000)` at v4 (~2.5 min at loaded-CI round rates).
- The top-up guard presumes a batch dead once it is older than the expiry, logs a WARN, reconciles `completed := instantiated`, and lets the pool top up again.
- The completion increment now saturates at `instantiated`, so a presumed-dead batch completing late cannot flip the counters into the opposite permanent imbalance.

The expiry reads only consensus-agreed inputs (round numbers and the shared counters), preserving committee-uniform top-up decisions — the counters derive the deterministic session identifiers, so releasing the slot from the local failure arm would be a consensus-divergence bug (and the local failure signal doesn't exist for silently-dying sessions anyway). Version-gated so a rolling-upgrade committee never mixes expiry and no-expiry behavior.

## Validation

- `test_internal_presign_stale_batch_expiry` (integration harness): kills a real batch by discarding all consensus messages, asserts the guard holds inside the expiry window, reconciles and refires past it, heals the pool once delivery resumes, and that all four validators' counters stay identical. **Fault-injection validated**: with the expiry out of reach the test fails at the refire assertion.
- All four `internal_presign` harness tests green (the three pre-existing ones confirm normal top-up behavior is unchanged).
- **Live localnet validation**: with this fix, the VSS pools heal ~2 minutes into every epoch (one wasted batch per entry window); without it, they starve for the entire epoch.

The remaining root fix — epoch-gating the overlay publication so entry adoption never sees epoch-(N−1) data (issue #1736 section 2) — is a separate change; this PR bounds the blast radius of *any* batch-death mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bi6Vr4KcRA4KpKHikcBhDN