### PR TITLE
ci: give the nightly heavy-suite dispatcher a repo context (GH_REPO)

### DIFF
--- a/.github/workflows/scheduled-all-suites.yaml
+++ b/.github/workflows/scheduled-all-suites.yaml
@@ -64,6 +64,11 @@ jobs:
       - name: Dispatch ${{ matrix.suite }} against ${{ matrix.branch }}
         env:
           GH_TOKEN: ${{ github.token }}
+          # There is no checkout step, so `gh` cannot infer the repository
+          # from a git remote ("fatal: not a git repository") — every nightly
+          # dispatch failed this way since the workflow landed. GH_REPO gives
+          # gh its target explicitly.
+          GH_REPO: ${{ github.repository }}
           BRANCH: ${{ matrix.branch }}
           SUITE: ${{ matrix.suite }}
         run: |


### PR DESCRIPTION
## What

One-line fix for the nightly heavy-suite orchestrator (`scheduled-all-suites.yaml`), found by the 1.2.0 release review's CI-evidence audit (item 3 of the pre-tag checklist).

The dispatch job has **no checkout step**, so `gh workflow run` cannot infer the repository from a git remote and every invocation dies with `fatal: not a git repository`. All 8 (branch × suite) matrix jobs have failed **every night since the workflow landed** (e.g. runs 29138980747, 29068916190) — the nightly cadence has never dispatched anything, and all heavy-suite evidence to date has been manual.

`GH_REPO: ${{ github.repository }}` is the gh CLI's documented way to target a repo without a local checkout. Cheaper than adding a full checkout step for a job that only calls the API.

## Verification

- YAML parses.
- After merge, a `workflow_dispatch` of this orchestrator should show all 8 jobs green and 8 suite runs appearing on main/dev — that run doubles as evidence toward the release checklist's "dispatch heavy suites on the final release commit" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)