### PR TITLE
fix(v4): pubkey-provider per-member robustness + prior-committee verification keying + SDK 0.5.0 changeset

### DIFF
--- a/.changeset/ripe-schnorrkel-v4.md
+++ b/.changeset/ripe-schnorrkel-v4.md
@@ -1,0 +1,19 @@
+---
+'@ika.xyz/sdk': minor
+'@ika.xyz/ika-wasm': minor
+---
+
+Release 0.5.0 — protocol-v4 readiness and the `SchnorrkelSubstrate` rename.
+
+**Breaking**
+
+- `SignatureAlgorithm.SchnorrkelSubstrate` is renamed to `SignatureAlgorithm.Schnorrkel`. Both the enum key AND its runtime string value changed from `'SchnorrkelSubstrate'` to `'Schnorrkel'`. Update every reference; a value persisted or transmitted as `'SchnorrkelSubstrate'` is no longer recognized.
+
+**Required before protocol v4 activates**
+
+- The bundled WASM is rebuilt to parse V3-tagged network reconfiguration outputs. When the network advances to protocol v4, validators write V3-tagged reconfiguration outputs each epoch; the WASM shipped in `@ika.xyz/ika-wasm@0.2.x` only understands V1/V2 and throws a BCS "unknown variant" error from `getProtocolPublicParameters`. dApps must be on this release before v4 activates on their network, or user-side dWallet operations stop until they upgrade.
+
+**Behavior change**
+
+- The default poll timeout for the `*InParticularState` waiters increased from 30s to 600s. Flows that relied on the old 30s default failing fast will now wait longer before timing out; pass an explicit timeout to restore the previous behavior.
+- Requesting the secp256k1 protocol public parameters from a network key that has no reconfiguration output yet now returns an error instead of silently succeeding. No deployed network key is in this state; the reconfiguration-output path that live keys use is unaffected.

