### PR TITLE
fix(dwallet-mpc): keep internal presign sequence numbers committee-uniform when a network key's installation lags

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -7,10 +7,22 @@ use crate::dwallet_mpc::integration_tests::utils::{
     TEST_PRESIGN_POOL_MINIMUM_SIZE, apply_test_presign_pool_overrides, build_test_state,
     create_test_protocol_config_guard,
 };
+use crate::dwallet_mpc::mpc_manager::ParkedInternalPresignRequest;
 use crate::dwallet_mpc::mpc_session::SessionStatus;
 use crate::dwallet_mpc::{NetworkOwnedAddressSignRequest, ValidatorMpcKeysByPartyId};
-use dwallet_mpc_types::dwallet_mpc::{DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm};
+use crate::network_key_id_mapping;
+use dwallet_mpc_types::dwallet_mpc::{
+    DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm, NetworkKeyId,
+};
 use ika_protocol_config::ProtocolConfig;
+use ika_types::message::DWalletCheckpointMessageKind;
+use ika_types::messages_dwallet_mpc::{
+    DWalletNetworkEncryptionKeyData, DWalletNetworkEncryptionKeyState, SessionIdentifier,
+    SessionType,
+};
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
+use sui_types::base_types::ObjectID;
 use tracing::info;
 
 /// The Fast Schnorr (VSS) signature algorithms — their internal presign pools
