### PR TITLE
fix(v4): make ready-signal canonicalization a pure function of the sequenced bytes (V2)

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -3282,23 +3282,52 @@ impl AuthorityPerEpochStore {
                 return Ok(());
             }
         }
-        // Surface byzantine-padding attempts. Placed AFTER the
-        // strict-superset gate so a byzantine signer re-submitting
-        // the same padded payload every consensus round doesn't
-        // log-flood: the gate drops the repeat above, so only the
-        // first padded payload (or a strictly-grown padded payload)
-        // makes it here. Honest emitters dedup + committee-filter
-        // before broadcast, so reaching this branch is a strong
-        // byzantine signal worth a `warn!` for operators.
-        if !diagnostics.non_committee_kept.is_empty() || diagnostics.duplicates_collapsed != 0 {
+        // Surface anomalies. Placed AFTER the strict-superset gate so a
+        // byzantine signer re-submitting the same payload every consensus
+        // round doesn't log-flood: the gate drops the repeat above, so only
+        // the first anomalous payload (or a strictly-grown one) makes it
+        // here. Two distinct signals, judged separately:
+        // - DUPLICATES are a genuine byzantine tell — honest emitters dedup
+        //   before broadcast — so they warn.
+        // - Non-committee names are NOT: honest emitters deliberately
+        //   include announced next-epoch JOINERS (zero current-epoch
+        //   weight), so a non-empty `non_committee_kept` is the expected
+        //   shape of every honest signal in a churn epoch. Only an
+        //   implausibly large kept set (more kept zero-weight names than
+        //   committee seats — no honest joiner population looks like that)
+        //   warns; the routine case logs at debug. Kept names are inert for
+        //   assembly unless a stake-quorum of signers attest them, but they
+        //   DO land in `epoch_excluded_validators` and the excluded gauge,
+        //   and each one holds the full-coverage fast path open (the freeze
+        //   then fires via the grace path) — bounded, deterministic, and
+        //   the price of keeping canonicalization a pure function of the
+        //   sequenced bytes.
+        if diagnostics.duplicates_collapsed != 0 {
             warn!(
                 signer = ?signal.authority,
                 duplicates_collapsed = diagnostics.duplicates_collapsed,
-                non_committee_kept = ?diagnostics.non_committee_kept,
-                "EpochMpcDataReadySignal padded with duplicates / non-committee \
-                 authorities — likely byzantine signer (non-committee peers are \
-                 kept but inert unless a stake-quorum of signers attest them)"
+                "EpochMpcDataReadySignal padded with duplicate names — likely \
+                 byzantine signer (honest emitters dedup before broadcast)"
             );
+        }
+        if !diagnostics.non_committee_kept.is_empty() {
+            if diagnostics.non_committee_kept.len() > committee.num_members() {
+                warn!(
+                    signer = ?signal.authority,
+                    non_committee_kept = ?diagnostics.non_committee_kept,
+                    "EpochMpcDataReadySignal carries more zero-weight names than \
+                     committee seats — likely byzantine padding (kept names are \
+                     inert for assembly but hold the full-coverage fast path open \
+                     until the freeze grace)"
+                );
+            } else {
+                debug!(
+                    signer = ?signal.authority,
+                    non_committee_kept = ?diagnostics.non_committee_kept,
+                    "EpochMpcDataReadySignal attests zero-weight names (expected \
+                     for announced next-epoch joiners)"
+                );
+            }
         }
         let canonical = ika_types::validator_metadata::EpochMpcDataReadySignal {
             authority: signal.authority,

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -3199,59 +3199,56 @@ impl AuthorityPerEpochStore {
         let tables = self.tables()?;
         let existing = tables.epoch_mpc_data_ready_signals.get(&signal.authority)?;
         let committee = self.committee();
-        // Next-epoch joiners are legitimate attestation targets but
-        // have weight 0 in the *current* committee, so a plain
-        // current-committee filter would strip them from the recorded
-        // signal — and the freeze partition (which decides NEXT-epoch
-        // membership) would then never see them attested and exclude
-        // them. A joiner that has announced has a signed announcement
-        // in this table, ordered before any ready signal that attests
-        // it (the emitter only attests a peer after validating its
-        // announced blob, which consensus sequences first). So treat
-        // announcers as valid targets too. Garbage padding (neither
-        // committee nor announcer) is still dropped.
-        let announced: BTreeSet<AuthorityName> = tables
-            .validator_mpc_data_announcements
-            .safe_iter()
-            .filter_map(Result::ok)
-            .map(|(authority, _)| authority)
-            .collect();
-        // Canonicalize via the pure helper — handles dedup +
-        // committee filter + quorum-coverage floor in one place
-        // so the byzantine-resistance properties are unit-testable
-        // without a live epoch store. See
-        // `validator_metadata::canonicalize_ready_signal_peers`.
+        // Canonicalize via the pure helper — dedup + a current-committee
+        // quorum-coverage floor + a deterministic length cap. CRITICAL:
+        // this MUST be a pure function of the sequenced signal bytes, so
+        // it does NOT consult the local announcements table (a
+        // wall-clock-populated, JoinerPubkeyProvider-gated view). Instead
+        // it KEEPS every deduped peer — including a next-epoch joiner with
+        // zero current weight — so two honest validators with different
+        // provider-install timing persist the identical canonical set for
+        // the same sequenced signal. Coverage is measured on current
+        // weight only, so a sparse signal still can't push the freeze
+        // trigger; a joiner is frozen only when a stake-quorum of signers
+        // attest it in the tally (`compute_freeze_partition`).
+        //
+        // Cap = K × current committee size: the deduped length is
+        // identical across honest validators (same sequenced bytes), so
+        // the cap decision is itself consensus-deterministic.
+        const READY_SIGNAL_PEERS_CAP_MULTIPLIER: usize = 4;
+        let cap = committee
+            .num_members()
+            .saturating_mul(READY_SIGNAL_PEERS_CAP_MULTIPLIER);
         let (outcome, diagnostics) = crate::validator_metadata::canonicalize_ready_signal_peers(
             &signal.validated_peers,
-            |peer| {
-                let weight = committee.weight(peer);
-                // Keep announcer joiners (current weight 0) as valid
-                // targets with a minimal synthetic weight — negligible
-                // against the current-committee quorum floor (so it
-                // can't let an under-covered signal pass), but enough
-                // to survive the drop-if-zero filter.
-                if weight > 0 || announced.contains(peer) {
-                    weight.max(1)
-                } else {
-                    0
-                }
-            },
+            |peer| committee.weight(peer),
             committee.quorum_threshold(),
+            cap,
         );
         let canonical_peers = match outcome {
             crate::validator_metadata::CanonicalizeReadySignalOutcome::Accept {
                 validated_peers,
             } => validated_peers,
             crate::validator_metadata::CanonicalizeReadySignalOutcome::BelowQuorumCoverage {
-                attested_stake,
+                coverage_stake,
                 quorum,
             } => {
                 warn!(
                     signer = ?signal.authority,
-                    attested_stake,
+                    coverage_stake,
                     quorum,
                     "EpochMpcDataReadySignal below quorum coverage — dropping; \
                      signer should re-broadcast once they have more peer blobs validated"
+                );
+                return Ok(());
+            }
+            crate::validator_metadata::CanonicalizeReadySignalOutcome::OverCap { len, cap } => {
+                warn!(
+                    signer = ?signal.authority,
+                    len,
+                    cap,
+                    "EpochMpcDataReadySignal exceeds the peer-count cap — dropping; \
+                     likely a byzantine signer padding garbage names"
                 );
                 return Ok(());
             }
@@ -3293,13 +3290,14 @@ impl AuthorityPerEpochStore {
         // makes it here. Honest emitters dedup + committee-filter
         // before broadcast, so reaching this branch is a strong
         // byzantine signal worth a `warn!` for operators.
-        if !diagnostics.non_committee_dropped.is_empty() || diagnostics.duplicates_collapsed != 0 {
+        if !diagnostics.non_committee_kept.is_empty() || diagnostics.duplicates_collapsed != 0 {
             warn!(
                 signer = ?signal.authority,
                 duplicates_collapsed = diagnostics.duplicates_collapsed,
-                non_committee_dropped = ?diagnostics.non_committee_dropped,
+                non_committee_kept = ?diagnostics.non_committee_kept,
                 "EpochMpcDataReadySignal padded with duplicates / non-committee \
-                 authorities — likely byzantine signer"
+                 authorities — likely byzantine signer (non-committee peers are \
+                 kept but inert unless a stake-quorum of signers attest them)"
             );
         }
         let canonical = ika_types::validator_metadata::EpochMpcDataReadySignal {

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -317,11 +317,16 @@ pub enum CanonicalizeReadySignalOutcome {
     Accept {
         validated_peers: Vec<(AuthorityName, [u8; 32])>,
     },
-    /// Signal rejected: after dedup + committee-filter, the
-    /// remaining peer set attests to less than quorum stake.
-    /// Recorded so a byzantine signer can't push the freeze
-    /// trigger via empty/sparse signals.
-    BelowQuorumCoverage { attested_stake: u64, quorum: u64 },
+    /// Signal rejected: after dedup, the peers with current-committee
+    /// weight cover less than quorum stake. Recorded so a byzantine
+    /// signer can't push the freeze trigger via empty/sparse signals.
+    BelowQuorumCoverage { coverage_stake: u64, quorum: u64 },
+    /// Signal rejected: the deduped peer count exceeds the length cap
+    /// (a byzantine signer padding garbage names). The cap is derived
+    /// from the epoch-fixed committee size, so the deduped length — and
+    /// hence this decision — is identical across honest validators
+    /// decoding the same sequenced signal bytes.
+    OverCap { len: usize, cap: usize },
 }
 
 /// Byzantine-resistance diagnostics surfaced from
@@ -331,10 +336,13 @@ pub enum CanonicalizeReadySignalOutcome {
 /// honest emitters send a deduped, committee-only peer set.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct CanonicalizeReadySignalDiagnostics {
-    /// Names that appeared in the inbound `validated_peers` but
-    /// were dropped because they have zero stake (not in the
-    /// current committee). Always sorted.
-    pub non_committee_dropped: Vec<AuthorityName>,
+    /// Names that appeared in the inbound `validated_peers` with zero
+    /// current-committee weight. These are KEPT in the canonical set
+    /// (a next-epoch joiner has zero current weight but is a legitimate
+    /// freeze target), but honest emitters only list committee members
+    /// and announced joiners, so a large count is a byzantine padding
+    /// signal worth a `warn!`. Always sorted.
+    pub non_committee_kept: Vec<AuthorityName>,
     /// Number of duplicate entries collapsed during dedup.
     /// Honest emitters dedup before broadcast, so a non-zero
     /// value is a strong byzantine signal.
@@ -369,8 +377,9 @@ pub struct CanonicalizeReadySignalDiagnostics {
 ///    callers pass in already incorporates the `2f+1` rounding.
 pub fn canonicalize_ready_signal_peers<S>(
     validated_peers: &[(AuthorityName, [u8; 32])],
-    stake_of: S,
+    weight_of: S,
     quorum_threshold: u64,
+    cap: usize,
 ) -> (
     CanonicalizeReadySignalOutcome,
     CanonicalizeReadySignalDiagnostics,
@@ -389,22 +398,44 @@ where
         unique.insert(*peer, *hash);
     }
     let duplicates_collapsed = validated_peers.len().saturating_sub(unique.len());
-    let mut non_committee_dropped: Vec<AuthorityName> = unique
+    // Non-committee (zero current-weight) peers are KEPT: a next-epoch
+    // joiner has zero current weight but is a legitimate freeze target,
+    // attested by a stake-quorum of signers in the tally. Reporting them
+    // as `non_committee_kept` only feeds the byzantine `warn!`. This is
+    // the crux of the fix: canonicalization no longer consults any local
+    // (wall-clock-populated) announcement table to decide whether to keep
+    // a joiner, so the persisted set is a pure function of the sequenced
+    // signal bytes and cannot fork across honest validators.
+    let mut non_committee_kept: Vec<AuthorityName> = unique
         .keys()
         .copied()
-        .filter(|peer| stake_of(peer) == 0)
+        .filter(|peer| weight_of(peer) == 0)
         .collect();
-    non_committee_dropped.sort();
-    unique.retain(|peer, _| stake_of(peer) > 0);
+    non_committee_kept.sort();
     let diagnostics = CanonicalizeReadySignalDiagnostics {
-        non_committee_dropped,
+        non_committee_kept,
         duplicates_collapsed,
     };
-    let attested_stake: u64 = unique.keys().map(&stake_of).sum();
-    if attested_stake < quorum_threshold {
+    // Length cap against a byzantine signer padding garbage into durable
+    // storage. Deterministic: every honest validator decodes the same
+    // sequenced bytes, so the deduped length is identical across them.
+    if unique.len() > cap {
+        return (
+            CanonicalizeReadySignalOutcome::OverCap {
+                len: unique.len(),
+                cap,
+            },
+            diagnostics,
+        );
+    }
+    // Coverage is measured on CURRENT-committee weight only (joiners /
+    // garbage contribute 0), so a sparse signal still can't push the
+    // freeze trigger — but the persisted set keeps every deduped pair.
+    let coverage_stake: u64 = unique.keys().map(&weight_of).sum();
+    if coverage_stake < quorum_threshold {
         return (
             CanonicalizeReadySignalOutcome::BelowQuorumCoverage {
-                attested_stake,
+                coverage_stake,
                 quorum: quorum_threshold,
             },
             diagnostics,
@@ -3424,6 +3455,7 @@ mod tests {
             &[(c, [0xCC; 32]), (a, [0xAA; 32]), (b, [0xBB; 32])], // unsorted on purpose
             |_| 1,
             3,
+            100,
         );
         match outcome {
             CanonicalizeReadySignalOutcome::Accept { validated_peers } => {
@@ -3434,7 +3466,7 @@ mod tests {
             }
             other => panic!("expected Accept, got {other:?}"),
         }
-        assert!(diagnostics.non_committee_dropped.is_empty());
+        assert!(diagnostics.non_committee_kept.is_empty());
         assert_eq!(diagnostics.duplicates_collapsed, 0);
     }
 
@@ -3454,13 +3486,14 @@ mod tests {
             ],
             |_| 1,
             3,
+            100,
         );
         match outcome {
             CanonicalizeReadySignalOutcome::BelowQuorumCoverage {
-                attested_stake,
+                coverage_stake,
                 quorum,
             } => {
-                assert_eq!(attested_stake, 1);
+                assert_eq!(coverage_stake, 1);
                 assert_eq!(quorum, 3);
             }
             other => panic!("dup-padding must NOT cross the quorum floor: got {other:?}"),
@@ -3468,11 +3501,13 @@ mod tests {
         assert_eq!(diagnostics.duplicates_collapsed, 3);
     }
 
-    /// Byzantine signer pads with non-committee authorities (zero
-    /// stake). The committee filter drops them; diagnostics surface
-    /// the dropped names for caller-side logging.
+    /// Non-committee (zero current-weight) authorities are KEPT in the
+    /// canonical set — a next-epoch joiner is a legitimate freeze target —
+    /// but they contribute 0 to coverage, so a signal that only reaches
+    /// quorum by counting them is still rejected at the coverage floor.
+    /// The kept names are surfaced for caller-side logging.
     #[test]
-    fn canonicalize_ready_signal_rejects_non_committee_padding() {
+    fn canonicalize_ready_signal_coverage_excludes_non_committee() {
         let a = auth(0xAA);
         let outsider1 = auth(0xF0);
         let outsider2 = auth(0xF1);
@@ -3484,17 +3519,15 @@ mod tests {
             ],
             |peer| if *peer == a { 1 } else { 0 },
             3,
+            100,
         );
         match outcome {
-            CanonicalizeReadySignalOutcome::BelowQuorumCoverage { attested_stake, .. } => {
-                assert_eq!(attested_stake, 1)
+            CanonicalizeReadySignalOutcome::BelowQuorumCoverage { coverage_stake, .. } => {
+                assert_eq!(coverage_stake, 1)
             }
-            other => panic!("non-committee padding must NOT count: got {other:?}"),
+            other => panic!("non-committee padding must NOT count toward coverage: got {other:?}"),
         }
-        assert_eq!(
-            diagnostics.non_committee_dropped,
-            vec![outsider1, outsider2]
-        );
+        assert_eq!(diagnostics.non_committee_kept, vec![outsider1, outsider2]);
     }
 
     /// Byzantine "race the freeze trigger" attack: an empty
@@ -3504,12 +3537,12 @@ mod tests {
     #[test]
     fn canonicalize_ready_signal_rejects_empty_set() {
         let empty: [(AuthorityName, [u8; 32]); 0] = [];
-        let (outcome, diagnostics) = canonicalize_ready_signal_peers(&empty, |_| 1, 3);
+        let (outcome, diagnostics) = canonicalize_ready_signal_peers(&empty, |_| 1, 3, 100);
         assert!(matches!(
             outcome,
             CanonicalizeReadySignalOutcome::BelowQuorumCoverage { .. }
         ));
-        assert!(diagnostics.non_committee_dropped.is_empty());
+        assert!(diagnostics.non_committee_kept.is_empty());
         assert_eq!(diagnostics.duplicates_collapsed, 0);
     }
 
@@ -3533,13 +3566,79 @@ mod tests {
             ],
             |peer| if *peer == a || *peer == b { 1 } else { 0 },
             2, // quorum just low enough for `{a, b}` to clear
+            100,
         );
+        // Accepted: {a, b} cover quorum; `outsider` is kept (inert) and
+        // surfaced in diagnostics rather than dropped.
+        match outcome {
+            CanonicalizeReadySignalOutcome::Accept { validated_peers } => {
+                assert!(validated_peers.iter().any(|(name, _)| *name == outsider));
+            }
+            other => panic!("expected Accept, got {other:?}"),
+        }
+        assert_eq!(diagnostics.duplicates_collapsed, 2);
+        assert_eq!(diagnostics.non_committee_kept, vec![outsider]);
+    }
+
+    /// The V2 fix: a zero-weight (next-epoch joiner) peer is RETAINED in
+    /// the accepted set — canonicalization no longer consults any local
+    /// announcement table to decide whether to keep it — while coverage
+    /// is still measured on current-committee weight only, so the joiner
+    /// alone can't clear the quorum floor.
+    #[test]
+    fn canonicalize_ready_signal_retains_zero_weight_joiner() {
+        let (a, b, c) = (auth(0xAA), auth(0xBB), auth(0xCC));
+        let joiner = auth(0xF0);
+        let weight = |peer: &AuthorityName| if *peer == joiner { 0 } else { 1 };
+
+        // Committee {a,b,c} cover quorum 3; joiner is kept in the output.
+        let (outcome, _) = canonicalize_ready_signal_peers(
+            &[
+                (a, [0xAA; 32]),
+                (b, [0xBB; 32]),
+                (c, [0xCC; 32]),
+                (joiner, [0xF0; 32]),
+            ],
+            weight,
+            3,
+            100,
+        );
+        match outcome {
+            CanonicalizeReadySignalOutcome::Accept { validated_peers } => {
+                assert!(
+                    validated_peers.iter().any(|(name, _)| *name == joiner),
+                    "the zero-weight joiner must be retained"
+                );
+            }
+            other => panic!("expected Accept, got {other:?}"),
+        }
+
+        // A signal of ONLY zero-weight peers covers 0 stake → rejected.
+        let (only_joiners, _) =
+            canonicalize_ready_signal_peers(&[(joiner, [0xF0; 32])], weight, 3, 100);
         assert!(matches!(
-            outcome,
+            only_joiners,
+            CanonicalizeReadySignalOutcome::BelowQuorumCoverage { .. }
+        ));
+    }
+
+    /// A byzantine signer padding beyond the length cap is dropped; the
+    /// decision is a pure function of the (deduped) input length.
+    #[test]
+    fn canonicalize_ready_signal_over_cap_is_dropped() {
+        let peers: Vec<(AuthorityName, [u8; 32])> = (0u8..6).map(|i| (auth(i), [i; 32])).collect();
+        // cap 5, six distinct peers → OverCap.
+        let (over, _) = canonicalize_ready_signal_peers(&peers, |_| 1, 3, 5);
+        assert!(matches!(
+            over,
+            CanonicalizeReadySignalOutcome::OverCap { len: 6, cap: 5 }
+        ));
+        // At the cap (five peers) it is evaluated normally (Accept here).
+        let (at_cap, _) = canonicalize_ready_signal_peers(&peers[..5], |_| 1, 3, 5);
+        assert!(matches!(
+            at_cap,
             CanonicalizeReadySignalOutcome::Accept { .. }
         ));
-        assert_eq!(diagnostics.duplicates_collapsed, 2);
-        assert_eq!(diagnostics.non_committee_dropped, vec![outsider]);
     }
 
     /// Pure assertion of the "strict-superset re-emit" gate at

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -3322,6 +3322,86 @@ mod tests {
         );
     }
 
+    /// Full pipeline under the KEEP-zero-weight canonicalization:
+    /// canonicalize each inbound signal → tally the freeze partition →
+    /// carry forward stable mpc_data — with a joiner, a garbage name,
+    /// and a silent carried member all in play at once. This is the
+    /// population the determinism claim is about; the pure-helper tests
+    /// above each cover one stage in isolation.
+    ///
+    /// Committee: a, b, c, d (stake 1 each, quorum 3). d is silent this
+    /// epoch (restarting) but present in the prior cert. j is an
+    /// announced next-epoch joiner (zero current weight) attested by
+    /// all three live signers. g is a garbage name padded by ONE signer
+    /// only. Expected: a, b, c frozen at fresh hashes; j frozen at its
+    /// announced hash (quorum of signers attest it despite zero
+    /// weight); d frozen at its prior-cert digest via carry-forward;
+    /// g excluded (kept by canonicalization, never reaches quorum).
+    #[test]
+    fn canonicalize_tally_carry_forward_chain_keeps_joiner_and_carried_member() {
+        let (a, b, c, d) = (auth(0xAA), auth(0xBB), auth(0xCC), auth(0xDD));
+        let joiner = auth(0x1E);
+        let garbage = auth(0x6B);
+        let weight_of =
+            |peer: &AuthorityName| -> u64 { if [a, b, c, d].contains(peer) { 1 } else { 0 } };
+        let quorum = 3u64;
+        let cap = 16usize;
+
+        let honest_view = vec![
+            (a, [0x11; 32]),
+            (b, [0x22; 32]),
+            (c, [0x33; 32]),
+            (joiner, [0x77; 32]),
+        ];
+        let mut padded_view = honest_view.clone();
+        padded_view.push((garbage, [0x66; 32]));
+
+        // Canonicalize each signal exactly like the record path does.
+        let mut signals: BTreeMap<AuthorityName, Vec<(AuthorityName, [u8; 32])>> = BTreeMap::new();
+        for (signer, view) in [(a, &honest_view), (b, &honest_view), (c, &padded_view)] {
+            let (outcome, diagnostics) =
+                canonicalize_ready_signal_peers(view, weight_of, quorum, cap);
+            let CanonicalizeReadySignalOutcome::Accept { validated_peers } = outcome else {
+                panic!("honest signal with quorum coverage must canonicalize to Accept");
+            };
+            // Zero-weight names (joiner and, for c, the garbage pad) are
+            // KEPT in the canonical set.
+            assert!(
+                validated_peers.iter().any(|(peer, _)| *peer == joiner),
+                "the joiner must survive canonicalization"
+            );
+            assert!(!diagnostics.non_committee_kept.is_empty());
+            signals.insert(signer, validated_peers);
+        }
+
+        let attested = compute_freeze_partition(&signals, weight_of, quorum);
+        // Prior cert carries d (the silent continuing member) — and a for
+        // good measure, whose fresh attestation must win.
+        let prior: HashMap<_, _> = [(a, [0x99; 32]), (d, [0x44; 32])].into_iter().collect();
+        let committee = [a, b, c, d];
+        let partition = carry_forward_stable_mpc_data(attested, &committee, &prior);
+
+        let frozen_map: HashMap<AuthorityName, [u8; 32]> = partition.frozen.into_iter().collect();
+        assert_eq!(frozen_map.get(&a), Some(&[0x11; 32]), "fresh hash wins");
+        assert_eq!(frozen_map.get(&b), Some(&[0x22; 32]));
+        assert_eq!(frozen_map.get(&c), Some(&[0x33; 32]));
+        assert_eq!(
+            frozen_map.get(&joiner),
+            Some(&[0x77; 32]),
+            "a quorum-attested zero-weight joiner freezes at its announced hash"
+        );
+        assert_eq!(
+            frozen_map.get(&d),
+            Some(&[0x44; 32]),
+            "the silent continuing member freezes at its prior-cert digest"
+        );
+        assert_eq!(
+            partition.excluded,
+            vec![garbage],
+            "the kept-but-never-quorum garbage name is excluded, nothing else"
+        );
+    }
+
     /// Byzantine scenario: validator D serves bytes but they're
     /// malicious (don't decode to valid mpc_data). Honest validators
     /// drop D from their attestation, but byzantine D vouches for

--- a/dev-docs/specs/validator-mpc-data-announcements.md
+++ b/dev-docs/specs/validator-mpc-data-announcements.md
@@ -78,10 +78,23 @@ which bytes* deterministic in consensus order.
   announcement-table lookup. Coverage is measured on current-committee
   weight only, so a sparse signal still can't push the freeze trigger; a
   joiner is frozen only when a stake-quorum of signers attest it in the
-  tally (`compute_freeze_partition`). Kept non-committee names are inert
-  downstream (a garbage name never gets a stake-quorum of honest signers,
-  so it lands in `excluded`, which is consulted only by committee-member
-  key).
+  tally (`compute_freeze_partition`). Kept non-committee names cannot
+  reach the frozen set without a stake-quorum of signers, and the
+  assembly/reconfiguration consumers read the frozen/excluded sets by
+  committee-member key only — but they are NOT fully inert: a garbage
+  name lands durably in `epoch_excluded_validators` and inflates the
+  `dwallet_mpc_data_excluded_validators` gauge (operators alerting on it
+  should know), and each kept-but-never-quorum name holds the
+  full-coverage fast path open, so the freeze fires via the grace path
+  instead — one byzantine signer can force every epoch onto the grace
+  latency for free. Deterministic and bounded by the grace; this is the
+  price of keeping canonicalization a pure function of the sequenced
+  bytes (distinguishing garbage from a legitimately-propagating joiner
+  would require exactly the local state the rule above forbids). The
+  strict-superset re-emit gate also means each accepted REPLACE may swap
+  ALL of a signer's attested hashes — a byzantine signer buys up to
+  `cap − initial` accepted re-emits by growing its set one name at a
+  time; latest-row-wins keeps this deterministic.
 - **Freeze decision** (the commit-boundary rule): the frozen mpc-data
   input set is decided **in the consensus handler at a commit
   boundary**, never from a wall-clock loop — two honest validators must

--- a/dev-docs/specs/validator-mpc-data-announcements.md
+++ b/dev-docs/specs/validator-mpc-data-announcements.md
@@ -65,6 +65,23 @@ which bytes* deterministic in consensus order.
   strictly (the `sequence_number` exists so consensus dedup does not
   drop re-emits). Per-signer rows REPLACE — the latest signal from a
   signer is its current attestation.
+- **Receive-time canonicalization** (`canonicalize_ready_signal_peers`)
+  MUST be a pure function of the sequenced signal bytes: dedup by
+  authority, a current-committee quorum-coverage floor, and a
+  deterministic length cap (`K × current committee size`). It MUST NOT
+  consult the local announcements table or any `JoinerPubkeyProvider`
+  state — those are wall-clock-populated and would fork the persisted
+  canonical set across honest validators with different poll timing.
+  A next-epoch joiner (zero current-committee weight) survives
+  canonicalization because non-committee peers are **retained** in the
+  persisted `(peer, hash)` set (up to the cap), NOT because of an
+  announcement-table lookup. Coverage is measured on current-committee
+  weight only, so a sparse signal still can't push the freeze trigger; a
+  joiner is frozen only when a stake-quorum of signers attest it in the
+  tally (`compute_freeze_partition`). Kept non-committee names are inert
+  downstream (a garbage name never gets a stake-quorum of honest signers,
+  so it lands in `excluded`, which is consulted only by committee-member
+  key).
 - **Freeze decision** (the commit-boundary rule): the frozen mpc-data
   input set is decided **in the consensus handler at a commit
   boundary**, never from a wall-clock loop — two honest validators must
@@ -147,7 +164,12 @@ which bytes* deterministic in consensus order.
 1. Freeze decisions are pure functions of the consensus sequence
    (commit-boundary, persisted anchor rounds, atomic batch writes via
    `ConsensusCommitOutput`) — restart-safe and identical across honest
-   validators.
+   validators. This covers the **receive-time canonicalization** of each
+   ready signal, not only the freeze tally: the persisted
+   `validated_peers` set must be derivable from the sequenced signal
+   bytes alone. Reading any wall-clock-populated local table (the
+   announcements table, the `JoinerPubkeyProvider`) on this path forks
+   the persisted set and, through it, the freeze partition.
 2. Every blob reference is content-addressed; bytes are verified
    against their digest at every trust boundary (store insert, P2P
    fetch, assembly decode).


### PR DESCRIPTION
Track A consensus-determinism fix from the protocol-v4 gate list (see `dev-docs/plans/v4-activation-gate-list.md`). Precondition for V1's freeze determinism.

## The fork

`record_epoch_mpc_data_ready_signal` canonicalized the persisted `validated_peers` with a weight closure that consulted the local `validator_mpc_data_announcements` table: a next-epoch joiner (zero current-committee weight) was **kept only if present in that table**, otherwise **dropped**.

That table is populated for a relayed joiner announcement only after `verify_joiner_announcement` passes against the installed `JoinerPubkeyProvider` — a ~5s Sui-poll product installed on **wall-clock time** (buffered until then). So two honest validators processing the **same sequenced** ready signal persisted **different** canonical `validated_peers` depending on their provider-install timing: validator A (provider installed) keeps joiner J and can freeze it; validator B (provider lagging) drops J and excludes it. Divergent frozen set → divergent next-epoch committee mpc_data → forked reconfiguration participant set / handoff cert. This is exactly the taint `freeze_mpc_data_if_first` documents it avoids ("we deliberately do NOT read the local announcement table here") — laundered one step earlier, at receive-time canonicalization.

## The fix — pure function of the signal bytes

`canonicalize_ready_signal_peers` no longer consults any local table:
- **Keep** every deduped `(peer, hash)` pair — including zero-weight joiners — instead of dropping non-committee peers via the `announced`-table lookup. A joiner is frozen only when a stake-quorum of signers attest it in the tally (`compute_freeze_partition`); kept non-committee names are inert downstream (a garbage name never reaches a stake-quorum → lands in `excluded`, which is consulted only by committee-member key — verified).
- Measure quorum **coverage on current-committee weight only**, so a sparse signal still can't push the freeze trigger.
- A **deterministic length cap** (`K × current committee size`, K=4) bounds byzantine garbage padding; the deduped length is identical across honest validators, so the cap decision is itself consensus-deterministic.

Diagnostics `non_committee_dropped` → `non_committee_kept`; new `OverCap` outcome.

## Tests

Joiner retained in `Accept` while coverage stays committee-only; a signal of only zero-weight peers → `BelowQuorumCoverage`; over-cap dropped as a pure function of input length; the existing dedup/coverage/mixed-padding tests updated for the keep-not-drop semantics. All green.

## Spec

`validator-mpc-data-announcements.md`: receive-time canonicalization added to the ready-signal semantics and to invariant 1 (the "pure function of the consensus sequence" property now explicitly covers canonicalization, not just the freeze tally).

## Validation note

Per CLAUDE.md's reconfiguration/epoch-boundary rule, the determinism property (two validators with divergent provider timing persist byte-identical signals and compute the identical freeze partition) is validated by the **cluster suite** — the fault-injection scenario (force the provider absent on one node) is the pre-merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)