### PR TITLE
docs: move the crypto-migration working docs from public docs/ to dev-docs/plans/

### DIFF
--- a/dev-docs/plans/breaking-changes-inkrypto-to-main.md
+++ b/dev-docs/plans/breaking-changes-inkrypto-to-main.md
@@ -1,3 +1,5 @@
+Status: landed — point-in-time compatibility analysis for the cryptography-private → inkrypto source migration (executed by 8d4c4d53e4 and #1806); kept for reference.
+
 ---
 ika repo: /mnt/nvme0n1p1/ika (branch: dev)
 ika pinned cryptography-private rev: babbb483 ("Remove redundant public key and nonce is neutral check")

--- a/dev-docs/plans/inkrypto-bump-diff.md
+++ b/dev-docs/plans/inkrypto-bump-diff.md
@@ -1,5 +1,7 @@
 # cryptography-private @ babbb483 → main: surface diff for ika
 
+Status: landed — point-in-time API/wire-format catalog for the crypto-source migration; kept for reference.
+
 Scope: catalog every API/wire-format change that affects ika's current
 consumption of cryptography-private. Verified directly against
 `/mnt/nvme0n1p1/cryptography-private2` clone of

--- a/dev-docs/plans/plan-bump-crypto-private-to-main.md
+++ b/dev-docs/plans/plan-bump-crypto-private-to-main.md
@@ -1,5 +1,7 @@
 # Plan: bump dev's cryptography-private from `babbb483` to `main` (= `9d35fa76`)
 
+Status: landed (2026-07) — executed across the crypto-source migration PRs (8d4c4d53e4, #1806).
+
 ## Scope (deliberately narrow)
 
 This is the **first step** of the broader crypto migration. The only goal

--- a/dev-docs/plans/plan-update-crypto-latest.md
+++ b/dev-docs/plans/plan-update-crypto-latest.md
@@ -1,5 +1,7 @@
 # Plan: Update inkrypto on `update-crypto-latest` branch
 
+Status: landed (2026-07) — executed; the dual-pin rolling-rollout caveat recorded below stays relevant for future crypto bumps.
+
 ## Context
 
 Mainnet-v1.1.8 ika depends on **`inkrypto @ 37bb549f`** ("Backward compatible


### PR DESCRIPTION
## What

Item 5 of the 1.2.0 pre-tag checklist (prior review finding S3, still open at head).

Four internal working documents sat at the root of `docs/` — the public documentation-website tree — instead of `dev-docs/`, where internal engineering docs live:

- `breaking-changes-inkrypto-to-main.md` — compatibility analysis with private-repo revs and a developer-machine path
- `inkrypto-bump-diff.md` — the wire-compat-sensitive type catalog
- `plan-bump-crypto-private-to-main.md`, `plan-update-crypto-latest.md` — migration plans

Pure `git mv` (98-99% rename similarity) plus the one-line `Status:` header the `dev-docs/plans/` convention requires — all four efforts landed with the crypto-source migration (8d4c4d53e4, #1806). The single in-repo reference (`dev-docs/plans/cross-binary-upgrade-testing.md:603`, bare filename) now resolves to a sibling file, so no edit needed.

Honest scope note: the repo is public, so this is convention/hygiene (and keeps the docs-site deploy from ever publishing them) — the content remains in git history; nothing here pretends to be secret-scrubbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)