@@ -1106,5 +1118,402 @@ async fn test_internal_presign_vss_parks_until_off_chain_keys_ingested() {
     info!(
         "Test completed: VSS internal presign batches park through the off-chain-key ingest \
          window and complete once it closes"
+    );
+}
+
+/// Per-validator map of every internal-presign session whose request is bound
+/// (sequence number known): `session_identifier → sequence number`. Excludes
+/// message/output stubs still in `WaitingForSessionRequest` with no request —
+/// a stub proves a peer derived the identifier, not that THIS validator did.
+/// Equality of these maps across validators is the invariant the shared
+/// sequence counter must preserve: a validator that skips a top-up other
+/// validators perform would bind different sequence numbers to different
+/// identifiers from that point on.
+fn bound_internal_presign_sessions(
+    test_state: &IntegrationTestState,
+    service_index: usize,
+) -> HashMap<SessionIdentifier, u64> {
+    test_state.dwallet_mpc_services[service_index]
+        .dwallet_mpc_manager()
+        .sessions
+        .iter()
+        .filter(|(_, session)| session.session_type == Some(SessionType::InternalPresign))
+        .filter_map(|(session_identifier, session)| {
+            session
+                .session_sequence_number
+                .map(|sequence_number| (*session_identifier, sequence_number))
+        })
+        .collect()
+}
+
+/// Test that a validator whose network-key INSTALLATION lags behind its peers
+/// in a multi-key epoch parks the affected internal presign batches with the
+/// sequence numbers consumed — instead of skipping them — so session
+/// identifier derivation stays committee-uniform.
+///
+/// The internal presign sequence counter is a single counter shared across
+/// all pools and keys, and the top-up loop iterates every ADOPTED key while
+/// installation into `network_keys` completes asynchronously per validator.
+/// Before the fix, a validator in the adopted-but-not-installed window
+/// early-returned without consuming the sequence number (while the caller
+/// still advanced the instantiated counter) — permanently desynchronizing
+/// every subsequent internal presign identifier from its peers'.
+///
+/// Flow:
+/// 1. K0 bootstraps normally; K1 is a second same-epoch DKG (both adopted +
+///    installed everywhere). K1's id is forced above K0's so the NOA-key
+///    tie-break deterministically keeps K0 as the NOA signing key.
+/// 2. Remove K1's INSTALLED data on validator 0 only (its adoption stays) —
+///    exactly the adopted-but-not-installed window. The manager re-spawns the
+///    installation in the background, which later heals the window naturally.
+/// 3. Run rounds: K1's first pool batches fire committee-wide. Validator 0
+///    must PARK them (identity from the pre-instantiation mapping, input
+///    construction not-ready) while peers activate them.
+/// 4. Run until the re-install heals validator 0: parked entries activate,
+///    and the bound identifier→sequence maps converge to equality across all
+///    validators, with no terminally-Failed session anywhere.
+/// 5. Coda: a fabricated key that is adopted but has NO installed data and NO
+///    `ObjectID → NetworkKeyId` mapping anywhere exercises the
+///    `AwaitingKeyIdentity` parking (sequence reserved, request not yet
+///    buildable), then a registered mapping transitions those entries to
+///    fully-built parked requests with identical identifiers on every
+///    validator.
+#[tokio::test]
+#[cfg(test)]
+async fn test_internal_presign_multi_key_install_lag_keeps_identifiers_uniform() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard();
+
+    let mut test_state = build_test_state(4);
+    let (next_round_after_k0, _k0_bytes, k0_id) = create_network_key_test(&mut test_state).await;
+    let k0_data = test_state.dwallet_mpc_services[0]
+        .dwallet_mpc_manager()
+        .adopted_network_key_data
+        .get(&k0_id)
+        .expect("K0 must be adopted after create_network_key_test")
+        .clone();
+
+    // === Phase 1: K1 — a second network DKG in the same epoch ===
+    let epoch_id = test_state
+        .dwallet_mpc_services
+        .first()
+        .expect("at least one service should exist")
+        .epoch;
+    // Force k1_id > k0_id: with equal `dkg_at_epoch` the NOA-key selection
+    // tie-breaks by key id, so K0 stays the NOA signing key on every
+    // validator regardless of which keys are installed at decision time.
+    let k1_id = loop {
+        let candidate = ObjectID::random();
+        if candidate > k0_id {
+            break candidate;
+        }
+    };
+    let all_parties: Vec<usize> = (0..test_state.sui_data_senders.len()).collect();
+    utils::send_configurable_start_network_dkg_event(
+        epoch_id,
+        &mut test_state.sui_data_senders,
+        [2u8; 32],
+        2,
+        &all_parties,
+        k1_id,
+    );
+    let (round_after_k1, k1_checkpoint) =
+        utils::advance_mpc_flow_until_completion(&mut test_state, next_round_after_k0).await;
+    let mut k1_bytes = Vec::new();
+    for message in k1_checkpoint.messages() {
+        let DWalletCheckpointMessageKind::RespondDWalletMPCNetworkDKGOutput(message) = message
+        else {
+            continue;
+        };
+        k1_bytes.extend(message.public_output.clone());
+    }
+    assert!(
+        !k1_bytes.is_empty(),
+        "K1 network DKG checkpoint should carry non-empty public output"
+    );
+
+    // Publish BOTH keys to the overlay so every validator adopts + installs K1.
+    let both_keys = Arc::new(HashMap::from([
+        (k0_id, k0_data),
+        (
+            k1_id,
+            DWalletNetworkEncryptionKeyData {
+                id: k1_id,
+                current_epoch: epoch_id,
+                dkg_at_epoch: epoch_id,
+                current_reconfiguration_public_output: vec![],
+                network_dkg_public_output: k1_bytes.clone(),
+                state: DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration,
+            },
+        ),
+    ]));
+    test_state.sui_data_senders.iter().for_each(|sender| {
+        let _ = sender.network_keys_sender.send(both_keys.clone());
+    });
+    for service in test_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration(vec![]).await;
+    }
+    utils::send_advance_results_between_parties(
+        &test_state.committee,
+        &mut test_state.sent_consensus_messages_collectors,
+        &mut test_state.epoch_stores,
+        round_after_k1 + 1,
+    );
+    test_state.consensus_round = (round_after_k1 + 2) as usize;
+    for service in test_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration(vec![]).await;
+    }
+    utils::run_service_loops_until_network_key_installed(
+        &mut test_state.dwallet_mpc_services,
+        k1_id,
+    )
+    .await;
+
+    // No K1 pool batch has fired yet: top-ups only run while processing a
+    // consensus round after installation, and the install-wait loop above
+    // distributes no new rounds. Verified so the window below provably opens
+    // before K1's first batch.
+    let lagging_validator = 0usize;
+    let k1_active_sessions = test_state.dwallet_mpc_services[lagging_validator]
+        .dwallet_mpc_manager()
+        .sessions
+        .values()
+        .filter(|session| {
+            matches!(&session.status, SessionStatus::Active { request, .. }
+                if request.protocol_data.network_encryption_key_id() == Some(k1_id))
+        })
+        .count();
+    assert_eq!(
+        k1_active_sessions, 0,
+        "no K1 presign session should exist before the first post-install round"
+    );
+
+    // === Phase 2: open the install-lag window on validator 0 ===
+    // Remove K1's INSTALLED data (adoption stays — the top-up loop keeps
+    // iterating K1). `instantiate_adopted_network_keys` re-spawns the
+    // installation on the next service iteration, and that async re-install
+    // is exactly what heals the window later — the production shape.
+    test_state.dwallet_mpc_services[lagging_validator]
+        .dwallet_mpc_manager_mut()
+        .network_keys
+        .network_encryption_keys
+        .remove(&k1_id)
+        .expect("K1 must be installed on validator 0 before the window opens");
+
+    // === Phase 3: K1's first batches fire; validator 0 must park them ===
+    let mut saw_parked_on_lagging_validator = false;
+    let mut healed = false;
+    for _ in 0..60 {
+        run_one_round_delivering_messages(&mut test_state).await;
+
+        let parked: usize = test_state.dwallet_mpc_services[lagging_validator]
+            .dwallet_mpc_manager()
+            .internal_presign_requests_pending_for_network_key_data
+            .len();
+        if parked > 0 {
+            saw_parked_on_lagging_validator = true;
+        }
+
+        // No validator may ever fail a session terminally in this flow.
+        for service_index in 0..test_state.dwallet_mpc_services.len() {
+            assert_eq!(
+                failed_session_count(&test_state, service_index),
+                0,
+                "validator {service_index}: install lag must never terminally fail a session"
+            );
+        }
+
+        // THE invariant: the shared sequence counter reads identically on
+        // every validator after every processed round — parking consumes the
+        // number, so even the validator missing K1's data stays in step.
+        let reference_next_sequence_number = test_state.dwallet_mpc_services[0]
+            .dwallet_mpc_manager()
+            .next_internal_presign_sequence_number;
+        for (service_index, service) in test_state.dwallet_mpc_services.iter().enumerate() {
+            assert_eq!(
+                service
+                    .dwallet_mpc_manager()
+                    .next_internal_presign_sequence_number,
+                reference_next_sequence_number,
+                "validator {service_index}: internal presign sequence counter diverged during \
+                 the install-lag window"
+            );
+        }
+
+        // Healed: the window saw parking and the re-install drained it (a
+        // parked entry whose session a peer quorum completed meanwhile is
+        // legitimately dropped unbound — bound maps are compared as
+        // subset-consistency below, not equality).
+        let parked_everywhere_empty = test_state.dwallet_mpc_services.iter().all(|service| {
+            service
+                .dwallet_mpc_manager()
+                .internal_presign_requests_pending_for_network_key_data
+                .is_empty()
+        });
+        if saw_parked_on_lagging_validator && parked_everywhere_empty {
+            healed = true;
+            break;
+        }
+    }
+    assert!(
+        saw_parked_on_lagging_validator,
+        "validator 0 should have parked K1's presign batches while K1 was not installed locally"
+    );
+    assert!(
+        healed,
+        "the re-install must drain validator 0's parked K1 batches with the shared sequence \
+         counter identical across all validators"
+    );
+
+    // Bound identifier→sequence consistency: every session the lagging
+    // validator bound must be bound to the SAME sequence number on every
+    // peer (peers never parked, so they bound every batch). A pre-fix skip
+    // shifts the lagging validator's counter and binds later batches to
+    // identifiers no peer derives.
+    let lagging_bound = bound_internal_presign_sessions(&test_state, lagging_validator);
+    assert!(
+        !lagging_bound.is_empty(),
+        "validator 0 should have bound internal presign sessions after healing"
+    );
+    for peer_index in 1..test_state.dwallet_mpc_services.len() {
+        let peer_bound = bound_internal_presign_sessions(&test_state, peer_index);
+        for (session_identifier, sequence_number) in &lagging_bound {
+            assert_eq!(
+                peer_bound.get(session_identifier),
+                Some(sequence_number),
+                "validator {peer_index}: session {session_identifier:?} bound to a different \
+                 sequence number than on validator 0 — identifier derivation diverged"
+            );
+        }
+    }
+
+    // === Phase 4: coda — a key with NO derivable identity anywhere ===
+    // Adopted on every validator, junk DKG bytes (its installation fails, so
+    // it never registers an `ObjectID → NetworkKeyId` mapping): top-ups for
+    // its pools must park `AwaitingKeyIdentity` with the sequence number
+    // reserved, uniformly across validators.
+    let k2_id = ObjectID::random();
+    for service in test_state.dwallet_mpc_services.iter_mut() {
+        service
+            .dwallet_mpc_manager_mut()
+            .adopted_network_key_data
+            .insert(
+                k2_id,
+                DWalletNetworkEncryptionKeyData {
+                    id: k2_id,
+                    current_epoch: epoch_id,
+                    dkg_at_epoch: epoch_id,
+                    current_reconfiguration_public_output: vec![],
+                    network_dkg_public_output: vec![7u8; 64],
+                    state: DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration,
+                },
+            );
+    }
+
+    // (sequence number, curve, algorithm) of the K2 batches awaiting identity,
+    // per validator — reservation uniformity is the property under test.
+    let awaiting_identity_reservations =
+        |test_state: &IntegrationTestState,
+         service_index: usize|
+         -> BTreeSet<(u64, DWalletCurve, DWalletSignatureAlgorithm)> {
+            test_state.dwallet_mpc_services[service_index]
+                .dwallet_mpc_manager()
+                .internal_presign_requests_pending_for_network_key_data
+                .iter()
+                .filter_map(|parked| match parked {
+                    ParkedInternalPresignRequest::AwaitingKeyIdentity {
+                        session_sequence_number,
+                        dwallet_network_encryption_key_id,
+                        curve,
+                        signature_algorithm,
+                    } if *dwallet_network_encryption_key_id == k2_id => {
+                        Some((*session_sequence_number, *curve, *signature_algorithm))
+                    }
+                    _ => None,
+                })
+                .collect()
+        };
+
+    let mut identity_parking_uniform = false;
+    for _ in 0..30 {
+        run_one_round_delivering_messages(&mut test_state).await;
+        let reference_next_sequence_number = test_state.dwallet_mpc_services[0]
+            .dwallet_mpc_manager()
+            .next_internal_presign_sequence_number;
+        for (service_index, service) in test_state.dwallet_mpc_services.iter().enumerate() {
+            assert_eq!(
+                service
+                    .dwallet_mpc_manager()
+                    .next_internal_presign_sequence_number,
+                reference_next_sequence_number,
+                "validator {service_index}: sequence counter diverged for the identity-less key"
+            );
+            assert_eq!(
+                failed_session_count(&test_state, service_index),
+                0,
+                "validator {service_index}: an underivable key identity must park, not fail"
+            );
+        }
+        let reference = awaiting_identity_reservations(&test_state, 0);
+        let uniform = !reference.is_empty()
+            && (1..test_state.dwallet_mpc_services.len()).all(|service_index| {
+                awaiting_identity_reservations(&test_state, service_index) == reference
+            });
+        if uniform {
+            identity_parking_uniform = true;
+            break;
+        }
+    }
+    assert!(
+        identity_parking_uniform,
+        "every validator must reserve identical (sequence, curve, algorithm) for the \
+         identity-less key's parked batches"
+    );
+
+    // Register a mapping for K2: the parked reservations must transition to
+    // fully-built requests — derived from the RESERVED sequence numbers —
+    // with byte-identical session identifiers on every validator (they stay
+    // parked as requests: the key still has no installed data).
+    network_key_id_mapping::register(k2_id, NetworkKeyId([0xAB; 32]));
+    for _ in 0..3 {
+        run_one_round_delivering_messages(&mut test_state).await;
+    }
+    let k2_request_identifiers =
+        |test_state: &IntegrationTestState, service_index: usize| -> BTreeSet<SessionIdentifier> {
+            test_state.dwallet_mpc_services[service_index]
+                .dwallet_mpc_manager()
+                .internal_presign_requests_pending_for_network_key_data
+                .iter()
+                .filter_map(|parked| match parked {
+                    ParkedInternalPresignRequest::Request(request)
+                        if request.protocol_data.network_encryption_key_id() == Some(k2_id) =>
+                    {
+                        Some(request.session_identifier)
+                    }
+                    _ => None,
+                })
+                .collect()
+        };
+    let reference_identifiers = k2_request_identifiers(&test_state, 0);
+    assert!(
+        !reference_identifiers.is_empty(),
+        "the registered mapping must let the reserved batches build their requests"
+    );
+    for service_index in 0..test_state.dwallet_mpc_services.len() {
+        assert!(
+            awaiting_identity_reservations(&test_state, service_index).is_empty(),
+            "validator {service_index}: no reservation may remain once the identity is derivable"
+        );
+        assert_eq!(
+            k2_request_identifiers(&test_state, service_index),
+            reference_identifiers,
+            "validator {service_index}: deferred-built requests must derive identical \
+             session identifiers from the reserved sequence numbers"
+        );
+    }
+
+    info!(
+        "Test completed: multi-key install lag parks internal presign batches with sequence \
+         numbers consumed, keeping identifier derivation committee-uniform"
     );
 }

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -26,6 +26,7 @@ use crate::dwallet_mpc::{
     get_validator_mpc_keys_by_party_id, party_id_to_authority_name,
 };
 use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionRequestMetricData};
