### PR TITLE
fix(v4): make the VSS Shamir-cache derivation outcome explicit and traceable (V9a)

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -138,17 +138,29 @@ pub struct VssShamirCachePerKey {
 /// Storing the outcome (not only successes) lets the VSS sign path tell
 /// "still coming" (park and retry) from "will never come" (fail, traceably)
 /// instead of collapsing all three to a bare missing entry.
+///
+/// EVERY variant carries the epoch of the key data it was derived from, and
+/// the accessor treats an epoch mismatch exactly like a missing entry — the
+/// terminal variants included. A terminal entry derived from a PREVIOUS view
+/// of the key (e.g. the boundary window where the first ingest carried the
+/// pre-V3 key view and the fresh V3 re-derivation is still running on rayon)
+/// is "re-derivation in flight", not "will never come"; without the epoch
+/// tag a consumer trusting the terminal/transient distinction would drop out
+/// of VSS signing for the whole re-derivation window while its peers sign.
 #[derive(Clone, Debug)]
 pub enum VssCacheEntry {
-    /// The three-curve cache derived successfully. Boxed: it dwarfs the two
-    /// unit variants, so an unboxed enum would carry that size everywhere.
+    /// The three-curve cache derived successfully (carries its epoch as
+    /// `VssShamirCachePerKey::derived_for_epoch`). Boxed: it dwarfs the
+    /// other variants, so an unboxed enum would carry that size everywhere.
     Derived(Box<VssShamirCachePerKey>),
-    /// The key has no V3 DKG / reconfiguration output, so VSS material does
-    /// not exist for it (a pre-V3 key). Terminal, not a transient wait.
-    NotApplicable,
-    /// A real deserialization / derivation failure (logged once at insertion).
-    /// Terminal; the operator has an `error!` line to act on.
-    Failed,
+    /// The key data had no V3 DKG / reconfiguration output, so VSS material
+    /// does not exist for it (a pre-V3 key). Terminal FOR THAT KEY-DATA
+    /// EPOCH, not a transient wait.
+    NotApplicable { derived_for_epoch: u64 },
+    /// A real deserialization / derivation failure (logged once at
+    /// insertion). Terminal for that key-data epoch; the operator has an
+    /// `error!` line to act on.
+    Failed { derived_for_epoch: u64 },
 }
 
 /// Holds the private decryption key data for a validator node.
@@ -331,10 +343,12 @@ impl ValidatorPrivateDecryptionKeyData {
         self.validator_decryption_key_shares
             .insert(key_id, decryption_key_shares);
 
-        // Pre-derive VSS Shamir shares + commitments at ingestion. All-or-
-        // nothing: if the network key is pre-V3 OR any per-curve derivation
-        // fails, we insert nothing into the cache and VSS sign sites then
-        // `?`-propagate `WaitingForNetworkKey` like the AHE wait path.
+        // Pre-derive VSS Shamir shares + commitments at ingestion. The
+        // OUTCOME is always recorded (`Derived`/`NotApplicable`/`Failed`),
+        // epoch-tagged with the source key data's epoch, so VSS sign sites
+        // can tell a still-running derivation (absent/stale entry → wait)
+        // from a completed-but-unusable one for the CURRENT key data
+        // (terminal → fail traceably).
         //
         // The derivation is heavy class-groups crypto (three curves), so run it
         // off the runtime thread on rayon — mirroring the AHE decrypt above —
@@ -348,6 +362,11 @@ impl ValidatorPrivateDecryptionKeyData {
         let party_id = self.party_id;
         let secrets = self.validator_pvss_secrets_for_vss.clone();
         let publics = self.validator_pvss_publics_for_vss.clone();
+        // The epoch of the key data this derivation reads — tagged onto every
+        // outcome variant so the accessor can treat an entry derived from a
+        // superseded key view as missing (re-derivation in flight), never as
+        // terminal.
+        let key_data_epoch = key.epoch();
         rayon::spawn_fifo(move || {
             #[cfg(msim)]
             let _node_guard = originating_sim_node.as_ref().map(|n| n.enter_node());
@@ -357,21 +376,25 @@ impl ValidatorPrivateDecryptionKeyData {
                 error!("failed to send VSS shamir cache");
             }
         });
-        // Always record the outcome (overwriting any prior epoch's entry — this
-        // runs on every network-key update, so a Failed/NotApplicable entry is
-        // re-derived and overwritten on the next update). Storing NotApplicable
-        // and Failed — not only successes — is what lets the VSS sign path fail
-        // fast (traceably) instead of parking forever on a completed-but-unusable
-        // derivation.
+        // Always record the outcome (overwriting the previous update's entry —
+        // this runs on every network-key update, so a Failed/NotApplicable
+        // entry is re-derived and overwritten on the next update of the key).
+        // Storing NotApplicable and Failed — not only successes — is what lets
+        // the VSS sign path fail fast (traceably) instead of parking forever
+        // on a completed-but-unusable derivation.
         let entry = match vss_receiver.await.map_err(|_| DwalletMPCError::TokioRecv)? {
             VssCacheDerivation::Derived(cache) => VssCacheEntry::Derived(cache),
-            VssCacheDerivation::NotApplicable => VssCacheEntry::NotApplicable,
+            VssCacheDerivation::NotApplicable => VssCacheEntry::NotApplicable {
+                derived_for_epoch: key_data_epoch,
+            },
             VssCacheDerivation::Failed(reason) => {
                 error!(
                     ?key_id,
                     reason, "VSS Shamir cache derivation failed for network key"
                 );
-                VssCacheEntry::Failed
+                VssCacheEntry::Failed {
+                    derived_for_epoch: key_data_epoch,
+                }
             }
         };
         self.validator_vss_shamir_cache.insert(key_id, entry);
@@ -597,33 +620,45 @@ impl DwalletMPCNetworkKeys {
     ) -> DwalletMPCResult<&VssShamirCachePerKey> {
         // Absent entry: derivation hasn't completed yet (still running on
         // rayon) — park and retry, same as the AHE wait path.
-        let cache = match self
+        let entry = self
             .validator_private_dec_key_data
             .validator_vss_shamir_cache
             .get(key_id)
-            .ok_or(DwalletMPCError::WaitingForNetworkKey(*key_id))?
-        {
-            VssCacheEntry::Derived(cache) => cache.as_ref(),
-            // Completed but unusable: a pre-V3 key (NotApplicable) or a real
-            // derivation failure (Failed, already logged once). This is NOT
-            // the not-ready class, so the VSS sign session fails terminally
-            // with a named, traceable error instead of parking forever.
-            VssCacheEntry::NotApplicable | VssCacheEntry::Failed => {
-                return Err(DwalletMPCError::VssShamirCacheUnavailable(*key_id));
-            }
-        };
-        // A cache derived from a previous epoch's key data mixed with the
-        // current epoch's public parameters fails MPC round one with
-        // `InvalidParameters` (the per-validator epoch-entry failure window
-        // of issue #1736: the re-derivation is heavy class-groups work that
-        // lands seconds to minutes after the key update, per validator).
-        // Treat a stale entry exactly like a missing one — the computation
-        // parks and retries once this validator's re-derivation lands.
+            .ok_or(DwalletMPCError::WaitingForNetworkKey(*key_id))?;
+        // Staleness FIRST, for EVERY variant: an entry (success or terminal)
+        // derived from a superseded view of the key is "re-derivation in
+        // flight", not an answer about the current key data. For `Derived`,
+        // mixing a previous epoch's shares with the current epoch's public
+        // parameters fails MPC round one with `InvalidParameters` (the
+        // per-validator epoch-entry failure window of issue #1736: the
+        // re-derivation is heavy class-groups work that lands seconds to
+        // minutes after the key update). For the terminal variants, the
+        // boundary window where the first ingest carried the pre-V3 key view
+        // records `NotApplicable` — reporting that as terminal while the
+        // fresh V3 re-derivation runs would drop this validator out of every
+        // VSS sign for the window. Treat all stale entries exactly like a
+        // missing one — park and retry until this validator's re-derivation
+        // lands.
         let current_key_epoch = self.get_network_encryption_key_public_data(key_id)?.epoch();
-        if cache.derived_for_epoch != current_key_epoch {
+        let derived_for_epoch = match entry {
+            VssCacheEntry::Derived(cache) => cache.derived_for_epoch,
+            VssCacheEntry::NotApplicable { derived_for_epoch }
+            | VssCacheEntry::Failed { derived_for_epoch } => *derived_for_epoch,
+        };
+        if derived_for_epoch != current_key_epoch {
             return Err(DwalletMPCError::WaitingForNetworkKey(*key_id));
         }
-        Ok(cache)
+        match entry {
+            VssCacheEntry::Derived(cache) => Ok(cache.as_ref()),
+            // Completed but unusable FOR THE CURRENT KEY DATA: a pre-V3 key
+            // (NotApplicable) or a real derivation failure (Failed, already
+            // logged once). This is NOT the not-ready class, so the VSS sign
+            // session fails with a named, traceable error instead of parking
+            // forever.
+            VssCacheEntry::NotApplicable { .. } | VssCacheEntry::Failed { .. } => {
+                Err(DwalletMPCError::VssShamirCacheUnavailable(*key_id))
+            }
+        }
     }
 
     pub fn key_public_data_exists(&self, key_id: &ObjectID) -> bool {

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -118,10 +118,7 @@ pub struct VssRistrettoShamirCache {
 /// reconfiguration output and without redoing the Shamir derivation.
 ///
 /// All three curves are populated atomically — they all derive from the same
-/// (V3) DKG / reconfiguration output. If that output is unavailable or any
-/// per-curve derivation fails, no `VssShamirCachePerKey` is inserted into the
-/// per-key map for that network key (and VSS sign sites then `?`-propagate
-/// `WaitingForNetworkKey`, same as the AHE wait path).
+/// (V3) DKG / reconfiguration output.
 #[derive(Clone, Debug)]
 pub struct VssShamirCachePerKey {
     /// The epoch of the key data this cache was derived from. The cache map
@@ -135,6 +132,23 @@ pub struct VssShamirCachePerKey {
     pub secp256k1: VssSecp256k1ShamirCache,
     pub curve25519: VssCurve25519ShamirCache,
     pub ristretto: VssRistrettoShamirCache,
+}
+
+/// The stored outcome of a VSS Shamir-cache derivation for one network key.
+/// Storing the outcome (not only successes) lets the VSS sign path tell
+/// "still coming" (park and retry) from "will never come" (fail, traceably)
+/// instead of collapsing all three to a bare missing entry.
+#[derive(Clone, Debug)]
+pub enum VssCacheEntry {
+    /// The three-curve cache derived successfully. Boxed: it dwarfs the two
+    /// unit variants, so an unboxed enum would carry that size everywhere.
+    Derived(Box<VssShamirCachePerKey>),
+    /// The key has no V3 DKG / reconfiguration output, so VSS material does
+    /// not exist for it (a pre-V3 key). Terminal, not a transient wait.
+    NotApplicable,
+    /// A real deserialization / derivation failure (logged once at insertion).
+    /// Terminal; the operator has an `error!` line to act on.
+    Failed,
 }
 
 /// Holds the private decryption key data for a validator node.
@@ -171,10 +185,14 @@ pub struct ValidatorPrivateDecryptionKeyData {
         HashMap<ObjectID, HashMap<PartyID, SecretKeyShareSizedInteger>>,
 
     /// Per-network-key Fast Schnorr (VSS) Shamir-share + polynomial-commitments
-    /// cache, populated alongside `validator_decryption_key_shares` from the
-    /// same network DKG / reconfiguration output. Read verbatim by VSS sign
-    /// (no per-sign re-derivation).
-    pub validator_vss_shamir_cache: HashMap<ObjectID, VssShamirCachePerKey>,
+    /// cache outcome, populated alongside `validator_decryption_key_shares`
+    /// from the same network DKG / reconfiguration output. Stores the
+    /// derivation OUTCOME per key (`Derived`/`NotApplicable`/`Failed`), not
+    /// only successes, so the VSS sign path distinguishes a still-running
+    /// derivation (absent entry → park) from a completed-but-unusable one
+    /// (`NotApplicable`/`Failed` → terminal). Read verbatim by VSS sign (no
+    /// per-sign re-derivation).
+    pub validator_vss_shamir_cache: HashMap<ObjectID, VssCacheEntry>,
 }
 
 async fn get_decryption_key_shares_from_public_output(
@@ -335,29 +353,55 @@ impl ValidatorPrivateDecryptionKeyData {
             let _node_guard = originating_sim_node.as_ref().map(|n| n.enter_node());
 
             let vss_cache = derive_vss_shamir_cache_for_key(&key, party_id, &secrets, &publics);
-            if let Err(err) = vss_sender.send(vss_cache) {
-                error!(error=?err, "failed to send VSS shamir cache");
+            if vss_sender.send(vss_cache).is_err() {
+                error!("failed to send VSS shamir cache");
             }
         });
-        if let Some(vss_cache) = vss_receiver.await.map_err(|_| DwalletMPCError::TokioRecv)? {
-            self.validator_vss_shamir_cache.insert(key_id, vss_cache);
-        }
+        // Always record the outcome (overwriting any prior epoch's entry — this
+        // runs on every network-key update, so a Failed/NotApplicable entry is
+        // re-derived and overwritten on the next update). Storing NotApplicable
+        // and Failed — not only successes — is what lets the VSS sign path fail
+        // fast (traceably) instead of parking forever on a completed-but-unusable
+        // derivation.
+        let entry = match vss_receiver.await.map_err(|_| DwalletMPCError::TokioRecv)? {
+            VssCacheDerivation::Derived(cache) => VssCacheEntry::Derived(cache),
+            VssCacheDerivation::NotApplicable => VssCacheEntry::NotApplicable,
+            VssCacheDerivation::Failed(reason) => {
+                error!(
+                    ?key_id,
+                    reason, "VSS Shamir cache derivation failed for network key"
+                );
+                VssCacheEntry::Failed
+            }
+        };
+        self.validator_vss_shamir_cache.insert(key_id, entry);
 
         Ok(())
     }
 }
 
+/// The outcome of deriving the VSS Shamir cache for one key: distinguishes a
+/// genuinely-inapplicable key (pre-V3) from a real derivation failure, so the
+/// caller can log the latter and the sign path can fail rather than park
+/// forever on either.
+enum VssCacheDerivation {
+    Derived(Box<VssShamirCachePerKey>),
+    NotApplicable,
+    Failed(String),
+}
+
 /// Pre-derive the Fast Schnorr (VSS) Shamir shares + secret-key polynomial
 /// commitments for all three VSS curves from a single network DKG /
 /// reconfiguration output. The output is deserialized at most once. Returns
-/// `None` if the network key has no V3 output (pre-V3) or any per-curve
-/// derivation fails — the three curves are always populated together.
+/// `NotApplicable` if the network key has no V3 output (pre-V3), or `Failed`
+/// if deserialization / any per-curve derivation fails — the three curves are
+/// always populated together.
 fn derive_vss_shamir_cache_for_key(
     key: &NetworkEncryptionKeyPublicData,
     party_id: PartyID,
     secrets: &ValidatorPvssSecretsForVss,
     publics: &ValidatorPvssEncryptionKeysForVss,
-) -> Option<VssShamirCachePerKey> {
+) -> VssCacheDerivation {
     use twopc_mpc::decentralized_party::{dkg as dec_dkg, reconfiguration as dec_reconf};
 
     enum DeserializedSource {
@@ -367,14 +411,26 @@ fn derive_vss_shamir_cache_for_key(
 
     let source: DeserializedSource = match key.latest_network_reconfiguration_public_output() {
         Some(VersionedDecryptionKeyReconfigurationOutput::V3(bytes)) => {
-            DeserializedSource::Reconfiguration(Box::new(bcs::from_bytes(&bytes).ok()?))
+            match bcs::from_bytes(&bytes) {
+                Ok(output) => DeserializedSource::Reconfiguration(Box::new(output)),
+                Err(e) => {
+                    return VssCacheDerivation::Failed(format!(
+                        "decoding the V3 reconfiguration output: {e}"
+                    ));
+                }
+            }
         }
         // Pre-V3 reconfiguration (or none yet) → fall through to network DKG output.
         _ => match key.network_dkg_output() {
-            VersionedNetworkDkgOutput::V3(bytes) => {
-                DeserializedSource::NetworkDkg(Box::new(bcs::from_bytes(bytes).ok()?))
-            }
-            _ => return None,
+            VersionedNetworkDkgOutput::V3(bytes) => match bcs::from_bytes(bytes) {
+                Ok(output) => DeserializedSource::NetworkDkg(Box::new(output)),
+                Err(e) => {
+                    return VssCacheDerivation::Failed(format!(
+                        "decoding the V3 network DKG output: {e}"
+                    ));
+                }
+            },
+            _ => return VssCacheDerivation::NotApplicable,
         },
     };
 
@@ -442,11 +498,28 @@ fn derive_vss_shamir_cache_for_key(
             ),
         };
 
-    let (secp256k1_first, secp256k1_second) = secp256k1_shares.ok()?;
-    let (curve25519_first, curve25519_second) = curve25519_shares.ok()?;
-    let (ristretto_first, ristretto_second) = ristretto_shares.ok()?;
+    let (secp256k1_first, secp256k1_second) = match secp256k1_shares {
+        Ok(shares) => shares,
+        Err(e) => {
+            return VssCacheDerivation::Failed(format!("secp256k1 Shamir-share derivation: {e:?}"));
+        }
+    };
+    let (curve25519_first, curve25519_second) = match curve25519_shares {
+        Ok(shares) => shares,
+        Err(e) => {
+            return VssCacheDerivation::Failed(format!(
+                "curve25519 Shamir-share derivation: {e:?}"
+            ));
+        }
+    };
+    let (ristretto_first, ristretto_second) = match ristretto_shares {
+        Ok(shares) => shares,
+        Err(e) => {
+            return VssCacheDerivation::Failed(format!("ristretto Shamir-share derivation: {e:?}"));
+        }
+    };
 
-    Some(VssShamirCachePerKey {
+    VssCacheDerivation::Derived(Box::new(VssShamirCachePerKey {
         derived_for_epoch: key.epoch(),
         secp256k1: VssSecp256k1ShamirCache {
             secret_key_share_first_part: secp256k1_first,
@@ -466,7 +539,7 @@ fn derive_vss_shamir_cache_for_key(
             first_secret_key_polynomial_commitments: ristretto_first_commitments,
             second_secret_key_polynomial_commitments: ristretto_second_commitments,
         },
-    })
+    }))
 }
 
 impl DwalletMPCNetworkKeys {
@@ -522,11 +595,23 @@ impl DwalletMPCNetworkKeys {
         &self,
         key_id: &ObjectID,
     ) -> DwalletMPCResult<&VssShamirCachePerKey> {
-        let cache = self
+        // Absent entry: derivation hasn't completed yet (still running on
+        // rayon) — park and retry, same as the AHE wait path.
+        let cache = match self
             .validator_private_dec_key_data
             .validator_vss_shamir_cache
             .get(key_id)
-            .ok_or(DwalletMPCError::WaitingForNetworkKey(*key_id))?;
+            .ok_or(DwalletMPCError::WaitingForNetworkKey(*key_id))?
+        {
+            VssCacheEntry::Derived(cache) => cache.as_ref(),
+            // Completed but unusable: a pre-V3 key (NotApplicable) or a real
+            // derivation failure (Failed, already logged once). This is NOT
+            // the not-ready class, so the VSS sign session fails terminally
+            // with a named, traceable error instead of parking forever.
+            VssCacheEntry::NotApplicable | VssCacheEntry::Failed => {
+                return Err(DwalletMPCError::VssShamirCacheUnavailable(*key_id));
+            }
+        };
         // A cache derived from a previous epoch's key data mixed with the
         // current epoch's public parameters fails MPC round one with
         // `InvalidParameters` (the per-validator epoch-entry failure window

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -42,7 +42,7 @@ use ika_protocol_config::ProtocolConfig;
 use ika_types::committee::{Committee, EpochId};
 use ika_types::crypto::AuthorityPublicKeyBytes;
 use ika_types::crypto::{AuthorityName, DefaultHash};
-use ika_types::dwallet_mpc_error::DwalletMPCResult;
+use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use ika_types::handoff::HandoffItemKey;
 use ika_types::message::DWalletCheckpointMessageKind;
 use ika_types::messages_dwallet_mpc::{
@@ -1622,7 +1622,14 @@ impl DWalletMPCManager {
                 // invariant violation — don't page on it. Internal presign
                 // requests park on it before ever getting here (see
                 // `instantiate_internal_presign_session`).
-                if is_internal && !e.is_network_key_data_not_ready() {
+                // `VssShamirCacheUnavailable` is terminal but BY-DESIGN
+                // reachable: during the v3→v4 boundary epoch every network key
+                // is pre-V3 (`NotApplicable` cache), so a NOA VSS sign attempt
+                // hitting it is the expected state of the whole fleet, not an
+                // invariant violation — log it as an error without paging.
+                let is_expected_error_class = e.is_network_key_data_not_ready()
+                    || matches!(e, DwalletMPCError::VssShamirCacheUnavailable(_));
+                if is_internal && !is_expected_error_class {
                     error!(should_never_happen = true, error=?e, ?request, "create internal session input from dWallet request with error");
                 } else {
                     error!(error=?e, ?request, "create session input from dWallet request with error");

--- a/crates/ika-types/src/dwallet_mpc_error.rs
+++ b/crates/ika-types/src/dwallet_mpc_error.rs
@@ -163,6 +163,9 @@ pub enum DwalletMPCError {
     #[error("waiting for network key with ID: {0}")]
     WaitingForNetworkKey(ObjectID),
 
+    #[error("VSS Shamir cache unavailable for network key {0}")]
+    VssShamirCacheUnavailable(ObjectID),
+
     #[error("the dwallet secret does not match the dwallet output")]
     DWalletSecretNotMatchedDWalletOutput,
 
@@ -321,6 +324,7 @@ impl DwalletMPCError {
             DwalletMPCError::ValidatorIDNotFound(_) => "validator_id_not_found",
             DwalletMPCError::IkaError(_) => "ika_error",
             DwalletMPCError::WaitingForNetworkKey(_) => "waiting_for_network_key",
+            DwalletMPCError::VssShamirCacheUnavailable(_) => "vss_shamir_cache_unavailable",
             DwalletMPCError::DWalletSecretNotMatchedDWalletOutput => {
                 "dwallet_secret_not_matched_output"
             }
@@ -354,5 +358,25 @@ impl DwalletMPCError {
             DwalletMPCError::OffChainAssemblyIncomplete { .. } => "off_chain_assembly_incomplete",
             DwalletMPCError::PresignAlreadyUsed(_) => "presign_already_used",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vss_cache_unavailable_is_terminal_not_a_transient_wait() {
+        let id = ObjectID::random();
+        // The not-ready class parks and retries; a completed-but-unusable VSS
+        // cache (pre-V3 key, or a real derivation failure) must NOT be in it,
+        // or a VSS sign session parks forever instead of failing fast.
+        assert!(DwalletMPCError::WaitingForNetworkKey(id).is_network_key_data_not_ready());
+        assert!(!DwalletMPCError::VssShamirCacheUnavailable(id).is_network_key_data_not_ready());
+        // Stable metric label (alerts depend on it).
+        assert_eq!(
+            DwalletMPCError::VssShamirCacheUnavailable(id).kind(),
+            "vss_shamir_cache_unavailable"
+        );
     }
 }

--- a/dev-docs/specs/fast-schnorr-vss.md
+++ b/dev-docs/specs/fast-schnorr-vss.md
@@ -113,6 +113,24 @@ against the active committee directly.
   instantiated/completed batch counters stay committee-uniform — parking is
   local participation deferral, invisible to the top-up guard and the
   stale-batch expiry. Any other input-construction error stays terminal.
+- **VSS Shamir-cache outcome tri-state (epoch-tagged).** The per-key cache
+  map stores the derivation OUTCOME, not only successes: `Derived` (the
+  three-curve cache), `NotApplicable` (the key data had no V3 output — a
+  pre-V3 key), or `Failed` (a real deserialization/derivation failure,
+  logged once at insertion). Every variant carries the epoch of the key data
+  it was derived from, and the accessor treats an epoch mismatch — terminal
+  variants INCLUDED — exactly like a missing entry (the not-ready class,
+  park and retry): an entry derived from a superseded key view is
+  "re-derivation in flight", not an answer about the current key data.
+  Without the epoch tag on the terminal variants, the boundary window where
+  the first ingest carries the pre-V3 key view would report terminal
+  `NotApplicable` for the whole multi-minute V3 re-derivation, dropping that
+  validator out of every VSS sign while its peers sign. A CURRENT-epoch
+  terminal entry surfaces as `VssShamirCacheUnavailable` — a named, terminal
+  error distinct from the not-ready class. It is by-design reachable during
+  the v3→v4 boundary epoch (every key is pre-V3 then), so the internal-
+  session failure log treats it as an expected error class, not a
+  should-never-happen page.
 - **Deferred instantiation for a not-yet-installed key (multi-key epochs).**
   The top-up loop iterates every ADOPTED key, but installation into
   `network_keys` completes asynchronously per validator, and the session


### PR DESCRIPTION
Track B, independent item from the protocol-v4 gate list (see `dev-docs/plans/v4-activation-gate-list.md`). No coupling to the handoff cluster or the presign-counter (C1) decision.

## The black hole

`derive_vss_shamir_cache_for_key` returned `Option`, and three distinct outcomes all collapsed to `None`:
- a **pre-V3 key** (VSS genuinely not applicable),
- a **bcs decode failure** of the V3 output,
- a **per-curve derivation failure**.

The call site inserted nothing and **logged nothing**. A VSS sign then read the cache via an accessor that returned `WaitingForNetworkKey` for a missing entry — indistinguishable from "derivation still running". With #1818's parking, the not-ready class parks and retries every service iteration, so a genuinely-failed or not-applicable key **parked forever, silently and untraceably** (the review's "untraceable `WaitingForNetworkKey` on every VSS sign").

## Fix — store the outcome, distinguish transient from terminal

- `derive_vss_shamir_cache_for_key` returns a tri-state `Derived / NotApplicable / Failed(reason)`; the two bcs decodes and three per-curve derivations map their error into `Failed` with a cause string instead of `.ok()?`.
- The cache field stores the **outcome** per key (`VssCacheEntry`), not only successes. The call site always records an entry and emits **exactly one** `error!` (with the cause) on `Failed`; it's overwritten on the next key update, so a transient failure re-derives.
- The accessor parks (`WaitingForNetworkKey`) only for an **absent** entry (derivation still running) or a **stale-epoch** `Derived` entry (the #1736 window — unchanged). A `NotApplicable`/`Failed` entry returns the new terminal `DwalletMPCError::VssShamirCacheUnavailable`, which is **not** in `is_network_key_data_not_ready()` — so a VSS sign **fails fast with a named error** instead of parking forever.

## Test

The load-bearing property: `VssShamirCacheUnavailable` is **not** classified as not-ready (so it doesn't park), while `WaitingForNetworkKey` is; plus a stable metric label. The six VSS-sign call sites are untouched (they inherit via `?`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)