### PR TITLE
fix(dwallet-mpc): park internal presign sessions on missing network-key data instead of failing them terminally

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -197,6 +197,13 @@ pub struct DWalletMPCMetrics {
     /// pending-request gauges target.
     pub(crate) requests_pending_for_frozen_mpc_data: IntGauge,
 
+    /// Size of `DWalletMPCManager.internal_presign_requests_pending_for_network_key_data`
+    /// — internal presign sessions parked because the target network key's data
+    /// (typically the off-chain VSS validator key set at epoch entry) isn't
+    /// locally available yet. Transient non-zero values at epoch entry are
+    /// expected; sustained ones mean the key data never arrived.
+    pub(crate) internal_presign_requests_pending_for_network_key_data: IntGauge,
+
     /// One series per user session currently tracked in `DWalletMPCManager.sessions`,
     /// labeled by `session_seq` (as a string) and `state`. Value is 1 for the
     /// state the session is currently in, 0 for the other four states. Sessions that leave
@@ -489,6 +496,12 @@ impl DWalletMPCMetrics {
             requests_pending_for_frozen_mpc_data: register_int_gauge_with_registry!(
                 "ika_dwallet_mpc_requests_pending_for_frozen_mpc_data",
                 "Sessions parked waiting for the off-chain mpc_data freeze gate",
+                registry,
+            )
+            .unwrap(),
+            internal_presign_requests_pending_for_network_key_data: register_int_gauge_with_registry!(
+                "ika_dwallet_mpc_internal_presign_requests_pending_for_network_key_data",
+                "Internal presign sessions parked waiting for their network key's data to be locally available",
                 registry,
             )
             .unwrap(),

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -497,6 +497,13 @@ impl DWalletMPCService {
             error!(error = ?e, "failed to ingest off-chain validator MPC keys");
         }
 
+        // Retry internal presign requests parked on missing network key data —
+        // per ITERATION, not per consensus round, because what they wait on
+        // (the ingest above / an asynchronous key install) completes on
+        // wall-clock time, and no new consensus round is guaranteed to follow.
+        self.dwallet_mpc_manager
+            .retry_internal_presign_requests_pending_for_network_key_data();
+
         self.sync_last_session_to_complete_in_current_epoch().await;
 
         // Process any pending network-owned-address sign requests.

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -1,5 +1,4 @@
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStoreTrait;
-use crate::dwallet_mpc::NetworkOwnedAddressSignRequest;
 use crate::dwallet_mpc::integration_tests::network_dkg::create_network_key_test;
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::{
@@ -8,9 +7,30 @@ use crate::dwallet_mpc::integration_tests::utils::{
     TEST_PRESIGN_POOL_MINIMUM_SIZE, apply_test_presign_pool_overrides, build_test_state,
     create_test_protocol_config_guard,
 };
+use crate::dwallet_mpc::mpc_session::SessionStatus;
+use crate::dwallet_mpc::{NetworkOwnedAddressSignRequest, ValidatorMpcKeysByPartyId};
 use dwallet_mpc_types::dwallet_mpc::{DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm};
 use ika_protocol_config::ProtocolConfig;
 use tracing::info;
+
+/// The Fast Schnorr (VSS) signature algorithms — their internal presign pools
+/// are driven alongside [`ALL_ALGORITHMS`] when `fast_schnorr_supported` is on,
+/// and their presign inputs additionally require the epoch's off-chain VSS
+/// validator key set to have been ingested.
+const VSS_ALGORITHMS: &[(DWalletCurve, DWalletSignatureAlgorithm)] = &[
+    (
+        DWalletCurve::Secp256k1,
+        DWalletSignatureAlgorithm::TaprootVSS,
+    ),
+    (
+        DWalletCurve::Curve25519,
+        DWalletSignatureAlgorithm::EdDSAVSS,
+    ),
+    (
+        DWalletCurve::Ristretto,
+        DWalletSignatureAlgorithm::SchnorrkelVSS,
+    ),
+];
 
 /// All signature algorithms that have internal presign pools.
 const ALL_ALGORITHMS: &[(DWalletCurve, DWalletSignatureAlgorithm)] = &[
@@ -859,4 +879,232 @@ async fn test_internal_presign_continues_when_idle() {
     }
 
     info!("Test completed: internal presigns continue when idle");
+}
+
+/// Counts terminally-Failed sessions across one service's session map.
+fn failed_session_count(test_state: &IntegrationTestState, service_index: usize) -> usize {
+    test_state.dwallet_mpc_services[service_index]
+        .dwallet_mpc_manager()
+        .sessions
+        .values()
+        .filter(|session| matches!(session.status, SessionStatus::Failed))
+        .count()
+}
+
+/// Test that VSS internal presign batches instantiated before the epoch's
+/// off-chain validator key set is ingested PARK (and later complete) instead
+/// of failing terminally.
+///
+/// At epoch entry the manager starts with an empty off-chain validator key
+/// set: the network key itself is adopted quickly from the handoff data, but
+/// the consensus-frozen key set is ingested later (its assembly and the
+/// network key's VSS derivation run asynchronously). Internal presign top-ups
+/// fire as soon as the network key is installed, so the VSS pools' input
+/// construction fails with the not-ready error class in that window. Mapping
+/// that failure to `SessionStatus::Failed` starved the EdDSA/Schnorrkel/
+/// Taproot VSS pools after every epoch transition (the batch died on every
+/// validator, blocking top-ups until the stale-batch expiry).
+///
+/// Flow:
+/// 1. Create the network key normally, then re-open the epoch-entry window on
+///    every validator: forget the ingested key set and empty the delivery
+///    channel (exactly the state a fresh manager is in before
+///    `ingest_offchain_mpc_keys` first succeeds).
+/// 2. Run rounds until the first VSS top-up batches fire; assert every
+///    validator PARKS them — no terminally-Failed session anywhere — and that
+///    parked batches are counted exactly once (no duplicate parking, no
+///    re-instantiation while parked).
+/// 3. Close the window (restore the ingested key set — the exact effect of
+///    `ingest_offchain_mpc_keys`); assert the parked batches activate,
+///    complete, and fill the previously starved pools, with counters uniform
+///    across validators.
+#[tokio::test]
+#[cfg(test)]
+async fn test_internal_presign_vss_parks_until_off_chain_keys_ingested() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard();
+
+    let mut test_state = build_test_state(4);
+    let (consensus_round, _network_key_bytes, network_key_id) =
+        create_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+
+    // No internal presign top-up has fired yet: batches only instantiate
+    // while processing a consensus round AFTER the network key is installed,
+    // and `create_network_key_test` returns without distributing such a
+    // round. Verified here so the window below provably opens before the
+    // first VSS batch.
+    for (curve, algorithm) in VSS_ALGORITHMS {
+        let (instantiated, _) = presign_batch_counters(&test_state, 0, *curve, *algorithm);
+        assert_eq!(
+            instantiated, 0,
+            "{curve:?}/{algorithm:?}: no VSS batch should have fired before the first post-install round"
+        );
+    }
+
+    // Expected first-batch sizes: the single test key IS the NOA signing key,
+    // so all pools use the NOA presign config.
+    let batch_size = TEST_NETWORK_OWNED_ADDRESS_SIGN_PRESIGN_SESSIONS_TO_INSTANTIATE;
+    let expected_parked = batch_size as usize * VSS_ALGORITHMS.len();
+
+    // === Phase 1: re-open the epoch-entry window on every validator ===
+    let saved_keys: Vec<ValidatorMpcKeysByPartyId> = test_state
+        .dwallet_mpc_services
+        .iter_mut()
+        .zip(&test_state.sui_data_senders)
+        .map(|(service, senders)| {
+            // Empty the delivery channel first so the next
+            // `ingest_offchain_mpc_keys` finds nothing to ingest.
+            let _ = senders.current_epoch_mpc_keys_sender.send(None);
+            let manager = service.dwallet_mpc_manager_mut();
+            let saved = manager.validator_mpc_keys_by_party_id.clone();
+            manager.validator_mpc_keys_by_party_id = ValidatorMpcKeysByPartyId::empty();
+            manager.current_epoch_keys_ingested = false;
+            saved
+        })
+        .collect();
+
+    // === Phase 2: first VSS top-up batches fire into the open window ===
+    let mut all_parked = false;
+    for _ in 0..12 {
+        run_one_round_delivering_messages(&mut test_state).await;
+        all_parked = test_state.dwallet_mpc_services.iter().all(|service| {
+            service
+                .dwallet_mpc_manager()
+                .internal_presign_requests_pending_for_network_key_data
+                .len()
+                == expected_parked
+        });
+        if all_parked {
+            break;
+        }
+    }
+    assert!(
+        all_parked,
+        "every validator should park exactly {expected_parked} VSS internal presign requests \
+         while the off-chain key set is not ingested"
+    );
+
+    for service_index in 0..test_state.dwallet_mpc_services.len() {
+        assert_eq!(
+            failed_session_count(&test_state, service_index),
+            0,
+            "validator {service_index}: VSS batches hitting the not-ready window must park, \
+             not create terminally-Failed sessions"
+        );
+        for (curve, algorithm) in VSS_ALGORITHMS {
+            assert_eq!(
+                presign_batch_counters(&test_state, service_index, *curve, *algorithm),
+                (batch_size, 0),
+                "validator {service_index}: {curve:?}/{algorithm:?} batch must be counted \
+                 instantiated exactly once while parked"
+            );
+        }
+    }
+
+    // Parked batches must be invisible to the top-up decision: more rounds
+    // with the window still open must not re-instantiate, duplicate-park, or
+    // fill the pool.
+    for _ in 0..4 {
+        run_one_round_delivering_messages(&mut test_state).await;
+    }
+    for service_index in 0..test_state.dwallet_mpc_services.len() {
+        assert_eq!(
+            test_state.dwallet_mpc_services[service_index]
+                .dwallet_mpc_manager()
+                .internal_presign_requests_pending_for_network_key_data
+                .len(),
+            expected_parked,
+            "validator {service_index}: parked requests must not duplicate while the window is open"
+        );
+        for (curve, algorithm) in VSS_ALGORITHMS {
+            assert_eq!(
+                presign_batch_counters(&test_state, service_index, *curve, *algorithm),
+                (batch_size, 0),
+                "validator {service_index}: {curve:?}/{algorithm:?} guard must hold while parked"
+            );
+        }
+    }
+    for (_, algorithm) in VSS_ALGORITHMS {
+        assert_eq!(
+            test_state.epoch_stores[0]
+                .presign_pool_size(*algorithm, network_key_id)
+                .unwrap_or(0),
+            0,
+            "{algorithm:?}: pool must stay empty while its only batch is parked"
+        );
+    }
+
+    // === Phase 3: close the window — the exact effect of `ingest_offchain_mpc_keys` ===
+    for (service, keys) in test_state
+        .dwallet_mpc_services
+        .iter_mut()
+        .zip(saved_keys.into_iter())
+    {
+        let manager = service.dwallet_mpc_manager_mut();
+        manager.validator_mpc_keys_by_party_id = keys;
+        manager.current_epoch_keys_ingested = true;
+    }
+
+    // The parked batches activate on the next service iteration and then run
+    // the full multi-round VSS presign protocol to completion.
+    let mut healed = false;
+    for _ in 0..80 {
+        run_one_round_delivering_messages(&mut test_state).await;
+        let parked_drained = test_state.dwallet_mpc_services.iter().all(|service| {
+            service
+                .dwallet_mpc_manager()
+                .internal_presign_requests_pending_for_network_key_data
+                .is_empty()
+        });
+        let first_batches_completed = VSS_ALGORITHMS.iter().all(|(curve, algorithm)| {
+            (0..test_state.dwallet_mpc_services.len()).all(|service_index| {
+                let (_, completed) =
+                    presign_batch_counters(&test_state, service_index, *curve, *algorithm);
+                completed >= batch_size
+            })
+        });
+        let pools_filled = VSS_ALGORITHMS.iter().all(|(_, algorithm)| {
+            test_state.epoch_stores[0]
+                .presign_pool_size(*algorithm, network_key_id)
+                .unwrap_or(0)
+                > 0
+        });
+        if parked_drained && first_batches_completed && pools_filled {
+            healed = true;
+            break;
+        }
+    }
+    assert!(
+        healed,
+        "once the off-chain key set lands, the parked VSS batches must activate, complete, \
+         and fill the previously starved pools"
+    );
+
+    // The not-ready window must never have produced a terminal failure.
+    for service_index in 0..test_state.dwallet_mpc_services.len() {
+        assert_eq!(
+            failed_session_count(&test_state, service_index),
+            0,
+            "validator {service_index}: no session may end terminally Failed in this flow"
+        );
+    }
+
+    // Cross-service counter consistency (identifier derivation is
+    // committee-uniform, so the counters must be too).
+    for (curve, algorithm) in VSS_ALGORITHMS {
+        let reference = presign_batch_counters(&test_state, 0, *curve, *algorithm);
+        for service_index in 1..test_state.dwallet_mpc_services.len() {
+            assert_eq!(
+                presign_batch_counters(&test_state, service_index, *curve, *algorithm),
+                reference,
+                "validator {service_index}: {curve:?}/{algorithm:?} counters diverged from validator 0"
+            );
+        }
+    }
+
+    info!(
+        "Test completed: VSS internal presign batches park through the off-chain-key ingest \
+         window and complete once it closes"
+    );
 }

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -13,7 +13,7 @@ use crate::dwallet_mpc::dwallet_mpc_metrics::{
     SESSION_STATE_WAITING_FOR_REQUEST, session_type_label,
 };
 use crate::dwallet_mpc::mpc_session::{
-    DWalletMPCSessionOutput, DWalletSession, SessionComputationType, SessionStatus,
+    DWalletMPCSessionOutput, DWalletSession, PublicInput, SessionComputationType, SessionStatus,
     session_input_from_request,
 };
 use crate::dwallet_mpc::network_dkg::{DwalletMPCNetworkKeys, ValidatorPrivateDecryptionKeyData};
@@ -28,8 +28,8 @@ use crate::dwallet_mpc::{
 use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionRequestMetricData};
 use dwallet_classgroups_types::ValidatorMPCSecrets;
 use dwallet_mpc_types::dwallet_mpc::{
-    DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm, NetworkEncryptionKeyPublicData,
-    NetworkKeyId, VersionedPresignOutput,
+    DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm, MPCPrivateInput,
+    NetworkEncryptionKeyPublicData, NetworkKeyId, VersionedPresignOutput,
 };
 use dwallet_mpc_types::mpc_protocol_configuration::network_presign_pool_algorithms;
 use dwallet_rng::RootSeed;
@@ -57,6 +57,7 @@ use ika_types::noa_checkpoint::CounterpartyChainKind;
 use mpc::{MajorityVote, WeightedThresholdAccessStructure};
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::mem;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
@@ -171,6 +172,19 @@ pub(crate) struct DWalletMPCManager {
     /// per-key DKG quorum, for DKG requests) is in place, they
     /// pass the gate and run normally.
     pub(crate) requests_pending_for_frozen_mpc_data: Vec<DWalletSessionRequest>,
+
+    /// Internal presign requests whose session input could not be built yet
+    /// because the target network key's data is not locally available — at
+    /// epoch entry the VSS (Fast Schnorr) pools instantiate before the
+    /// consensus-frozen off-chain validator key set has been ingested, so
+    /// their input construction fails with the not-ready error class. The
+    /// session identifier (and its sequence number) was already consumed at
+    /// instantiation — identifier derivation stays committee-uniform — and
+    /// only this validator's participation is deferred: the request is
+    /// retried once per service iteration and activated when the key data
+    /// lands. Genuinely-fatal input errors never land here (they fail the
+    /// session terminally at instantiation).
+    pub(crate) internal_presign_requests_pending_for_network_key_data: Vec<DWalletSessionRequest>,
     pub(crate) next_active_committee: Option<Committee>,
     pub(crate) dwallet_mpc_metrics: Arc<DWalletMPCMetrics>,
 
@@ -477,6 +491,7 @@ impl DWalletMPCManager {
             requests_pending_for_next_active_committee: Vec::new(),
             requests_pending_for_network_key: HashMap::new(),
             requests_pending_for_frozen_mpc_data: Vec::new(),
+            internal_presign_requests_pending_for_network_key_data: Vec::new(),
             dwallet_mpc_metrics,
             next_active_committee: None,
             validator_name,
@@ -1532,13 +1547,14 @@ impl DWalletMPCManager {
         session.add_message(consensus_round, sender_party_id, message);
     }
 
-    pub(super) fn session_status_from_request(
+    /// Builds the MPC session input for a request from this manager's current
+    /// committee/key state.
+    fn session_input(
         &self,
-        request: DWalletSessionRequest,
-        is_internal: bool,
-    ) -> SessionStatus {
-        match session_input_from_request(
-            &request,
+        request: &DWalletSessionRequest,
+    ) -> DwalletMPCResult<(PublicInput, MPCPrivateInput)> {
+        session_input_from_request(
+            request,
             &self.access_structure,
             &self.committee,
             &self.network_keys,
@@ -1546,15 +1562,28 @@ impl DWalletMPCManager {
             self.validator_mpc_keys_by_party_id.clone(),
             self.next_epoch_validator_mpc_keys.clone(),
             &self.protocol_config,
-        ) {
+        )
+    }
+
+    pub(super) fn session_status_from_request(
+        &self,
+        request: DWalletSessionRequest,
+        is_internal: bool,
+    ) -> SessionStatus {
+        match self.session_input(&request) {
             Ok((public_input, private_input)) => SessionStatus::Active {
                 public_input,
                 private_input,
                 request,
             },
             Err(e) => {
-                if is_internal {
-                    error!(                        should_never_happen = true, error=?e, ?request, "create internal session input from dWallet request with error");
+                // The not-ready class (key install / off-chain key ingest still
+                // in flight) is a reachable transient at epoch entry, not an
+                // invariant violation — don't page on it. Internal presign
+                // requests park on it before ever getting here (see
+                // `instantiate_internal_presign_session`).
+                if is_internal && !e.is_network_key_data_not_ready() {
+                    error!(should_never_happen = true, error=?e, ?request, "create internal session input from dWallet request with error");
                 } else {
                     error!(error=?e, ?request, "create session input from dWallet request with error");
                 }
@@ -1802,25 +1831,145 @@ impl DWalletMPCManager {
         );
 
         let session_identifier = request.session_identifier;
-        let status = self.session_status_from_request(request, true);
-
-        let session_computation_type = SessionComputationType::MPC {
-            messages_by_consensus_round: HashMap::new(),
-        };
-
-        debug!(
-            status=?status,
-            consensus_round,
-            ?curve,
-            ?signature_algorithm,
-            ?session_sequence_number,
-            ?session_identifier,
-            "instantiating new internal presign session",
-        );
-
-        self.new_session(&session_identifier, status, None, session_computation_type);
+        match self.session_input(&request) {
+            Ok((public_input, private_input)) => {
+                let status = SessionStatus::Active {
+                    public_input,
+                    private_input,
+                    request,
+                };
+                debug!(
+                    status=?status,
+                    consensus_round,
+                    ?curve,
+                    ?signature_algorithm,
+                    ?session_sequence_number,
+                    ?session_identifier,
+                    "instantiating new internal presign session",
+                );
+                self.new_session(
+                    &session_identifier,
+                    status,
+                    None,
+                    SessionComputationType::MPC {
+                        messages_by_consensus_round: HashMap::new(),
+                    },
+                );
+            }
+            Err(e) if e.is_network_key_data_not_ready() => {
+                // The key's data isn't locally available yet (typically the VSS
+                // pools at epoch entry, before the frozen off-chain validator
+                // key set has been ingested). Park the request and retry once
+                // per service iteration; peers that already have the data run
+                // the session meanwhile, and any of their messages buffer in a
+                // `WaitingForSessionRequest` entry until activation. The
+                // sequence number is still consumed below — the batch counters
+                // and identifier derivation must stay committee-uniform, so
+                // parking is invisible to the top-up and stale-batch-expiry
+                // decisions.
+                info!(
+                    error=?e,
+                    consensus_round,
+                    ?curve,
+                    ?signature_algorithm,
+                    ?session_sequence_number,
+                    ?session_identifier,
+                    "network key data not ready for internal presign session; parking it for retry",
+                );
+                self.internal_presign_requests_pending_for_network_key_data
+                    .push(request);
+            }
+            Err(e) => {
+                error!(should_never_happen = true, error=?e, ?request, "create internal session input from dWallet request with error");
+                self.new_session(
+                    &session_identifier,
+                    SessionStatus::Failed,
+                    None,
+                    SessionComputationType::MPC {
+                        messages_by_consensus_round: HashMap::new(),
+                    },
+                );
+            }
+        }
 
         self.next_internal_presign_sequence_number += 1;
+    }
+
+    /// Retries internal presign requests parked because their network key's
+    /// data wasn't locally available at instantiation time (see
+    /// `internal_presign_requests_pending_for_network_key_data`). Called once
+    /// per service iteration — the inputs it waits on (network-key install,
+    /// off-chain validator key ingest) complete on wall-clock time,
+    /// independently of consensus rounds.
+    pub(crate) fn retry_internal_presign_requests_pending_for_network_key_data(&mut self) {
+        if self
+            .internal_presign_requests_pending_for_network_key_data
+            .is_empty()
+        {
+            return;
+        }
+
+        let parked = mem::take(&mut self.internal_presign_requests_pending_for_network_key_data);
+        for request in parked {
+            let session_identifier = request.session_identifier;
+
+            if let Some(session) = self.sessions.get(&session_identifier)
+                && !matches!(session.status, SessionStatus::WaitingForSessionRequest)
+            {
+                // Already resolved without us (e.g. completed by a quorum of
+                // peers while we were parked) — drop the parked request.
+                continue;
+            }
+
+            match self.session_input(&request) {
+                Ok((public_input, private_input)) => {
+                    info!(
+                        session_identifier=?session_identifier,
+                        session_sequence_number=?request.session_sequence_number,
+                        "network key data arrived; activating parked internal presign session",
+                    );
+                    let session_sequence_number = request.session_sequence_number;
+                    let session_type = request.session_type;
+                    let status = SessionStatus::Active {
+                        public_input,
+                        private_input,
+                        request,
+                    };
+                    if let Some(session) = self.sessions.get_mut(&session_identifier) {
+                        // Peer messages arrived while parked and created the
+                        // session entry; upgrade it in place so the buffered
+                        // messages survive.
+                        session.status = status;
+                        session.set_request_metadata(session_sequence_number, session_type);
+                    } else {
+                        self.new_session(
+                            &session_identifier,
+                            status,
+                            None,
+                            SessionComputationType::MPC {
+                                messages_by_consensus_round: HashMap::new(),
+                            },
+                        );
+                    }
+                }
+                Err(e) if e.is_network_key_data_not_ready() => {
+                    // Still not ready — keep it parked.
+                    self.internal_presign_requests_pending_for_network_key_data
+                        .push(request);
+                }
+                Err(e) => {
+                    error!(should_never_happen = true, error=?e, ?request, "create internal session input from dWallet request with error");
+                    self.new_session(
+                        &session_identifier,
+                        SessionStatus::Failed,
+                        None,
+                        SessionComputationType::MPC {
+                            messages_by_consensus_round: HashMap::new(),
+                        },
+                    );
+                }
+            }
+        }
     }
 
     /// Instantiates a generic network-owned-address sign session.
@@ -3200,6 +3349,12 @@ impl DWalletMPCManager {
         metrics
             .requests_pending_for_frozen_mpc_data
             .set(self.requests_pending_for_frozen_mpc_data.len() as i64);
+        metrics
+            .internal_presign_requests_pending_for_network_key_data
+            .set(
+                self.internal_presign_requests_pending_for_network_key_data
+                    .len() as i64,
+            );
 
         // ----- per-network-encryption-key loaded epoch -----
         // Drift between this and the current epoch is the silent-skip cause

--- a/crates/ika-types/src/dwallet_mpc_error.rs
+++ b/crates/ika-types/src/dwallet_mpc_error.rs
@@ -238,6 +238,19 @@ impl From<serde_json::Error> for DwalletMPCError {
 }
 
 impl DwalletMPCError {
+    /// Whether this error means required network-key material is not locally
+    /// available YET (the key's installation or the off-chain validator key
+    /// ingest is still in flight) rather than a permanent failure. Sessions
+    /// hitting this class should be retried once the material lands, not
+    /// failed terminally.
+    pub fn is_network_key_data_not_ready(&self) -> bool {
+        matches!(
+            self,
+            DwalletMPCError::WaitingForNetworkKey(_)
+                | DwalletMPCError::NetworkDecryptionKeyNotReady
+        )
+    }
+
     /// Returns a short, stable label suitable for use as a Prometheus metric label value.
     /// Cardinality is bounded: one variant ⇒ one label. Keep these strings stable —
     /// alerts depend on them.

--- a/dev-docs/playbooks/mpc-stall-postmortem.md
+++ b/dev-docs/playbooks/mpc-stall-postmortem.md
@@ -111,14 +111,23 @@ counted.) The roots seen for #1736, keyed by which field is false
   # then confirm that seq never returns (no completion, no re-pull):
   grep "session_sequence_number=<SEQ>" $L
   ```
-  A second, correlated signature at every epoch entry: a burst of
-  `FailedToAdvanceMPC(InvalidParameters)` in `compute_presign` round 1
-  with `should_never_happen=true`, VSS algorithms only, never retried to
-  quorum — the internal-presign refill sessions created inside the
-  epoch-entry key gap. Unlike the three roots above (all fixed), this one
-  has no fix yet; the healthy-vs-wedged discriminator and the standing
-  evidence are on issue #1736. Diagnosis needs a FAILING instrumented run
-  (most runs are healthy) — the captured one is CI run 28577745311.
+  A second, correlated signature at every epoch entry: VSS-algorithm
+  internal-presign refill sessions created inside the epoch-entry key gap
+  (network key installed, off-chain validator key set not yet ingested).
+  Historically this appeared as a `FailedToAdvanceMPC(InvalidParameters)`
+  round-1 burst, later as `should_never_happen=true
+  error=NetworkDecryptionKeyNotReady` with terminally-Failed sessions
+  starving the VSS pools. Both are fixed: those requests now PARK
+  ("network key data not ready for internal presign session; parking it
+  for retry") and activate once the key data lands ("network key data
+  arrived; activating parked internal presign session"). The wedge
+  signature today is a park line with NO later activation line for the
+  same session, or a sustained non-zero
+  `ika_dwallet_mpc_internal_presign_requests_pending_for_network_key_data`
+  gauge — that means the off-chain key set never arrived (back to the
+  announcement/freeze checks). Residual #1736 evidence (the
+  parked-sessions-never-compute CI link) is tracked on that issue; the
+  captured instrumented run is CI run 28577745311.
 
 ## 4. Chain counters — the over/undershoot discriminator
 

--- a/dev-docs/specs/fast-schnorr-vss.md
+++ b/dev-docs/specs/fast-schnorr-vss.md
@@ -98,6 +98,21 @@ against the active committee directly.
   (non-VSS) sign.
 - Internal NOA-VSS is reachable at v4; external user-driven VSS sign is not yet
   enabled.
+- **Epoch-entry parking of VSS presign top-ups.** Internal presign top-up
+  batches fire as soon as the network key is installed (fast, from the handoff
+  data), which is typically *before* the epoch's consensus-frozen off-chain
+  validator key set has been ingested — so the VSS pools' presign input
+  construction fails with the not-ready error class
+  (`NetworkDecryptionKeyNotReady` / `WaitingForNetworkKey`). Such a request is
+  **parked** (`internal_presign_requests_pending_for_network_key_data` on the
+  MPC manager), retried once per service iteration, and activated once the key
+  data lands — never terminally failed (terminal failure on every validator
+  starved the VSS pools after each epoch transition until the stale-batch
+  expiry). The session identifier and sequence number are consumed at
+  instantiation regardless of parking, so identifier derivation and the
+  instantiated/completed batch counters stay committee-uniform — parking is
+  local participation deferral, invisible to the top-up guard and the
+  stale-batch expiry. Any other input-construction error stays terminal.
 
 ## Invariants
 


### PR DESCRIPTION
## Problem

At epoch entry the VSS (Fast Schnorr) internal presign pools instantiate as soon as the network key installs — before the consensus-frozen off-chain validator key set is ingested — so their session-input construction fails with `NetworkDecryptionKeyNotReady`. `session_status_from_request` mapped every input error to terminal `SessionStatus::Failed`, killing the batch on every validator: `should_never_happen=true` error spam and terminally-dead sessions at every epoch entry, with the EdDSAVSS/SchnorrkelVSS/TaprootVSS pools starved until the stale-batch expiry (#1807) forgave the batch.

Proven live in CI run 29153674855: 222 `should_never_happen=true error=NetworkDecryptionKeyNotReady` errors at every epoch entry, 18 terminally failed sessions, EdDSA/Schnorrkel future-sign tests timing out while secp passes (vs green run 29162432790 on equivalent code). v4-gated (`internal_presign_sessions`), so no effect on the v3 mainnet rollout — but a v4-activation gate: at v4 it would starve EdDSA/Schnorrkel/Taproot NOA signing after every reconfiguration, and it makes the TS CI suite flaky today.

## Fix

Requests hitting the not-ready error class (`NetworkDecryptionKeyNotReady` / `WaitingForNetworkKey`, classified by the new `DwalletMPCError::is_network_key_data_not_ready()`) are **parked** in a new manager queue (`internal_presign_requests_pending_for_network_key_data`) and retried once per service iteration — per iteration, not per consensus round, because what they wait on (off-chain key ingest, async key install) completes on wall-clock time. On activation, an existing `WaitingForSessionRequest` entry is upgraded in place so peer messages that arrived while parked survive. Genuinely-fatal input errors remain terminal, and the reachable not-ready condition no longer logs `should_never_happen=true`.

**Why park rather than gate instantiation on readiness**: `next_internal_presign_sequence_number` is a single counter interleaved across all pools, and readiness is per-validator wall-clock — a validator that skipped a pool while another instantiated it would permanently desync every subsequent session identifier (sessions could never reach quorum). Parking consumes the sequence number at instantiation, so identifier derivation and the instantiated/completed batch counters stay committee-uniform. That also makes parking invisible to #1807's stale-batch expiry: no double-counting, and a pathological expiry-while-parked just adds a late-completing batch that the existing saturating-completion logic absorbs.

Also adds a parked-queue gauge (`ika_dwallet_mpc_internal_presign_requests_pending_for_network_key_data`), updates `dev-docs/specs/fast-schnorr-vss.md` (epoch-entry parking decision rule) and the mpc-stall playbook (the wedge signature is now a park line with no later activation line / a sustained non-zero gauge).

## Testing

- New integration test `test_internal_presign_vss_parks_until_off_chain_keys_ingested`: re-opens the epoch-entry window (empties the current-epoch key channel + resets the ingest state), asserts all three VSS pools park exactly one batch each with zero Failed sessions and no duplicate top-ups across extra rounds, then closes the window and asserts activation, completion, pool fill, and cross-validator counter uniformity.
- **Fault-injection validated** (dev-docs/playbooks/test-testing.md): with the parking guard disabled (pre-fix behavior), the test fails at the parking assert and the log reproduces the production signature exactly — 24 `should_never_happen=true error=NetworkDecryptionKeyNotReady` lines (6 sessions × 4 validators), zero park lines. With the fix: 24 park lines → 24 activate lines, zero errors, pass.
- All 5 `dwallet_mpc::integration_tests::internal_presign` tests green in release (1046s); clippy clean on ika-core + ika-types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)