### PR TITLE
fix(release): restore the executable bit on published binaries + de-collide per-network release names

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -302,8 +302,14 @@ jobs:
         run: gcloud auth configure-docker us-docker.pkg.dev
 
       - name: Build and push Docker image
+        env:
+          DOCKER_BUILDKIT: "1" # required by COPY --chmod in the runtime Dockerfiles
         run: |
           set -e
+
+          # download-artifact strips unix modes (all files land 644); restore
+          # the executable bit before the binary is copied into the image.
+          chmod +x binaries/*
 
           DOCKER_TAG="${{ matrix.registry }}/${{ matrix.image }}:${{ needs.version.outputs.network }}-v${{ needs.version.outputs.docker_tag }}"
           GIT_REVISION="$(git describe --always --abbrev=12 --dirty --exclude '*')"
@@ -423,6 +429,9 @@ jobs:
           VERSION="v${{ needs.version.outputs.version }}"
           for dir in artifacts/*/; do
             platform="$(basename "$dir")"
+            # download-artifact strips unix modes; restore the executable bit
+            # so the tarballs (and the Homebrew install) carry runnable binaries.
+            chmod +x "$dir"*
             tar -czvf "ika-${VERSION}-${platform}.tar.gz" -C "$dir" .
           done
 
@@ -431,9 +440,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="v${{ needs.version.outputs.version }}"
-          gh release create "$VERSION" \
+          # Mainnet keeps the bare v-tag: the Homebrew formula's download URL
+          # interpolates it. Other networks get a qualified tag so pushing
+          # release/mainnet-X and release/testnet-X for the same version does
+          # not collide on one release name (as happened for 1.1.8).
+          NETWORK="${{ needs.version.outputs.network }}"
+          if [ "$NETWORK" = "mainnet" ]; then
+            RELEASE_TAG="$VERSION"
+          else
+            RELEASE_TAG="${NETWORK}-${VERSION}"
+          fi
+          gh release create "$RELEASE_TAG" \
             --draft \
-            --title "$VERSION" \
+            --title "$RELEASE_TAG" \
             --generate-notes \
             ika-${VERSION}-*.tar.gz
 

--- a/docker/ika-node/Dockerfile.runtime
+++ b/docker/ika-node/Dockerfile.runtime
@@ -19,8 +19,10 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 
 WORKDIR /opt/ika
 
-COPY ${BIN} /opt/ika/bin/${BIN}
-COPY ${BIN} /usr/local/bin/${BIN}
+# --chmod: the binary arrives via actions/download-artifact, which strips
+# the executable bit (GitHub artifacts are zip-based and drop unix modes).
+COPY --chmod=0755 ${BIN} /opt/ika/bin/${BIN}
+COPY --chmod=0755 ${BIN} /usr/local/bin/${BIN}
 
 LABEL build-date=$BUILD_DATE
 LABEL git-revision=$GIT_REVISION

--- a/docker/ika-proxy/Dockerfile.runtime
+++ b/docker/ika-proxy/Dockerfile.runtime
@@ -8,4 +8,6 @@ RUN apt-get update && \
 
 WORKDIR /opt/ika
 
-COPY ika-proxy /opt/ika/bin/ika-proxy
+# --chmod: the binary arrives via actions/download-artifact, which strips
+# the executable bit (GitHub artifacts are zip-based and drop unix modes).
+COPY --chmod=0755 ika-proxy /opt/ika/bin/ika-proxy


### PR DESCRIPTION
## What

Release-blocker fix from the 1.2.0 release review (item 1 of the pre-tag checklist).

The rewritten release pipeline moves binaries through `actions/upload-artifact`, which is zip-based and **strips unix modes** — every published deliverable shipped mode-644 binaries:

- **docker images** (`ika-validator` / `ika-fullnode` / `ika-notifier` / `ika-proxy`): `Dockerfile.runtime` does a plain `COPY` of the downloaded file, so containers exit immediately with `permission denied`. 1.1.8 never hit this because its image compiled the binary inside the image build.
- **GitHub-release tarballs** (and therefore the **Homebrew** install): `tar` of the downloaded artifacts preserves the stripped mode.
- **GCP generic artifacts**: the protocol cannot carry modes at all — unchanged, consumers `chmod +x` after download (now the only channel with that caveat).

The release workflow has never completed a green run (both July 9 attempts failed/cancelled), so none of this was observable from CI history.

## Changes

1. `COPY --chmod=0755` in both runtime Dockerfiles (BuildKit — already required on the `linux-32-runner` pool by build-linux's `--output type=local`), plus an explicit `DOCKER_BUILDKIT=1` and `chmod +x binaries/*` in the docker job so the fix doesn't depend on the Dockerfile alone.
2. `chmod +x` before `tar` in *Package release assets* — tarballs and brew carry runnable binaries; the tap formula's own `ika --version` test becomes a real regression check.
3. Release-name collision: pushing `release/mainnet-X` and `release/testnet-X` for the same version collided on the bare `vX` release name (the second job failed `release already exists`, as happened for 1.1.8). **Mainnet keeps the bare v-tag** — the tap formula URL interpolates `v#{version}` ([verified](https://github.com/ika-xyz/homebrew-tap/blob/main/Formula/ika.rb)) — other networks get `<network>-vX`.

## Verification

- Root cause hand-verified end-to-end in the review: build job exports with `+x` (docker `--output type=local` preserves modes) → artifact round-trip drops to 644 → plain `COPY`/`tar` propagate it.
- YAML parses; asset filenames (`ika-vX-<platform>.tar.gz`) unchanged in both release flavors, so the brew download pattern and formula sed are unaffected.
- **Full proof requires one end-to-end pipeline run on a test tag** (e.g. `release/mainnet-1.2.0-test2`) followed by `docker run <image> ika-validator --version` and a tarball `tar -tvzf` mode check — recommended as the next step after merge, before the real tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)