### PR TITLE
ci: gate clippy -D warnings on every PR for both compilation universes (regular + msim)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,8 +96,10 @@ jobs:
         # see dev-docs/conventions/sui-version-bump.md.
         run: ./scripts/check-sui-version-consistency.sh
 
+  # Runs on PRs AND pushes: clippy used to be push-to-main-only, which let a
+  # workspace-wide lint backlog accumulate invisibly (PRs merged unlinted and
+  # only the FIRST failing crate ever surfaced on main).
   clippy:
-    if: github.event_name == 'push'
     name: Clippy
     runs-on: ubuntu-latest
     steps:
@@ -117,6 +119,41 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+  # The msim compilation universe (`--cfg msim` + msim-patched tokio and the
+  # `[target.'cfg(msim)']` deps) is invisible to the regular clippy job above;
+  # without this pass, simtest-only code only fails at the next (manual or
+  # nightly) simtest run. `cargo simtest clippy` is the shim's clippy mode.
+  clippy-simtest:
+    name: Clippy (msim / simtest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup SSH
+        uses: ./.github/actions/setup-ssh
+        with:
+          deploy-key: ${{ secrets.GH_DEPLOY_KEY }}
+
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.rust_stable }}
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # msim artifacts don't overlap with the normal CI cache (same
+          # prefix as the simtest workflow, which shares the dep graph).
+          prefix-key: "simtest"
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - name: Install cargo-simtest shim
+        run: ./scripts/simtest/install.sh
+      - name: Run Clippy under msim
+        run: cargo simtest clippy --all-targets --all-features -- -D warnings
 
   cargo-check:
     name: Cargo Test Check

--- a/crates/ika-config/src/local_ip_utils.rs
+++ b/crates/ika-config/src/local_ip_utils.rs
@@ -15,6 +15,13 @@ pub struct SimAddressManager {
 }
 
 #[cfg(msim)]