+use crate::network_key_id_mapping::network_key_id_for;
 use dwallet_classgroups_types::ValidatorMPCSecrets;
 use dwallet_mpc_types::dwallet_mpc::{
     DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm, MPCPrivateInput,
@@ -98,6 +99,34 @@ fn compute_chain_context<C: CounterpartyChain>(
         );
         *current_context = Some(context);
     }
+}
+
+/// An internal presign session deferred because its network key's data is not
+/// locally available yet. In BOTH shapes the session sequence number was
+/// already consumed at instantiation, so identifier derivation and the batch
+/// counters stay committee-uniform; parking defers only this validator's
+/// participation. Entries retry once per service iteration.
+#[derive(Debug, Clone)]
+pub(crate) enum ParkedInternalPresignRequest {
+    /// The request is fully built, but its MPC input construction failed with
+    /// the not-ready error class — typically a VSS pool at epoch entry,
+    /// before the consensus-frozen off-chain validator key set is ingested,
+    /// or a key adopted but not yet locally installed. Boxed: the request
+    /// dwarfs the other variant.
+    Request(Box<DWalletSessionRequest>),
+    /// The request could not even be BUILT: the key's content-derived
+    /// identity (its `NetworkKeyId`, bound into the session identifier) is
+    /// not derivable locally yet — the key is adopted but its installation
+    /// hasn't completed and the `ObjectID → NetworkKeyId` mapping has no
+    /// entry (a fresh key with no handoff-cert pin). The reserved sequence
+    /// number is carried here; the request is built at retry time, once the
+    /// identity becomes derivable.
+    AwaitingKeyIdentity {
+        session_sequence_number: u64,
+        dwallet_network_encryption_key_id: ObjectID,
+        curve: DWalletCurve,
+        signature_algorithm: DWalletSignatureAlgorithm,
+    },
 }
 
 /// The [`DWalletMPCManager`] manages MPC sessions:
