### PR TITLE
fix(v4): fail-stop the mpc_data freeze on a prior-cert read error (V1 part 1)

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -3355,35 +3355,49 @@ impl AuthorityPerEpochStore {
     /// The prior epoch's handoff-certificate `validator -> mpc_data
     /// digest` map, used to carry forward stable mpc_data for committee
     /// members that did not freshly announce this epoch (see
-    /// `carry_forward_stable_mpc_data`). Empty when there is no prior
-    /// certificate (genesis epoch, v3, or a read error) — carry-forward
-    /// then degrades to announce-only. The certificate is perpetual and
-    /// stake-quorum-signed, and the prepare-then-start barrier guarantees
-    /// every validator holds the prior-epoch certificate before
-    /// processing this epoch's consensus, so the returned map is
-    /// identical across honest validators — a precondition for the freeze
-    /// staying deterministic.
-    fn prior_epoch_mpc_data_digests(&self) -> HashMap<AuthorityName, [u8; 32]> {
+    /// `carry_forward_stable_mpc_data`). Empty (`Ok(HashMap::new())`) only
+    /// for the chain-true no-cert epochs — genesis, a v3 prior epoch, or the
+    /// first v4 epoch — where carry-forward legitimately degrades to
+    /// announce-only uniformly across the committee. The certificate is
+    /// perpetual and stake-quorum-signed, and the prepare-then-start barrier
+    /// guarantees every validator holds the prior-epoch certificate before
+    /// processing this epoch's consensus, so the returned map is identical
+    /// across honest validators — a precondition for the freeze staying
+    /// deterministic.
+    ///
+    /// A cert READ ERROR is PROPAGATED, not degraded to empty: silently
+    /// returning an empty map on a transient read failure would shrink THIS
+    /// validator's frozen set (dropping every carry-forward member) while
+    /// peers that read the cert fine keep them — a divergent frozen set is a
+    /// consensus fork. Propagating makes the freeze fail-stop: the commit
+    /// errors, the consensus handler's `.expect` panics the node, and the
+    /// commit replays on restart until the read succeeds. This is the
+    /// freeze-path realization of handoff.md invariant 4 ("fail open with
+    /// retry on read errors"), and it mirrors the ready-signals read in
+    /// `freeze_mpc_data_if_first`, which already `?`-propagates.
+    fn prior_epoch_mpc_data_digests(&self) -> IkaResult<HashMap<AuthorityName, [u8; 32]>> {
         let Some(prior_epoch) = self.epoch().checked_sub(1) else {
-            return HashMap::new();
+            return Ok(HashMap::new());
         };
         let Some(perpetual) = self.perpetual_tables_for_handoff.load_full() else {
-            return HashMap::new();
+            return Ok(HashMap::new());
         };
         let cert = match perpetual.get_certified_handoff_attestation(prior_epoch) {
             Ok(Some(cert)) => cert,
-            Ok(None) => return HashMap::new(),
+            Ok(None) => return Ok(HashMap::new()),
             Err(e) => {
-                warn!(
+                error!(
                     error = ?e,
                     prior_epoch,
                     "failed to read prior-epoch handoff cert for mpc_data carry-forward; \
-                     degrading to announce-only",
+                     failing the freeze so the commit replays rather than freezing a \
+                     divergent (shrunken) mpc_data set",
                 );
-                return HashMap::new();
+                return Err(e);
             }
         };
-        cert.attestation
+        Ok(cert
+            .attestation
             .items
             .iter()
             .filter_map(|(key, digest)| match key {
@@ -3392,7 +3406,7 @@ impl AuthorityPerEpochStore {
                 }
                 _ => None,
             })
-            .collect()
+            .collect())
     }
 
     fn freeze_mpc_data_if_first(&self, tables: &AuthorityEpochTables) -> IkaResult {
@@ -3437,7 +3451,7 @@ impl AuthorityPerEpochStore {
             .iter()
             .map(|(name, _)| *name)
             .collect();
-        let prior_mpc_data = self.prior_epoch_mpc_data_digests();
+        let prior_mpc_data = self.prior_epoch_mpc_data_digests()?;
         let partition = crate::validator_metadata::carry_forward_stable_mpc_data(
             attested,
             &committee_members,

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -3359,11 +3359,17 @@ impl AuthorityPerEpochStore {
     /// for the chain-true no-cert epochs — genesis, a v3 prior epoch, or the
     /// first v4 epoch — where carry-forward legitimately degrades to
     /// announce-only uniformly across the committee. The certificate is
-    /// perpetual and stake-quorum-signed, and the prepare-then-start barrier
-    /// guarantees every validator holds the prior-epoch certificate before
-    /// processing this epoch's consensus, so the returned map is identical
-    /// across honest validators — a precondition for the freeze staying
-    /// deterministic.
+    /// perpetual and stake-quorum-signed. NOTE the uniformity of `Ok(None)`
+    /// currently rests on the prepare-then-start barrier holding the
+    /// prior-epoch certificate before this epoch's consensus is processed —
+    /// which today is wired only into the continuing-validator reconfigure
+    /// path; the joiner-promotion and cold-startup consensus-start paths do
+    /// not yet pass the barrier (deferred — see
+    /// dev-docs/plans/handoff-barrier-escape-and-pure-close-gate.md), so a
+    /// first-time joiner racing its bootstrap fetch can still hit `Ok(None)`
+    /// and freeze without the carry-forward map. This function closes the
+    /// READ-ERROR flavor of the shrunken-set fork; the absent-cert flavor
+    /// closes when the barrier covers all consensus-start paths.
     ///
     /// A cert READ ERROR is PROPAGATED, not degraded to empty: silently
     /// returning an empty map on a transient read failure would shrink THIS
@@ -3379,8 +3385,24 @@ impl AuthorityPerEpochStore {
         let Some(prior_epoch) = self.epoch().checked_sub(1) else {
             return Ok(HashMap::new());
         };
+        // A missing perpetual handle at a freeze commit is a LOCAL
+        // initialization fault, not a chain-true no-cert case: both
+        // epoch-store creation sites install the handle before consensus can
+        // process a commit, and the freeze only runs under v4 where the
+        // handle must be present. Fail the commit (replay) like the read
+        // error below — a silent Ok(empty) here would reintroduce the exact
+        // shrunken-set fork this function exists to close, via the arm two
+        // lines above the fix. Unreachable today; guards future init-order
+        // refactors.
         let Some(perpetual) = self.perpetual_tables_for_handoff.load_full() else {
-            return Ok(HashMap::new());
+            error!(
+                prior_epoch,
+                "perpetual-tables handle missing at the mpc_data freeze; failing the \
+                 commit so it replays after initialization completes"
+            );
+            return Err(IkaError::Unknown(
+                "perpetual-tables handle not installed at the mpc_data freeze".to_string(),
+            ));
         };
         let cert = match perpetual.get_certified_handoff_attestation(prior_epoch) {
             Ok(Some(cert)) => cert,

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -181,10 +181,20 @@ next epoch inherits.
    empty (shrunken) carry-forward map that would diverge this validator's
    frozen set from its peers'. An empty map is returned only for the
    chain-true no-cert epochs (genesis, a v3 prior epoch, the first v4
-   epoch), which are uniform across the committee.
+   epoch). CAVEAT: the committee-uniformity of that empty-map case rests
+   on invariant 5 holding on EVERY consensus-start path; today the
+   barrier is wired only into the continuing-validator reconfigure path
+   (joiner-promotion and cold startup are pending — see
+   `dev-docs/plans/handoff-barrier-escape-and-pure-close-gate.md`), so
+   a joiner racing its bootstrap fetch can still freeze absent-cert.
+   The read-error flavor of the fork is closed; the absent-cert flavor
+   closes with the barrier wiring.
 5. The barrier guarantee: no validator participates in epoch E+1
    sessions without locally holding the verified epoch-E handoff
-   artifacts.
+   artifacts. Currently enforced on the continuing-validator
+   reconfigure path; extending it to the fullnode→validator promotion
+   and cold-startup consensus-start paths is planned work (see the
+   plan referenced in invariant 4).
 
 Code anchors: `crates/ika-types/src/handoff.rs` (types),
 `crates/ika-core/src/handoff_cert.rs` (aggregation + verification),

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -174,7 +174,14 @@ next epoch inherits.
    sign byte-identical attestations.
 4. Fail closed on contradiction (`Rejected`, persisted-cert
    re-verification failure); fail open with retry on absence
-   (`Unavailable`, read errors).
+   (`Unavailable`, read errors). The freeze is a cert CONSUMER too:
+   `prior_epoch_mpc_data_digests` (carry-forward source) reads the prior
+   cert's `ValidatorMpcData` items, and a READ ERROR there PROPAGATES —
+   the commit fails and replays on restart — rather than degrading to an
+   empty (shrunken) carry-forward map that would diverge this validator's
+   frozen set from its peers'. An empty map is returned only for the
+   chain-true no-cert epochs (genesis, a v3 prior epoch, the first v4
+   epoch), which are uniform across the committee.
 5. The barrier guarantee: no validator participates in epoch E+1
    sessions without locally holding the verified epoch-E handoff
    artifacts.

--- a/dev-docs/specs/validator-mpc-data-announcements.md
+++ b/dev-docs/specs/validator-mpc-data-announcements.md
@@ -100,19 +100,25 @@ which bytes* deterministic in consensus order.
   frozen even once stays covered while it is down, so even a
   permanently-down-but-staked member never wedges reconfiguration.
   Carry-forward is deterministic: the prior certificate is
-  consensus-anchored, perpetual, and (by the prepare-then-start
-  barrier) held by every validator before it processes this epoch's
-  consensus. A fresh announcement that diverged (landing a member in
-  `excluded`) is overridden by the known-good prior digest, since the
-  true blob cannot legitimately change between epochs. A cert READ
-  ERROR at the freeze (`prior_epoch_mpc_data_digests`) fails the commit
-  rather than degrading to announce-only: a transient read failure that
-  silently dropped the carry-forward map would freeze a shrunken set on
-  that one validator while peers freeze the full set — a divergent
-  frozen set. The commit errors, the consensus handler panics, and the
-  commit replays on restart until the read succeeds (`Ok(empty)` is
-  reserved for the chain-true no-cert epochs: genesis, a v3 prior epoch,
-  the first v4 epoch).
+  consensus-anchored and perpetual, and the prepare-then-start barrier
+  holds it locally before this epoch's consensus is processed — on the
+  continuing-validator reconfigure path today; the joiner-promotion and
+  cold-startup consensus-start paths are pending the barrier wiring
+  (see `dev-docs/plans/handoff-barrier-escape-and-pure-close-gate.md`),
+  so until then a first-time joiner racing its bootstrap fetch can
+  freeze without the carried map. A fresh announcement that diverged
+  (landing a member in `excluded`) is overridden by the known-good
+  prior digest, since the true blob cannot legitimately change between
+  epochs. A cert READ ERROR at the freeze
+  (`prior_epoch_mpc_data_digests`) fails the commit rather than
+  degrading to announce-only: a transient read failure that silently
+  dropped the carry-forward map would freeze a shrunken set on that one
+  validator while peers freeze the full set — a divergent frozen set.
+  The commit errors, the consensus handler panics, and the commit
+  replays on restart until the read succeeds (`Ok(empty)` is reserved
+  for the chain-true no-cert epochs: genesis, a v3 prior epoch, the
+  first v4 epoch; a missing perpetual-tables handle also fails the
+  commit — it is a local initialization fault, not a chain-true case).
 - The certificate cannot backfill an announcement for a validator with
   no prior frozen blob (a first-time joiner). For joiners the only
   mechanism is announcement propagation reaching a stake quorum BEFORE

--- a/dev-docs/specs/validator-mpc-data-announcements.md
+++ b/dev-docs/specs/validator-mpc-data-announcements.md
@@ -104,7 +104,15 @@ which bytes* deterministic in consensus order.
   barrier) held by every validator before it processes this epoch's
   consensus. A fresh announcement that diverged (landing a member in
   `excluded`) is overridden by the known-good prior digest, since the
-  true blob cannot legitimately change between epochs.
+  true blob cannot legitimately change between epochs. A cert READ
+  ERROR at the freeze (`prior_epoch_mpc_data_digests`) fails the commit
+  rather than degrading to announce-only: a transient read failure that
+  silently dropped the carry-forward map would freeze a shrunken set on
+  that one validator while peers freeze the full set — a divergent
+  frozen set. The commit errors, the consensus handler panics, and the
+  commit replays on restart until the read succeeds (`Ok(empty)` is
+  reserved for the chain-true no-cert epochs: genesis, a v3 prior epoch,
+  the first v4 epoch).
 - The certificate cannot backfill an announcement for a validator with
   no prior frozen blob (a first-time joiner). For joiners the only
   mechanism is announcement propagation reaching a stake quorum BEFORE


### PR DESCRIPTION
## What

`prior_epoch_mpc_data_digests` (the carry-forward source at the mpc_data freeze) reads the prior epoch's handoff certificate. On a cert **read error** it previously returned an empty map and logged *"degrading to announce-only"*.

That degrade is a **consensus-fork surface**: a transient read failure on one validator drops every carry-forward member from its frozen set while peers that read the cert fine keep them → that validator freezes a **shrunken** `frozen_validator_mpc_data_input_set`. The frozen set is consensus-derived state that must be byte-identical across the committee; a divergent one makes the validator honestly compute divergent MPC outputs (convicted malicious by the output-quorum byte-equality tally) and can wedge the next reconfiguration.

## Fix

`prior_epoch_mpc_data_digests` now returns `IkaResult<HashMap<AuthorityName, [u8; 32]>>` and **propagates** the read error. `freeze_mpc_data_if_first` already returns `IkaResult`; the `?` flows to `process_consensus_transactions_and_commit_boundary`, and `consensus_handler.rs:354`'s `.expect("Unrecoverable error in consensus handler")` panics the node — the commit was never durably written, so consensus replays it on restart and the freeze retries until the read succeeds.

This mirrors the **sibling read in the same function** — `epoch_mpc_data_ready_signals.safe_iter()` → `entry?` — which already `?`-propagates. It's the freeze-path realization of `handoff.md` invariant 4 (*"fail open with retry on read errors"*). `Ok(empty)` is now reserved for the chain-true no-cert epochs only (genesis / v3 prior / first v4), which are uniform across the committee.

## Scope

This is the **independent, strictly-safer half of the V1 cluster**. The second half — wiring `wait_for_handoff_data_ready` into the joiner-promotion and cold-startup consensus-start paths — is **deferred**: it depends on the barrier's cert-less escape (the "wedge" change), which deliberately relaxes the barrier's block-forever gate and is pending review. This PR makes nothing worse on those paths and fixes the Err path unconditionally.

## Specs

- `handoff.md` invariant 4 — freeze is a cert consumer that fail-stops on a read error.
- `validator-mpc-data-announcements.md` carry-forward — read error fails the commit rather than degrading to announce-only.

## Validation

- `cargo check -p ika-core --tests`, `cargo clippy -p ika-core --lib`, `cargo fmt --all` — clean.
- Pure carry-forward / freeze tally unit tests (`validator_metadata.rs`) are unaffected (logic unchanged; only the cert-read error handling that feeds `prior_mpc_data` changed).
- **Recommended follow-up (CI cluster):** fault-injection per `dev-docs/playbooks/test-testing.md` — in a v4 cluster where the E-1 cert is present, make `get_certified_handoff_attestation` return `Err` at the freeze commit (fail-point / table-handle poison). **Expected evidence:** the node panics with `"Unrecoverable error in consensus handler"`, and after restart+replay the freeze produces a carry-forward frozen set **byte-identical to peers** (not a shrunken set). This proves the fail-stop reacts; it's a heavy cluster test best run on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)