+impl Default for SimAddressManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(msim)]
 impl SimAddressManager {
     pub fn new() -> Self {
         Self {

--- a/crates/ika-core/src/authority.rs
+++ b/crates/ika-core/src/authority.rs
@@ -51,8 +51,6 @@ use crate::stake_aggregator::StakeAggregator;
 use crate::authority::authority_perpetual_tables::AuthorityPerpetualTables;
 use crate::dwallet_checkpoints::DWalletCheckpointStore;
 use ika_types::messages_dwallet_mpc::SessionIdentifier;
-#[cfg(msim)]
-use sui_types::committee::CommitteeTrait;
 
 pub mod authority_per_epoch_store;
 

--- a/crates/ika-core/src/consensus_handler.rs
+++ b/crates/ika-core/src/consensus_handler.rs
@@ -362,7 +362,7 @@ impl<C: DWalletCheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
         fail_point_if!("correlated-crash-after-consensus-commit-boundary", || {
             let key = [commit_sub_dag_index, self.epoch_store.epoch()];
-            if sui_simulator::random::deterministic_probability(&key, 0.01) {
+            if sui_simulator::random::deterministic_probability(key, 0.01) {
                 sui_simulator::task::kill_current_node(None);
             }
         });

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
@@ -403,7 +403,9 @@ impl CryptographicComputationsOrchestrator {
 /// `panic = "abort"` the abort stands (a fail-loud crash-restart, not a silent
 /// wedge), which is this guard's deliberate boundary. The msim path runs
 /// `compute()` inline and is intentionally left to die with its node (see the
-/// caller), so it does not route through here.
+/// caller), so it does not route through here — hence dead outside tests in
+/// the msim build.
+#[cfg(any(not(msim), test))]
 fn compute_catching_panic(
     computation_id: ComputationId,
     compute: impl FnOnce() -> DwalletMPCResult<mpc::GuaranteedOutputDeliveryRoundResult>,

--- a/crates/ika-node/src/handle.rs
+++ b/crates/ika-node/src/handle.rs
@@ -129,7 +129,9 @@ impl Drop for IkaNodeHandle {
     fn drop(&mut self) {
         if self.shutdown_on_drop {
             let node_id = self.inner().sim_state.sim_node.id();
-            sui_simulator::runtime::Handle::try_current().map(|h| h.delete_node(node_id));
+            if let Some(handle) = sui_simulator::runtime::Handle::try_current() {
+                handle.delete_node(node_id);
+            }
         }
     }
 }

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -128,7 +128,6 @@ pub struct P2pComponents {
 mod simulator {
     use std::sync::atomic::AtomicBool;
 
-    use super::*;
     pub(super) struct SimState {
         pub sim_node: sui_simulator::runtime::NodeHandle,
         pub sim_safe_mode_expected: AtomicBool,

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -493,7 +493,7 @@ static POISON_VERSION_METHODS: AtomicBool = AtomicBool::new(false);
 // Use a thread local in sim tests for test isolation.
 #[cfg(msim)]
 thread_local! {
-    static POISON_VERSION_METHODS: AtomicBool = AtomicBool::new(false);
+    static POISON_VERSION_METHODS: AtomicBool = const { AtomicBool::new(false) };
 }
 
 /// Process-global switch, set by the local in-memory swarm / `ika start`, to

--- a/crates/ika-swarm/src/memory/container-sim.rs
+++ b/crates/ika-swarm/src/memory/container-sim.rs
@@ -29,7 +29,9 @@ impl Drop for Container {
     fn drop(&mut self) {
         if let Some(handle) = self.handle.take() {
             tracing::info!("shutting down {}", handle.node_id);
-            sui_simulator::runtime::Handle::try_current().map(|h| h.delete_node(handle.node_id));
+            if let Some(runtime) = sui_simulator::runtime::Handle::try_current() {
+                runtime.delete_node(handle.node_id);
+            }
         }
     }
 }
@@ -52,7 +54,7 @@ impl Container {
         let startup_sender = Arc::new(startup_sender);
         let node = builder
             .ip(ip)
-            .name(&format!("{:?}", config.protocol_public_key().concise()))
+            .name(format!("{:?}", config.protocol_public_key().concise()))
             .init(move || {
                 info!("Node restarted");
                 let config = config.clone();

--- a/crates/ika-test-cluster/src/lib.rs
+++ b/crates/ika-test-cluster/src/lib.rs
@@ -17,7 +17,9 @@ use ika_config::initiation::InitiationParameters;
 use ika_config::local_ip_utils;
 use ika_config::node::SuiDataSource;
 use ika_node::IkaNodeHandle;
-use ika_protocol_config::{Chain, ProtocolVersion};
+#[cfg(not(msim))]
+use ika_protocol_config::Chain;
+use ika_protocol_config::ProtocolVersion;
 use ika_sui_client::SuiConnectorClient;
 use ika_sui_client::ika_dwallet_transactions::{
     PaymentCoinArgs, register_encryption_key, request_dwallet_dkg,

--- a/dev-docs/conventions/simtest.md
+++ b/dev-docs/conventions/simtest.md
@@ -74,6 +74,13 @@ MPC-degrading a validator while its consensus stays alive.
 Driver: `scripts/simtest/cargo-simtest`. Smoke entry point:
 `crates/ika-test-cluster/` (`IkaTestCluster` + `IkaTestClusterBuilder`).
 
+Besides running tests, the driver has `build` and `clippy` modes.
+`cargo simtest clippy --all-targets --all-features -- -D warnings` lints
+the msim compilation universe (`--cfg msim` + the msim-patched deps),
+which regular `cargo clippy` never compiles — CI runs it as the
+`Clippy (msim / simtest)` job on every PR and push, so msim-gated code
+can't rot between (manual/nightly) simtest runs.
+
 ## Short Sui epochs in cluster tests
 
 `ika-test-cluster` runs TWO epoch clocks, and they are independent:

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -95,6 +95,12 @@ CARGO_COMMAND=(nextest run --cargo-profile simulator)
 if [ "$1" = "build" ]; then
   shift
   CARGO_COMMAND=(build --profile simulator)
+elif [ "$1" = "clippy" ]; then
+  # Lint the msim compilation universe (`--cfg msim` + the msim-patched
+  # deps), which regular `cargo clippy` never sees. CI runs
+  # `cargo simtest clippy --all-targets --all-features -- -D warnings`.
+  shift
+  CARGO_COMMAND=(clippy --profile simulator)
 fi
 
 # Must supply a new temp dir - the test is deterministic and can't choose one randomly itself.


### PR DESCRIPTION
Closes the two coverage gaps that let clippy debt accumulate invisibly.

## Gap 1: PRs never ran clippy
The CI `clippy` job was `if: github.event_name == 'push'` — push-to-default-branch only. PRs merged unlinted, and the push job only ever surfaced the FIRST failing crate. (This is exactly how the recent workspace-wide lint backlog built up.) **Now runs on every PR and push.**

## Gap 2: the msim universe was never linted at all
`--cfg msim` is a separate compilation universe (msim-patched tokio, `#[cfg(msim)]` code, `[target.'cfg(msim)']` deps) that regular `cargo clippy` never compiles — and simtest runs are manual/nightly. Added:
- a **`clippy` mode to `scripts/simtest/cargo-simtest`** (same msim rustflags + dep patches, `clippy --profile simulator`);
- a **`Clippy (msim / simtest)` CI job** running `cargo simtest clippy --all-targets --all-features -- -D warnings` on every PR and push (uses the `simtest` cache prefix shared with the simtest workflow).

## Proof the gap was real: 10 msim-only lints, invisible to regular clippy by construction
All fixed at the source (no `#[allow]`s), including one **rotted msim-gated import** — the class of decay this gate prevents:

| Crate | Lint | Fix |
|---|---|---|
| ika-protocol-config | `missing_const_for_thread_local` | `const {}` init |
| ika-config | `new_without_default` (SimAddressManager) | `Default` impl |
| ika-core | unused `#[cfg(msim)]` import (rotted) | deleted |
| ika-core | `compute_catching_panic` dead under msim lib | `#[cfg(any(not(msim), test))]` (msim runs `compute()` inline; unit tests still exercise it) |
| ika-core | needless borrow (fail-point closure) | `&key` → `key` |
| ika-node | unused `use super::*` (msim module) | deleted |
| ika-node | `option_map_unit_fn` (msim `Drop`) | `if let` |
| ika-swarm | `option_map_unit_fn` + needless borrow (`container-sim.rs`) | `if let`; drop `&` |
| ika-test-cluster | `Chain` import unused under msim | split to `#[cfg(not(msim))]` |

## Verification
- `cargo simtest clippy --all-targets --all-features -- -D warnings` → **clean (exit 0)** end-to-end locally.
- `cargo test -p ika-protocol-config` (snapshot tests) → pass.
- Non-msim side: the deltas are cfg-scoped (msim-only blocks) or cfg-neutral; **this PR's own newly-enabled per-PR Clippy job validates it in CI** — check the PR checks.
- `dev-docs/conventions/simtest.md` documents the driver's `clippy` mode and the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)