### PR TITLE
fix(ci): give the nightly orchestrator a repo context so its dispatches fire

### DIFF
--- a/.github/workflows/scheduled-all-suites.yaml
+++ b/.github/workflows/scheduled-all-suites.yaml
@@ -61,9 +61,15 @@ jobs:
       # `github.token` (a.k.a. secrets.GITHUB_TOKEN) carries the
       # `actions: write` permission granted above, which is all `gh workflow
       # run` needs to dispatch a sibling workflow.
+      #
+      # GH_REPO is REQUIRED: there is no checkout step, so without it `gh`
+      # tries to infer the repo from a local git checkout and dies with
+      # "fatal: not a git repository" before dispatching anything (which
+      # silently killed every nightly fan-out).
       - name: Dispatch ${{ matrix.suite }} against ${{ matrix.branch }}
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           BRANCH: ${{ matrix.branch }}
           SUITE: ${{ matrix.suite }}
         run: |


### PR DESCRIPTION
## Problem

The nightly heavy-suite orchestrator (`scheduled-all-suites.yaml`) is completely broken: **all 8 `dispatch <suite> on <branch>` jobs fail** with

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

before dispatching anything — see runs [29138980747](https://github.com/dwallet-labs/ika/actions/runs/29138980747) (Jul 11) and [29068916190](https://github.com/dwallet-labs/ika/actions/runs/29068916190) (Jul 10). The workflow has **no checkout step**, and `gh` infers its target repo from a local git checkout that doesn't exist on the bare runner.

It's been broken **since its very first cron firing**: cron only runs from the default branch, and this workflow only reached the default branch in the recent history flatten. Net effect: both long-lived branches have had **zero nightly heavy-suite signal** (cluster/integration/TS/simtest) — which is why known cluster flakes (issue #1736 family) weren't surfacing nightly.

## Fix

One line: set `GH_REPO: ${{ github.repository }}` on the dispatch step — gh's documented repo-context override. No checkout needed (cheaper than checking out the repo just for context). Comment updated to say why it's load-bearing.

## Verification

Replicated the runner's condition locally (a directory with no git repo):
- **without** `GH_REPO`: `gh` fails with the **byte-identical** error from the nightly logs;
- **with** `GH_REPO`: `gh workflow list` works and a real `gh workflow run deploy-docs.yaml` dispatch succeeded end-to-end ([29173526331](https://github.com/dwallet-labs/ika/actions/runs/29173526331)) — the exact invocation shape the fixed step uses.

After merge, the definitive check is the next 03:00 UTC cron (or one manual `workflow_dispatch` of the orchestrator): all 8 dispatch jobs green **and** 8 child suite runs actually created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)