### PR TITLE
ci(test-cluster): one fresh-process retry for the swarm-startup port race

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,6 +10,27 @@ retries = 3
 # Timeout tests after 4 minutes
 slow-timeout = { period = "60s", terminate-after = 5 }
 
+[profile.cluster]
+# For the in-process Sui+ika swarm suite (test-cluster.yaml). Deliberately
+# NOT profile.ci: its 60s-slow x5 terminate-after would kill legitimate
+# cluster tests, which run for many minutes.
+#
+# One retry, in a fresh process, for the port-allocation race at swarm
+# startup: get_available_port binds-then-releases a port, and under
+# process-per-test parallelism another node can grab it before the swarm
+# node binds ("Address already in use" inside sui-node's p2p startup, the
+# test dies in <1s). A fresh process re-picks ports, so one retry clears
+# it; a deterministic failure still fails (twice), and nextest reports any
+# retried-then-passed test as FLAKY in the summary — retries never hide a
+# test that flaked.
+retries = 1
+# Match the flags the workflow passes explicitly, so behavior is identical
+# with or without them.
+fail-fast = false
+# Replay a failing test's captured output immediately — when the runner pod
+# dies (OOM/eviction), the live log is the only surviving evidence.
+failure-output = "immediate"
+
 [profile.simtestnightly]
 # Print out output for failing tests as soon as they fail, and also at the end
 # of the run (for easy scrollability).

--- a/.github/workflows/test-cluster.yaml
+++ b/.github/workflows/test-cluster.yaml
@@ -152,14 +152,18 @@ jobs:
           # Failure replays stay inline ON PURPOSE: when the runner pod dies
           # (OOM/eviction) the artifact upload never happens and the live
           # log is the only surviving evidence.
+          # --profile cluster (.config/nextest.toml): one fresh-process
+          # retry for the swarm-startup port-allocation race; a retried-
+          # then-passed test is reported FLAKY, never silently green.
           cargo nextest run --release -p "$PACKAGE" $TEST_FILTER \
+            --profile cluster \
             --test-threads "$TEST_THREADS" --no-fail-fast --cargo-quiet \
             2>&1 | tee cluster-tests.log
 
       - name: Summarize results
         if: always()
         run: |
-          grep -E "PASS |FAIL |SLOW |Summary" cluster-tests.log | tail -40 || true
+          grep -E "PASS |FAIL |FLAKY |TRY |SLOW |Summary" cluster-tests.log | tail -40 || true
 
       - name: Upload CPU sampler log
         if: always()


### PR DESCRIPTION
## Problem

The cluster suite invokes nextest with **no profile** → zero retries. The in-process swarm's port allocation is a bind-then-release TOCTOU: under process-per-test parallelism, another node can grab the released port before the swarm node binds. The test then dies **at spawn in <1s** with `Address already in use (os error 98)` inside `sui_node::SuiNode::create_p2p_network` (pinned `sui-swarm`) — observed on [run 29318021536](https://github.com/dwallet-labs/ika/actions/runs/29318021536): 21/22 passed, `test_sessions_complete_across_epoch_switch` dead at startup, no ika code in the backtrace.

The existing `profile.ci` (`retries = 3`) can't be reused: its `60s × 5` terminate-after would kill legitimate multi-minute cluster tests.

## Fix

- `.config/nextest.toml`: new `profile.cluster` — `retries = 1`, no slow-timeout termination, failure replay inline (the pod-death evidence rule).
- `test-cluster.yaml`: pass `--profile cluster`; the summary grep now also surfaces `FLAKY`/`TRY` lines.

**Why this doesn't mask real bugs:** a retry runs in a fresh process (fresh ports), so only the port race clears; a deterministic failure fails twice and the job stays red. nextest explicitly marks retried-then-passed tests as `FLAKY` in the summary, so every flake remains visible in the log and the summary step — the suite keeps its role as the determinism gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)