### PR TITLE
fix(observability): bound the MPC metrics hot path; refuse mock-crypto builds on real networks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,8 +148,13 @@ here. The rules below are the ones lints can't check:
 
 ```bash
 # Rust tests - MUST use release mode for crypto
+# WARNING: workspace scope (no -p) runs MOCKED crypto — ika-test-cluster's
+# self-dev-dependency enables dwallet-mpc-unsafe-mock and cargo feature
+# unification spreads it to ika-core's own tests in the same invocation
+# (verify: cargo tree -f "{p} {f}" -p dwallet-mpc-types --workspace).
+# Real-crypto evidence requires package scope, e.g. -p ika-core.
 cargo test --release
-cargo test --release -p ika-core           # Single crate
+cargo test --release -p ika-core           # Single crate (real crypto)
 cargo test --release -- --test-threads=1   # Sequential execution
 
 # Integration tests — CPU-bound (real class-groups MPC). Heavy MPC tests

--- a/crates/ika-core/src/dwallet_checkpoints/mod.rs
+++ b/crates/ika-core/src/dwallet_checkpoints/mod.rs
@@ -431,6 +431,12 @@ impl DWalletCheckpointBuilder {
         max_dwallet_checkpoint_size_bytes: usize,
         previous_epoch_last_checkpoint_sequence_number: u64,
     ) -> Self {
+        // The per-session-seq gauge lives in the process-global registry, and
+        // nothing removes label values once set — one series per user session
+        // for the process lifetime. The builder is constructed once per
+        // epoch, so resetting here bounds the label set to the current
+        // epoch's sessions.
+        metrics.user_session_written_at_seq.reset();
         Self {
             tables,
             epoch_store,

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -976,60 +976,72 @@ mod network_key_id_derivation_tool {
         network_dkg_public_output_to_protocol_pp_inner,
         reconfiguration_public_output_to_protocol_pp_inner,
     };
+    use dwallet_mpc_types::dwallet_mpc::{
+        VersionedDecryptionKeyReconfigurationOutput, VersionedNetworkDkgOutput,
+    };
     use ika_sui_client::SuiConnectorClient;
     use ika_sui_client::metrics::SuiClientMetrics;
     use ika_types::messages_dwallet_mpc::IkaNetworkConfig;
     use ika_types::sui::DWalletCoordinatorInner;
     use std::str::FromStr;
     use sui_types::base_types::ObjectID;
+    use twopc_mpc::decentralized_party_backward_compatible::reconfiguration as bwd_compat_reconfig;
+
+    // (env, rpc, ika, common, twopc, system_pkg, system_obj, coordinator_obj) — from ika_sui_config.yaml
+    type DeployedEnv<'a> = (
+        &'a str,
+        &'a str,
+        &'a str,
+        &'a str,
+        &'a str,
+        &'a str,
+        &'a str,
+        &'a str,
+    );
+
+    const DEPLOYED_ENVS: &[DeployedEnv<'static>] = &[
+        (
+            "testnet",
+            "https://fullnode.testnet.sui.io:443",
+            "0x1f26bb2f711ff82dcda4d02c77d5123089cb7f8418751474b9fb744ce031526a",
+            "0x96fc75633b6665cf84690587d1879858ff76f88c10c945e299f90bf4e0985eb0",
+            "0x6573a6c13daf26a64eb8a37d3c7a4391b353031e223072ca45b1ff9366f59293",
+            "0xde05f49e5f1ee13ed06c1e243c0a8e8fe858e1d8689476fdb7009af8ddc3c38b",
+            "0x2172c6483ccd24930834e30102e33548b201d0607fb1fdc336ba3267d910dec6",
+            "0x4d157b7415a298c56ec2cb1dcab449525fa74aec17ddba376a83a7600f2062fc",
+        ),
+        (
+            "mainnet",
+            "https://fullnode.mainnet.sui.io:443",
+            "0x7262fb2f7a3a14c888c438a3cd9b912469a58cf60f367352c46584262e8299aa",
+            "0x9e1e9f8e4e51ee2421a8e7c0c6ab3ef27c337025d15333461b72b1b813c44175",
+            "0x23b5bd96051923f800c3a2150aacdcdd8d39e1df2dce4dac69a00d2d8c7f7e77",
+            "0xd69f947d7ee6f224dd0dd31ec3ec30c0dd0f713a1de55d564e8e98910c4f9553",
+            "0x215de95d27454d102d6f82ff9c54d8071eb34d5706be85b5c73cbd8173013c80",
+            "0x5ea59bce034008a006425df777da925633ef384ce25761657ea89e2a08ec75f3",
+        ),
+    ];
+
+    fn ika_network_config(env: &DeployedEnv<'_>) -> IkaNetworkConfig {
+        let (_, _, ika, common, twopc, sys_pkg, sys_obj, coord) = env;
+        let oid = |s: &str| ObjectID::from_str(s).unwrap();
+        IkaNetworkConfig::new(
+            oid(ika),
+            oid(common),
+            oid(twopc),
+            None,
+            oid(sys_pkg),
+            oid(sys_obj),
+            oid(coord),
+        )
+    }
 
     #[ignore = "real-network tool; run manually to derive deployed NetworkKeyIds"]
     #[tokio::test]
     async fn print_deployed_network_key_ids() {
-        // (env, rpc, ika, common, twopc, system_pkg, system_obj, coordinator_obj) — from ika_sui_config.yaml
-        type DeployedEnv<'a> = (
-            &'a str,
-            &'a str,
-            &'a str,
-            &'a str,
-            &'a str,
-            &'a str,
-            &'a str,
-            &'a str,
-        );
-        let envs: &[DeployedEnv] = &[
-            (
-                "testnet",
-                "https://fullnode.testnet.sui.io:443",
-                "0x1f26bb2f711ff82dcda4d02c77d5123089cb7f8418751474b9fb744ce031526a",
-                "0x96fc75633b6665cf84690587d1879858ff76f88c10c945e299f90bf4e0985eb0",
-                "0x6573a6c13daf26a64eb8a37d3c7a4391b353031e223072ca45b1ff9366f59293",
-                "0xde05f49e5f1ee13ed06c1e243c0a8e8fe858e1d8689476fdb7009af8ddc3c38b",
-                "0x2172c6483ccd24930834e30102e33548b201d0607fb1fdc336ba3267d910dec6",
-                "0x4d157b7415a298c56ec2cb1dcab449525fa74aec17ddba376a83a7600f2062fc",
-            ),
-            (
-                "mainnet",
-                "https://fullnode.mainnet.sui.io:443",
-                "0x7262fb2f7a3a14c888c438a3cd9b912469a58cf60f367352c46584262e8299aa",
-                "0x9e1e9f8e4e51ee2421a8e7c0c6ab3ef27c337025d15333461b72b1b813c44175",
-                "0x23b5bd96051923f800c3a2150aacdcdd8d39e1df2dce4dac69a00d2d8c7f7e77",
-                "0xd69f947d7ee6f224dd0dd31ec3ec30c0dd0f713a1de55d564e8e98910c4f9553",
-                "0x215de95d27454d102d6f82ff9c54d8071eb34d5706be85b5c73cbd8173013c80",
-                "0x5ea59bce034008a006425df777da925633ef384ce25761657ea89e2a08ec75f3",
-            ),
-        ];
-        let oid = |s: &str| ObjectID::from_str(s).unwrap();
-        for (name, rpc, ika, common, twopc, sys_pkg, sys_obj, coord) in envs {
-            let config = IkaNetworkConfig::new(
-                oid(ika),
-                oid(common),
-                oid(twopc),
-                None,
-                oid(sys_pkg),
-                oid(sys_obj),
-                oid(coord),
-            );
+        for env in DEPLOYED_ENVS {
+            let (name, rpc, ..) = env;
+            let config = ika_network_config(env);
             let client = SuiConnectorClient::new(rpc, SuiClientMetrics::new_for_testing(), config)
                 .await
                 .unwrap();
@@ -1071,6 +1083,107 @@ mod network_key_id_derivation_tool {
                     "NETWORK_KEY_ID {name}: object_id={id} network_key_id=0x{}",
                     hex::encode(network_key_id)
                 );
+            }
+        }
+    }
+
+    /// One-off release-evidence tool: fetches the DEPLOYED network keys from
+    /// testnet/mainnet and proves their on-chain bytes decode on the exact
+    /// types the v3 backward-compatible reconfiguration arm consumes — the
+    /// real-chain-bytes check the synthesized-anchor regression tests cannot
+    /// provide (those re-encode a fresh output under the current crypto
+    /// crates, so a bcs layout drift against the deployed bytes would not
+    /// trip them). Run with:
+    ///   cargo test -p ika-core --release decode_deployed_network_key_bytes -- --ignored --nocapture
+    #[ignore = "real-network tool; run manually to verify deployed key bytes decode under the pinned crypto crates"]
+    #[tokio::test]
+    async fn decode_deployed_network_key_bytes() {
+        for env in DEPLOYED_ENVS {
+            let (name, rpc, ..) = env;
+            let config = ika_network_config(env);
+            let client = SuiConnectorClient::new(rpc, SuiClientMetrics::new_for_testing(), config)
+                .await
+                .unwrap();
+            let (_, coordinator_inner) = client.must_get_dwallet_coordinator_inner().await;
+            let DWalletCoordinatorInner::V1(inner) = &coordinator_inner;
+            let epoch = inner.current_epoch;
+            let network_keys = client
+                .get_dwallet_mpc_network_keys(&coordinator_inner)
+                .await
+                .unwrap();
+            for (id, key) in &network_keys {
+                let key_data = client
+                    .get_network_encryption_key_with_full_data_by_epoch(key, epoch)
+                    .await
+                    .unwrap();
+
+                let anchor: VersionedNetworkDkgOutput =
+                    bcs::from_bytes(&key_data.network_dkg_public_output)
+                        .expect("anchor bytes must decode as VersionedNetworkDkgOutput");
+                match &anchor {
+                    VersionedNetworkDkgOutput::V1(v1_inner) => {
+                        // The exact decode the v3 bwd-compat V1 arm performs on
+                        // every reconfiguration of a deployed key.
+                        let decoded: class_groups::dkg::PublicOutput<
+                            { twopc_mpc::secp256k1::SCALAR_LIMBS },
+                            { twopc_mpc::secp256k1::class_groups::FUNDAMENTAL_DISCRIMINANT_LIMBS },
+                            {
+                                twopc_mpc::secp256k1::class_groups::NON_FUNDAMENTAL_DISCRIMINANT_LIMBS
+                            },
+                        > = bcs::from_bytes(v1_inner).expect(
+                            "V1 anchor inner bytes must decode as the class-groups DKG output",
+                        );
+                        let reencoded = bcs::to_bytes(&decoded).unwrap();
+                        println!(
+                            "DECODE {name}: key {id}: V1 anchor OK ({} bytes, re-encode {})",
+                            v1_inner.len(),
+                            if reencoded == *v1_inner {
+                                "byte-identical".to_string()
+                            } else {
+                                format!("DIFFERS ({} bytes)", reencoded.len())
+                            }
+                        );
+                    }
+                    VersionedNetworkDkgOutput::V2(bytes) => println!(
+                        "DECODE {name}: key {id}: V2-tagged anchor ({} bytes) — not the deployed V1 shape",
+                        bytes.len()
+                    ),
+                    VersionedNetworkDkgOutput::V3(bytes) => println!(
+                        "DECODE {name}: key {id}: V3-tagged anchor ({} bytes) — not the deployed V1 shape",
+                        bytes.len()
+                    ),
+                }
+
+                if key_data.current_reconfiguration_public_output.is_empty() {
+                    println!("DECODE {name}: key {id}: no reconfiguration output on chain");
+                    continue;
+                }
+                let reconfiguration: VersionedDecryptionKeyReconfigurationOutput =
+                    bcs::from_bytes(&key_data.current_reconfiguration_public_output).expect(
+                        "reconfiguration bytes must decode as VersionedDecryptionKeyReconfigurationOutput",
+                    );
+                match &reconfiguration {
+                    VersionedDecryptionKeyReconfigurationOutput::V2(bytes) => {
+                        // The exact decode the v3 bwd-compat V1 arm performs on
+                        // the prior reconfiguration output.
+                        let _: <bwd_compat_reconfig::Party as mpc::Party>::PublicOutput =
+                            bcs::from_bytes(bytes).expect(
+                                "V2 reconfiguration output must decode as the bwd-compat PublicOutput",
+                            );
+                        println!(
+                            "DECODE {name}: key {id}: V2 reconfiguration output OK ({} bytes)",
+                            bytes.len()
+                        );
+                    }
+                    VersionedDecryptionKeyReconfigurationOutput::V1(bytes) => println!(
+                        "DECODE {name}: key {id}: V1-tagged reconfiguration output ({} bytes) — unsupported by the bwd-compat arm",
+                        bytes.len()
+                    ),
+                    VersionedDecryptionKeyReconfigurationOutput::V3(bytes) => println!(
+                        "DECODE {name}: key {id}: V3-tagged reconfiguration output ({} bytes) — main-path shape",
+                        bytes.len()
+                    ),
+                }
             }
         }
     }

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -987,10 +987,12 @@ mod network_key_id_derivation_tool {
     use sui_types::base_types::ObjectID;
     use twopc_mpc::decentralized_party_backward_compatible::reconfiguration as bwd_compat_reconfig;
 
-    // (env, rpc, ika, common, twopc, system_pkg, system_obj, coordinator_obj) — from ika_sui_config.yaml
+    // (env, rpcs, ika, common, twopc, system_pkg, system_obj, coordinator_obj) — from ika_sui_config.yaml.
+    // rpcs: canonical Mysten endpoint first, public fallback second — these
+    // are read-only tools and either endpoint can be temporarily down.
     type DeployedEnv<'a> = (
         &'a str,
-        &'a str,
+        &'a [&'a str],
         &'a str,
         &'a str,
         &'a str,
@@ -1002,7 +1004,10 @@ mod network_key_id_derivation_tool {
     const DEPLOYED_ENVS: &[DeployedEnv<'static>] = &[
         (
             "testnet",
-            "https://fullnode.testnet.sui.io:443",
+            &[
+                "https://fullnode.testnet.sui.io:443",
+                "https://sui-testnet-rpc.publicnode.com",
+            ],
             "0x1f26bb2f711ff82dcda4d02c77d5123089cb7f8418751474b9fb744ce031526a",
             "0x96fc75633b6665cf84690587d1879858ff76f88c10c945e299f90bf4e0985eb0",
             "0x6573a6c13daf26a64eb8a37d3c7a4391b353031e223072ca45b1ff9366f59293",
@@ -1012,7 +1017,10 @@ mod network_key_id_derivation_tool {
         ),
         (
             "mainnet",
-            "https://fullnode.mainnet.sui.io:443",
+            &[
+                "https://fullnode.mainnet.sui.io:443",
+                "https://sui-rpc.publicnode.com",
+            ],
             "0x7262fb2f7a3a14c888c438a3cd9b912469a58cf60f367352c46584262e8299aa",
             "0x9e1e9f8e4e51ee2421a8e7c0c6ab3ef27c337025d15333461b72b1b813c44175",
             "0x23b5bd96051923f800c3a2150aacdcdd8d39e1df2dce4dac69a00d2d8c7f7e77",
@@ -1036,15 +1044,38 @@ mod network_key_id_derivation_tool {
         )
     }
 
+    /// Tries each of the env's RPC endpoints in order; `None` (with a printed
+    /// reason) when none is reachable, so one downed endpoint doesn't sink
+    /// the other env's run.
+    async fn connect(env: &DeployedEnv<'_>) -> Option<SuiConnectorClient> {
+        let (name, rpcs, ..) = env;
+        for rpc in rpcs.iter().copied() {
+            match SuiConnectorClient::new(
+                rpc,
+                SuiClientMetrics::new_for_testing(),
+                ika_network_config(env),
+            )
+            .await
+            {
+                Ok(client) => {
+                    println!("CONNECT {name}: using {rpc}");
+                    return Some(client);
+                }
+                Err(e) => println!("CONNECT {name}: {rpc} failed: {e}"),
+            }
+        }
+        println!("SKIP {name}: no RPC endpoint reachable");
+        None
+    }
+
     #[ignore = "real-network tool; run manually to derive deployed NetworkKeyIds"]
     #[tokio::test]
     async fn print_deployed_network_key_ids() {
         for env in DEPLOYED_ENVS {
-            let (name, rpc, ..) = env;
-            let config = ika_network_config(env);
-            let client = SuiConnectorClient::new(rpc, SuiClientMetrics::new_for_testing(), config)
-                .await
-                .unwrap();
+            let (name, ..) = env;
+            let Some(client) = connect(env).await else {
+                continue;
+            };
             let (_, coordinator_inner) = client.must_get_dwallet_coordinator_inner().await;
             let DWalletCoordinatorInner::V1(inner) = &coordinator_inner;
             let epoch = inner.current_epoch;
@@ -1099,11 +1130,10 @@ mod network_key_id_derivation_tool {
     #[tokio::test]
     async fn decode_deployed_network_key_bytes() {
         for env in DEPLOYED_ENVS {
-            let (name, rpc, ..) = env;
-            let config = ika_network_config(env);
-            let client = SuiConnectorClient::new(rpc, SuiClientMetrics::new_for_testing(), config)
-                .await
-                .unwrap();
+            let (name, ..) = env;
+            let Some(client) = connect(env).await else {
+                continue;
+            };
             let (_, coordinator_inner) = client.must_get_dwallet_coordinator_inner().await;
             let DWalletCoordinatorInner::V1(inner) = &coordinator_inner;
             let epoch = inner.current_epoch;

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -328,6 +328,16 @@ pub(crate) struct DWalletMPCManager {
     /// sessions that have left `self.sessions` so dashboards don't read a
     /// stale "this session is still in state X" forever.
     previously_emitted_user_session_seqs: HashSet<u64>,
+    /// User-session sequence numbers whose terminal (Completed/Failed) state
+    /// has already been emitted to the per-seq gauges. Terminal sessions stay
+    /// in `self.sessions` until epoch end; without this set every refresh
+    /// would re-emit the epoch's whole cumulative session history instead of
+    /// only in-flight sessions.
+    finalized_emitted_user_session_seqs: HashSet<u64>,
+    /// When the observability gauges were last refreshed; refreshes are
+    /// rate-limited because the service loop ticks every ~20ms and the
+    /// refresh iterates every tracked session.
+    last_observability_refresh: Option<Instant>,
 
     /// NOA finalization observation votes: tx_ref → set of party IDs that observed finalization.
     noa_finalization_observations: HashMap<NOACheckpointTxRef, HashSet<PartyID>>,
@@ -509,6 +519,8 @@ impl DWalletMPCManager {
             sui_chain_observations_by_party: HashMap::new(),
             agreed_sui_chain_context: None,
             previously_emitted_user_session_seqs: HashSet::new(),
+            finalized_emitted_user_session_seqs: HashSet::new(),
+            last_observability_refresh: None,
             noa_finalization_observations: HashMap::new(),
             noa_failure_observations: HashMap::new(),
             finalized_tx_refs: HashSet::new(),
@@ -3140,14 +3152,26 @@ impl DWalletMPCManager {
     /// for empty buckets/states) is what clears stale values when sessions
     /// move between buckets or leave the map.
     pub(crate) fn refresh_observability_metrics(&mut self) {
-        let metrics = &self.dwallet_mpc_metrics;
         let now = Instant::now();
+        // The service loop calls this every iteration (~20ms); gauges don't
+        // need that cadence, and the refresh scans every session tracked this
+        // epoch — rate-limit it off the hot path.
+        if self
+            .last_observability_refresh
+            .is_some_and(|last| now.duration_since(last) < OBSERVABILITY_REFRESH_INTERVAL)
+        {
+            return;
+        }
+        self.last_observability_refresh = Some(now);
+
+        let metrics = &self.dwallet_mpc_metrics;
 
         // ----- session-state counts + Active-session age buckets -----
         // Only Active sessions get an age: Completed/Failed entries stay in
         // the map until epoch end and don't represent in-flight work.
         let mut state_counts: HashMap<&str, i64> = HashMap::new();
         let mut age_bucket_counts: HashMap<(&str, &str), i64> = HashMap::new();
+        let mut sessions_with_self_output_no_quorum = 0i64;
         for session in self.sessions.values() {
             *state_counts
                 .entry(session_state_label(&session.status))
@@ -3161,6 +3185,15 @@ impl DWalletMPCManager {
                 *age_bucket_counts
                     .entry((session_type_label(request.session_type), age_bucket))
                     .or_default() += 1;
+            }
+            // "We did our part, the network didn't" — the single most useful
+            // gauge for "are we stuck waiting on quorum from peers".
+            if session.session_sequence_number.is_some()
+                && matches!(session.session_type, Some(SessionType::User))
+                && session.self_output_consensus_round.is_some()
+                && session.quorum_consensus_round.is_none()
+            {
+                sessions_with_self_output_no_quorum += 1;
             }
         }
         for state in ALL_SESSION_STATES.iter().copied() {
@@ -3213,10 +3246,12 @@ impl DWalletMPCManager {
         }
 
         // ----- per-user-session series, labeled by sequence number -----
-        // Cardinality bound: max_active_sessions_buffer sessions × 5 states
-        // (plus × committee size for the output-received-from matrix).
+        // Registry cardinality grows with the epoch's user-session count (the
+        // sessions map is only dropped at epoch end), but per-refresh WORK is
+        // bounded by in-flight sessions: a terminal (Completed/Failed)
+        // session gets one final emission recording its terminal state and is
+        // skipped afterwards, its series frozen at those values.
         let mut current_seqs = HashSet::new();
-        let mut sessions_with_self_output_no_quorum = 0i64;
         for session in self.sessions.values() {
             let (Some(session_sequence_number), Some(SessionType::User)) =
                 (session.session_sequence_number, session.session_type)
@@ -3226,6 +3261,28 @@ impl DWalletMPCManager {
                 // exposed once the request arrives).
                 continue;
             };
+
+            let terminal = matches!(
+                session.status,
+                SessionStatus::Completed | SessionStatus::Failed
+            );
+            if terminal {
+                if !self
+                    .finalized_emitted_user_session_seqs
+                    .insert(session_sequence_number)
+                {
+                    // Final values already emitted. Keep the seq in
+                    // current_seqs so the stale-zeroing block below doesn't
+                    // wipe the terminal record while the session is tracked.
+                    current_seqs.insert(session_sequence_number);
+                    continue;
+                }
+            } else {
+                // A session observed non-terminal must be re-armed for a
+                // final emission if it ever terminates.
+                self.finalized_emitted_user_session_seqs
+                    .remove(&session_sequence_number);
+            }
 
             let seq_label = session_sequence_number.to_string();
             let current_state = session_state_label(&session.status);
@@ -3287,14 +3344,6 @@ impl DWalletMPCManager {
                     .set(received as i64);
             }
 
-            // "We did our part, the network didn't" — the single most useful
-            // gauge for "are we stuck waiting on quorum from peers".
-            if session.self_output_consensus_round.is_some()
-                && session.quorum_consensus_round.is_none()
-            {
-                sessions_with_self_output_no_quorum += 1;
-            }
-
             current_seqs.insert(session_sequence_number);
         }
         metrics
@@ -3350,6 +3399,10 @@ impl DWalletMPCManager {
         self.previously_emitted_user_session_seqs = current_seqs;
     }
 }
+
+/// Minimum interval between observability-gauge refreshes; the caller (the
+/// dwallet MPC service loop) ticks every ~20ms, far faster than gauges need.
+const OBSERVABILITY_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 fn session_state_label(status: &SessionStatus) -> &'static str {
     match status {

--- a/crates/ika-core/src/runtime.rs
+++ b/crates/ika-core/src/runtime.rs
@@ -41,10 +41,32 @@ fn should_enforce_minimum_cpu(
         && matches!(ika_chain, Chain::Mainnet | Chain::Testnet)
 }
 
+/// A binary compiled with the INSECURE `dwallet-mpc-unsafe-mock` feature
+/// (deterministic mock crypto for fast tests) must never join a real
+/// network, regardless of role: mocked MPC neither interoperates with real
+/// validators nor produces real signatures. Derived from the deployed ika
+/// system object's `ChainIdentifier`, same as the minimum-CPU gate above.
+fn mock_crypto_forbidden_on(ika_chain: Chain) -> bool {
+    matches!(ika_chain, Chain::Mainnet | Chain::Testnet)
+}
+
 impl IkaRuntimes {
     pub fn new(config: &NodeConfig, node_mode: NodeMode) -> Self {
         let ika_chain =
             ChainIdentifier::from(config.sui_connector_config.ika_system_object_id).chain();
+        if cfg!(feature = "dwallet-mpc-unsafe-mock") {
+            assert!(
+                !mock_crypto_forbidden_on(ika_chain),
+                "this binary was built with dwallet-mpc-unsafe-mock (INSECURE deterministic \
+                 mock crypto for tests) and refuses to run against the ika {ika_chain:?} network"
+            );
+            // Loud, grep-able marker so a mocked binary can never be mistaken
+            // for a real-crypto one in logs or test evidence.
+            error!(
+                insecure_mock_crypto = true,
+                "running with dwallet-mpc-unsafe-mock: all dwallet MPC crypto is MOCKED and INSECURE — test builds only"
+            );
+        }
         let enforce =
             should_enforce_minimum_cpu(cfg!(feature = "enforce-minimum-cpu"), node_mode, ika_chain);
         let _ = ENFORCE_MINIMUM_CPU.set(enforce);
@@ -138,5 +160,15 @@ mod tests {
             ChainIdentifier::from(ObjectID::ZERO).chain(),
             Chain::Unknown
         );
+    }
+
+    #[test]
+    fn mock_crypto_forbidden_exactly_on_real_networks() {
+        for chain in [Chain::Mainnet, Chain::Testnet] {
+            assert!(mock_crypto_forbidden_on(chain));
+        }
+        for chain in [Chain::Devnet, Chain::Unknown] {
+            assert!(!mock_crypto_forbidden_on(chain));
+        }
     }
 }


### PR DESCRIPTION
## What

Item 7 of the 1.2.0 pre-tag checklist ([release review](https://claude.ai/code/artifact/ac3c4e16-048b-46b9-946e-0c616b8133e5)) — the cheap fixes worth taking before the tag.

### 1. MPC metrics hot path (hand-verified findings)

`refresh_observability_metrics` ran on **every ~20ms service iteration** and re-emitted ~11 per-seq gauge series (plus a per-committee-member matrix) for **every session tracked this epoch** — terminal sessions stay in `self.sessions` until epoch end (zero `remove`/`retain`), so per-tick work grew with the epoch's cumulative session count, on the same loop that advances MPC sessions. The in-code "bounded by max_active_sessions_buffer" claim was false.

- Refresh rate-limited to 1/s (`OBSERVABILITY_REFRESH_INTERVAL`).
- Terminal (Completed/Failed) sessions get exactly one final emission recording the terminal state, then are skipped; re-armed if a session ever leaves terminal state. Their seqs stay in `current_seqs` so the existing stale-zeroing block doesn't wipe the terminal record.
- The `sessions_with_self_output_no_quorum` counter moved into the cheap unconditional scan — semantics unchanged.

### 2. Checkpoint per-session gauge label leak

`ika_dwallet_checkpoint_user_session_written_at_seq` accumulated one labeled series per user session **for the process lifetime**. The builder is per-epoch, so its constructor now `reset()`s the gauge — label set bounded to the current epoch.

### 3. unsafe-mock tripwire

A binary compiled with `dwallet-mpc-unsafe-mock` now **refuses to boot against ika mainnet/testnet** (chain derived from the deployed ika system object, exactly like #1810's minimum-CPU gate; predicate unit-tested in the same style) and logs a grep-able `insecure_mock_crypto=true` error banner on any other network. CLAUDE.md documents the verified footgun that **workspace-scope `cargo test` silently mocks ika-core's crypto** via ika-test-cluster's self-dev-dependency feature unification (verified both directions with `cargo tree`: dev-graph resolution enables it; plain `ika-node` builds do not).

### 4. Deployed-bytes decode tool (G1 evidence residual)

New `#[ignore]`d `decode_deployed_network_key_bytes` (sharing the deployed-envs table with the existing NetworkKeyId tool): fetches the real mainnet/testnet network-key bytes and decodes them on the **exact types the v3 backward-compatible reconfiguration arm consumes** — V1 anchor inner → class-groups DKG output (+ byte-identical re-encode check), V2 reconfiguration output → bwd-compat `PublicOutput`. This is the real-chain-bytes check the synthesized-anchor regression tests can't provide; run results will be posted on this PR.

## Verification

- `cargo clippy -p ika-core --lib --tests` clean; `cargo fmt --all`.
- `runtime::tests` 4/4 green (new `mock_crypto_forbidden_exactly_on_real_networks` included).
- Behavior notes: rate limit and once-per-terminal emission change gauge *freshness* (1s) only; series values and meanings are unchanged. Registry cardinality within an epoch is unchanged (per-seq series still exist); steady-state per-tick work drops from O(epoch sessions × 50/s) to O(in-flight sessions × 1/s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)