@@ -173,18 +202,17 @@ pub(crate) struct DWalletMPCManager {
     /// pass the gate and run normally.
     pub(crate) requests_pending_for_frozen_mpc_data: Vec<DWalletSessionRequest>,
 
-    /// Internal presign requests whose session input could not be built yet
-    /// because the target network key's data is not locally available — at
-    /// epoch entry the VSS (Fast Schnorr) pools instantiate before the
-    /// consensus-frozen off-chain validator key set has been ingested, so
-    /// their input construction fails with the not-ready error class. The
-    /// session identifier (and its sequence number) was already consumed at
-    /// instantiation — identifier derivation stays committee-uniform — and
-    /// only this validator's participation is deferred: the request is
-    /// retried once per service iteration and activated when the key data
-    /// lands. Genuinely-fatal input errors never land here (they fail the
-    /// session terminally at instantiation).
-    pub(crate) internal_presign_requests_pending_for_network_key_data: Vec<DWalletSessionRequest>,
+    /// Internal presign requests deferred because the target network key's
+    /// data is not locally available yet (see
+    /// [`ParkedInternalPresignRequest`] for the two deferral shapes). The
+    /// session sequence number was already consumed at instantiation —
+    /// identifier derivation stays committee-uniform — and only this
+    /// validator's participation is deferred: entries are retried once per
+    /// service iteration and activated when the key data lands.
+    /// Genuinely-fatal input errors never land here (they fail the session
+    /// terminally at instantiation).
+    pub(crate) internal_presign_requests_pending_for_network_key_data:
+        Vec<ParkedInternalPresignRequest>,
     pub(crate) next_active_committee: Option<Committee>,
     pub(crate) dwallet_mpc_metrics: Arc<DWalletMPCMetrics>,
 
@@ -294,7 +322,7 @@ pub(crate) struct DWalletMPCManager {
     // Different epochs will see repeating values of this variable,
     // but that is safe as they are synced within an epoch and
     // the session identifier is derived from the epoch as well.
-    next_internal_presign_sequence_number: u64,
+    pub(crate) next_internal_presign_sequence_number: u64,
 
     /// Monotonically increasing count of instantiated internal presign sessions
     /// per (curve, signature_algorithm). Incremented when a session is created.
@@ -1606,11 +1634,17 @@ impl DWalletMPCManager {
 
     /// Returns the network encryption key ID used for network-owned-address signing (the oldest by DKG epoch).
     /// Used by internal presign session instantiation to determine internal-signing-specific pool params.
+    ///
+    /// Ties on `dkg_at_epoch` (two keys DKG'd in the same epoch) break by key
+    /// id: without the tie-break, `min_by` keeps the LAST minimum in `HashMap`
+    /// iteration order — per-process-random, so validators could disagree on
+    /// which key is the NOA key and apply different pool configs (different
+    /// batch sizes ⇒ divergent internal-presign sequence numbers).
     fn network_owned_address_signing_network_encryption_key_id(&self) -> Option<ObjectID> {
         self.network_keys
             .network_encryption_keys
             .iter()
-            .min_by(|(_, a), (_, b)| a.dkg_at_epoch.cmp(&b.dkg_at_epoch))
+            .min_by(|(a_id, a), (b_id, b)| a.dkg_at_epoch.cmp(&b.dkg_at_epoch).then(a_id.cmp(b_id)))
             .map(|(id, _)| *id)
     }
 
@@ -1798,6 +1832,37 @@ impl DWalletMPCManager {
     }
 
     /// Instantiates an internal presign sessions.
+    /// The network key identity bytes bound into internal presign session
+    /// identifiers: the key's flip-invariant, content-derived `NetworkKeyId`.
+    /// Read from the installed key data when available; before installation,
+    /// fall back to the pre-instantiation `ObjectID → NetworkKeyId` mapping
+    /// (seeded deployed keys, handoff-cert background derivation,
+    /// registrations from an earlier install). `None` when neither source has
+    /// it yet — a fresh key adopted but not yet installed, with no cert pin.
+    /// Callers must then DEFER without skipping: skipping a top-up other
+    /// validators perform desynchronizes the shared sequence counter and with
+    /// it every subsequent internal presign session identifier.
+    fn internal_presign_network_key_identity_bytes(
+        &self,
+        dwallet_network_encryption_key_id: &ObjectID,
+    ) -> Option<Vec<u8>> {
+        match self
+            .network_keys
+            .get_network_encryption_key_public_data(dwallet_network_encryption_key_id)
+        {
+            // Fall back to the network DKG output bytes only for a malformed
+            // key with no derivable id (deterministic, so still
+            // committee-uniform).
+            Ok(key_data) => Some(
+                key_data
+                    .network_key_id()
+                    .map(|id| id.0.to_vec())
+                    .unwrap_or_else(|_| key_data.network_dkg_output().as_bytes().to_vec()),
+            ),
+            Err(_) => network_key_id_for(dwallet_network_encryption_key_id).map(|id| id.0.to_vec()),
+        }
+    }
+
     fn instantiate_internal_presign_session(
         &mut self,
         consensus_round: u64,
@@ -1805,30 +1870,43 @@ impl DWalletMPCManager {
         curve: DWalletCurve,
         signature_algorithm: DWalletSignatureAlgorithm,
     ) {
-        let network_key_identity_bytes = match self
-            .network_keys
-            .get_network_encryption_key_public_data(&dwallet_network_encryption_key_id)
-        {
-            // Use the key's flip-invariant NetworkKeyId as the session-identifier
-            // basis; fall back to the network DKG output bytes only for a
-            // malformed key with no derivable id (deterministic, so still
-            // committee-uniform).
-            Ok(key_data) => key_data
-                .network_key_id()
-                .map(|id| id.0.to_vec())
-                .unwrap_or_else(|_| key_data.network_dkg_output().as_bytes().to_vec()),
-            Err(e) => {
-                error!(
-                    ?dwallet_network_encryption_key_id,
-                    error = ?e,
-                    "Failed to get network encryption key data for internal presign session"
-                );
-                return;
-            }
+        // Consume the sequence number FIRST, unconditionally: the caller's
+        // top-up decision is committee-uniform, so every validator MUST
+        // account this session — whether it can run it right now or not —
+        // or identifier derivation (a single counter shared across all
+        // pools and keys) permanently diverges across the committee.
+        let session_sequence_number = self.next_internal_presign_sequence_number;
+        self.next_internal_presign_sequence_number += 1;
+
+        let Some(network_key_identity_bytes) =
+            self.internal_presign_network_key_identity_bytes(&dwallet_network_encryption_key_id)
+        else {
+            // The key is adopted (the caller iterates the adopted set) but
+            // not installed yet, and no mapping entry exists to derive the
+            // identifier from. Park a deferred-instantiation record carrying
+            // the reserved sequence number; the request is built at retry
+            // time (the installation spawned by
+            // `instantiate_adopted_network_keys` registers the mapping when
+            // it completes).
+            info!(
+                consensus_round,
+                ?dwallet_network_encryption_key_id,
+                ?curve,
+                ?signature_algorithm,
+                ?session_sequence_number,
+                "network key identity not derivable yet for internal presign session; parking it for retry",
+            );
+            self.internal_presign_requests_pending_for_network_key_data
+                .push(ParkedInternalPresignRequest::AwaitingKeyIdentity {
+                    session_sequence_number,
+                    dwallet_network_encryption_key_id,
+                    curve,
+                    signature_algorithm,
+                });
+            return;
         };
 
-        let session_sequence_number = self.next_internal_presign_sequence_number;
-        // `consensus_round` is logged below for traceability but is
+        // `consensus_round` is logged for traceability but is
         // deliberately NOT part of the request/session identifier:
         // validators reach this point at different rounds (the network
         // key installs asynchronously), and the identifier must come out
@@ -1842,9 +1920,53 @@ impl DWalletMPCManager {
             &network_key_identity_bytes,
         );
 
+        if let Err(request) = self.try_activate_internal_presign_request(consensus_round, request) {
+            // The key's data isn't locally available yet (typically the VSS
+            // pools at epoch entry, before the frozen off-chain validator
+            // key set has been ingested; or a key installed on peers but not
+            // here). Park the request and retry once per service iteration;
+            // peers that already have the data run the session meanwhile,
+            // and any of their messages buffer in a
+            // `WaitingForSessionRequest` entry until activation.
+            info!(
+                consensus_round,
+                ?curve,
+                ?signature_algorithm,
+                ?session_sequence_number,
+                session_identifier=?request.session_identifier,
+                "network key data not ready for internal presign session; parking it for retry",
+            );
+            self.internal_presign_requests_pending_for_network_key_data
+                .push(ParkedInternalPresignRequest::Request(request));
+        }
+    }
+
+    /// Applies a built internal presign request to the session map: activates
+    /// it when its MPC input is constructible, upgrading a
+    /// `WaitingForSessionRequest` entry in place (peers that built the input
+    /// earlier may already have sent messages, which buffer there and must
+    /// survive). Returns `Err(request)` when input construction hit the
+    /// not-ready class — the caller decides how to park it. Fatal input
+    /// errors fail the session terminally (`Ok`).
+    fn try_activate_internal_presign_request(
+        &mut self,
+        consensus_round: u64,
+        request: DWalletSessionRequest,
+    ) -> Result<(), Box<DWalletSessionRequest>> {
         let session_identifier = request.session_identifier;
+
+        if let Some(session) = self.sessions.get(&session_identifier)
+            && !matches!(session.status, SessionStatus::WaitingForSessionRequest)
+        {
+            // Already resolved without us (e.g. completed by a quorum of
+            // peers before this validator could build the input).
+            return Ok(());
+        }
+
         match self.session_input(&request) {
             Ok((public_input, private_input)) => {
+                let session_sequence_number = request.session_sequence_number;
+                let session_type = request.session_type;
                 let status = SessionStatus::Active {
                     public_input,
                     private_input,
@@ -1853,44 +1975,26 @@ impl DWalletMPCManager {
                 debug!(
                     status=?status,
                     consensus_round,
-                    ?curve,
-                    ?signature_algorithm,
                     ?session_sequence_number,
                     ?session_identifier,
                     "instantiating new internal presign session",
                 );
-                self.new_session(
-                    &session_identifier,
-                    status,
-                    None,
-                    SessionComputationType::MPC {
-                        messages_by_consensus_round: HashMap::new(),
-                    },
-                );
+                if let Some(session) = self.sessions.get_mut(&session_identifier) {
+                    session.status = status;
+                    session.set_request_metadata(session_sequence_number, session_type);
+                } else {
+                    self.new_session(
+                        &session_identifier,
+                        status,
+                        None,
+                        SessionComputationType::MPC {
+                            messages_by_consensus_round: HashMap::new(),
+                        },
+                    );
+                }
+                Ok(())
             }
-            Err(e) if e.is_network_key_data_not_ready() => {
-                // The key's data isn't locally available yet (typically the VSS
-                // pools at epoch entry, before the frozen off-chain validator
-                // key set has been ingested). Park the request and retry once
-                // per service iteration; peers that already have the data run
-                // the session meanwhile, and any of their messages buffer in a
-                // `WaitingForSessionRequest` entry until activation. The
-                // sequence number is still consumed below — the batch counters
-                // and identifier derivation must stay committee-uniform, so
-                // parking is invisible to the top-up and stale-batch-expiry
-                // decisions.
-                info!(
-                    error=?e,
-                    consensus_round,
-                    ?curve,
-                    ?signature_algorithm,
-                    ?session_sequence_number,
-                    ?session_identifier,
-                    "network key data not ready for internal presign session; parking it for retry",
-                );
-                self.internal_presign_requests_pending_for_network_key_data
-                    .push(request);
-            }
+            Err(e) if e.is_network_key_data_not_ready() => Err(Box::new(request)),
             Err(e) => {
                 error!(should_never_happen = true, error=?e, ?request, "create internal session input from dWallet request with error");
                 self.new_session(
@@ -1901,13 +2005,12 @@ impl DWalletMPCManager {
                         messages_by_consensus_round: HashMap::new(),
                     },
                 );
+                Ok(())
             }
         }
-
-        self.next_internal_presign_sequence_number += 1;
     }
 
-    /// Retries internal presign requests parked because their network key's
+    /// Retries internal presign sessions parked because their network key's
     /// data wasn't locally available at instantiation time (see
     /// `internal_presign_requests_pending_for_network_key_data`). Called once
     /// per service iteration — the inputs it waits on (network-key install,
@@ -1922,63 +2025,72 @@ impl DWalletMPCManager {
         }
 
         let parked = mem::take(&mut self.internal_presign_requests_pending_for_network_key_data);
-        for request in parked {
-            let session_identifier = request.session_identifier;
-
-            if let Some(session) = self.sessions.get(&session_identifier)
-                && !matches!(session.status, SessionStatus::WaitingForSessionRequest)
-            {
-                // Already resolved without us (e.g. completed by a quorum of
-                // peers while we were parked) — drop the parked request.
-                continue;
-            }
-
-            match self.session_input(&request) {
-                Ok((public_input, private_input)) => {
-                    info!(
-                        session_identifier=?session_identifier,
-                        session_sequence_number=?request.session_sequence_number,
-                        "network key data arrived; activating parked internal presign session",
-                    );
-                    let session_sequence_number = request.session_sequence_number;
-                    let session_type = request.session_type;
-                    let status = SessionStatus::Active {
-                        public_input,
-                        private_input,
-                        request,
+        for parked_request in parked {
+            let request = match parked_request {
+                ParkedInternalPresignRequest::Request(request) => *request,
+                ParkedInternalPresignRequest::AwaitingKeyIdentity {
+                    session_sequence_number,
+                    dwallet_network_encryption_key_id,
+                    curve,
+                    signature_algorithm,
+                } => {
+                    let Some(network_key_identity_bytes) = self
+                        .internal_presign_network_key_identity_bytes(
+                            &dwallet_network_encryption_key_id,
+                        )
+                    else {
+                        // Identity still not derivable — keep it parked.
+                        self.internal_presign_requests_pending_for_network_key_data
+                            .push(ParkedInternalPresignRequest::AwaitingKeyIdentity {
+                                session_sequence_number,
+                                dwallet_network_encryption_key_id,
+                                curve,
+                                signature_algorithm,
+                            });
+                        continue;
                     };
-                    if let Some(session) = self.sessions.get_mut(&session_identifier) {
-                        // Peer messages arrived while parked and created the
-                        // session entry; upgrade it in place so the buffered
-                        // messages survive.
-                        session.status = status;
-                        session.set_request_metadata(session_sequence_number, session_type);
-                    } else {
-                        self.new_session(
-                            &session_identifier,
-                            status,
-                            None,
-                            SessionComputationType::MPC {
-                                messages_by_consensus_round: HashMap::new(),
-                            },
+                    // Build the request with the sequence number reserved at
+                    // instantiation time — the identifier comes out identical
+                    // to the one peers derived when they instantiated.
+                    DWalletSessionRequest::new_internal_presign(
+                        self.epoch_id,
+                        session_sequence_number,
+                        curve,
+                        signature_algorithm,
+                        dwallet_network_encryption_key_id,
+                        &network_key_identity_bytes,
+                    )
+                }
+            };
+
+            let session_identifier = request.session_identifier;
+            let session_sequence_number = request.session_sequence_number;
+            // Retry has no consensus-round context; 0 marks "activated on a
+            // service tick" in the debug log.
+            match self.try_activate_internal_presign_request(0, request) {
+                Ok(()) => {
+                    // Log only a real parked→active transition (not the
+                    // already-resolved drop or a terminal failure) — the
+                    // stall playbook pairs this line with the park line.
+                    if self
+                        .sessions
+                        .get(&session_identifier)
+                        .is_some_and(|session| {
+                            matches!(session.status, SessionStatus::Active { .. })
+                        })
+                    {
+                        info!(
+                            session_identifier=?session_identifier,
+                            ?session_sequence_number,
+                            "network key data arrived; activating parked internal presign session",
                         );
                     }
                 }
-                Err(e) if e.is_network_key_data_not_ready() => {
-                    // Still not ready — keep it parked.
+                Err(request) => {
+                    // Input still not constructible — keep it parked (silently:
+                    // this runs every service iteration).
                     self.internal_presign_requests_pending_for_network_key_data
-                        .push(request);
-                }
-                Err(e) => {
-                    error!(should_never_happen = true, error=?e, ?request, "create internal session input from dWallet request with error");
-                    self.new_session(
-                        &session_identifier,
-                        SessionStatus::Failed,
-                        None,
-                        SessionComputationType::MPC {
-                            messages_by_consensus_round: HashMap::new(),
-                        },
-                    );
+                        .push(ParkedInternalPresignRequest::Request(request));
                 }
             }
         }

--- a/dev-docs/specs/fast-schnorr-vss.md
+++ b/dev-docs/specs/fast-schnorr-vss.md
@@ -113,6 +113,23 @@ against the active committee directly.
   instantiated/completed batch counters stay committee-uniform — parking is
   local participation deferral, invisible to the top-up guard and the
   stale-batch expiry. Any other input-construction error stays terminal.
+- **Deferred instantiation for a not-yet-installed key (multi-key epochs).**
+  The top-up loop iterates every ADOPTED key, but installation into
+  `network_keys` completes asynchronously per validator, and the session
+  identifier binds the key's content-derived `NetworkKeyId`. A validator whose
+  key is adopted but not installed derives the identity from the
+  pre-instantiation `ObjectID → NetworkKeyId` mapping and parks the built
+  request on the input's not-ready error; when even the mapping has no entry
+  (a fresh key with no handoff-cert pin), it parks an `AwaitingKeyIdentity`
+  record carrying the RESERVED sequence number and builds the request at
+  retry time. In every case the sequence number is consumed — skipping a
+  top-up that peers perform would desynchronize the single sequence counter
+  shared across all pools and keys, and with it every subsequent internal
+  presign identifier (sessions could then never reach quorum). Relatedly, the
+  NOA-signing-key choice (oldest installed key by `dkg_at_epoch`) tie-breaks
+  by key id: `min_by` alone would resolve same-epoch ties by `HashMap`
+  iteration order — per-process-random, giving validators different pool
+  configs and thus divergent batch sizes.
 
 ## Invariants
 


### PR DESCRIPTION
> **Was stacked on #1818** (the not-ready parking fix — this change reuses its parking queue). #1818 merged as `3a88f2c99c`; this branch is rebased onto it and the diff is the single commit `c0e0ed6c81`.

## Problem

The internal presign top-up loop iterates every **adopted** network key, but a key's installation into `network_keys` completes asynchronously per validator, and the session-identifier preimage binds the installed key's content-derived `NetworkKeyId`. A validator in the adopted-but-not-installed window early-returned from `instantiate_internal_presign_session` **without consuming `next_internal_presign_sequence_number`** — while the caller still advanced the instantiated batch counter. Since that sequence counter is a single counter shared across all pools and keys, the validator's identifier derivation permanently desynchronizes from its peers': every subsequent internal presign identifier diverges and those sessions can never reach quorum, plus the instantiated/completed guard counters desync (instantiated advances with no session behind it).

Only reachable in multi-key epochs — with a single key the outer NOA-key gate returns before any counter is touched — which is why it hasn't bitten. All v4-gated (`internal_presign_sessions`), no deployed-network constraints.

## Fix

- **Sequence number is consumed unconditionally at instantiation**, before identity resolution. The top-up decision is committee-uniform, so every validator must account every session whether it can run it locally yet or not.
- **Not-installed keys defer instead of skipping**, in two shapes: the identity falls back to the pre-instantiation `ObjectID → NetworkKeyId` mapping (seeded deployed keys / handoff-cert background derivation) and the built request parks on the input's not-ready error (the #1818 queue); when even the mapping has no entry (a fresh key with no cert pin), an `AwaitingKeyIdentity` record parks carrying the **reserved** sequence number and the request is built at retry time — deriving the identical identifier peers derived at instantiation.
- **NOA-signing-key selection tie-breaks equal `dkg_at_epoch` by key id**: bare `min_by` resolved same-epoch ties by `HashMap` iteration order — per-process-random, so validators could disagree on which key is the NOA key and apply different pool configs (different batch sizes ⇒ the same divergence through another door).
- **Activation upgrades `WaitingForSessionRequest` entries in place** (shared by instantiation and retry), fixing the pre-existing `new_session` overwrite that dropped peer messages buffered before late local instantiation.

The alternative — skipping the whole (key, curve, algorithm) iteration including the counter increment until install — is ruled out in the code comments: install timing is per-validator wall-clock and the counter interleaves across pools, so any timing-dependent skip diverges it.

## Testing

- New two-key integration test `test_internal_presign_multi_key_install_lag_keeps_identifiers_uniform`: K0 bootstraps, K1 is a second same-epoch DKG; K1's installed data is removed on one validator (its adoption stays, and the manager's background re-install heals the window naturally — the production shape). Asserts the shared sequence counter reads identically on every validator **after every round**, parked batches drain, bound identifier→sequence maps stay subset-consistent, and no session ever fails terminally. A coda exercises the identity-less key: uniform `(sequence, curve, algorithm)` reservations across validators, then a registered mapping transitions them to fully-built parked requests with byte-identical identifiers.
- The run also organically hit the **natural** race: K1's first batches fired while K1 was adopted-but-not-installed on all four validators (12 identity-parks at the same round), with park→activate and park→already-resolved-drop paths both exercised.
- **Fault-injection validated** (dev-docs/playbooks/test-testing.md): restoring the skip-without-consuming behavior fails the test at the per-round counter assert with the exact production divergence (`left: 33, right: 31`).
- Full `dwallet_mpc::integration_tests::internal_presign` suite (all 6 tests, including #1818's) green in release; clippy clean.

Known multi-key uniformity holes **out of scope** and documented in `dev-docs/specs/fast-schnorr-vss.md` + tracked for follow-up: NOA-selection reads the installed set (divergent while installs lag), cross-pool sequence interleaving under adoption-timing skew, and guard counters keyed `(curve, algorithm)` shared across keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
