### PR TITLE
fix(v4): retry a failed NetworkKeyId derivation when its inputs change (networkkeyid Minor 1)

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -430,17 +430,57 @@ async fn unmapped_cert_referenced_key_defers_and_spawns_derivation() {
         "an unmapped cert-referenced key must be deferred, not adopted"
     );
     assert!(
-        manager.network_key_id_derivations_spawned.contains(&key_id),
+        manager
+            .network_key_id_derivations_spawned
+            .contains_key(&key_id),
         "the background NetworkKeyId derivation must be spawned for the unmapped key"
     );
 
-    // Same overlay again: the deferral must have skipped the memoization
-    // (so the pass re-evaluates) and must not respawn the derivation.
+    // Same overlay again (identical derivation inputs): the memo is keyed on
+    // the input digest, so an unchanged overlay must not respawn.
     manager.adopt_cert_verified_keys(&overlay);
     assert_eq!(
         manager.network_key_id_derivations_spawned.len(),
         1,
-        "the derivation must be spawned at most once per key"
+        "the derivation must not respawn for unchanged derivation inputs"
+    );
+
+    // Changed derivation inputs (a fresh reconfiguration output, as the
+    // overlay republishes during convergence) MUST re-spawn: the memo is
+    // keyed on the input digest, so a transient-input failure self-heals.
+    let mut changed_reconfiguration_output = reconfiguration_output.clone();
+    changed_reconfiguration_output.push(0xEE);
+    let changed_overlay = Arc::new(HashMap::from([(
+        key_id,
+        network_key_data(
+            key_id,
+            epoch_id,
+            dkg_output.clone(),
+            changed_reconfiguration_output,
+        ),
+    )]));
+    manager.adopt_cert_verified_keys(&changed_overlay);
+    assert_eq!(
+        manager.network_key_id_derivations_spawned.len(),
+        1,
+        "one key id, memoized by digest (the entry is replaced, not added)"
+    );
+    // The stored digest reflects the NEW inputs, proving a re-spawn happened.
+    let expected_digest = ika_network::mpc_artifacts::mpc_data_blob_hash(
+        &bcs::to_bytes(&(&dkg_output, &{
+            let mut r = reconfiguration_output.clone();
+            r.push(0xEE);
+            r
+        }))
+        .unwrap(),
+    );
+    assert_eq!(
+        manager
+            .network_key_id_derivations_spawned
+            .get(&key_id)
+            .copied(),
+        Some(expected_digest),
+        "changed inputs must update the memo digest (i.e. re-spawn the derivation)"
     );
 
     // Simulate the background derivation completing: registration alone —

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -304,11 +304,15 @@ pub(crate) struct DWalletMPCManager {
     warned_cert_digest_mismatches: HashSet<(ObjectID, [u8; 32])>,
 
     /// Keys whose background `NetworkKeyId` derivation has been spawned by
-    /// the adoption pass, so the expensive class-groups derive runs at most
-    /// once per key per manager (i.e. per epoch). A successful derivation
-    /// registers in the process-global mapping, so later epochs resolve the
-    /// key without re-deriving.
-    pub(crate) network_key_id_derivations_spawned: HashSet<ObjectID>,
+    /// the adoption pass, memoized by the digest of the exact derivation
+    /// inputs (DKG output + current reconfiguration output). The expensive
+    /// class-groups derive runs at most once per key per distinct input set:
+    /// a deterministic failure on unchanged inputs is not retried (no rayon
+    /// hammering), but a NEW reconfiguration output (the overlay republishes
+    /// during convergence) changes the digest and re-derives — so a
+    /// transient-input failure self-heals. A successful derivation registers
+    /// in the process-global mapping, short-circuiting before this gate.
+    pub(crate) network_key_id_derivations_spawned: HashMap<ObjectID, [u8; 32]>,
 
     /// Sessions whose protocol-cryptographic-data generation already
     /// failed and was logged. The generation re-runs every 20ms service
@@ -550,7 +554,7 @@ impl DWalletMPCManager {
             pending_network_key_instantiations: HashMap::new(),
             last_cert_read_warn: None,
             warned_cert_digest_mismatches: HashSet::new(),
-            network_key_id_derivations_spawned: HashSet::new(),
+            network_key_id_derivations_spawned: HashMap::new(),
             warned_cryptographic_data_generation_failures: HashSet::new(),
             last_failed_network_key_data: HashMap::new(),
             next_internal_presign_sequence_number: 1,
@@ -1114,7 +1118,23 @@ impl DWalletMPCManager {
             if network_key_id.is_none()
                 && (!dkg_digests.is_empty() || !reconfiguration_digests.is_empty())
             {
-                if self.network_key_id_derivations_spawned.insert(*key_id) {
+                // Memoize on the derivation inputs, not just the key id, so a
+                // failure while the overlay's reconfiguration output is
+                // transiently empty/incomplete is retried once the overlay
+                // republishes a different (complete) output — instead of
+                // being pinned to failure for the whole epoch.
+                let derivation_input_digest = mpc_data_blob_hash(
+                    &bcs::to_bytes(&(
+                        &data.network_dkg_public_output,
+                        &data.current_reconfiguration_public_output,
+                    ))
+                    .unwrap_or_default(),
+                );
+                if self.network_key_id_derivations_spawned.get(key_id)
+                    != Some(&derivation_input_digest)
+                {
+                    self.network_key_id_derivations_spawned
+                        .insert(*key_id, derivation_input_digest);
                     info!(
                         ?key_id,
                         "handoff cert references network keys but this key's ObjectID has \


### PR DESCRIPTION
Small, standalone item from the protocol-v4 gate list (`dev-docs/plans/v4-activation-gate-list.md`). Follow-up to #1789's on-demand NetworkKeyId derivation.

## The bug

The cert-anchored adoption pass gated the expensive background NetworkKeyId derivation on a bare ObjectID set (`network_key_id_derivations_spawned: HashSet<ObjectID>`, insert-once). The spawned derivation **can fail** (its `Err` arm only logs and never `register`s), so `network_key_id_for` keeps returning `None` and the pass re-enters the unmapped-key block every overlay republish (~5s) — but the insert-once memo **suppresses re-spawn**, pinning the key to failure for the whole epoch.

The derivation is input-dependent (empty reconfiguration output → DKG path; non-empty → reconfiguration path), and the overlay legitimately republishes partial blobs during convergence. So a failure while the reconfiguration output is transiently empty/incomplete never self-heals.

## The fix

Memoize on the derivation-**input digest**: `HashMap<ObjectID, [u8;32]>` keyed by `Blake2b256(bcs(dkg_output, reconfiguration_output))`. Re-spawn iff the memoized digest differs.

- A deterministic failure on unchanged inputs is still spawned at most once (no rayon hammering).
- A new reconfiguration output changes the digest and re-derives — a transient-input failure self-heals on the next republish.
- A success registers in the global map and short-circuits before the gate, so the memo only governs the retry-on-failure case (exactly the bug).

## Test

The existing `unmapped_cert_referenced_key_defers_and_spawns_derivation` integration test is extended: an unchanged overlay does not respawn (len stays 1); a changed reconfiguration output updates the memo digest, proving a re-spawn happened. Green under real crypto.

> networkkeyid **Minor 2** (the barrier-side on-demand derivation, so an unmapped cert key isn't never-ready at the prepare-then-start barrier) folds into the barrier rewrite alongside V1/wedge/V4 per the cross-check, and is **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)