--- a/crates/ika-core/src/storage.rs
+++ b/crates/ika-core/src/storage.rs
@@ -115,7 +115,13 @@ impl ReadStore for RocksDbStore {
         &self,
         epoch: EpochId,
     ) -> Result<Option<Arc<Committee>>, ika_types::storage::error::Error> {
-        Ok(self.committee_store.get_committee(&epoch).unwrap())
+        // Propagate rather than unwrap: a committee_map read can fail on a
+        // decode error (e.g. a record written by an older binary with a
+        // different `Committee` layout), and a panic here on the read path
+        // would crash-loop under panic=abort.
+        self.committee_store
+            .get_committee(&epoch)
+            .map_err(ika_types::storage::error::Error::custom)
     }
 
     fn get_latest_dwallet_checkpoint(&self) -> Result<VerifiedDWalletCheckpointMessage> {

--- a/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
+++ b/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
@@ -28,7 +28,7 @@ use ika_sui_client::{SuiClient, SuiClientInner};
 use ika_types::committee::{Committee, EpochId, StakeUnit};
 use ika_types::crypto::AuthorityName;
 use ika_types::sui::{SystemInner, SystemInnerTrait, SystemInnerV1};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 use sui_types::base_types::ObjectID;
@@ -55,8 +55,8 @@ fn select_next_epoch_committee(system_inner: &SystemInnerV1) -> Vec<ObjectID> {
 /// Chain-reads the **previous** committee as a quorum-checkable
 /// `Committee`, for a joiner that never locally observed/persisted that
 /// epoch (so its `committee_store` has no entry for it). The membership
-/// is decoded with `read_bls_committee`; each member's consensus key is
-/// fetched and carried on the committee so its prior-epoch handoff
+/// is decoded with `read_bls_committee_lossy`; each member's consensus key
+/// is fetched and carried on the committee so its prior-epoch handoff
 /// signatures verify by name (best-effort per member: one whose
 /// validator_info fails to decode is skipped and only its signatures are
 /// lost, never the whole committee). The class-groups / PVSS maps are left empty:
@@ -114,8 +114,33 @@ pub async fn fetch_previous_committee<C: SuiClientInner>(
     // validator id (StakingPool.id == BlsCommitteeMember.validator_id).
     // Lossy: a departed prior-committee member with an unparseable protocol
     // pubkey is skipped, not fatal — bootstrap must not crash-loop on one bad
-    // record. Its stake then simply doesn't count toward the cert quorum.
+    // record. NOTE: the skip is NOT graceful quorum degradation. The skipped
+    // member is absent from `voting_rights`, and cert verification
+    // HARD-REJECTS a certificate carrying a weight-0 signer's signature —
+    // and since that member's own node runs fine, its signature is in every
+    // aggregated cert, so every served cert fails verification and bootstrap
+    // surfaces `Rejected`. The warn below makes that outcome attributable to
+    // the corrupt prior-committee record instead of the Rejected log's
+    // default "wrong prior-committee view / wrong peers" guidance. (Trigger
+    // requires registration-validated snapshot bytes to fail BLS parse —
+    // near-unreachable; the pre-lossy behavior was a panic crash-loop.)
     let bls_members = system_inner.read_bls_committee_lossy(bls_committee);
+    if bls_members.len() < bls_committee.members.len() {
+        let parsed_ids: HashSet<ObjectID> = bls_members.iter().map(|(id, _)| *id).collect();
+        let dropped: Vec<ObjectID> = bls_committee
+            .members
+            .iter()
+            .map(|member| member.validator_id)
+            .filter(|id| !parsed_ids.contains(id))
+            .collect();
+        warn!(
+            ?dropped,
+            "prior-committee members dropped by the lossy read (unparseable protocol \
+             pubkey in the frozen snapshot): any handoff cert carrying their signatures \
+             will FAIL verification (weight-0 signer) — a subsequent Rejected outcome \
+             means a corrupt prior-committee record, not wrong peers"
+        );
+    }
     let snapshot_name_by_id: HashMap<ObjectID, AuthorityName> = bls_members
         .iter()
         .map(|(id, (name, _))| (*id, *name))
@@ -344,35 +369,21 @@ where
         // announcements still reach peers), and cert verification needs only a
         // quorum of the members that DO verify.
         let mut consensus_keys_by_name: BTreeMap<AuthorityName, Ed25519PublicKey> = BTreeMap::new();
-        let mut skipped = 0usize;
+        // Collect skips silently here; the warns are emitted AFTER the
+        // `last_installed` dedup below, so a deterministically-bad record
+        // warns once per actual map change instead of twice per 5s poll
+        // tick for the rest of the epoch (~34k lines/day).
+        let mut skipped_members: Vec<(ObjectID, u64)> = Vec::new();
         for pool in &staking_pools {
             let verified = match pool.validator_info.verify() {
                 Ok(verified) => verified,
                 Err(code) => {
-                    skipped += 1;
-                    warn!(
-                        code,
-                        validator_id = ?pool.id,
-                        epoch = self.epoch_id,
-                        label = self.label,
-                        "committee member validator_info failed verify; skipping — \
-                         its relayed announcements won't be verifiable this epoch"
-                    );
+                    skipped_members.push((pool.id, code));
                     continue;
                 }
             };
             let name: AuthorityName = (&verified.protocol_pubkey).into();
             consensus_keys_by_name.insert(name, verified.consensus_pubkey.clone());
-        }
-        if skipped > 0 {
-            warn!(
-                epoch = self.epoch_id,
-                label = self.label,
-                skipped,
-                installed = consensus_keys_by_name.len(),
-                "installing pubkey provider with an incomplete member set; \
-                 relayed announcements from the skipped members will be dropped"
-            );
         }
 
         {
@@ -380,6 +391,18 @@ where
             if last.as_ref() == Some(&consensus_keys_by_name) {
                 return Ok(());
             }
+        }
+
+        if !skipped_members.is_empty() {
+            warn!(
+                epoch = self.epoch_id,
+                label = self.label,
+                skipped = ?skipped_members,
+                installed = consensus_keys_by_name.len(),
+                "installing pubkey provider with an incomplete member set \
+                 (validator_info failed verify; (validator_id, code) pairs listed); \
+                 relayed announcements from the skipped members will be dropped"
+            );
         }
 
         let entries: Vec<(AuthorityName, Ed25519PublicKey)> =

--- a/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
+++ b/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
@@ -112,7 +112,10 @@ pub async fn fetch_previous_committee<C: SuiClientInner>(
     // resolve a consensus key and drop, silently dropping its stake from the
     // cert quorum. Resolve each fetched pool to its snapshot name by
     // validator id (StakingPool.id == BlsCommitteeMember.validator_id).
-    let bls_members = system_inner.read_bls_committee(bls_committee);
+    // Lossy: a departed prior-committee member with an unparseable protocol
+    // pubkey is skipped, not fatal — bootstrap must not crash-loop on one bad
+    // record. Its stake then simply doesn't count toward the cert quorum.
+    let bls_members = system_inner.read_bls_committee_lossy(bls_committee);
     let snapshot_name_by_id: HashMap<ObjectID, AuthorityName> = bls_members
         .iter()
         .map(|(id, (name, _))| (*id, *name))

--- a/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
+++ b/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
@@ -101,6 +101,22 @@ pub async fn fetch_previous_committee<C: SuiClientInner>(
         .map(|m| m.validator_id)
         .collect();
     let staking_pools = sui_client.get_validators_info_by_ids(validator_ids).await?;
+    // Both name-keyed maps on the returned `Committee` must use the SAME name
+    // space, and it must be the PRIOR-epoch snapshot's — that is the name each
+    // member signed its handoff attestation under. `voting_rights` already
+    // comes from the frozen `previous_committee` snapshot; the consensus-key
+    // map must too. Keying the consensus map by the member's CURRENT on-chain
+    // protocol_pubkey (from which `AuthorityName` is derived) would diverge
+    // for any validator that rotated its protocol key at the boundary — its
+    // handoff signatures, signed under the old name, would then fail to
+    // resolve a consensus key and drop, silently dropping its stake from the
+    // cert quorum. Resolve each fetched pool to its snapshot name by
+    // validator id (StakingPool.id == BlsCommitteeMember.validator_id).
+    let bls_members = system_inner.read_bls_committee(bls_committee);
+    let snapshot_name_by_id: HashMap<ObjectID, AuthorityName> = bls_members
+        .iter()
+        .map(|(id, (name, _))| (*id, *name))
+        .collect();
     // Tolerate a member whose validator_info fails to decode: `verify()`
     // rejects on ANY malformed metadata field (addresses, next-epoch keys),
     // not just the consensus key needed here, and the member may have
@@ -123,11 +139,19 @@ pub async fn fetch_previous_committee<C: SuiClientInner>(
                 continue;
             }
         };
-        let name: AuthorityName = (&verified.protocol_pubkey).into();
+        // The consensus pubkey VALUE is fixed at registration, so reading the
+        // current one is correct; only the map KEY must be the snapshot name.
+        let Some(name) = snapshot_name_by_id.get(&pool.id).copied() else {
+            warn!(
+                validator_id = ?pool.id,
+                "prior-committee staking pool absent from the previous_committee \
+                 snapshot; skipping"
+            );
+            continue;
+        };
         consensus_keys.insert(name, verified.consensus_pubkey.clone());
     }
-    let voting_rights: Vec<(AuthorityName, StakeUnit)> = system_inner
-        .read_bls_committee(bls_committee)
+    let voting_rights: Vec<(AuthorityName, StakeUnit)> = bls_members
         .into_iter()
         .map(|(_, (name, stake))| (name, stake))
         .collect();
@@ -307,14 +331,45 @@ where
             .get_validators_info_by_ids(validator_ids)
             .await?;
 
+        // Tolerate a member whose validator_info fails to decode, exactly as
+        // `fetch_previous_committee` does: `verify()` rejects on ANY malformed
+        // metadata field, not just the consensus key needed here. Failing the
+        // whole refresh on one bad record would return Err every 5s forever
+        // and install NO provider — suppressing joiner-announcement relay for
+        // the entire epoch on a single deterministic error. Skipping costs
+        // only that member's relayed announcements (its own direct
+        // announcements still reach peers), and cert verification needs only a
+        // quorum of the members that DO verify.
         let mut consensus_keys_by_name: BTreeMap<AuthorityName, Ed25519PublicKey> = BTreeMap::new();
+        let mut skipped = 0usize;
         for pool in &staking_pools {
-            let verified = pool
-                .validator_info
-                .verify()
-                .map_err(|code| anyhow::anyhow!("validator info verify failed: code {code}"))?;
+            let verified = match pool.validator_info.verify() {
+                Ok(verified) => verified,
+                Err(code) => {
+                    skipped += 1;
+                    warn!(
+                        code,
+                        validator_id = ?pool.id,
+                        epoch = self.epoch_id,
+                        label = self.label,
+                        "committee member validator_info failed verify; skipping — \
+                         its relayed announcements won't be verifiable this epoch"
+                    );
+                    continue;
+                }
+            };
             let name: AuthorityName = (&verified.protocol_pubkey).into();
             consensus_keys_by_name.insert(name, verified.consensus_pubkey.clone());
+        }
+        if skipped > 0 {
+            warn!(
+                epoch = self.epoch_id,
+                label = self.label,
+                skipped,
+                installed = consensus_keys_by_name.len(),
+                "installing pubkey provider with an incomplete member set; \
+                 relayed announcements from the skipped members will be dropped"
+            );
         }
 
         {

--- a/crates/ika-types/src/sui/mod.rs
+++ b/crates/ika-types/src/sui/mod.rs
@@ -225,6 +225,16 @@ pub trait SystemInnerTrait {
         &self,
         committee: &BlsCommittee,
     ) -> Vec<(ObjectID, (AuthorityName, StakeUnit))>;
+    /// Like [`read_bls_committee`], but skips (rather than panics on) a member
+    /// whose `protocol_pubkey` bytes don't parse into an `AuthorityName`.
+    /// For the PRIOR-committee bootstrap anchor only, where a departed member
+    /// may carry a stale/unreadable on-chain record and one bad member must
+    /// not abort the whole read. Active/next-committee reads use the strict
+    /// [`read_bls_committee`], where an unparseable member is a chain fault.
+    fn read_bls_committee_lossy(
+        &self,
+        committee: &BlsCommittee,
+    ) -> Vec<(ObjectID, (AuthorityName, StakeUnit))>;
     fn validator_set(&self) -> &ValidatorSetV1;
 }
 

--- a/crates/ika-types/src/sui/mod.rs
+++ b/crates/ika-types/src/sui/mod.rs
@@ -229,8 +229,15 @@ pub trait SystemInnerTrait {
     /// whose `protocol_pubkey` bytes don't parse into an `AuthorityName`.
     /// For the PRIOR-committee bootstrap anchor only, where a departed member
     /// may carry a stale/unreadable on-chain record and one bad member must
-    /// not abort the whole read. Active/next-committee reads use the strict
-    /// [`read_bls_committee`], where an unparseable member is a chain fault.
+    /// not crash-loop the reading node. NOTE the consequence of a skip: the
+    /// member is absent from the built committee's `voting_rights`, and
+    /// handoff-cert verification HARD-REJECTS any certificate carrying a
+    /// weight-0 signer's signature — certs that include the skipped member's
+    /// signature fail verification outright (surfacing as `Rejected`); they
+    /// do not gracefully lose one member's stake. Callers must log the skip
+    /// so that outcome is attributable. Active/next-committee reads use the
+    /// strict [`read_bls_committee`], where an unparseable member is a chain
+    /// fault.
     fn read_bls_committee_lossy(
         &self,
         committee: &BlsCommittee,

--- a/crates/ika-types/src/sui/system_inner_v1.rs
+++ b/crates/ika-types/src/sui/system_inner_v1.rs
@@ -280,6 +280,26 @@ impl SystemInnerTrait for SystemInnerV1 {
             .collect()
     }
 
+    fn read_bls_committee_lossy(
+        &self,
+        bls_committee: &BlsCommittee,
+    ) -> Vec<(ObjectID, (AuthorityName, StakeUnit))> {
+        bls_committee
+            .members
+            .iter()
+            .filter_map(|v| {
+                match AuthorityPublicKey::from_bytes(v.protocol_pubkey.bytes.as_ref()) {
+                    Ok(pubkey) => Some((v.validator_id, ((&pubkey).into(), 1))),
+                    // A prior-committee member with an unparseable protocol
+                    // pubkey is dropped, not fatal: it costs only that member's
+                    // handoff signature (it can't be verified anyway), whereas
+                    // panicking would crash-loop a bootstrapping validator.
+                    Err(_) => None,
+                }
+            })
+            .collect()
+    }
+
     fn validator_set(&self) -> &ValidatorSetV1 {
         &self.validator_set
     }

--- a/crates/ika-types/src/sui/system_inner_v1.rs
+++ b/crates/ika-types/src/sui/system_inner_v1.rs
@@ -291,9 +291,20 @@ impl SystemInnerTrait for SystemInnerV1 {
                 match AuthorityPublicKey::from_bytes(v.protocol_pubkey.bytes.as_ref()) {
                     Ok(pubkey) => Some((v.validator_id, ((&pubkey).into(), 1))),
                     // A prior-committee member with an unparseable protocol
-                    // pubkey is dropped, not fatal: it costs only that member's
-                    // handoff signature (it can't be verified anyway), whereas
-                    // panicking would crash-loop a bootstrapping validator.
+                    // pubkey is dropped, not fatal — panicking here would
+                    // crash-loop a bootstrapping validator on a chain-record
+                    // fault it cannot fix. BUT the drop is NOT graceful
+                    // degradation: the member is absent from the built
+                    // committee's `voting_rights` (weight 0), and handoff-cert
+                    // verification HARD-REJECTS a certificate carrying a
+                    // signature from a weight-0 signer ("signer is not a
+                    // member of the verifying committee"). Since the member's
+                    // node runs fine (its local keys are intact) and its
+                    // signature lands in every aggregated cert, every served
+                    // cert then fails verification — surfacing as
+                    // `BootstrapOutcome::Rejected`. An operator seeing
+                    // Rejected together with this log line should suspect a
+                    // corrupt prior-committee record, not wrong peers.
                     Err(_) => None,
                 }
             })

--- a/dev-docs/plans/v4-activation-gate-list.md
+++ b/dev-docs/plans/v4-activation-gate-list.md
@@ -1,0 +1,95 @@
+Status: active (2026-07-12) — fixes in progress on branch `fix/v4-gate-list`; PR #1820 landed the first isolated batch.
+
+# Protocol-v4 activation gate list
+
+Every issue here ships **dark** in 1.2.0 (the paths are v4-gated) but protocol
+v4 **activates automatically** ~one epoch after enough stake runs a
+v4-advertising binary — validators advertise `SupportedProtocolVersions::SYSTEM_DEFAULT`
+(= MIN..=MAX = v3..=v4), capabilities are tallied at every epoch close
+(`choose_highest_protocol_version_and_move_contracts_upgrades_v1`, `authority.rs:571`),
+and `SetNextConfigVersion(4)` is emitted once quorum+buffer stake supports it.
+There is **no separate vote**. So this whole list must be sound before any
+v4-advertising binary rolls out fleet-wide — or the 1.2.0 default advertisement
+must be capped at v3 and lifted in the release that closes this list.
+
+Source: the 1.2.0 release review's §3, re-verified at head `c7cfd03f4c` by a
+14-item design pass + cross-check (2026-07-12).
+
+## Landed
+
+- **PR #1820** (`fix/v4-gate-list`): V5 (`refresh()` per-member skip), V9c
+  (prior-committee snapshot-name keying), `read_bls_committee_lossy` for the
+  bootstrap anchor, V7-partial (`get_committee` unwrap→propagate), SDK 0.5.0
+  changeset + README rename fix. Cluster + integration suites dispatched.
+
+## Open — two tracks
+
+### Track A — handoff / barrier (consensus-critical; precedes any v4 rollout)
+
+Ordering DAG (from the cross-check; each arrow = "must precede"):
+
+1. **V7** committee legacy-decode (medium) — PREREQUISITE: the v3→v4 transition
+   epoch can panic reading a 1.1.8 `committee_map` record before anything else
+   runs. Legacy-fallback decode via a `LegacyCommittee` mirror + `From`
+   (empty `consensus_keys`), a reopened `legacy_committee_map` DBMap view over
+   the same cf, distinct decode-failure logging at `lib.rs:2313`. Standalone PR.
+2. **V5 + V9c** — landed in #1820 (one PR, shared `fetch_previous_committee`).
+3. **V2** ready-signal receive-time canonicalization (small) — precondition for
+   V1's freeze determinism. Keep zero-weight joiner pairs in the persisted
+   `validated_peers`; never filter against the wall-clock joiner-provider table.
+4. **V1** freeze fail-stop + barrier call-sites (medium) — `prior_epoch_mpc_data_digests`
+   must return `IkaResult` and propagate read errors (crash-replay), reserving
+   the empty map for `Ok(None)`; add the `wait_for_handoff_data_ready` barrier to
+   the joiner-promotion (`lib.rs:2865`) and startup (`lib.rs:1121`) consensus-start
+   paths, not just the continuing-validator path. Depends on V2 and on the escape.
+5. **wedge** barrier escape (medium) — must land WITH or BEFORE V1 (so V1's new
+   call sites aren't new indefinite wedges) and before V4. Bounded barrier wait
+   then chain-import of the certified reconfiguration output; fail-stop, never
+   "start consensus without E-1 data". Owns the barrier's final shape.
+6. **networkkeyid-minors** (small) — Minor 1 (memo invalidation on changed
+   inputs) standalone; Minor 2 (unmapped-key never-ready) folds into the barrier
+   rewrite (step 5).
+7. **V3 + V9b** (one PR) — run snapshot-ready+build+install before the durable
+   early-return in `handoff_signature_sender.rs:246`; batch-delete non-verifying
+   `handoff_signatures` rows in the install replay. Independent of the freeze work.
+8. **V4** pure close-gate tally (medium) — LAST: tally sequenced EndOfPublishV2
+   bundles per attestation digest, RETIRE `handoff_signatures_meet_quorum` (don't
+   coexist). Depends on wedge (escape), V3 (restart recovery). If multi-key-holes
+   Part B ships (NOA attestation anchor), settle the `HandoffAttestation` schema here.
+
+Barrier caveat (I1/I2 from the cross-check): V3's local re-install re-mints the
+validator's OWN attestation; divergent-validator recovery is 100% the barrier
+peer-fetch of the cert for the quorum digest D — confirm the barrier covers the
+CONTINUING (not just joining) validator path.
+
+### Track B — presign uniformity (node-side; parallel except the S3 coupling)
+
+- **V9a** VSS-cache tri-state (small) — independent; `derive_vss_shamir_cache_for_key`
+  `.ok()?` → `Result` with a `NotApplicable` (pre-V3 key) variant + one `error!`
+  per real failure. Land anytime.
+- **expiry-desync + multi-key-holes** (ONE PR — forced by C1/C2):
+  - **DECISION REQUIRED (C1):** `next_internal_presign_sequence_number` is a
+    single `u64` shared across all keys+algos, and #1819's `fast-schnorr-vss.md`
+    spec *enshrines* that. multi-key-holes Part A would re-key it per
+    `(key,curve,algo)` — MORE correct (closes the adoption-lag hole where
+    `agreed_key_ids` is a wall-clock set) but it **rewrites** the #1819 invariant
+    + the `mpc_manager.rs:1674` comment. Choose: (a) keep the shared counter and
+    make `agreed_key_ids` consensus-uniform instead, or (b) adopt per-key counters
+    and rewrite the spec. Do not ship both framings.
+  - expiry-desync and multi-key-holes both re-key `internal_presign_batch_instantiated_at_round`
+    — must be one PR or the second clobbers the first.
+  - multi-key-holes Part B (NOA attestation anchor) is the only bridge to Track A
+    (S3) — if included, gate on V4's `HandoffAttestation` schema.
+
+## SDK 0.5.0 (rollout precondition, zero code coupling)
+
+Publish before any v4-advertising binary reaches quorum stake: the published
+`@ika.xyz/ika-wasm@0.2.1` cannot parse V3-tagged reconfiguration outputs.
+Changeset landed in #1820; the version bump + `npm publish` are release-process
+acts. README hash-validity row (DoubleSHA256/secp256r1) still needs verifying
+against the TS+Rust tables (deferred — correctness question, not a rename).
+
+## Not on this list (further out, separate flags)
+
+NOA (N1–N3) and OCS (O1–O5) sit behind their own flags, not the v4 capability
+vote. See the 1.2.0 release review §1.3–1.4.

--- a/dev-docs/plans/v4-activation-gate-list.md
+++ b/dev-docs/plans/v4-activation-gate-list.md
@@ -1,4 +1,7 @@
-Status: active (2026-07-12) — fixes in progress on branch `fix/v4-gate-list`; PR #1820 landed the first isolated batch.
+Status: active (updated 2026-07-12) — all in-scope fixes are now open PRs
+awaiting review (#1820–#1827); the barrier/close-gate cluster is deliberately
+deferred with its own plan (see below). Flip to `landed` when the fix PRs
+merge and the deferred cluster has an owner.
 
 # Protocol-v4 activation gate list
 
@@ -10,86 +13,85 @@ v4-advertising binary — validators advertise `SupportedProtocolVersions::SYSTE
 and `SetNextConfigVersion(4)` is emitted once quorum+buffer stake supports it.
 There is **no separate vote**. So this whole list must be sound before any
 v4-advertising binary rolls out fleet-wide — or the 1.2.0 default advertisement
-must be capped at v3 and lifted in the release that closes this list.
+must be capped at v3 and lifted in the release that closes this list
+(decision pending; the mixed-binary caveat below strengthens the cap option).
 
-Source: the 1.2.0 release review's §3, re-verified at head `c7cfd03f4c` by a
-14-item design pass + cross-check (2026-07-12).
+Source: the 1.2.0 pre-release code review, re-verified at head `c7cfd03f4c`
+by a 14-item design pass (2026-07-12).
 
-## Landed
+## Fix PRs (open, awaiting review)
 
-- **PR #1820** (`fix/v4-gate-list`): V5 (`refresh()` per-member skip), V9c
-  (prior-committee snapshot-name keying), `read_bls_committee_lossy` for the
-  bootstrap anchor, V7-partial (`get_committee` unwrap→propagate), SDK 0.5.0
-  changeset + README rename fix. Cluster + integration suites dispatched.
+- **#1820** (`fix/v4-gate-list`): pubkey-provider `refresh()` per-member
+  verify-skip; prior-committee consensus-key map keyed by snapshot name;
+  `read_bls_committee_lossy` for the bootstrap anchor; `get_committee`
+  unwrap→propagate; SDK 0.5.0 changeset.
+- **#1821** (`fix/v4-committee-legacy-decode`): mainnet-v1.1.8
+  `committee_map` records decode via a `LegacyCommittee` fallback, so the
+  v3→v4 transition epoch cannot panic on a 1.1.8-written record.
+- **#1822** (`fix/v4-vss-cache-tristate`): the VSS Shamir-cache derivation
+  outcome is an explicit, epoch-tagged tri-state
+  (`Derived`/`NotApplicable`/`Failed`); stale terminal entries read as
+  not-ready.
+- **#1823** (`fix/v4-ready-signal-determinism`): ready-signal
+  canonicalization is a pure function of the sequenced bytes (zero-weight
+  joiner pairs kept; no wall-clock provider-table filter) — the freeze
+  precondition.
+- **#1824** (`fix/v4-handoff-attestation-recovery`): the handoff aggregator
+  recovers after a post-EndOfPublish restart (install runs before the vote
+  gate, with a steady-state early-out once the aggregator is built); stale
+  signature rows are batch-deleted so the interim close gate cannot count
+  superseded endorsements.
+- **#1825** (`fix/v4-networkkeyid-memo-retry`): a failed NetworkKeyId
+  derivation retries when its input bytes change instead of being memoized
+  as permanently failed.
+- **#1826** (`fix/v4-presign-per-key-counters`): internal-presign
+  sequence/guard counters keyed per `(NetworkKeyId, curve, algorithm)` pool
+  (the shared-counter design was retired — a key adopted at different
+  rounds on different validators shifted every other pool's identifiers);
+  consensus-agreed NOA-key selection; adoption defers unmapped keys on
+  every branch.
+- **#1827** (`fix/v4-freeze-cert-read-fail-stop`): the mpc_data freeze
+  fail-stops on a prior-cert read error instead of freezing a shrunken
+  (divergent) carry-forward set.
 
-## Open — two tracks
+## Deferred — barrier escape + sequence-pure close gate
 
-### Track A — handoff / barrier (consensus-critical; precedes any v4 rollout)
+The remaining cluster (the prepare-then-start barrier's cert-less chain
+fallback, barrier coverage of the joiner-promotion and cold-startup
+consensus-start paths, and the sequence-pure epoch-close tally that retires
+`handoff_signatures_meet_quorum`) is designed but deliberately NOT built for
+1.2.0: the escape relaxes the barrier's block-forever safety gate and needs
+its own review cycle. Full design, ordering constraints, and safety
+analysis: [`handoff-barrier-escape-and-pure-close-gate.md`](handoff-barrier-escape-and-pure-close-gate.md).
 
-Ordering DAG (from the cross-check; each arrow = "must precede"):
+Recovery-mechanism note that shaped the deferred design: the handoff
+signature sender's restart replay re-mints the validator's OWN attestation,
+so it recovers only a NON-divergent validator; a validator whose attestation
+diverged from the quorum's recovers exclusively via the barrier peer-fetch
+of the quorum's certificate — confirmed to cover continuing (not just
+joining) validators at head.
 
-1. **V7** committee legacy-decode (medium) — PREREQUISITE: the v3→v4 transition
-   epoch can panic reading a 1.1.8 `committee_map` record before anything else
-   runs. Legacy-fallback decode via a `LegacyCommittee` mirror + `From`
-   (empty `consensus_keys`), a reopened `legacy_committee_map` DBMap view over
-   the same cf, distinct decode-failure logging at `lib.rs:2313`. Standalone PR.
-2. **V5 + V9c** — landed in #1820 (one PR, shared `fetch_previous_committee`).
-3. **V2** ready-signal receive-time canonicalization (small) — precondition for
-   V1's freeze determinism. Keep zero-weight joiner pairs in the persisted
-   `validated_peers`; never filter against the wall-clock joiner-provider table.
-4. **V1** freeze fail-stop + barrier call-sites (medium) — `prior_epoch_mpc_data_digests`
-   must return `IkaResult` and propagate read errors (crash-replay), reserving
-   the empty map for `Ok(None)`; add the `wait_for_handoff_data_ready` barrier to
-   the joiner-promotion (`lib.rs:2865`) and startup (`lib.rs:1121`) consensus-start
-   paths, not just the continuing-validator path. Depends on V2 and on the escape.
-5. **wedge** barrier escape (medium) — must land WITH or BEFORE V1 (so V1's new
-   call sites aren't new indefinite wedges) and before V4. Bounded barrier wait
-   then chain-import of the certified reconfiguration output; fail-stop, never
-   "start consensus without E-1 data". Owns the barrier's final shape.
-6. **networkkeyid-minors** (small) — Minor 1 (memo invalidation on changed
-   inputs) standalone; Minor 2 (unmapped-key never-ready) folds into the barrier
-   rewrite (step 5).
-7. **V3 + V9b** (one PR) — run snapshot-ready+build+install before the durable
-   early-return in `handoff_signature_sender.rs:246`; batch-delete non-verifying
-   `handoff_signatures` rows in the install replay. Independent of the freeze work.
-8. **V4** pure close-gate tally (medium) — LAST: tally sequenced EndOfPublishV2
-   bundles per attestation digest, RETIRE `handoff_signatures_meet_quorum` (don't
-   coexist). Depends on wedge (escape), V3 (restart recovery). If multi-key-holes
-   Part B ships (NOA attestation anchor), settle the `HandoffAttestation` schema here.
+## Rollout caveats
 
-Barrier caveat (I1/I2 from the cross-check): V3's local re-install re-mints the
-validator's OWN attestation; divergent-validator recovery is 100% the barrier
-peer-fetch of the cert for the quorum digest D — confirm the barrier covers the
-CONTINUING (not just joining) validator path.
-
-### Track B — presign uniformity (node-side; parallel except the S3 coupling)
-
-- **V9a** VSS-cache tri-state (small) — independent; `derive_vss_shamir_cache_for_key`
-  `.ok()?` → `Result` with a `NotApplicable` (pre-V3 key) variant + one `error!`
-  per real failure. Land anytime.
-- **expiry-desync + multi-key-holes** (ONE PR — forced by C1/C2):
-  - **DECISION REQUIRED (C1):** `next_internal_presign_sequence_number` is a
-    single `u64` shared across all keys+algos, and #1819's `fast-schnorr-vss.md`
-    spec *enshrines* that. multi-key-holes Part A would re-key it per
-    `(key,curve,algo)` — MORE correct (closes the adoption-lag hole where
-    `agreed_key_ids` is a wall-clock set) but it **rewrites** the #1819 invariant
-    + the `mpc_manager.rs:1674` comment. Choose: (a) keep the shared counter and
-    make `agreed_key_ids` consensus-uniform instead, or (b) adopt per-key counters
-    and rewrite the spec. Do not ship both framings.
-  - expiry-desync and multi-key-holes both re-key `internal_presign_batch_instantiated_at_round`
-    — must be one PR or the second clobbers the first.
-  - multi-key-holes Part B (NOA attestation anchor) is the only bridge to Track A
-    (S3) — if included, gate on V4's `HandoffAttestation` schema.
-
-## SDK 0.5.0 (rollout precondition, zero code coupling)
-
-Publish before any v4-advertising binary reaches quorum stake: the published
-`@ika.xyz/ika-wasm@0.2.1` cannot parse V3-tagged reconfiguration outputs.
-Changeset landed in #1820; the version bump + `npm publish` are release-process
-acts. README hash-validity row (DoubleSHA256/secp256r1) still needs verifying
-against the TS+Rust tables (deferred — correctness question, not a rename).
+- **Mixed-binary determinism (strengthens the cap-at-v3 option).** The
+  ready-signal canonicalization change (#1823) is consensus-visible across
+  binary versions: an old binary keeps zero-weight names only if present in
+  its local announcements table, the new binary keeps them all. Under
+  ACTIVE v4 a mixed-binary committee could persist divergent rows from the
+  same sequenced signal — the exact fork class the fix closes. Ship
+  fleet-complete before v4 activates (automatic ~1 epoch after quorum
+  advertises v4), or cap the 1.2.0 default advertisement at v3.
+- **SDK 0.5.0 (rollout precondition, zero code coupling).** Publish before
+  any v4-advertising binary reaches quorum stake: the published
+  `@ika.xyz/ika-wasm@0.2.1` cannot parse V3-tagged reconfiguration outputs.
+  Changeset landed in #1820; the version bump + `npm publish` are
+  release-process acts. README hash-validity row (DoubleSHA256/secp256r1)
+  still needs verifying against the TS+Rust tables (deferred — correctness
+  question, not a rename).
 
 ## Not on this list (further out, separate flags)
 
-NOA (N1–N3) and OCS (O1–O5) sit behind their own flags, not the v4 capability
-vote. See the 1.2.0 release review §1.3–1.4.
+The network-owned-address (NOA) signing/checkpoint system and the
+on-chain-state (OCS) verified-read hardening items sit behind their own
+feature flags and are not activated by the v4 capability tally; they are
+tracked in their own plans/issues.

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -97,6 +97,25 @@ next epoch inherits.
   Consensus pubkeys are fixed at registration; members that have since
   left the active set are resolved from chain (their staking pool
   object persists) so churn cannot wrongly reject a valid certificate.
+  Two properties of the chain-read prior committee
+  (`fetch_previous_committee`) are load-bearing here:
+  - **Snapshot-name keying.** The consensus-key map is keyed by each
+    member's PRIOR-epoch snapshot name (resolved by validator id from
+    the frozen `previous_committee`), never by the member's current
+    on-chain protocol pubkey — a member that rotated its protocol key
+    at the boundary signed under the old name, and current-name keying
+    would silently drop its stake from the cert quorum.
+  - **Lossy membership read (and its sharp edge).** A prior-committee
+    member whose frozen snapshot `protocol_pubkey` bytes fail to parse
+    is SKIPPED rather than panicking the reader — but the skip is not
+    graceful degradation: the member is absent from `voting_rights`,
+    and verification hard-rejects any certificate carrying a weight-0
+    signer's signature. Since such a member's own node keeps signing,
+    its signature is in every aggregated cert, so every served cert
+    fails and bootstrap surfaces `Rejected`. The reader logs the
+    dropped ids so that outcome is attributable to the corrupt record
+    (near-unreachable trigger: the bytes are validated at
+    registration; the pre-lossy behavior was a panic crash-loop).
 
 ## Consuming the certificate
 
@@ -106,8 +125,16 @@ next epoch inherits.
    and installs the network-key outputs it certifies. Outcomes:
    - `Verified` — persist + install.
    - `Rejected` (peers served certificates but NONE verified) — a
-     genuine trust-anchor mismatch or eclipse: **fail closed, halt the
-     node**. A single bad peer cannot cause this (every peer is tried).
+     genuine trust-anchor mismatch or eclipse: **fail closed** — the
+     node must never anchor on an unverified cert. A single bad peer
+     cannot cause this (every peer is tried). Enforcement today: the
+     epoch-start bootstrap task logs `Rejected` at error and installs
+     nothing (it does NOT hard-halt the process; a refuse-participation
+     policy layers above it), and the prepare-then-start barrier simply
+     never becomes ready without a verified anchor — the node blocks
+     out of MPC participation. The one place that DOES halt the node is
+     the barrier's re-verification failure of a locally-PERSISTED cert
+     (local DB tampering/corruption — see step 2).
    - `Unavailable` (no peer served one) — benign propagation lag;
      retry.
    A validator that already holds the certificate re-verifies it before

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -346,7 +346,7 @@ const digest = sessionIdentifierDigest(bytesToHash, senderAddressBytes);
 | SECP256K1 | Taproot             | SHA256                          |
 | SECP256R1 | ECDSASecp256r1      | SHA256, DoubleSHA256            |
 | ED25519   | EdDSA               | SHA512                          |
-| RISTRETTO | SchnorrkelSubstrate | Merlin                          |
+| RISTRETTO | Schnorrkel          | Merlin                          |
 
 The SDK provides compile-time type safety and runtime validation for curve/signature/hash
 combinations via `hash-signature-validation`.


### PR DESCRIPTION
First batch of the protocol-v4 gate-list fixes from the 1.2.0 release review. These paths ship dark in 1.2.0 but **activate automatically ~one epoch after the fleet finishes upgrading** (capabilities → `SetNextConfigVersion`, no separate vote), so they must be sound before a v4-advertising binary rolls out fleet-wide.

Scoped to the **isolated, low-risk** items; the interacting handoff-attestation cluster (V1/V2/V3/V4/V9b) and the presign-uniformity family land as separate PRs.

### V5 — one bad `validator_info` no longer suppresses joiner relay for the epoch
`pubkey_provider_updater::refresh()` aborted the whole joiner-provider install (`verify().map_err(...)?`) on any single unverifiable next-epoch member — retried every 5s forever, installing no provider, dropping every relayed joiner announcement. Now skips-and-logs per member (matching the reviewed `fetch_previous_committee` tolerance) with a loud incomplete-set warning. Design confirms the next-epoch path legitimately keys by current names, so the fix is skip-only, not re-keying.

### V9c — protocol-key rotation no longer silently drops a validator's cert stake
`fetch_previous_committee` keyed the consensus-key map by each member's **current** on-chain `protocol_pubkey`, while `voting_rights` uses the frozen `previous_committee` snapshot name. A validator that rotated its protocol key at the boundary signed its handoff attestation under the **old** name; the lookup by the new name returned `None`, its signature dropped as unverifiable, and its stake silently left the cert quorum — a benign rotation could fail the cert and fail-closed-halt a joiner. Both maps now key by the same prior-epoch snapshot name (resolved by validator id). The consensus-key *value* is fixed at registration, so reading the current one stays correct; only the map key changes. Out of scope (unfixable from chain state): consensus-key *value* rotation between signing and bootstrap.

### V7 (partial) — `get_committee` no longer panics on a decode error
`RocksDbStore::get_committee` unwrapped the `committee_map` read, crash-looping under `panic=abort` on any decode failure. Now propagates. The legacy-layout fallback decode for 1.1.8-written `Committee` records (mid-struct `consensus_keys` addition) is a **separate** change still in design — this PR only removes the panic.

### SDK 0.5.0 changeset
Adds the changeset (SchnorrkelSubstrate→Schnorrkel rename — key and runtime string; 30s→600s default poll timeout; V3-capable wasm **required before v4 activation**, since published `@ika.xyz/ika-wasm@0.2.1` throws on V3-tagged reconfiguration outputs) and fixes the stale `SchnorrkelSubstrate` row in the SDK README. npm 0.4.1 is wedged (= latest, breaking rename unpublished); this unblocks the bump.

## Validation
Compiles clean, clippy-clean, existing `pubkey_provider` tests pass. Per CLAUDE.md's reconfiguration/`sui_connector` verification rule, the cert-quorum and joiner-bootstrap behavior is validated by the **cluster suite** (dispatched on this branch) — the V5/V9c fault-injection scenarios (malformed member; boundary key-rotation) run through the `joiner.rs` harness. Fault-injection validation per the test-testing playbook is the pre-merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)