### PR TITLE
fix(v4): per-(key,curve,algorithm) internal-presign counters + consensus-agreed NOA key (multi-key-holes, expiry cross-key)

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -10,17 +10,14 @@ use crate::dwallet_mpc::integration_tests::utils::{
 use crate::dwallet_mpc::mpc_manager::ParkedInternalPresignRequest;
 use crate::dwallet_mpc::mpc_session::SessionStatus;
 use crate::dwallet_mpc::{NetworkOwnedAddressSignRequest, ValidatorMpcKeysByPartyId};
-use crate::network_key_id_mapping;
-use dwallet_mpc_types::dwallet_mpc::{
-    DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm, NetworkKeyId,
-};
+use dwallet_mpc_types::dwallet_mpc::{DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm};
 use ika_protocol_config::ProtocolConfig;
 use ika_types::message::DWalletCheckpointMessageKind;
 use ika_types::messages_dwallet_mpc::{
     DWalletNetworkEncryptionKeyData, DWalletNetworkEncryptionKeyState, SessionIdentifier,
     SessionType,
 };
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 use sui_types::base_types::ObjectID;
 use tracing::info;
@@ -72,11 +69,17 @@ const TEST_STALE_BATCH_EXPIRY_ROUNDS: u64 = 12;
 fn presign_batch_counters(
     test_state: &IntegrationTestState,
     service_index: usize,
-    network_key_id: ObjectID,
+    network_key_object_id: ObjectID,
     curve: DWalletCurve,
     algorithm: DWalletSignatureAlgorithm,
 ) -> (u64, u64) {
     let manager = test_state.dwallet_mpc_services[service_index].dwallet_mpc_manager();
+    // The counters are keyed by the content-derived NetworkKeyId; resolve it
+    // from the key's ObjectID the same way production does.
+    let Some(network_key_id) = manager.internal_presign_network_key_id(&network_key_object_id)
+    else {
+        return (0, 0);
+    };
     (
         manager
             .instantiated_internal_presign_sessions
@@ -360,17 +363,8 @@ async fn test_internal_presign_instantiation_at_correct_rounds() {
         let pre_loop_snapshots: Vec<_> = ALL_ALGORITHMS
             .iter()
             .map(|(curve, algorithm)| {
-                let manager = test_state.dwallet_mpc_services[0].dwallet_mpc_manager();
-                let instantiated = manager
-                    .instantiated_internal_presign_sessions
-                    .get(&(network_key_id, *curve, *algorithm))
-                    .copied()
-                    .unwrap_or(0);
-                let completed = manager
-                    .completed_internal_presign_sessions
-                    .get(&(network_key_id, *curve, *algorithm))
-                    .copied()
-                    .unwrap_or(0);
+                let (instantiated, completed) =
+                    presign_batch_counters(&test_state, 0, network_key_id, *curve, *algorithm);
                 let pool_size = test_state.epoch_stores[0]
                     .presign_pool_size(*algorithm, network_key_id)
                     .unwrap_or(0);
@@ -401,12 +395,8 @@ async fn test_internal_presign_instantiation_at_correct_rounds() {
             let sessions_to_instantiate =
                 TEST_NETWORK_OWNED_ADDRESS_SIGN_PRESIGN_SESSIONS_TO_INSTANTIATE;
 
-            let post_instantiated = test_state.dwallet_mpc_services[0]
-                .dwallet_mpc_manager()
-                .instantiated_internal_presign_sessions
-                .get(&(network_key_id, *curve, *algorithm))
-                .copied()
-                .unwrap_or(0);
+            let post_instantiated =
+                presign_batch_counters(&test_state, 0, network_key_id, *curve, *algorithm).0;
             let delta_instantiated = post_instantiated - pre_instantiated;
 
             // Predict using exactly the state step 3 saw:
@@ -453,18 +443,8 @@ async fn test_internal_presign_instantiation_at_correct_rounds() {
 
     // Final: all 4 services must agree on instantiated/completed counters.
     for (curve, algorithm) in ALL_ALGORITHMS {
-        let reference_instantiated = test_state.dwallet_mpc_services[0]
-            .dwallet_mpc_manager()
-            .instantiated_internal_presign_sessions
-            .get(&(network_key_id, *curve, *algorithm))
-            .copied()
-            .unwrap_or(0);
-        let reference_completed = test_state.dwallet_mpc_services[0]
-            .dwallet_mpc_manager()
-            .completed_internal_presign_sessions
-            .get(&(network_key_id, *curve, *algorithm))
-            .copied()
-            .unwrap_or(0);
+        let (reference_instantiated, reference_completed) =
+            presign_batch_counters(&test_state, 0, network_key_id, *curve, *algorithm);
 
         // Monotonic invariant.
         assert!(
@@ -477,19 +457,14 @@ async fn test_internal_presign_instantiation_at_correct_rounds() {
         );
 
         // Cross-service consistency.
-        for (service_idx, service) in test_state.dwallet_mpc_services.iter().enumerate().skip(1) {
-            let instantiated = service
-                .dwallet_mpc_manager()
-                .instantiated_internal_presign_sessions
-                .get(&(network_key_id, *curve, *algorithm))
-                .copied()
-                .unwrap_or(0);
-            let completed = service
-                .dwallet_mpc_manager()
-                .completed_internal_presign_sessions
-                .get(&(network_key_id, *curve, *algorithm))
-                .copied()
-                .unwrap_or(0);
+        for (service_idx, _service) in test_state.dwallet_mpc_services.iter().enumerate().skip(1) {
+            let (instantiated, completed) = presign_batch_counters(
+                &test_state,
+                service_idx,
+                network_key_id,
+                *curve,
+                *algorithm,
+            );
             assert_eq!(
                 instantiated, reference_instantiated,
                 "{:?}/{:?}: service {} instantiated ({}) != service 0 ({})",
@@ -869,16 +844,12 @@ async fn test_internal_presign_continues_when_idle() {
     // Verify idle-fill triggered for all algorithms by checking instantiation counts.
     // We can't assert pool sizes because ECDSA presigns are multi-round with class
     // groups — EdDSA reaches max before ECDSA sessions complete enough batches.
-    let manager = test_state.dwallet_mpc_services[0].dwallet_mpc_manager();
     for (curve, algorithm) in ALL_ALGORITHMS {
         if *curve == DWalletCurve::Curve25519 && *algorithm == DWalletSignatureAlgorithm::EdDSA {
             continue; // Already verified above.
         }
-        let instantiated = manager
-            .instantiated_internal_presign_sessions
-            .get(&(network_key_id, *curve, *algorithm))
-            .copied()
-            .unwrap_or(0);
+        let instantiated =
+            presign_batch_counters(&test_state, 0, network_key_id, *curve, *algorithm).0;
         assert!(
             instantiated > 0,
             "{:?}/{:?}: idle-fill should have instantiated at least one presign session (got={})",
@@ -1180,13 +1151,14 @@ fn bound_internal_presign_sessions(
 /// sequence numbers consumed — instead of skipping them — so session
 /// identifier derivation stays committee-uniform.
 ///
-/// The internal presign sequence counter is a single counter shared across
-/// all pools and keys, and the top-up loop iterates every ADOPTED key while
-/// installation into `network_keys` completes asynchronously per validator.
-/// Before the fix, a validator in the adopted-but-not-installed window
-/// early-returned without consuming the sequence number (while the caller
-/// still advanced the instantiated counter) — permanently desynchronizing
-/// every subsequent internal presign identifier from its peers'.
+/// The internal presign sequence counters are keyed per (network key, curve,
+/// signature algorithm) pool, and the top-up loop iterates every ADOPTED key
+/// while installation into `network_keys` completes asynchronously per
+/// validator. Before the fix, a validator in the adopted-but-not-installed
+/// window early-returned without consuming the sequence number (while the
+/// caller still advanced the instantiated counter) — permanently
+/// desynchronizing every subsequent internal presign identifier in that pool
+/// from its peers'.
 ///
 /// Flow:
 /// 1. K0 bootstraps normally; K1 is a second same-epoch DKG (both adopted +
@@ -1202,11 +1174,12 @@ fn bound_internal_presign_sessions(
 ///    and the bound identifier→sequence maps converge to equality across all
 ///    validators, with no terminally-Failed session anywhere.
 /// 5. Coda: a fabricated key that is adopted but has NO installed data and NO
-///    `ObjectID → NetworkKeyId` mapping anywhere exercises the
-///    `AwaitingKeyIdentity` parking (sequence reserved, request not yet
-///    buildable), then a registered mapping transitions those entries to
-///    fully-built parked requests with identical identifiers on every
-///    validator.
+///    `ObjectID → NetworkKeyId` mapping anywhere has an unresolvable
+///    content-derived `NetworkKeyId`, so the top-up loop SKIPS it uniformly on
+///    every validator — no batch parked, no sequence number consumed, no
+///    session failed. (Adoption defers an unmapped key in production, so this
+///    is a should-never-happen the loop must handle deterministically rather
+///    than fall back to a divergent identity.)
 #[tokio::test]
 #[cfg(test)]
 async fn test_internal_presign_multi_key_install_lag_keeps_identifiers_uniform() {
@@ -1420,12 +1393,23 @@ async fn test_internal_presign_multi_key_install_lag_keeps_identifiers_uniform()
         }
     }
 
-    // === Phase 4: coda — a key with NO derivable identity anywhere ===
-    // Adopted on every validator, junk DKG bytes (its installation fails, so
-    // it never registers an `ObjectID → NetworkKeyId` mapping): top-ups for
-    // its pools must park `AwaitingKeyIdentity` with the sequence number
-    // reserved, uniformly across validators.
-    let k2_id = ObjectID::random();
+    // === Phase 4: coda — an adopted key with NO resolvable NetworkKeyId ===
+    // Adopted on every validator, junk DKG bytes so its installation fails,
+    // and a random id that never underwent DKG so no `ObjectID → NetworkKeyId`
+    // mapping exists for it anywhere. The session identifier and the per-pool
+    // counters both key by the content-derived `NetworkKeyId`, which is
+    // therefore unresolvable — the top-up loop must SKIP the key uniformly (a
+    // should-never-happen: adoption defers an unmapped key in production), not
+    // park it, fail it, or move any counter. Force k2_id above k1_id so the
+    // NOA-key tie-break still keeps K0 as the signing key (equal
+    // `dkg_at_epoch` → smallest id wins) and this coda leaves the pool roles
+    // established above untouched.
+    let k2_id = loop {
+        let candidate = ObjectID::random();
+        if candidate > k1_id {
+            break candidate;
+        }
+    };
     for service in test_state.dwallet_mpc_services.iter_mut() {
         service
             .dwallet_mpc_manager_mut()
@@ -1442,34 +1426,35 @@ async fn test_internal_presign_multi_key_install_lag_keeps_identifiers_uniform()
                 },
             );
     }
-
-    // (sequence number, curve, algorithm) of the K2 batches awaiting identity,
-    // per validator — reservation uniformity is the property under test.
-    let awaiting_identity_reservations =
-        |test_state: &IntegrationTestState,
-         service_index: usize|
-         -> BTreeSet<(u64, DWalletCurve, DWalletSignatureAlgorithm)> {
-            test_state.dwallet_mpc_services[service_index]
+    // Sanity: the key really is unresolvable on every validator (no installed
+    // data, no mapping), so the skip branch is the one under test.
+    for (service_index, service) in test_state.dwallet_mpc_services.iter().enumerate() {
+        assert!(
+            service
                 .dwallet_mpc_manager()
-                .internal_presign_requests_pending_for_network_key_data
-                .iter()
-                .filter_map(|parked| match parked {
-                    ParkedInternalPresignRequest::AwaitingKeyIdentity {
-                        session_sequence_number,
-                        dwallet_network_encryption_key_id,
-                        curve,
-                        signature_algorithm,
-                    } if *dwallet_network_encryption_key_id == k2_id => {
-                        Some((*session_sequence_number, *curve, *signature_algorithm))
-                    }
-                    _ => None,
-                })
-                .collect()
-        };
+                .internal_presign_network_key_id(&k2_id)
+                .is_none(),
+            "validator {service_index}: K2 must have no resolvable NetworkKeyId"
+        );
+    }
 
-    let mut identity_parking_uniform = false;
-    for _ in 0..30 {
+    // Counts K2-referencing parked batches on one validator — must stay zero
+    // (the key is skipped before any request is built, so it never parks).
+    let k2_parked_count = |test_state: &IntegrationTestState, service_index: usize| -> usize {
+        test_state.dwallet_mpc_services[service_index]
+            .dwallet_mpc_manager()
+            .internal_presign_requests_pending_for_network_key_data
+            .iter()
+            .filter(|ParkedInternalPresignRequest(request)| {
+                request.protocol_data.network_encryption_key_id() == Some(k2_id)
+            })
+            .count()
+    };
+    for _ in 0..3 {
         run_one_round_delivering_messages(&mut test_state).await;
+        // The unresolvable key contributes nothing on any validator, so the
+        // per-pool sequence counters (advanced only by the installed K0/K1
+        // pools) stay identical committee-wide — the whole test's invariant.
         let reference_next_sequence_number = test_state.dwallet_mpc_services[0]
             .dwallet_mpc_manager()
             .next_internal_presign_sequence_number
@@ -1480,74 +1465,25 @@ async fn test_internal_presign_multi_key_install_lag_keeps_identifiers_uniform()
                     .dwallet_mpc_manager()
                     .next_internal_presign_sequence_number,
                 reference_next_sequence_number,
-                "validator {service_index}: sequence counter diverged for the identity-less key"
+                "validator {service_index}: sequence counters diverged after adopting the \
+                 unresolvable key"
+            );
+            assert_eq!(
+                k2_parked_count(&test_state, service_index),
+                0,
+                "validator {service_index}: an unresolvable adopted key must be skipped, not parked"
             );
             assert_eq!(
                 failed_session_count(&test_state, service_index),
                 0,
-                "validator {service_index}: an underivable key identity must park, not fail"
+                "validator {service_index}: an unresolvable adopted key must not fail a session"
             );
         }
-        let reference = awaiting_identity_reservations(&test_state, 0);
-        let uniform = !reference.is_empty()
-            && (1..test_state.dwallet_mpc_services.len()).all(|service_index| {
-                awaiting_identity_reservations(&test_state, service_index) == reference
-            });
-        if uniform {
-            identity_parking_uniform = true;
-            break;
-        }
-    }
-    assert!(
-        identity_parking_uniform,
-        "every validator must reserve identical (sequence, curve, algorithm) for the \
-         identity-less key's parked batches"
-    );
-
-    // Register a mapping for K2: the parked reservations must transition to
-    // fully-built requests — derived from the RESERVED sequence numbers —
-    // with byte-identical session identifiers on every validator (they stay
-    // parked as requests: the key still has no installed data).
-    network_key_id_mapping::register(k2_id, NetworkKeyId([0xAB; 32]));
-    for _ in 0..3 {
-        run_one_round_delivering_messages(&mut test_state).await;
-    }
-    let k2_request_identifiers =
-        |test_state: &IntegrationTestState, service_index: usize| -> BTreeSet<SessionIdentifier> {
-            test_state.dwallet_mpc_services[service_index]
-                .dwallet_mpc_manager()
-                .internal_presign_requests_pending_for_network_key_data
-                .iter()
-                .filter_map(|parked| match parked {
-                    ParkedInternalPresignRequest::Request(request)
-                        if request.protocol_data.network_encryption_key_id() == Some(k2_id) =>
-                    {
-                        Some(request.session_identifier)
-                    }
-                    _ => None,
-                })
-                .collect()
-        };
-    let reference_identifiers = k2_request_identifiers(&test_state, 0);
-    assert!(
-        !reference_identifiers.is_empty(),
-        "the registered mapping must let the reserved batches build their requests"
-    );
-    for service_index in 0..test_state.dwallet_mpc_services.len() {
-        assert!(
-            awaiting_identity_reservations(&test_state, service_index).is_empty(),
-            "validator {service_index}: no reservation may remain once the identity is derivable"
-        );
-        assert_eq!(
-            k2_request_identifiers(&test_state, service_index),
-            reference_identifiers,
-            "validator {service_index}: deferred-built requests must derive identical \
-             session identifiers from the reserved sequence numbers"
-        );
     }
 
     info!(
         "Test completed: multi-key install lag parks internal presign batches with sequence \
-         numbers consumed, keeping identifier derivation committee-uniform"
+         numbers consumed, and an unresolvable adopted key is skipped uniformly, keeping \
+         identifier derivation committee-uniform"
     );
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -68,10 +68,11 @@ const ALL_ALGORITHMS: &[(DWalletCurve, DWalletSignatureAlgorithm)] = &[
 const TEST_STALE_BATCH_EXPIRY_ROUNDS: u64 = 12;
 
 /// Reads the (instantiated, completed) internal-presign counters of one
-/// service for one (curve, algorithm) pair.
+/// service for one (network key, curve, algorithm) pool.
 fn presign_batch_counters(
     test_state: &IntegrationTestState,
     service_index: usize,
+    network_key_id: ObjectID,
     curve: DWalletCurve,
     algorithm: DWalletSignatureAlgorithm,
 ) -> (u64, u64) {
@@ -79,12 +80,12 @@ fn presign_batch_counters(
     (
         manager
             .instantiated_internal_presign_sessions
-            .get(&(curve, algorithm))
+            .get(&(network_key_id, curve, algorithm))
             .copied()
             .unwrap_or(0),
         manager
             .completed_internal_presign_sessions
-            .get(&(curve, algorithm))
+            .get(&(network_key_id, curve, algorithm))
             .copied()
             .unwrap_or(0),
     )
@@ -180,7 +181,8 @@ async fn test_internal_presign_stale_batch_expiry() {
     let mut batch_seen = false;
     for _ in 0..12 {
         run_one_round_discarding_all_messages(&mut test_state).await;
-        let (instantiated, completed) = presign_batch_counters(&test_state, 0, curve, algorithm);
+        let (instantiated, completed) =
+            presign_batch_counters(&test_state, 0, network_key_id, curve, algorithm);
         if instantiated > 0 {
             assert_eq!(instantiated, batch_size, "exactly one batch should fire");
             assert_eq!(completed, 0, "the dead batch must never complete");
@@ -196,7 +198,8 @@ async fn test_internal_presign_stale_batch_expiry() {
     // regardless of that lag.
     for round_offset in 0..(TEST_STALE_BATCH_EXPIRY_ROUNDS - 3) {
         run_one_round_discarding_all_messages(&mut test_state).await;
-        let (instantiated, completed) = presign_batch_counters(&test_state, 0, curve, algorithm);
+        let (instantiated, completed) =
+            presign_batch_counters(&test_state, 0, network_key_id, curve, algorithm);
         assert_eq!(
             (instantiated, completed),
             (batch_size, 0),
@@ -209,7 +212,8 @@ async fn test_internal_presign_stale_batch_expiry() {
     let mut refired = false;
     for _ in 0..(TEST_STALE_BATCH_EXPIRY_ROUNDS + 10) {
         run_one_round_discarding_all_messages(&mut test_state).await;
-        let (instantiated, _) = presign_batch_counters(&test_state, 0, curve, algorithm);
+        let (instantiated, _) =
+            presign_batch_counters(&test_state, 0, network_key_id, curve, algorithm);
         if instantiated > batch_size {
             refired = true;
             break;
@@ -221,7 +225,7 @@ async fn test_internal_presign_stale_batch_expiry() {
     );
     for service_index in 0..test_state.dwallet_mpc_services.len() {
         let (instantiated, completed) =
-            presign_batch_counters(&test_state, service_index, curve, algorithm);
+            presign_batch_counters(&test_state, service_index, network_key_id, curve, algorithm);
         assert_eq!(
             (instantiated, completed),
             (batch_size * 2, batch_size),
@@ -237,7 +241,8 @@ async fn test_internal_presign_stale_batch_expiry() {
         pool_size = test_state.epoch_stores[0]
             .presign_pool_size(algorithm, network_key_id)
             .unwrap_or(0);
-        let (instantiated, completed) = presign_batch_counters(&test_state, 0, curve, algorithm);
+        let (instantiated, completed) =
+            presign_batch_counters(&test_state, 0, network_key_id, curve, algorithm);
         if pool_size > 0 && instantiated == completed {
             break;
         }
@@ -249,10 +254,10 @@ async fn test_internal_presign_stale_batch_expiry() {
 
     // Final cross-service consistency: instantiation is consensus-driven, so
     // every validator must hold identical counters.
-    let reference = presign_batch_counters(&test_state, 0, curve, algorithm);
+    let reference = presign_batch_counters(&test_state, 0, network_key_id, curve, algorithm);
     for service_index in 1..test_state.dwallet_mpc_services.len() {
         assert_eq!(
-            presign_batch_counters(&test_state, service_index, curve, algorithm),
+            presign_batch_counters(&test_state, service_index, network_key_id, curve, algorithm),
             reference,
             "service {service_index}: counters diverged from service 0"
         );
@@ -358,12 +363,12 @@ async fn test_internal_presign_instantiation_at_correct_rounds() {
                 let manager = test_state.dwallet_mpc_services[0].dwallet_mpc_manager();
                 let instantiated = manager
                     .instantiated_internal_presign_sessions
-                    .get(&(*curve, *algorithm))
+                    .get(&(network_key_id, *curve, *algorithm))
                     .copied()
                     .unwrap_or(0);
                 let completed = manager
                     .completed_internal_presign_sessions
-                    .get(&(*curve, *algorithm))
+                    .get(&(network_key_id, *curve, *algorithm))
                     .copied()
                     .unwrap_or(0);
                 let pool_size = test_state.epoch_stores[0]
@@ -399,7 +404,7 @@ async fn test_internal_presign_instantiation_at_correct_rounds() {
             let post_instantiated = test_state.dwallet_mpc_services[0]
                 .dwallet_mpc_manager()
                 .instantiated_internal_presign_sessions
-                .get(&(*curve, *algorithm))
+                .get(&(network_key_id, *curve, *algorithm))
                 .copied()
                 .unwrap_or(0);
             let delta_instantiated = post_instantiated - pre_instantiated;
@@ -451,13 +456,13 @@ async fn test_internal_presign_instantiation_at_correct_rounds() {
         let reference_instantiated = test_state.dwallet_mpc_services[0]
             .dwallet_mpc_manager()
             .instantiated_internal_presign_sessions
-            .get(&(*curve, *algorithm))
+            .get(&(network_key_id, *curve, *algorithm))
             .copied()
             .unwrap_or(0);
         let reference_completed = test_state.dwallet_mpc_services[0]
             .dwallet_mpc_manager()
             .completed_internal_presign_sessions
-            .get(&(*curve, *algorithm))
+            .get(&(network_key_id, *curve, *algorithm))
             .copied()
             .unwrap_or(0);
 
@@ -476,13 +481,13 @@ async fn test_internal_presign_instantiation_at_correct_rounds() {
             let instantiated = service
                 .dwallet_mpc_manager()
                 .instantiated_internal_presign_sessions
-                .get(&(*curve, *algorithm))
+                .get(&(network_key_id, *curve, *algorithm))
                 .copied()
                 .unwrap_or(0);
             let completed = service
                 .dwallet_mpc_manager()
                 .completed_internal_presign_sessions
-                .get(&(*curve, *algorithm))
+                .get(&(network_key_id, *curve, *algorithm))
                 .copied()
                 .unwrap_or(0);
             assert_eq!(
@@ -871,7 +876,7 @@ async fn test_internal_presign_continues_when_idle() {
         }
         let instantiated = manager
             .instantiated_internal_presign_sessions
-            .get(&(*curve, *algorithm))
+            .get(&(network_key_id, *curve, *algorithm))
             .copied()
             .unwrap_or(0);
         assert!(
@@ -947,7 +952,8 @@ async fn test_internal_presign_vss_parks_until_off_chain_keys_ingested() {
     // round. Verified here so the window below provably opens before the
     // first VSS batch.
     for (curve, algorithm) in VSS_ALGORITHMS {
-        let (instantiated, _) = presign_batch_counters(&test_state, 0, *curve, *algorithm);
+        let (instantiated, _) =
+            presign_batch_counters(&test_state, 0, network_key_id, *curve, *algorithm);
         assert_eq!(
             instantiated, 0,
             "{curve:?}/{algorithm:?}: no VSS batch should have fired before the first post-install round"
@@ -1006,7 +1012,13 @@ async fn test_internal_presign_vss_parks_until_off_chain_keys_ingested() {
         );
         for (curve, algorithm) in VSS_ALGORITHMS {
             assert_eq!(
-                presign_batch_counters(&test_state, service_index, *curve, *algorithm),
+                presign_batch_counters(
+                    &test_state,
+                    service_index,
+                    network_key_id,
+                    *curve,
+                    *algorithm
+                ),
                 (batch_size, 0),
                 "validator {service_index}: {curve:?}/{algorithm:?} batch must be counted \
                  instantiated exactly once while parked"
@@ -1031,7 +1043,13 @@ async fn test_internal_presign_vss_parks_until_off_chain_keys_ingested() {
         );
         for (curve, algorithm) in VSS_ALGORITHMS {
             assert_eq!(
-                presign_batch_counters(&test_state, service_index, *curve, *algorithm),
+                presign_batch_counters(
+                    &test_state,
+                    service_index,
+                    network_key_id,
+                    *curve,
+                    *algorithm
+                ),
                 (batch_size, 0),
                 "validator {service_index}: {curve:?}/{algorithm:?} guard must hold while parked"
             );
@@ -1071,8 +1089,13 @@ async fn test_internal_presign_vss_parks_until_off_chain_keys_ingested() {
         });
         let first_batches_completed = VSS_ALGORITHMS.iter().all(|(curve, algorithm)| {
             (0..test_state.dwallet_mpc_services.len()).all(|service_index| {
-                let (_, completed) =
-                    presign_batch_counters(&test_state, service_index, *curve, *algorithm);
+                let (_, completed) = presign_batch_counters(
+                    &test_state,
+                    service_index,
+                    network_key_id,
+                    *curve,
+                    *algorithm,
+                );
                 completed >= batch_size
             })
         });
@@ -1105,10 +1128,16 @@ async fn test_internal_presign_vss_parks_until_off_chain_keys_ingested() {
     // Cross-service counter consistency (identifier derivation is
     // committee-uniform, so the counters must be too).
     for (curve, algorithm) in VSS_ALGORITHMS {
-        let reference = presign_batch_counters(&test_state, 0, *curve, *algorithm);
+        let reference = presign_batch_counters(&test_state, 0, network_key_id, *curve, *algorithm);
         for service_index in 1..test_state.dwallet_mpc_services.len() {
             assert_eq!(
-                presign_batch_counters(&test_state, service_index, *curve, *algorithm),
+                presign_batch_counters(
+                    &test_state,
+                    service_index,
+                    network_key_id,
+                    *curve,
+                    *algorithm
+                ),
                 reference,
                 "validator {service_index}: {curve:?}/{algorithm:?} counters diverged from validator 0"
             );
@@ -1323,19 +1352,23 @@ async fn test_internal_presign_multi_key_install_lag_keeps_identifiers_uniform()
             );
         }
 
-        // THE invariant: the shared sequence counter reads identically on
+        // THE invariant: the per-pool sequence counters read identically on
         // every validator after every processed round — parking consumes the
-        // number, so even the validator missing K1's data stays in step.
+        // number, so even the validator missing K1's data stays in step. The
+        // whole per-(key,curve,algo) map must match (a stronger check than a
+        // single shared counter: it also proves no pool's stream leaked into
+        // another's).
         let reference_next_sequence_number = test_state.dwallet_mpc_services[0]
             .dwallet_mpc_manager()
-            .next_internal_presign_sequence_number;
+            .next_internal_presign_sequence_number
+            .clone();
         for (service_index, service) in test_state.dwallet_mpc_services.iter().enumerate() {
             assert_eq!(
                 service
                     .dwallet_mpc_manager()
                     .next_internal_presign_sequence_number,
                 reference_next_sequence_number,
-                "validator {service_index}: internal presign sequence counter diverged during \
+                "validator {service_index}: internal presign sequence counters diverged during \
                  the install-lag window"
             );
         }
@@ -1439,7 +1472,8 @@ async fn test_internal_presign_multi_key_install_lag_keeps_identifiers_uniform()
         run_one_round_delivering_messages(&mut test_state).await;
         let reference_next_sequence_number = test_state.dwallet_mpc_services[0]
             .dwallet_mpc_manager()
-            .next_internal_presign_sequence_number;
+            .next_internal_presign_sequence_number
+            .clone();
         for (service_index, service) in test_state.dwallet_mpc_services.iter().enumerate() {
             assert_eq!(
                 service

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -464,15 +464,17 @@ async fn unmapped_cert_referenced_key_defers_and_spawns_derivation() {
 /// sequence/guard counters and the session identifier both key by the
 /// content-derived `NetworkKeyId`, and the top-up loop treats an adopted
 /// key that does not resolve as a should-never-happen skip — so adoption
-/// (`adopt_cert_verified_keys`) must never admit an unmapped key while a
-/// prior-epoch cert references keys: it defers until the background
-/// derivation registers the `ObjectID → NetworkKeyId` mapping.
+/// (`adopt_cert_verified_keys`) must never admit an unmapped key on ANY
+/// adoption branch (cert-anchored or cert-less): it defers until the
+/// background derivation registers the `ObjectID → NetworkKeyId` mapping.
 ///
-/// Drives the REAL adoption path with a cert pinning two keys — one
-/// mapped, one not — and asserts the invariant over the whole adopted set
-/// after every pass. (The cert-less v3→v4-boundary adoption path is
-/// outside this gate by design: the keys crossing that boundary are the
-/// deployed ones, seeded into the mapping as constants.)
+/// Drives the REAL adoption path in two phases and asserts the invariant
+/// over the whole adopted set after every pass:
+/// 1. cert-anchored — a cert pins two keys, one mapped, one not;
+/// 2. cert-less (the v3/v3→v4-boundary path) — no cert at all, a fresh
+///    unmapped key must STILL defer (pre-fix it was blindly adopted, so on
+///    any fresh network's first v4 epoch the top-up loop's
+///    should-never-happen skip fired routinely).
 #[tokio::test]
 async fn adopted_keys_always_resolve_a_network_key_id() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
@@ -614,4 +616,56 @@ async fn adopted_keys_always_resolve_a_network_key_id() {
         "registration must let the deferred key be adopted on the next pass"
     );
     assert_all_adopted_resolve(manager, "after the registration pass");
+
+    // === Phase 2: the CERT-LESS adoption branch (v3 / v3→v4 boundary) ===
+    // Remove the cert entirely: a fresh unmapped key arriving through the
+    // cert-less path must be deferred exactly like the cert-anchored case —
+    // pre-fix this branch blindly adopted it, violating the invariant on any
+    // fresh network's first v4 epoch.
+    epoch_stores
+        .first()
+        .unwrap()
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .remove(&prior_epoch);
+    let certless_key_id = ObjectID::random();
+    let certless_network_key_id = NetworkKeyId([0x63; 32]);
+    let certless_dkg_output = b"certless key network dkg public output".to_vec();
+    let certless_reconfiguration_output = b"certless key reconfiguration public output".to_vec();
+    let certless_overlay = Arc::new(HashMap::from([(
+        certless_key_id,
+        network_key_data(
+            certless_key_id,
+            epoch_id,
+            certless_dkg_output.clone(),
+            certless_reconfiguration_output.clone(),
+        ),
+    )]));
+    let manager = service.dwallet_mpc_manager_mut();
+    manager.adopt_cert_verified_keys(&certless_overlay);
+    assert!(
+        !manager
+            .adopted_network_key_data
+            .contains_key(&certless_key_id),
+        "an unmapped key must be deferred on the CERT-LESS adoption branch too"
+    );
+    assert!(
+        manager
+            .network_key_id_derivations_spawned
+            .contains(&certless_key_id),
+        "the background NetworkKeyId derivation must be spawned for the cert-less unmapped key"
+    );
+    assert_all_adopted_resolve(manager, "after the cert-less deferral pass");
+
+    // Registration unwedges the cert-less branch the same way.
+    crate::network_key_id_mapping::register(certless_key_id, certless_network_key_id);
+    manager.adopt_cert_verified_keys(&certless_overlay);
+    assert!(
+        manager
+            .adopted_network_key_data
+            .contains_key(&certless_key_id),
+        "registration must let the cert-less deferred key be adopted on the next pass"
+    );
+    assert_all_adopted_resolve(manager, "after the cert-less registration pass");
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -457,3 +457,161 @@ async fn unmapped_cert_referenced_key_defers_and_spawns_derivation() {
         "the adopted data must carry the cert-pinned reconfiguration bytes"
     );
 }
+
+/// THE invariant the internal-presign top-up loop builds on: every key in
+/// `adopted_network_key_data` has a resolvable `NetworkKeyId`
+/// (`internal_presign_network_key_id` returns `Some`). The per-pool
+/// sequence/guard counters and the session identifier both key by the
+/// content-derived `NetworkKeyId`, and the top-up loop treats an adopted
+/// key that does not resolve as a should-never-happen skip — so adoption
+/// (`adopt_cert_verified_keys`) must never admit an unmapped key while a
+/// prior-epoch cert references keys: it defers until the background
+/// derivation registers the `ObjectID → NetworkKeyId` mapping.
+///
+/// Drives the REAL adoption path with a cert pinning two keys — one
+/// mapped, one not — and asserts the invariant over the whole adopted set
+/// after every pass. (The cert-less v3→v4-boundary adoption path is
+/// outside this gate by design: the keys crossing that boundary are the
+/// deployed ones, seeded into the mapping as constants.)
+#[tokio::test]
+async fn adopted_keys_always_resolve_a_network_key_id() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (
+        mut dwallet_mpc_services,
+        _sui_data_senders,
+        _sent_consensus_messages_collectors,
+        epoch_stores,
+        _notify_services,
+        _network_owned_address_sign_request_senders,
+        _network_owned_address_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services(1);
+    let service = dwallet_mpc_services.first_mut().unwrap();
+    let epoch_id = service.epoch;
+    let prior_epoch = epoch_id - 1;
+
+    // Two cert-pinned keys: one with a registered mapping, one without.
+    let mapped_key_id = ObjectID::random();
+    let mapped_network_key_id = NetworkKeyId([0x61; 32]);
+    crate::network_key_id_mapping::register(mapped_key_id, mapped_network_key_id);
+    let unmapped_key_id = ObjectID::random();
+    let unmapped_network_key_id = NetworkKeyId([0x62; 32]);
+
+    let mapped_dkg_output = b"mapped key network dkg public output".to_vec();
+    let mapped_reconfiguration_output = b"mapped key reconfiguration public output".to_vec();
+    let unmapped_dkg_output = b"unmapped key network dkg public output".to_vec();
+    let unmapped_reconfiguration_output = b"unmapped key reconfiguration public output".to_vec();
+
+    // Items sorted by `HandoffItemKey`'s derived `Ord` (all DKG items
+    // before all reconfiguration items, then by key id within a variant).
+    let mut dkg_items = vec![
+        (
+            HandoffItemKey::NetworkDkgOutput {
+                key_id: mapped_network_key_id,
+            },
+            mpc_data_blob_hash(&mapped_dkg_output),
+        ),
+        (
+            HandoffItemKey::NetworkDkgOutput {
+                key_id: unmapped_network_key_id,
+            },
+            mpc_data_blob_hash(&unmapped_dkg_output),
+        ),
+    ];
+    let mut reconfiguration_items = vec![
+        (
+            HandoffItemKey::NetworkReconfigurationOutput {
+                key_id: mapped_network_key_id,
+            },
+            mpc_data_blob_hash(&mapped_reconfiguration_output),
+        ),
+        (
+            HandoffItemKey::NetworkReconfigurationOutput {
+                key_id: unmapped_network_key_id,
+            },
+            mpc_data_blob_hash(&unmapped_reconfiguration_output),
+        ),
+    ];
+    dkg_items.sort_by(|(a, _), (b, _)| a.cmp(b));
+    reconfiguration_items.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let items = dkg_items.into_iter().chain(reconfiguration_items).collect();
+    let attestation = HandoffAttestation {
+        epoch: prior_epoch,
+        next_committee_pubkey_set_hash: [0u8; 32],
+        items,
+    };
+    epoch_stores
+        .first()
+        .unwrap()
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(
+            prior_epoch,
+            CertifiedHandoffAttestation {
+                attestation,
+                signatures: vec![],
+            },
+        );
+
+    let overlay = Arc::new(HashMap::from([
+        (
+            mapped_key_id,
+            network_key_data(
+                mapped_key_id,
+                epoch_id,
+                mapped_dkg_output.clone(),
+                mapped_reconfiguration_output.clone(),
+            ),
+        ),
+        (
+            unmapped_key_id,
+            network_key_data(
+                unmapped_key_id,
+                epoch_id,
+                unmapped_dkg_output.clone(),
+                unmapped_reconfiguration_output.clone(),
+            ),
+        ),
+    ]));
+    let manager = service.dwallet_mpc_manager_mut();
+
+    // The invariant checked after every pass: nothing enters the adopted
+    // set without a resolvable NetworkKeyId.
+    let assert_all_adopted_resolve =
+        |manager: &crate::dwallet_mpc::mpc_manager::DWalletMPCManager, pass: &str| {
+            for key_id in manager.adopted_network_key_data.keys() {
+                assert!(
+                    manager.internal_presign_network_key_id(key_id).is_some(),
+                    "{pass}: adopted key {key_id:?} has no resolvable NetworkKeyId — the \
+                 internal-presign top-up loop would hit its should-never-happen skip"
+                );
+            }
+        };
+
+    manager.adopt_cert_verified_keys(&overlay);
+    assert!(
+        manager
+            .adopted_network_key_data
+            .contains_key(&mapped_key_id),
+        "the mapped cert-matching key must be adopted"
+    );
+    assert!(
+        !manager
+            .adopted_network_key_data
+            .contains_key(&unmapped_key_id),
+        "the unmapped key must be deferred, not adopted"
+    );
+    assert_all_adopted_resolve(manager, "after the first pass");
+
+    // The background derivation lands: the unmapped key becomes mapped and
+    // the next pass adopts it. The invariant must hold over BOTH keys.
+    crate::network_key_id_mapping::register(unmapped_key_id, unmapped_network_key_id);
+    manager.adopt_cert_verified_keys(&overlay);
+    assert!(
+        manager
+            .adopted_network_key_data
+            .contains_key(&unmapped_key_id),
+        "registration must let the deferred key be adopted on the next pass"
+    );
+    assert_all_adopted_resolve(manager, "after the registration pass");
+}

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -320,9 +320,13 @@ pub(crate) struct DWalletMPCManager {
     /// cert-gated and not round-uniform) would shift every other pool's
     /// sequence numbers, so the session identifiers — bound to the sequence
     /// number — diverge and never reach quorum. Per-pool counters make each
-    /// pool's stream a pure function of that pool's own consensus-agreed
-    /// inputs: a late-adopted key simply starts fresh at 1 whenever it
-    /// starts, identically on every validator.
+    /// pool's ordinal stream start-time-invariant: a late-adopted key simply
+    /// starts fresh at 1 whenever it starts, identically on every validator —
+    /// PROVIDED the start skew stays under one batch lifecycle. A validator
+    /// entering a pool only after a full batch quorum-completed elsewhere
+    /// (mid-epoch restart, very late install) is permanently ordinal-offset
+    /// for that pool; see the top-up loop comment for the scope and the
+    /// tracked fast-forward heal.
     pub(crate) next_internal_presign_sequence_number:
         HashMap<(NetworkKeyId, DWalletCurve, DWalletSignatureAlgorithm), u64>,
 
@@ -1060,7 +1064,7 @@ impl DWalletMPCManager {
             }
         }
         let off_chain_on = self.epoch_store.off_chain_validator_metadata_enabled();
-        let mut deferred_unmapped_cert_key = false;
+        let mut deferred_unmapped_key = false;
         for (key_id, data) in overlay.iter() {
             if data.network_dkg_public_output.is_empty() {
                 continue; // nothing computed/fetched locally yet
@@ -1101,31 +1105,37 @@ impl DWalletMPCManager {
                 }
             }
             let local_dkg_digest = mpc_data_blob_hash(&data.network_dkg_public_output);
-            // The cert is keyed by the content-derived NetworkKeyId; translate
-            // this overlay key's ObjectID via the temporary map. An unmapped
-            // key is ambiguous: a brand-new key the prior epoch's cert never
-            // references (genuinely not-pinned), or a key this validator
-            // simply never instantiated — the mapping registers at
-            // instantiation, instantiation needs adoption, and adoption
-            // needs the mapping to see the cert's digests. A joiner
-            // consuming the cert lands in exactly that cycle: treating its
-            // key as "not pinned" either adopts parameters the committee
-            // never agreed to (initial-DKG branch) or wedges forever on a
-            // phantom digest mismatch (reconfigured branch). When the cert
-            // references any key, break the cycle: derive this key's
-            // NetworkKeyId from the locally-held blobs on the rayon pool
-            // (an expensive class-groups computation) and defer adoption
-            // until the background derivation registers the mapping.
+            // Adoption is what upholds the invariant the rest of the manager
+            // builds on: EVERY adopted key has a resolvable content-derived
+            // `NetworkKeyId` (the cert digests, the internal-presign per-pool
+            // counters, and the session identifiers all key by it). An
+            // unmapped key therefore defers on EVERY adoption branch — not
+            // only when the cert references keys. The cert-referenced case is
+            // additionally a correctness cycle: the mapping registers at
+            // instantiation, instantiation needs adoption, and adoption needs
+            // the mapping to see the cert's digests — a joiner consuming the
+            // cert lands exactly there, and treating its key as "not pinned"
+            // either adopts parameters the committee never agreed to
+            // (initial-DKG branch) or wedges forever on a phantom digest
+            // mismatch (reconfigured branch). The cert-less case (v3, the
+            // v3→v4 boundary, a fresh key before any cert pins it) would
+            // otherwise adopt an unresolvable key and make the top-up loop's
+            // should-never-happen skip fire routinely on fresh networks.
+            // Break the cycle the same way in both cases: derive this key's
+            // NetworkKeyId from the locally-held blobs on the rayon pool (an
+            // expensive class-groups computation) and defer adoption until
+            // the background derivation registers the mapping. (Deployed
+            // mainnet/testnet keys are seeded into the mapping as constants
+            // and never defer; a fresh DKG registers at output processing on
+            // every validator, so this defer is rare and short.)
             let network_key_id = crate::network_key_id_mapping::network_key_id_for(key_id);
-            if network_key_id.is_none()
-                && (!dkg_digests.is_empty() || !reconfiguration_digests.is_empty())
-            {
+            if network_key_id.is_none() {
                 if self.network_key_id_derivations_spawned.insert(*key_id) {
                     info!(
                         ?key_id,
-                        "handoff cert references network keys but this key's ObjectID has \
-                         no NetworkKeyId mapping (not seeded, never instantiated here) — \
-                         deriving it from the locally-held key data in the background"
+                        "adopting a network key whose ObjectID has no NetworkKeyId mapping \
+                         (not seeded, never instantiated here) — deferring adoption and \
+                         deriving the id from the locally-held key data in the background"
                     );
                     spawn_network_key_id_registration(
                         *key_id,
@@ -1133,7 +1143,7 @@ impl DWalletMPCManager {
                         data.current_reconfiguration_public_output.clone(),
                     );
                 }
-                deferred_unmapped_cert_key = true;
+                deferred_unmapped_key = true;
                 continue;
             }
             let cert_dkg_digest = network_key_id.as_ref().and_then(|id| dkg_digests.get(id));
@@ -1377,7 +1387,7 @@ impl DWalletMPCManager {
         // gains an entry) — memoizing would make the deferral permanent.
         // Skip the memo so the pass re-runs every tick until the mapping
         // resolves.
-        if deferred_unmapped_cert_key {
+        if deferred_unmapped_key {
             return;
         }
         self.last_adoption_input = Some((overlay.clone(), cert.is_some()));
@@ -1687,9 +1697,19 @@ impl DWalletMPCManager {
         // counters are now PER (key, curve, algorithm) pool (not a single shared
         // counter consumed in iteration order), so a pool's sequence stream no
         // longer depends on when other keys are adopted or the iteration order.
-        // Each pool's stream is a pure function of that pool's own consensus-
-        // agreed inputs, so a key adopted at a different round on different
-        // validators still derives identical session identifiers for its pool.
+        // Per-pool ordinals are START-TIME-INVARIANT: a key adopted at a
+        // different round on different validators still derives identical
+        // session identifiers for its pool, as long as the skew stays under
+        // one batch lifecycle. A validator whose first top-up of a pool lags
+        // past a full batch's quorum completion (mid-epoch restart replaying
+        // rounds before adoption lands, a very late install) starts its
+        // ordinal stream offset from its peers' and never converges — it sits
+        // out that pool's live sessions for the rest of the epoch (peers'
+        // quorum keeps the pool serving; the loss is this validator's
+        // redundancy). The heal — fast-forwarding the pool counter from the
+        // completed sequence numbers observed in consensus outputs — is
+        // tracked as follow-up work; the same exposure existed with the old
+        // shared counter, with cross-pool blast radius on top.
         let agreed_key_ids: BTreeSet<_> = self.adopted_network_key_data.keys().copied().collect();
         let mut pools_filled: Vec<String> = Vec::new();
         for key_id in agreed_key_ids {
@@ -1873,13 +1893,17 @@ impl DWalletMPCManager {
         &self,
         dwallet_network_encryption_key_id: &ObjectID,
     ) -> Option<NetworkKeyId> {
-        match self
-            .network_keys
+        // Installed data first; on either "not installed" OR a (deterministic,
+        // committee-uniform) derivation failure from the installed data, fall
+        // through to the mapping — the doc contract is "installed data when
+        // available, ELSE the mapping", and the mapping entry (seeded,
+        // registered at DKG output processing, or background-derived) is the
+        // same identity the installed data would derive.
+        self.network_keys
             .get_network_encryption_key_public_data(dwallet_network_encryption_key_id)
-        {
-            Ok(key_data) => key_data.network_key_id().ok(),
-            Err(_) => network_key_id_for(dwallet_network_encryption_key_id),
-        }
+            .ok()
+            .and_then(|key_data| key_data.network_key_id().ok())
+            .or_else(|| network_key_id_for(dwallet_network_encryption_key_id))
     }
 
     fn instantiate_internal_presign_session(

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -101,33 +101,21 @@ fn compute_chain_context<C: CounterpartyChain>(
     }
 }
 
-/// An internal presign session deferred because its network key's data is not
-/// locally available yet. In BOTH shapes the session sequence number was
-/// already consumed at instantiation, so identifier derivation and the batch
-/// counters stay committee-uniform; parking defers only this validator's
-/// participation. Entries retry once per service iteration.
+/// An internal presign session that was BUILT (its session identifier is
+/// fixed) but whose MPC input could not be constructed yet because the target
+/// network key's data is not locally available — typically a VSS pool at
+/// epoch entry before the consensus-frozen off-chain validator key set is
+/// ingested, or a key installed on peers but not here. The sequence number
+/// was already consumed at instantiation, so identifier derivation and the
+/// batch counters stay committee-uniform; parking defers only this
+/// validator's participation. Retried once per service iteration.
+///
+/// (There is no "identity not derivable" variant: instantiation resolves the
+/// key's content-derived `NetworkKeyId` FIRST — an adopted key always has one
+/// — and keys the per-pool sequence counter by it, so the identifier is
+/// always buildable at instantiation time.)
 #[derive(Debug, Clone)]
-pub(crate) enum ParkedInternalPresignRequest {
-    /// The request is fully built, but its MPC input construction failed with
-    /// the not-ready error class — typically a VSS pool at epoch entry,
-    /// before the consensus-frozen off-chain validator key set is ingested,
-    /// or a key adopted but not yet locally installed. Boxed: the request
-    /// dwarfs the other variant.
-    Request(Box<DWalletSessionRequest>),
-    /// The request could not even be BUILT: the key's content-derived
-    /// identity (its `NetworkKeyId`, bound into the session identifier) is
-    /// not derivable locally yet — the key is adopted but its installation
-    /// hasn't completed and the `ObjectID → NetworkKeyId` mapping has no
-    /// entry (a fresh key with no handoff-cert pin). The reserved sequence
-    /// number is carried here; the request is built at retry time, once the
-    /// identity becomes derivable.
-    AwaitingKeyIdentity {
-        session_sequence_number: u64,
-        dwallet_network_encryption_key_id: ObjectID,
-        curve: DWalletCurve,
-        signature_algorithm: DWalletSignatureAlgorithm,
-    },
-}
+pub(crate) struct ParkedInternalPresignRequest(pub(crate) Box<DWalletSessionRequest>);
 
 /// The [`DWalletMPCManager`] manages MPC sessions:
 /// — Keeping track of all MPC sessions,
@@ -323,17 +311,20 @@ pub(crate) struct DWalletMPCManager {
     // but that is safe as they are synced within an epoch and
     // the session identifier is derived from the epoch as well.
     /// Next internal-presign session sequence number, PER
-    /// (network_key, curve, signature_algorithm) pool. A single shared
-    /// counter would let one pool's stream depend on another's
-    /// instantiation timing: a key adopted at a different consensus round on
-    /// different validators (adoption is cert-gated and not round-uniform)
-    /// would shift every other pool's sequence numbers, so the session
-    /// identifiers — bound to the sequence number — diverge and never reach
-    /// quorum. Per-pool counters make each pool's stream a pure function of
-    /// that pool's own consensus-agreed inputs: a late-adopted key simply
-    /// starts fresh at 1 whenever it starts, identically on every validator.
+    /// (`NetworkKeyId`, curve, signature_algorithm) pool. Keyed by the key's
+    /// content-derived `NetworkKeyId` — the SAME identity bound into the
+    /// session identifier — so the counter and the identifier can never use
+    /// divergent key axes. A single shared counter would let one pool's
+    /// stream depend on another's instantiation timing: a key adopted at a
+    /// different consensus round on different validators (adoption is
+    /// cert-gated and not round-uniform) would shift every other pool's
+    /// sequence numbers, so the session identifiers — bound to the sequence
+    /// number — diverge and never reach quorum. Per-pool counters make each
+    /// pool's stream a pure function of that pool's own consensus-agreed
+    /// inputs: a late-adopted key simply starts fresh at 1 whenever it
+    /// starts, identically on every validator.
     pub(crate) next_internal_presign_sequence_number:
-        HashMap<(ObjectID, DWalletCurve, DWalletSignatureAlgorithm), u64>,
+        HashMap<(NetworkKeyId, DWalletCurve, DWalletSignatureAlgorithm), u64>,
 
     /// Monotonically increasing count of instantiated internal presign sessions
     /// per (network_key, curve, signature_algorithm). Incremented when a
@@ -346,7 +337,7 @@ pub(crate) struct DWalletMPCManager {
     /// Consensus-safe: instantiation is consensus-agreed, so all honest parties
     /// maintain identical values.
     pub(crate) instantiated_internal_presign_sessions:
-        HashMap<(ObjectID, DWalletCurve, DWalletSignatureAlgorithm), u64>,
+        HashMap<(NetworkKeyId, DWalletCurve, DWalletSignatureAlgorithm), u64>,
 
     /// Monotonically increasing count of completed internal presign sessions
     /// per (network_key, curve, signature_algorithm). Incremented when a
@@ -354,7 +345,7 @@ pub(crate) struct DWalletMPCManager {
     /// `instantiated_internal_presign_sessions` for a given tuple, new sessions
     /// may be instantiated.
     pub(crate) completed_internal_presign_sessions:
-        HashMap<(ObjectID, DWalletCurve, DWalletSignatureAlgorithm), u64>,
+        HashMap<(NetworkKeyId, DWalletCurve, DWalletSignatureAlgorithm), u64>,
 
     /// Consensus round at which the most recent internal-presign top-up batch
     /// was instantiated, per (network_key, curve, signature_algorithm). Drives
@@ -366,7 +357,7 @@ pub(crate) struct DWalletMPCManager {
     /// Consensus-safe: written only with consensus-agreed round numbers, so
     /// all honest parties maintain identical values.
     internal_presign_batch_instantiated_at_round:
-        HashMap<(ObjectID, DWalletCurve, DWalletSignatureAlgorithm), u64>,
+        HashMap<(NetworkKeyId, DWalletCurve, DWalletSignatureAlgorithm), u64>,
 
     /// The epoch store for persisting presign pools to disk.
     pub(crate) epoch_store: Arc<dyn AuthorityPerEpochStoreTrait>,
@@ -1702,6 +1693,20 @@ impl DWalletMPCManager {
         let agreed_key_ids: BTreeSet<_> = self.adopted_network_key_data.keys().copied().collect();
         let mut pools_filled: Vec<String> = Vec::new();
         for key_id in agreed_key_ids {
+            // The per-pool counters and the session identifier both key by the
+            // key's content-derived `NetworkKeyId`, so resolve it once here. An
+            // adopted key always resolves (adoption defers an unmapped key), so
+            // `None` is a should-never-happen — skip the key rather than fall
+            // back to a divergent identity axis.
+            let Some(network_key_id) = self.internal_presign_network_key_id(&key_id) else {
+                error!(
+                    should_never_happen = true,
+                    ?key_id,
+                    "adopted network key has no resolvable NetworkKeyId in the internal-presign \
+                     top-up loop; skipping its pools this iteration"
+                );
+                continue;
+            };
             for (curve, signature_algorithm) in pool_algorithms.iter().copied() {
                 let is_network_owned_address_signing_presign =
                     agreed_network_owned_address_signing_key_id == key_id;
@@ -1772,12 +1777,12 @@ impl DWalletMPCManager {
                 // presigns (1 to n-t), so overlapping batches cause pool overshoot.
                 let instantiated = self
                     .instantiated_internal_presign_sessions
-                    .get(&(key_id, curve, signature_algorithm))
+                    .get(&(network_key_id, curve, signature_algorithm))
                     .copied()
                     .unwrap_or(0);
                 let completed = self
                     .completed_internal_presign_sessions
-                    .get(&(key_id, curve, signature_algorithm))
+                    .get(&(network_key_id, curve, signature_algorithm))
                     .copied()
                     .unwrap_or(0);
                 if instantiated != completed {
@@ -1801,7 +1806,7 @@ impl DWalletMPCManager {
                     };
                     let batch_round = self
                         .internal_presign_batch_instantiated_at_round
-                        .get(&(key_id, curve, signature_algorithm))
+                        .get(&(network_key_id, curve, signature_algorithm))
                         .copied()
                         .unwrap_or(0);
                     if consensus_round.saturating_sub(batch_round) < expiry_rounds {
@@ -1817,7 +1822,7 @@ impl DWalletMPCManager {
                         "internal presign top-up batch never completed; presuming it dead and releasing the pool for new top-ups"
                     );
                     self.completed_internal_presign_sessions
-                        .insert((key_id, curve, signature_algorithm), instantiated);
+                        .insert((network_key_id, curve, signature_algorithm), instantiated);
                 }
 
                 if (number_of_consensus_rounds.is_multiple_of(consensus_round_delay)
@@ -1827,17 +1832,20 @@ impl DWalletMPCManager {
                     for _ in 1..=sessions_to_instantiate {
                         self.instantiate_internal_presign_session(
                             consensus_round,
+                            network_key_id,
                             key_id,
                             curve,
                             signature_algorithm,
                         );
                         *self
                             .instantiated_internal_presign_sessions
-                            .entry((key_id, curve, signature_algorithm))
+                            .entry((network_key_id, curve, signature_algorithm))
                             .or_insert(0) += 1;
                     }
-                    self.internal_presign_batch_instantiated_at_round
-                        .insert((key_id, curve, signature_algorithm), consensus_round);
+                    self.internal_presign_batch_instantiated_at_round.insert(
+                        (network_key_id, curve, signature_algorithm),
+                        consensus_round,
+                    );
                     pools_filled.push(format!(
                         "{curve:?}/{signature_algorithm:?}={current_pool_size}(min{minimal_pool_size})+{sessions_to_instantiate}"
                     ));
@@ -1853,90 +1861,48 @@ impl DWalletMPCManager {
         }
     }
 
-    /// Instantiates an internal presign sessions.
-    /// The network key identity bytes bound into internal presign session
-    /// identifiers: the key's flip-invariant, content-derived `NetworkKeyId`.
-    /// Read from the installed key data when available; before installation,
-    /// fall back to the pre-instantiation `ObjectID → NetworkKeyId` mapping
-    /// (seeded deployed keys, handoff-cert background derivation,
-    /// registrations from an earlier install). `None` when neither source has
-    /// it yet — a fresh key adopted but not yet installed, with no cert pin.
-    /// Callers must then DEFER without skipping: skipping a top-up other
-    /// validators perform desynchronizes the shared sequence counter and with
-    /// it every subsequent internal presign session identifier.
-    fn internal_presign_network_key_identity_bytes(
+    /// The key's flip-invariant, content-derived `NetworkKeyId` — the identity
+    /// bound into internal presign session identifiers and the key of the
+    /// per-pool sequence/guard counters. Read from the installed key data when
+    /// available, else from the pre-instantiation `ObjectID → NetworkKeyId`
+    /// mapping (seeded deployed keys, handoff-cert background derivation,
+    /// registrations from an earlier install). An ADOPTED key always resolves
+    /// (adoption defers a key with no mapping — see `adopt_cert_verified_keys`),
+    /// so the top-up path treats `None` as a should-never-happen skip.
+    pub(crate) fn internal_presign_network_key_id(
         &self,
         dwallet_network_encryption_key_id: &ObjectID,
-    ) -> Option<Vec<u8>> {
+    ) -> Option<NetworkKeyId> {
         match self
             .network_keys
             .get_network_encryption_key_public_data(dwallet_network_encryption_key_id)
         {
-            // Fall back to the network DKG output bytes only for a malformed
-            // key with no derivable id (deterministic, so still
-            // committee-uniform).
-            Ok(key_data) => Some(
-                key_data
-                    .network_key_id()
-                    .map(|id| id.0.to_vec())
-                    .unwrap_or_else(|_| key_data.network_dkg_output().as_bytes().to_vec()),
-            ),
-            Err(_) => network_key_id_for(dwallet_network_encryption_key_id).map(|id| id.0.to_vec()),
+            Ok(key_data) => key_data.network_key_id().ok(),
+            Err(_) => network_key_id_for(dwallet_network_encryption_key_id),
         }
     }
 
     fn instantiate_internal_presign_session(
         &mut self,
         consensus_round: u64,
+        network_key_id: NetworkKeyId,
         dwallet_network_encryption_key_id: ObjectID,
         curve: DWalletCurve,
         signature_algorithm: DWalletSignatureAlgorithm,
     ) {
-        // Consume the sequence number FIRST, unconditionally: the caller's
-        // top-up decision is committee-uniform, so every validator MUST
-        // account this session — whether it can run it right now or not —
-        // or identifier derivation diverges across the committee. The
-        // counter is PER (key, curve, algorithm) pool: a key adopted at a
-        // different round on different validators starts its own pool's
-        // stream fresh at 1 without perturbing any other pool's stream.
+        // Consume the sequence number, keyed by the key's content-derived
+        // `NetworkKeyId` — the SAME identity bound into the session
+        // identifier below, so the counter and the identifier can never use
+        // divergent key axes. The counter is PER (`NetworkKeyId`, curve,
+        // algorithm) pool: a key adopted at a different round on different
+        // validators starts its own pool's stream fresh at 1 without
+        // perturbing any other pool's stream.
         let sequence_entry = self
             .next_internal_presign_sequence_number
-            .entry((
-                dwallet_network_encryption_key_id,
-                curve,
-                signature_algorithm,
-            ))
+            .entry((network_key_id, curve, signature_algorithm))
             .or_insert(1);
         let session_sequence_number = *sequence_entry;
         *sequence_entry += 1;
-
-        let Some(network_key_identity_bytes) =
-            self.internal_presign_network_key_identity_bytes(&dwallet_network_encryption_key_id)
-        else {
-            // The key is adopted (the caller iterates the adopted set) but
-            // not installed yet, and no mapping entry exists to derive the
-            // identifier from. Park a deferred-instantiation record carrying
-            // the reserved sequence number; the request is built at retry
-            // time (the installation spawned by
-            // `instantiate_adopted_network_keys` registers the mapping when
-            // it completes).
-            info!(
-                consensus_round,
-                ?dwallet_network_encryption_key_id,
-                ?curve,
-                ?signature_algorithm,
-                ?session_sequence_number,
-                "network key identity not derivable yet for internal presign session; parking it for retry",
-            );
-            self.internal_presign_requests_pending_for_network_key_data
-                .push(ParkedInternalPresignRequest::AwaitingKeyIdentity {
-                    session_sequence_number,
-                    dwallet_network_encryption_key_id,
-                    curve,
-                    signature_algorithm,
-                });
-            return;
-        };
 
         // `consensus_round` is logged for traceability but is
         // deliberately NOT part of the request/session identifier:
@@ -1949,7 +1915,7 @@ impl DWalletMPCManager {
             curve,
             signature_algorithm,
             dwallet_network_encryption_key_id,
-            &network_key_identity_bytes,
+            &network_key_id.0,
         );
 
         if let Err(request) = self.try_activate_internal_presign_request(consensus_round, request) {
@@ -1969,7 +1935,7 @@ impl DWalletMPCManager {
                 "network key data not ready for internal presign session; parking it for retry",
             );
             self.internal_presign_requests_pending_for_network_key_data
-                .push(ParkedInternalPresignRequest::Request(request));
+                .push(ParkedInternalPresignRequest(request));
         }
     }
 
@@ -2057,44 +2023,8 @@ impl DWalletMPCManager {
         }
 
         let parked = mem::take(&mut self.internal_presign_requests_pending_for_network_key_data);
-        for parked_request in parked {
-            let request = match parked_request {
-                ParkedInternalPresignRequest::Request(request) => *request,
-                ParkedInternalPresignRequest::AwaitingKeyIdentity {
-                    session_sequence_number,
-                    dwallet_network_encryption_key_id,
-                    curve,
-                    signature_algorithm,
-                } => {
-                    let Some(network_key_identity_bytes) = self
-                        .internal_presign_network_key_identity_bytes(
-                            &dwallet_network_encryption_key_id,
-                        )
-                    else {
-                        // Identity still not derivable — keep it parked.
-                        self.internal_presign_requests_pending_for_network_key_data
-                            .push(ParkedInternalPresignRequest::AwaitingKeyIdentity {
-                                session_sequence_number,
-                                dwallet_network_encryption_key_id,
-                                curve,
-                                signature_algorithm,
-                            });
-                        continue;
-                    };
-                    // Build the request with the sequence number reserved at
-                    // instantiation time — the identifier comes out identical
-                    // to the one peers derived when they instantiated.
-                    DWalletSessionRequest::new_internal_presign(
-                        self.epoch_id,
-                        session_sequence_number,
-                        curve,
-                        signature_algorithm,
-                        dwallet_network_encryption_key_id,
-                        &network_key_identity_bytes,
-                    )
-                }
-            };
-
+        for ParkedInternalPresignRequest(request) in parked {
+            let request = *request;
             let session_identifier = request.session_identifier;
             let session_sequence_number = request.session_sequence_number;
             // Retry has no consensus-round context; 0 marks "activated on a
@@ -2122,7 +2052,7 @@ impl DWalletMPCManager {
                     // Input still not constructible — keep it parked (silently:
                     // this runs every service iteration).
                     self.internal_presign_requests_pending_for_network_key_data
-                        .push(ParkedInternalPresignRequest::Request(request));
+                        .push(ParkedInternalPresignRequest(request));
                 }
             }
         }
@@ -3182,26 +3112,30 @@ impl DWalletMPCManager {
                 // stale-batch expiry already had its slot reconciled, so a
                 // late completion must not push `completed` past
                 // `instantiated` — the top-up skip compares them for
-                // equality and would block the pool permanently.
-                let instantiated = self
-                    .instantiated_internal_presign_sessions
-                    .get(&(
-                        dwallet_network_encryption_key_id,
-                        curve,
-                        signature_algorithm,
-                    ))
-                    .copied()
-                    .unwrap_or(0);
-                let completed = self
-                    .completed_internal_presign_sessions
-                    .entry((
-                        dwallet_network_encryption_key_id,
-                        curve,
-                        signature_algorithm,
-                    ))
-                    .or_insert(0);
-                if *completed < instantiated {
-                    *completed += 1;
+                // equality and would block the pool permanently. Keyed by the
+                // same content-derived `NetworkKeyId` the top-up loop uses.
+                if let Some(network_key_id) =
+                    self.internal_presign_network_key_id(&dwallet_network_encryption_key_id)
+                {
+                    let instantiated = self
+                        .instantiated_internal_presign_sessions
+                        .get(&(network_key_id, curve, signature_algorithm))
+                        .copied()
+                        .unwrap_or(0);
+                    let completed = self
+                        .completed_internal_presign_sessions
+                        .entry((network_key_id, curve, signature_algorithm))
+                        .or_insert(0);
+                    if *completed < instantiated {
+                        *completed += 1;
+                    }
+                } else {
+                    error!(
+                        should_never_happen = true,
+                        ?dwallet_network_encryption_key_id,
+                        "completed internal presign output for a key with no resolvable \
+                         NetworkKeyId; completion counter not advanced"
+                    );
                 }
             }
             DWalletInternalMPCOutputKind::NetworkOwnedAddressSign {

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -322,36 +322,51 @@ pub(crate) struct DWalletMPCManager {
     // Different epochs will see repeating values of this variable,
     // but that is safe as they are synced within an epoch and
     // the session identifier is derived from the epoch as well.
-    pub(crate) next_internal_presign_sequence_number: u64,
+    /// Next internal-presign session sequence number, PER
+    /// (network_key, curve, signature_algorithm) pool. A single shared
+    /// counter would let one pool's stream depend on another's
+    /// instantiation timing: a key adopted at a different consensus round on
+    /// different validators (adoption is cert-gated and not round-uniform)
+    /// would shift every other pool's sequence numbers, so the session
+    /// identifiers — bound to the sequence number — diverge and never reach
+    /// quorum. Per-pool counters make each pool's stream a pure function of
+    /// that pool's own consensus-agreed inputs: a late-adopted key simply
+    /// starts fresh at 1 whenever it starts, identically on every validator.
+    pub(crate) next_internal_presign_sequence_number:
+        HashMap<(ObjectID, DWalletCurve, DWalletSignatureAlgorithm), u64>,
 
     /// Monotonically increasing count of instantiated internal presign sessions
-    /// per (curve, signature_algorithm). Incremented when a session is created.
-    /// Used with `completed_internal_presign_sessions` to prevent instantiating
-    /// new sessions while existing ones haven't completed — each session produces
-    /// a variable number of presigns (1 to n-t), so overlapping batches cause
-    /// pool overshoot.
+    /// per (network_key, curve, signature_algorithm). Incremented when a
+    /// session is created. Used with `completed_internal_presign_sessions` to
+    /// prevent instantiating new sessions while existing ones haven't completed
+    /// — each session produces a variable number of presigns (1 to n-t), so
+    /// overlapping batches cause pool overshoot. Keyed by network key too so
+    /// one key's in-flight batch never gates another key's pool of the same
+    /// algorithm.
     /// Consensus-safe: instantiation is consensus-agreed, so all honest parties
     /// maintain identical values.
     pub(crate) instantiated_internal_presign_sessions:
-        HashMap<(DWalletCurve, DWalletSignatureAlgorithm), u64>,
+        HashMap<(ObjectID, DWalletCurve, DWalletSignatureAlgorithm), u64>,
 
     /// Monotonically increasing count of completed internal presign sessions
-    /// per (curve, signature_algorithm). Incremented when a session's output
-    /// reaches consensus majority. When this equals `instantiated_internal_presign_sessions`
-    /// for a given pair, new sessions may be instantiated.
+    /// per (network_key, curve, signature_algorithm). Incremented when a
+    /// session's output reaches consensus majority. When this equals
+    /// `instantiated_internal_presign_sessions` for a given tuple, new sessions
+    /// may be instantiated.
     pub(crate) completed_internal_presign_sessions:
-        HashMap<(DWalletCurve, DWalletSignatureAlgorithm), u64>,
+        HashMap<(ObjectID, DWalletCurve, DWalletSignatureAlgorithm), u64>,
 
     /// Consensus round at which the most recent internal-presign top-up batch
-    /// was instantiated, per (curve, signature_algorithm). Drives the
-    /// stale-batch expiry in `instantiate_internal_presign_sessions`: a batch
-    /// that never reaches an output quorum (e.g. every validator's
+    /// was instantiated, per (network_key, curve, signature_algorithm). Drives
+    /// the stale-batch expiry in `instantiate_internal_presign_sessions`: a
+    /// batch that never reaches an output quorum (e.g. every validator's
     /// computation failed locally) would otherwise block its pool's top-up
-    /// for the rest of the epoch, starving the pool.
+    /// for the rest of the epoch, starving the pool. Per-key so each pool
+    /// carries its own batch-instantiated round.
     /// Consensus-safe: written only with consensus-agreed round numbers, so
     /// all honest parties maintain identical values.
     internal_presign_batch_instantiated_at_round:
-        HashMap<(DWalletCurve, DWalletSignatureAlgorithm), u64>,
+        HashMap<(ObjectID, DWalletCurve, DWalletSignatureAlgorithm), u64>,
 
     /// The epoch store for persisting presign pools to disk.
     pub(crate) epoch_store: Arc<dyn AuthorityPerEpochStoreTrait>,
@@ -553,7 +568,7 @@ impl DWalletMPCManager {
             network_key_id_derivations_spawned: HashSet::new(),
             warned_cryptographic_data_generation_failures: HashSet::new(),
             last_failed_network_key_data: HashMap::new(),
-            next_internal_presign_sequence_number: 1,
+            next_internal_presign_sequence_number: HashMap::new(),
             instantiated_internal_presign_sessions: HashMap::new(),
             completed_internal_presign_sessions: HashMap::new(),
             internal_presign_batch_instantiated_at_round: HashMap::new(),
@@ -1641,11 +1656,17 @@ impl DWalletMPCManager {
     /// which key is the NOA key and apply different pool configs (different
     /// batch sizes ⇒ divergent internal-presign sequence numbers).
     fn network_owned_address_signing_network_encryption_key_id(&self) -> Option<ObjectID> {
-        self.network_keys
-            .network_encryption_keys
-            .iter()
-            .min_by(|(a_id, a), (b_id, b)| a.dkg_at_epoch.cmp(&b.dkg_at_epoch).then(a_id.cmp(b_id)))
-            .map(|(id, _)| *id)
+        // Select over the ADOPTED (consensus-agreed) set, not the installed set
+        // (`network_keys.network_encryption_keys`): installation completes on
+        // wall-clock time per validator, so choosing over it would let two
+        // honest validators pick a different NOA key while their installs lag,
+        // apply different pool configs (batch sizes), and diverge the
+        // internal-presign top-up decision. The adopted set drives the same
+        // top-up loop, so both agree on the NOA key by construction.
+        self.adopted_network_key_data
+            .values()
+            .min_by(|a, b| a.dkg_at_epoch.cmp(&b.dkg_at_epoch).then(a.id.cmp(&b.id)))
+            .map(|data| data.id)
     }
 
     /// Instantiates internal presign sessions based on consensus-agreed network key IDs.
@@ -1671,12 +1692,13 @@ impl DWalletMPCManager {
         // externally requestable on-chain.
         let pool_algorithms =
             network_presign_pool_algorithms(self.protocol_config.fast_schnorr_supported());
-        // Ordered (`BTreeSet`) on purpose: the loop below assigns internal presign
-        // session sequence numbers from a single shared counter in iteration order,
-        // and the sequence number is bound into the session identifier. Every
-        // validator must iterate keys in the same order (and `pool_algorithms` is
-        // already a deterministically-ordered list), or they derive different
-        // session identifiers for the same work and the sessions never reach quorum.
+        // Ordered (`BTreeSet`) for stable iteration/logging, but the sequence
+        // counters are now PER (key, curve, algorithm) pool (not a single shared
+        // counter consumed in iteration order), so a pool's sequence stream no
+        // longer depends on when other keys are adopted or the iteration order.
+        // Each pool's stream is a pure function of that pool's own consensus-
+        // agreed inputs, so a key adopted at a different round on different
+        // validators still derives identical session identifiers for its pool.
         let agreed_key_ids: BTreeSet<_> = self.adopted_network_key_data.keys().copied().collect();
         let mut pools_filled: Vec<String> = Vec::new();
         for key_id in agreed_key_ids {
@@ -1750,12 +1772,12 @@ impl DWalletMPCManager {
                 // presigns (1 to n-t), so overlapping batches cause pool overshoot.
                 let instantiated = self
                     .instantiated_internal_presign_sessions
-                    .get(&(curve, signature_algorithm))
+                    .get(&(key_id, curve, signature_algorithm))
                     .copied()
                     .unwrap_or(0);
                 let completed = self
                     .completed_internal_presign_sessions
-                    .get(&(curve, signature_algorithm))
+                    .get(&(key_id, curve, signature_algorithm))
                     .copied()
                     .unwrap_or(0);
                 if instantiated != completed {
@@ -1779,7 +1801,7 @@ impl DWalletMPCManager {
                     };
                     let batch_round = self
                         .internal_presign_batch_instantiated_at_round
-                        .get(&(curve, signature_algorithm))
+                        .get(&(key_id, curve, signature_algorithm))
                         .copied()
                         .unwrap_or(0);
                     if consensus_round.saturating_sub(batch_round) < expiry_rounds {
@@ -1795,7 +1817,7 @@ impl DWalletMPCManager {
                         "internal presign top-up batch never completed; presuming it dead and releasing the pool for new top-ups"
                     );
                     self.completed_internal_presign_sessions
-                        .insert((curve, signature_algorithm), instantiated);
+                        .insert((key_id, curve, signature_algorithm), instantiated);
                 }
 
                 if (number_of_consensus_rounds.is_multiple_of(consensus_round_delay)
@@ -1811,11 +1833,11 @@ impl DWalletMPCManager {
                         );
                         *self
                             .instantiated_internal_presign_sessions
-                            .entry((curve, signature_algorithm))
+                            .entry((key_id, curve, signature_algorithm))
                             .or_insert(0) += 1;
                     }
                     self.internal_presign_batch_instantiated_at_round
-                        .insert((curve, signature_algorithm), consensus_round);
+                        .insert((key_id, curve, signature_algorithm), consensus_round);
                     pools_filled.push(format!(
                         "{curve:?}/{signature_algorithm:?}={current_pool_size}(min{minimal_pool_size})+{sessions_to_instantiate}"
                     ));
@@ -1873,10 +1895,20 @@ impl DWalletMPCManager {
         // Consume the sequence number FIRST, unconditionally: the caller's
         // top-up decision is committee-uniform, so every validator MUST
         // account this session — whether it can run it right now or not —
-        // or identifier derivation (a single counter shared across all
-        // pools and keys) permanently diverges across the committee.
-        let session_sequence_number = self.next_internal_presign_sequence_number;
-        self.next_internal_presign_sequence_number += 1;
+        // or identifier derivation diverges across the committee. The
+        // counter is PER (key, curve, algorithm) pool: a key adopted at a
+        // different round on different validators starts its own pool's
+        // stream fresh at 1 without perturbing any other pool's stream.
+        let sequence_entry = self
+            .next_internal_presign_sequence_number
+            .entry((
+                dwallet_network_encryption_key_id,
+                curve,
+                signature_algorithm,
+            ))
+            .or_insert(1);
+        let session_sequence_number = *sequence_entry;
+        *sequence_entry += 1;
 
         let Some(network_key_identity_bytes) =
             self.internal_presign_network_key_identity_bytes(&dwallet_network_encryption_key_id)
@@ -3153,12 +3185,20 @@ impl DWalletMPCManager {
                 // equality and would block the pool permanently.
                 let instantiated = self
                     .instantiated_internal_presign_sessions
-                    .get(&(curve, signature_algorithm))
+                    .get(&(
+                        dwallet_network_encryption_key_id,
+                        curve,
+                        signature_algorithm,
+                    ))
                     .copied()
                     .unwrap_or(0);
                 let completed = self
                     .completed_internal_presign_sessions
-                    .entry((curve, signature_algorithm))
+                    .entry((
+                        dwallet_network_encryption_key_id,
+                        curve,
+                        signature_algorithm,
+                    ))
                     .or_insert(0);
                 if *completed < instantiated {
                     *completed += 1;

--- a/crates/ika-core/src/dwallet_session_request.rs
+++ b/crates/ika-core/src/dwallet_session_request.rs
@@ -41,9 +41,11 @@ impl DWalletSessionRequest {
     /// while processing DIFFERENT consensus rounds. Baking the round in
     /// gave each validator a private session id — sessions with one
     /// participant each, no quorum, a permanently empty presign pool.
-    /// Uniqueness comes from (epoch, session sequence number, session
-    /// type); determinism of the sequence numbers comes from every
-    /// validator walking keys/curves/algorithms in sorted order.
+    /// Uniqueness comes from (epoch, network key identity, curve,
+    /// algorithm, session sequence number, session type); determinism of
+    /// the sequence numbers comes from each (network key, curve,
+    /// algorithm) POOL keeping its own counter, consumed only on that
+    /// pool's consensus-agreed top-up decisions.
     pub fn new_internal_presign(
         epoch: u64,
         session_sequence_number: u64,

--- a/dev-docs/specs/fast-schnorr-vss.md
+++ b/dev-docs/specs/fast-schnorr-vss.md
@@ -115,33 +115,41 @@ against the active committee directly.
   stale-batch expiry. Any other input-construction error stays terminal.
 - **Per-pool sequence counters (multi-key epochs).** The internal-presign
   session sequence number, the instantiated/completed guard counters, and the
-  stale-batch-instantiated round are keyed per `(network_key, curve,
+  stale-batch-instantiated round are keyed per `(NetworkKeyId, curve,
   signature_algorithm)` POOL — not a single counter shared across all keys.
-  A single shared counter would couple every pool's stream: because key
-  ADOPTION completes at a different consensus round on different validators
-  (adoption is cert-gated, not round-uniform), a key adopted earlier on one
-  validator would shift every other pool's sequence numbers, diverging the
-  session identifiers (which bind the sequence number). Per-pool counters make
-  each pool's stream a pure function of that pool's own consensus-agreed
+  The key axis is the key's content-derived `NetworkKeyId` (its flip-invariant
+  curve25519 NOA public key), which is the SAME identity bound into the session
+  identifier, so the counter and the identifier can never diverge onto
+  different key axes. A single shared counter would couple every pool's stream:
+  because key ADOPTION completes at a different consensus round on different
+  validators (adoption is cert-gated, not round-uniform), a key adopted earlier
+  on one validator would shift every other pool's sequence numbers, diverging
+  the session identifiers (which bind the sequence number). Per-pool counters
+  make each pool's stream a pure function of that pool's own consensus-agreed
   inputs: a late-adopted key simply starts its own pool's stream fresh at 1
   whenever it starts, identically on every validator, without perturbing any
   other pool.
 - **Deferred instantiation for a not-yet-installed key.** The top-up loop
   iterates every ADOPTED key, but installation into `network_keys` completes
-  asynchronously per validator, and the session identifier binds the key's
-  content-derived `NetworkKeyId`. A validator whose key is adopted but not
-  installed derives the identity from the pre-instantiation
-  `ObjectID → NetworkKeyId` mapping and parks the built request on the input's
-  not-ready error; when even the mapping has no entry (a fresh key with no
-  handoff-cert pin), it parks an `AwaitingKeyIdentity` record carrying the
-  RESERVED sequence number and builds the request at retry time. In every case
-  the sequence number is consumed FROM THAT POOL'S counter — skipping a top-up
-  that peers perform would desynchronize that pool's counter and, with it,
-  every subsequent identifier in that pool. Relatedly, the NOA-signing-key
-  choice (oldest key by `dkg_at_epoch`) is made over the ADOPTED set (not the
-  wall-clock-installed set) and tie-breaks equal `dkg_at_epoch` by key id, so
-  every validator picks the same NOA key and applies the same pool configs
-  regardless of install timing.
+  asynchronously per validator. Because the counters and the session identifier
+  both key by the `NetworkKeyId`, the loop resolves it ONCE per key before
+  touching either — from the installed key data when present, else from the
+  pre-instantiation `ObjectID → NetworkKeyId` mapping (seeded deployed keys,
+  handoff-cert background derivation, an earlier install's registration). An
+  adopted key ALWAYS resolves: adoption (`adopt_cert_verified_keys`) defers a
+  key that has no mapping, so a `None` here is a should-never-happen and the
+  loop SKIPS that key for the iteration rather than falling back to a divergent
+  identity axis — it does not park or fail it. A validator whose key is adopted
+  and resolvable but not yet installed builds the request normally (identity
+  from the mapping), consumes the sequence number from that pool's counter, and
+  parks the BUILT request on the input's not-ready error; the sequence number
+  is consumed regardless, since skipping a top-up that peers perform would
+  desynchronize that pool's counter and, with it, every subsequent identifier
+  in that pool. Relatedly, the NOA-signing-key choice (oldest key by
+  `dkg_at_epoch`) is made over the ADOPTED set (not the wall-clock-installed
+  set) and tie-breaks equal `dkg_at_epoch` by key id, so every validator picks
+  the same NOA key and applies the same pool configs regardless of install
+  timing.
 
 ## Invariants
 

--- a/dev-docs/specs/fast-schnorr-vss.md
+++ b/dev-docs/specs/fast-schnorr-vss.md
@@ -113,23 +113,35 @@ against the active committee directly.
   instantiated/completed batch counters stay committee-uniform — parking is
   local participation deferral, invisible to the top-up guard and the
   stale-batch expiry. Any other input-construction error stays terminal.
-- **Deferred instantiation for a not-yet-installed key (multi-key epochs).**
-  The top-up loop iterates every ADOPTED key, but installation into
-  `network_keys` completes asynchronously per validator, and the session
-  identifier binds the key's content-derived `NetworkKeyId`. A validator whose
-  key is adopted but not installed derives the identity from the
-  pre-instantiation `ObjectID → NetworkKeyId` mapping and parks the built
-  request on the input's not-ready error; when even the mapping has no entry
-  (a fresh key with no handoff-cert pin), it parks an `AwaitingKeyIdentity`
-  record carrying the RESERVED sequence number and builds the request at
-  retry time. In every case the sequence number is consumed — skipping a
-  top-up that peers perform would desynchronize the single sequence counter
-  shared across all pools and keys, and with it every subsequent internal
-  presign identifier (sessions could then never reach quorum). Relatedly, the
-  NOA-signing-key choice (oldest installed key by `dkg_at_epoch`) tie-breaks
-  by key id: `min_by` alone would resolve same-epoch ties by `HashMap`
-  iteration order — per-process-random, giving validators different pool
-  configs and thus divergent batch sizes.
+- **Per-pool sequence counters (multi-key epochs).** The internal-presign
+  session sequence number, the instantiated/completed guard counters, and the
+  stale-batch-instantiated round are keyed per `(network_key, curve,
+  signature_algorithm)` POOL — not a single counter shared across all keys.
+  A single shared counter would couple every pool's stream: because key
+  ADOPTION completes at a different consensus round on different validators
+  (adoption is cert-gated, not round-uniform), a key adopted earlier on one
+  validator would shift every other pool's sequence numbers, diverging the
+  session identifiers (which bind the sequence number). Per-pool counters make
+  each pool's stream a pure function of that pool's own consensus-agreed
+  inputs: a late-adopted key simply starts its own pool's stream fresh at 1
+  whenever it starts, identically on every validator, without perturbing any
+  other pool.
+- **Deferred instantiation for a not-yet-installed key.** The top-up loop
+  iterates every ADOPTED key, but installation into `network_keys` completes
+  asynchronously per validator, and the session identifier binds the key's
+  content-derived `NetworkKeyId`. A validator whose key is adopted but not
+  installed derives the identity from the pre-instantiation
+  `ObjectID → NetworkKeyId` mapping and parks the built request on the input's
+  not-ready error; when even the mapping has no entry (a fresh key with no
+  handoff-cert pin), it parks an `AwaitingKeyIdentity` record carrying the
+  RESERVED sequence number and builds the request at retry time. In every case
+  the sequence number is consumed FROM THAT POOL'S counter — skipping a top-up
+  that peers perform would desynchronize that pool's counter and, with it,
+  every subsequent identifier in that pool. Relatedly, the NOA-signing-key
+  choice (oldest key by `dkg_at_epoch`) is made over the ADOPTED set (not the
+  wall-clock-installed set) and tie-breaks equal `dkg_at_epoch` by key id, so
+  every validator picks the same NOA key and applies the same pool configs
+  regardless of install timing.
 
 ## Invariants
 

--- a/dev-docs/specs/fast-schnorr-vss.md
+++ b/dev-docs/specs/fast-schnorr-vss.md
@@ -125,31 +125,46 @@ against the active committee directly.
   validators (adoption is cert-gated, not round-uniform), a key adopted earlier
   on one validator would shift every other pool's sequence numbers, diverging
   the session identifiers (which bind the sequence number). Per-pool counters
-  make each pool's stream a pure function of that pool's own consensus-agreed
-  inputs: a late-adopted key simply starts its own pool's stream fresh at 1
-  whenever it starts, identically on every validator, without perturbing any
-  other pool.
+  make each pool's ordinal stream start-time-invariant: a late-adopted key
+  starts its own pool's stream fresh at 1 whenever it starts, without
+  perturbing any other pool.
+  **Scope of the guarantee**: start-time invariance holds while a validator's
+  start skew for a pool stays under ONE BATCH LIFECYCLE. A validator whose
+  first top-up of a pool happens only after a full batch quorum-completed
+  among its peers (a mid-epoch restart that replays committed rounds before
+  adoption re-lands, an extremely late install) begins that pool's ordinals
+  offset from its peers' and never converges — for the rest of the epoch it
+  instantiates already-completed identifiers and contributes nothing to that
+  pool's live sessions. The pool keeps serving from the peers' quorum; the
+  cost is that validator's redundancy (and, if more than f validators are in
+  that state simultaneously, the pool itself). The heal — fast-forwarding a
+  pool's counter from the completed sequence numbers observed in consensus
+  outputs, which are consensus-anchored — is tracked follow-up work. The same
+  exposure existed under the old shared counter, with every pool coupled to
+  the divergence instead of one.
 - **Deferred instantiation for a not-yet-installed key.** The top-up loop
   iterates every ADOPTED key, but installation into `network_keys` completes
   asynchronously per validator. Because the counters and the session identifier
   both key by the `NetworkKeyId`, the loop resolves it ONCE per key before
   touching either — from the installed key data when present, else from the
   pre-instantiation `ObjectID → NetworkKeyId` mapping (seeded deployed keys,
-  handoff-cert background derivation, an earlier install's registration). An
-  adopted key ALWAYS resolves: adoption (`adopt_cert_verified_keys`) defers a
-  key that has no mapping, so a `None` here is a should-never-happen and the
-  loop SKIPS that key for the iteration rather than falling back to a divergent
-  identity axis — it does not park or fail it. A validator whose key is adopted
-  and resolvable but not yet installed builds the request normally (identity
-  from the mapping), consumes the sequence number from that pool's counter, and
-  parks the BUILT request on the input's not-ready error; the sequence number
-  is consumed regardless, since skipping a top-up that peers perform would
-  desynchronize that pool's counter and, with it, every subsequent identifier
-  in that pool. Relatedly, the NOA-signing-key choice (oldest key by
-  `dkg_at_epoch`) is made over the ADOPTED set (not the wall-clock-installed
-  set) and tie-breaks equal `dkg_at_epoch` by key id, so every validator picks
-  the same NOA key and applies the same pool configs regardless of install
-  timing.
+  registration at DKG output processing, background derivation). An adopted
+  key ALWAYS resolves: adoption (`adopt_cert_verified_keys`) defers any key
+  whose ObjectID has no mapping — on EVERY adoption branch, cert-anchored or
+  cert-less — spawning the background derivation and retrying each tick until
+  the registration lands. A `None` in the top-up loop is therefore a
+  should-never-happen and the loop SKIPS that key for the iteration rather
+  than falling back to a divergent identity axis — it does not park or fail
+  it. A validator whose key is adopted and resolvable but not yet installed
+  builds the request normally (identity from the mapping), consumes the
+  sequence number from that pool's counter, and parks the BUILT request on the
+  input's not-ready error; the sequence number is consumed regardless, since
+  skipping a top-up that peers perform would desynchronize that pool's counter
+  and, with it, every subsequent identifier in that pool. Relatedly, the
+  NOA-signing-key choice (oldest key by `dkg_at_epoch`) is made over the
+  ADOPTED set (not the wall-clock-installed set) and tie-breaks equal
+  `dkg_at_epoch` by key id, so every validator picks the same NOA key and
+  applies the same pool configs regardless of install timing.
 
 ## Invariants
 


### PR DESCRIPTION
Track B of the protocol-v4 gate list (`dev-docs/plans/v4-activation-gate-list.md`), implementing the **per-key counter** decision (C1). Builds on #1818/#1819.

## The coupling bug

A single shared internal-presign sequence counter — plus shared `instantiated`/`completed` guard counters and a shared batch-instantiated round, all keyed only by `(curve, algorithm)` — coupled every pool's stream across keys. Because network-key **adoption** completes at a different consensus round on different validators (cert-gated, not round-uniform):

- a key adopted earlier on one validator shifted **every other pool's** sequence numbers → session identifiers (which bind the sequence number) diverged and never reached quorum (multi-key hole 2);
- one key's in-flight batch gated another key's pool of the same algorithm (hole 3);
- one key's stale-batch expiry perturbed another's batch-round (the cross-key dimension of #1807's expiry desync).

## PART A — per-`(key, curve, algorithm)` counters

Re-key four `mpc_manager` maps by `(ObjectID, DWalletCurve, DWalletSignatureAlgorithm)`: `next_internal_presign_sequence_number` (now a map, `entry().or_insert(1)`, still consumed **first and unconditionally** so #1819's parking stays aligned within a pool), `instantiated_`/`completed_internal_presign_sessions`, and `internal_presign_batch_instantiated_at_round`. Each pool's stream is now a pure function of that pool's own consensus-agreed inputs: a late-adopted key starts its pool fresh at 1 whenever it starts, identically on every validator, without perturbing any other pool.

## PART B (interim) — consensus-agreed NOA key

Select the NOA-signing key over the **adopted** set (`adopted_network_key_data`) instead of the wall-clock-**installed** set (`network_keys.network_encryption_keys`), so two validators with lagging installs can't pick different NOA keys and apply divergent pool configs (hole 1). The `dkg_at_epoch` + key-id tie-break is unchanged.

## Verification

Preserves #1818/#1819's consume-first/parking semantics (now per-pool). The **multi-key install-lag uniformity test passes** under real crypto (352s), and its cross-validator assertion is now the whole per-pool sequence **map** — a strictly stronger check that no pool's stream leaked into another's. clippy-clean, fmt.

## Out of scope (deferred to NOA-sign enablement)

The expiry-desync **root** fix — moving NOA-sign pool **consumption** onto the consensus round drain (it currently pops per wall-clock service iteration in `process_network_owned_address_sign_requests`). NOA sign is not live; the pool must not drain off the consensus timeline once it is, and that wiring lands with NOA-sign enablement. PART A already removes the cross-key dimension of the desync.

## Spec

`fast-schnorr-vss.md`: replaced the single-shared-counter invariant (from #1819) with the per-pool-counter invariant + the adopted-set NOA-key rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)