### PR TITLE
fix(dwallet-mpc): level-triggered drain for requests parked on a network key — reshare across a restart no longer wedges the epoch (#1834)

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -68,7 +68,6 @@ use prometheus::Registry;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use sui_types::base_types::ObjectID;
 use sui_types::messages_consensus::Round;
 #[cfg(any(test, feature = "test-utils"))]
 use tokio::sync::watch;
@@ -437,7 +436,6 @@ impl DWalletMPCService {
             "Spawning dWallet MPC Service"
         );
 
-        let mut newly_instantiated_network_key_ids = vec![];
         loop {
             match self.exit.has_changed() {
                 Ok(true) => {
@@ -470,18 +468,13 @@ impl DWalletMPCService {
                 break;
             }
 
-            newly_instantiated_network_key_ids = self
-                .run_service_loop_iteration(newly_instantiated_network_key_ids)
-                .await;
+            self.run_service_loop_iteration().await;
 
             tokio::time::sleep(Duration::from_millis(READ_INTERVAL_MS)).await;
         }
     }
 
-    pub(crate) async fn run_service_loop_iteration(
-        &mut self,
-        newly_instantiated_network_key_ids: Vec<ObjectID>,
-    ) -> Vec<ObjectID> {
+    pub(crate) async fn run_service_loop_iteration(&mut self) {
         debug!("Running DWalletMPCService loop");
 
         // Ingest the per-epoch off-chain validator MPC keys (3 PVSS + VSS HPKE)
@@ -510,13 +503,10 @@ impl DWalletMPCService {
         self.process_network_owned_address_sign_requests();
 
         // Receive **new** dWallet MPC events and save them in the local DB.
-        let rejected_sessions = self
-            .handle_new_requests(newly_instantiated_network_key_ids)
-            .await
-            .unwrap_or_else(|e| {
-                error!(error=?e, "failed to handle new events from DWallet MPC service");
-                vec![]
-            });
+        let rejected_sessions = self.handle_new_requests().await.unwrap_or_else(|e| {
+            error!(error=?e, "failed to handle new events from DWallet MPC service");
+            vec![]
+        });
 
         // Adopt locally-observed network-key outputs (cert-digest-gated)
         // and spawn instantiation for any not yet installed — once per
@@ -538,9 +528,12 @@ impl DWalletMPCService {
         self.process_consensus_rounds_from_storage().await;
         // Network-key instantiations complete asynchronously on the rayon
         // pool; poll them once per ITERATION (not per consensus round) so
-        // a completed key installs even when no new rounds arrived.
-        let newly_instantiated_network_key_ids = self
-            .dwallet_mpc_manager
+        // a completed key installs even when no new rounds arrived. Requests
+        // parked on a key drain via the level-triggered check in
+        // `handle_mpc_request_batch` on the next iteration — regardless of
+        // whether the key materialized here or through the chain-copy
+        // adoption path (issue #1834).
+        self.dwallet_mpc_manager
             .poll_pending_network_key_instantiations()
             .await;
 
@@ -559,8 +552,6 @@ impl DWalletMPCService {
             .service_end_of_publish_local
             .set(self.end_of_publish as i64);
         self.dwallet_mpc_manager.refresh_observability_metrics();
-
-        newly_instantiated_network_key_ids
     }
 
     /// Process network-owned-address sign requests received via the channel.
@@ -820,10 +811,7 @@ impl DWalletMPCService {
         self.send_status_update_to_consensus(is_idle).await;
     }
 
-    async fn handle_new_requests(
-        &mut self,
-        newly_instantiated_network_key_ids: Vec<ObjectID>,
-    ) -> DwalletMPCResult<Vec<DWalletSessionRequest>> {
+    async fn handle_new_requests(&mut self) -> DwalletMPCResult<Vec<DWalletSessionRequest>> {
         let uncompleted_requests = self.load_uncompleted_requests().await;
         let pulled_requests = match self.receive_new_sui_requests() {
             Ok(requests) => requests,
@@ -882,7 +870,7 @@ impl DWalletMPCService {
 
         let rejected_sessions = self
             .dwallet_mpc_manager
-            .handle_mpc_request_batch(requests, newly_instantiated_network_key_ids)
+            .handle_mpc_request_batch(requests)
             .await;
 
         Ok(rejected_sessions)

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/computation_results_batch.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/computation_results_batch.rs
@@ -46,7 +46,7 @@ async fn computation_results_batch_survives_stale_entries() {
         test_state.consensus_round += 1;
 
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
     }
 

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/idle_status_voting.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/idle_status_voting.rs
@@ -204,7 +204,7 @@ async fn test_validators_compute_idle_status_correctly() {
         test_state.consensus_round += 1;
 
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
 
         // Give rayon threads time to finish MPC computations between rounds.
@@ -289,7 +289,7 @@ async fn test_status_updates_distributed_through_consensus() {
     for round in 0..10 {
         // First, run service loops to generate status updates
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
 
         // Distribute results to all parties
@@ -546,7 +546,7 @@ async fn test_split_idle_status_vote_does_not_reach_consensus() {
         test_state.consensus_round += 1;
 
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
         utils::wait_for_computations(&mut test_state).await;
 
@@ -599,7 +599,7 @@ async fn test_split_idle_status_vote_does_not_reach_consensus() {
     // 2. Distribute and process the divergent status updates (round 2)
     for _ in 0..2 {
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
         utils::send_advance_results_between_parties(
             &test_state.committee,
@@ -609,7 +609,7 @@ async fn test_split_idle_status_vote_does_not_reach_consensus() {
         );
         test_state.consensus_round += 1;
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
     }
 
@@ -678,7 +678,7 @@ async fn test_no_idle_status_update_emitted_below_activation() {
 
     for _round in 0..10 {
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
         // Wire-level assertion, checked BEFORE this round's messages are
         // drained for distribution: nothing submitted may be an

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -113,7 +113,7 @@ async fn run_one_round_discarding_all_messages(test_state: &mut IntegrationTestS
     );
     test_state.consensus_round += 1;
     for service in test_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
 }
 
@@ -127,7 +127,7 @@ async fn run_one_round_delivering_messages(test_state: &mut IntegrationTestState
     );
     test_state.consensus_round += 1;
     for service in test_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     utils::wait_for_computations(test_state).await;
 }
@@ -374,7 +374,7 @@ async fn test_internal_presign_instantiation_at_correct_rounds() {
 
         // Run service loop for all services (processes the consensus round).
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
 
         // Read post-loop values that were set DURING round processing
@@ -557,7 +557,7 @@ async fn test_internal_presign_stops_at_min_pool_size_when_not_idle() {
         );
         test_state.consensus_round += 1;
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
         utils::wait_for_computations(&mut test_state).await;
 
@@ -630,7 +630,7 @@ async fn test_internal_presign_stops_at_min_pool_size_when_not_idle() {
         );
         test_state.consensus_round += 1;
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
     }
 
@@ -662,7 +662,7 @@ async fn test_internal_presign_stops_at_min_pool_size_when_not_idle() {
         );
         test_state.consensus_round += 1;
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
     }
 
@@ -751,7 +751,7 @@ async fn test_internal_presign_continues_when_idle() {
         );
         test_state.consensus_round += 1;
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
         utils::wait_for_computations(&mut test_state).await;
 
@@ -1253,7 +1253,7 @@ async fn test_internal_presign_multi_key_install_lag_keeps_identifiers_uniform()
         let _ = sender.network_keys_sender.send(both_keys.clone());
     });
     for service in test_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     utils::send_advance_results_between_parties(
         &test_state.committee,
@@ -1263,7 +1263,7 @@ async fn test_internal_presign_multi_key_install_lag_keeps_identifiers_uniform()
     );
     test_state.consensus_round = (round_after_k1 + 2) as usize;
     for service in test_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     utils::run_service_loops_until_network_key_installed(
         &mut test_state.dwallet_mpc_services,

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/message_before_event.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/message_before_event.rs
@@ -51,7 +51,7 @@ async fn some_parties_receive_mpc_message_before_session_start_event() {
         consensus_round,
     );
     for dwallet_mpc_service in dwallet_mpc_services.iter_mut() {
-        dwallet_mpc_service.run_service_loop_iteration(vec![]).await;
+        dwallet_mpc_service.run_service_loop_iteration().await;
     }
     consensus_round += 1;
     for i in &parties_that_receive_session_message_before_start_event {

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/missing_network_key.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/missing_network_key.rs
@@ -132,7 +132,7 @@ async fn network_key_received_after_start_event() {
         key_id.unwrap(),
     );
     for dwallet_mpc_service in test_state.dwallet_mpc_services.iter_mut() {
-        dwallet_mpc_service.run_service_loop_iteration(vec![]).await;
+        dwallet_mpc_service.run_service_loop_iteration().await;
     }
     for i in &parties_that_receive_network_key_after_start_event {
         let dwallet_mpc_service = &mut test_state.dwallet_mpc_services[*i];

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg.rs
@@ -396,7 +396,7 @@ pub(crate) async fn create_network_key_test(
     // We therefore distribute the key data status updates at `consensus_round + 1` so
     // that the second service loop run can read the new round and install the key.
     for service in test_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     // Distribute a fresh consensus round so the next service iterations
     // drive adoption and `instantiate_adopted_network_keys` populates
@@ -409,7 +409,7 @@ pub(crate) async fn create_network_key_test(
     );
     // Process the new round to instantiate the agreed network key in every party.
     for service in test_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     // The instantiation runs on the rayon pool and installs on a later
     // tick — keep iterating until it lands everywhere.
@@ -562,7 +562,7 @@ async fn test_two_network_keys_same_epoch_dkg() {
     // further iterations until each key installs on every party,
     // populating `manager.network_keys`.
     for service in test_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     utils::send_advance_results_between_parties(
         &test_state.committee,
@@ -571,7 +571,7 @@ async fn test_two_network_keys_same_epoch_dkg() {
         round_after_k1 + 1,
     );
     for service in test_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     // Both instantiations complete asynchronously on the rayon pool.
     utils::run_service_loops_until_network_key_installed(

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg_bwd_compat.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg_bwd_compat.rs
@@ -298,7 +298,7 @@ async fn test_v2_to_v3_reconfiguration_migration() {
                 )])));
         });
     for service in v3_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     // Fresh phase-2 services start with `last_read_consensus_round = Some(0)`, so the next
     // round read from storage must be `1`. Distribute the status updates from the loop above
@@ -311,7 +311,7 @@ async fn test_v2_to_v3_reconfiguration_migration() {
         1,
     );
     for service in v3_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     // The instantiation runs on the rayon pool and installs on a later
     // tick — keep iterating until it lands everywhere.
@@ -582,7 +582,7 @@ async fn test_v1_anchor_bwd_compat_reconfiguration() {
                 )])));
         });
     for service in p2_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     // Fresh phase-2 services start with `last_read_consensus_round = Some(0)`, so
     // distribute the status updates from the loop above at round 1 to keep
@@ -594,7 +594,7 @@ async fn test_v1_anchor_bwd_compat_reconfiguration() {
         1,
     );
     for service in p2_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     utils::run_service_loops_until_network_key_installed(
         &mut p2_state.dwallet_mpc_services,
@@ -823,7 +823,7 @@ async fn test_v1_anchor_main_reconfiguration_and_anchor_migration() {
                 )])));
         });
     for service in p2_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     utils::send_advance_results_between_parties(
         &p2_state.committee,
@@ -832,7 +832,7 @@ async fn test_v1_anchor_main_reconfiguration_and_anchor_migration() {
         1,
     );
     for service in p2_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     utils::run_service_loops_until_network_key_installed(
         &mut p2_state.dwallet_mpc_services,
@@ -942,7 +942,7 @@ async fn test_v1_anchor_main_reconfiguration_and_anchor_migration() {
                 )])));
         });
     for service in p3_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     utils::send_advance_results_between_parties(
         &p3_state.committee,
@@ -951,7 +951,7 @@ async fn test_v1_anchor_main_reconfiguration_and_anchor_migration() {
         1,
     );
     for service in p3_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
     utils::run_service_loops_until_network_key_installed(
         &mut p3_state.dwallet_mpc_services,

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
@@ -147,7 +147,7 @@ async fn network_owned_address_sign_flow(
 
     // Run service loop iterations to process the requests.
     for service in test_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
 
     // Check that NetworkOwnedAddressSign sessions were created.
@@ -231,7 +231,7 @@ async fn wait_for_network_owned_address_sign_output(
         );
         test_state.consensus_round += 1;
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
         utils::wait_for_computations(test_state).await;
         result = test_state.network_owned_address_sign_output_receivers[0]
@@ -488,7 +488,7 @@ async fn test_presign_pool_exhaustion_buffers_excess_sign_requests() {
 
     // Run one service loop iteration to drain the channel and process requests.
     for service in test_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
 
     // Assert: pool is empty (all presigns consumed).
@@ -528,7 +528,7 @@ async fn test_presign_pool_exhaustion_buffers_excess_sign_requests() {
         test_state.consensus_round += 1;
 
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
         utils::wait_for_computations(&mut test_state).await;
 
@@ -643,7 +643,7 @@ async fn network_owned_address_vss_sign_flow(
             .expect("failed to send network-owned-address VSS sign request");
     }
     for service in test_state.dwallet_mpc_services.iter_mut() {
-        service.run_service_loop_iteration(vec![]).await;
+        service.run_service_loop_iteration().await;
     }
 
     let sign_output = wait_for_network_owned_address_sign_output(&mut test_state).await;

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/noa_checkpoint.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/noa_checkpoint.rs
@@ -78,7 +78,7 @@ async fn run_until(
         test_state.consensus_round += 1;
 
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
 
         utils::wait_for_computations(test_state).await;
@@ -359,7 +359,7 @@ async fn test_noa_checkpoint_buffered_context() {
         );
         test_state.consensus_round += 1;
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
     }
 

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/presign_consensus.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/presign_consensus.rs
@@ -93,7 +93,7 @@ async fn test_global_presign_requests_tracked_and_reported() {
         test_state.consensus_round += 1;
 
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
     }
 
@@ -217,7 +217,7 @@ async fn test_partial_visibility_consensus_and_pool_retrieval() {
         test_state.consensus_round += 1;
 
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
     }
 
@@ -429,7 +429,7 @@ async fn run_rounds(test_state: &mut utils::IntegrationTestState, rounds: usize)
         test_state.consensus_round += 1;
 
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
     }
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/sign.rs
@@ -598,7 +598,7 @@ async fn global_presign_request_uses_correct_metadata_test() {
         test_state.consensus_round += 1;
         // Now services can read from the round we just set up
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
     }
 

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -997,7 +997,7 @@ pub(crate) async fn wait_for_computations(test_state: &mut IntegrationTestState)
         // rounds in the epoch store, `process_consensus_rounds_from_storage`
         // is a no-op, so only `process_cryptographic_computations` does work.
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
         if iteration > 0 && iteration % 100 == 0 {
             info!(
@@ -1041,7 +1041,7 @@ pub(crate) async fn run_service_loops_until_network_key_installed(
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
         for service in dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
     }
 }
@@ -1096,12 +1096,6 @@ pub(crate) async fn advance_some_parties_and_wait_for_completions(
     let mut pending_checkpoints = vec![];
     let mut completed_parties = vec![];
     let mut iterations = 0usize;
-    // Track per-party newly-instantiated network key IDs so that sessions waiting
-    // for a key (in `requests_pending_for_network_key`) are activated as soon as the
-    // key is adopted and installed, without requiring a second outer-loop
-    // iteration.
-    let mut party_newly_instantiated_network_key_ids: Vec<Vec<ObjectID>> =
-        vec![vec![]; committee.voting_rights.len()];
     while completed_parties.len() < parties_to_advance.len() {
         iterations += 1;
         if iterations >= max_party_iterations() {
@@ -1189,11 +1183,10 @@ pub(crate) async fn advance_some_parties_and_wait_for_completions(
                     _ => false,
                 });
             }
-            let key_ids = std::mem::take(&mut party_newly_instantiated_network_key_ids[i]);
-            let new_key_ids = dwallet_mpc_service
-                .run_service_loop_iteration(key_ids)
-                .await;
-            party_newly_instantiated_network_key_ids[i] = new_key_ids;
+            // Parked-on-network-key requests drain via the level-triggered
+            // check inside `handle_mpc_request_batch` — no id threading
+            // between iterations is needed.
+            dwallet_mpc_service.run_service_loop_iteration().await;
 
             // Check if the party has produced MPC messages or outputs in THIS iteration.
             // We filter for DWalletMPCMessage and DWalletMPCOutput because IdleStatusUpdate
@@ -1256,7 +1249,7 @@ pub(crate) async fn advance_some_parties_and_wait_for_completions(
             let dwallet_mpc_service = dwallet_mpc_services.get_mut(i).unwrap();
             // Run the service loop to allow tokio tasks spawned by rayon to complete
             // and to call receive_completed_computations internally.
-            let _ = dwallet_mpc_service.run_service_loop_iteration(vec![]).await;
+            let _ = dwallet_mpc_service.run_service_loop_iteration().await;
             if !dwallet_mpc_service
                 .dwallet_mpc_manager()
                 .cryptographic_computations_orchestrator
@@ -1513,7 +1506,7 @@ pub(crate) async fn send_start_network_dkg_event_to_all_parties(
         key_id,
     );
     for dwallet_mpc_service in test_state.dwallet_mpc_services.iter_mut() {
-        dwallet_mpc_service.run_service_loop_iteration(vec![]).await;
+        dwallet_mpc_service.run_service_loop_iteration().await;
         assert_eq!(dwallet_mpc_service.dwallet_mpc_manager().sessions.len(), 1);
         let session = dwallet_mpc_service
             .dwallet_mpc_manager()
@@ -1689,14 +1682,14 @@ pub(crate) async fn advance_rounds_while_presign_pool_empty(
         );
         consensus_round += 1;
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
         // Poll the service loop to collect rayon results, giving up to
         // POLLS_PER_ROUND × 100ms for single-round computations to finish.
         for _ in 0..POLLS_PER_ROUND {
             tokio::time::sleep(Duration::from_millis(100)).await;
             for service in test_state.dwallet_mpc_services.iter_mut() {
-                service.run_service_loop_iteration(vec![]).await;
+                service.run_service_loop_iteration().await;
             }
         }
         let pool_size = test_state

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/validator_restart.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/validator_restart.rs
@@ -77,7 +77,7 @@ async fn test_presign_pool_not_consumed_without_sign_requests() {
         test_state.consensus_round += 1;
 
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
     }
 
@@ -146,7 +146,7 @@ async fn test_validators_continue_sessions_across_rounds() {
             test_state.consensus_round += 1;
 
             for service in test_state.dwallet_mpc_services.iter_mut() {
-                service.run_service_loop_iteration(vec![]).await;
+                service.run_service_loop_iteration().await;
             }
         }
 
@@ -250,7 +250,7 @@ async fn test_system_resilience_to_temporary_unresponsiveness() {
 
         for (i, service) in test_state.dwallet_mpc_services.iter_mut().enumerate() {
             if i != unresponsive_validator {
-                service.run_service_loop_iteration(vec![]).await;
+                service.run_service_loop_iteration().await;
             }
         }
     }
@@ -300,7 +300,7 @@ async fn test_system_resilience_to_temporary_unresponsiveness() {
         test_state.consensus_round += 1;
 
         for service in test_state.dwallet_mpc_services.iter_mut() {
-            service.run_service_loop_iteration(vec![]).await;
+            service.run_service_loop_iteration().await;
         }
     }
 

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -177,8 +177,14 @@ pub(crate) struct DWalletMPCManager {
     pub(crate) last_session_to_complete_in_current_epoch: u64,
     pub(crate) recognized_self_as_malicious: bool,
     pub(crate) network_keys: Box<DwalletMPCNetworkKeys>,
-    /// Events that wait for the network key to update.
-    /// Once we get the network key, these events will be executed.
+    /// Requests parked until their network key's PUBLIC DATA is locally
+    /// available. Drained LEVEL-triggered on every
+    /// `handle_mpc_request_batch` (any parked key whose data now exists),
+    /// never edge-triggered on the consensus instantiation path — the key
+    /// can also materialize via the cert-less chain-copy adoption on a
+    /// fresh boot, which emits no such edge; an edge-only drain stranded a
+    /// reshare in flight across a restart forever and wedged the epoch
+    /// (issue #1834).
     pub(crate) requests_pending_for_network_key: HashMap<ObjectID, Vec<DWalletSessionRequest>>,
     pub(crate) requests_pending_for_next_active_committee: Vec<DWalletSessionRequest>,
 
@@ -2658,8 +2664,7 @@ impl DWalletMPCManager {
     /// per service ITERATION — not per consensus round — so a completed
     /// key installs even when no new consensus rounds arrived. Returns
     /// the IDs whose instantiation completed and installed this poll.
-    pub(crate) async fn poll_pending_network_key_instantiations(&mut self) -> Vec<ObjectID> {
-        let mut new_key_ids = Vec::new();
+    pub(crate) async fn poll_pending_network_key_instantiations(&mut self) {
         let in_flight_key_ids: Vec<ObjectID> = self
             .pending_network_key_instantiations
             .keys()
@@ -2834,7 +2839,6 @@ impl DWalletMPCManager {
                         }
                         // Succeeded — drop any prior failure record.
                         self.last_failed_network_key_data.remove(&key_id);
-                        new_key_ids.push(key_id);
                     }
                 }
                 Err(err) => {
@@ -2854,8 +2858,6 @@ impl DWalletMPCManager {
         self.dwallet_mpc_metrics
             .network_key_instantiations_in_flight
             .set(self.pending_network_key_instantiations.len() as i64);
-
-        new_key_ids
     }
 
     /// Instantiates network keys from the cert-verified outputs adopted into `adopted_network_key_data`.

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -502,7 +502,6 @@ impl DWalletMPCManager {
     pub(crate) async fn handle_mpc_request_batch(
         &mut self,
         requests: Vec<DWalletSessionRequest>,
-        newly_instantiated_network_key_ids: Vec<ObjectID>,
     ) -> Vec<DWalletSessionRequest> {
         // We only update `next_active_committee` in this block. Once it's set,
         // there will no longer be any pending events targeting it for this epoch.
@@ -530,16 +529,33 @@ impl DWalletMPCManager {
             }
         }
 
-        // Now handle events for which we've just received the corresponding public data.
-        // Since events are only queued in `events_pending_for_network_key` in `handle_mpc_request()` calls from this function,
-        // receiving the network key ensures no further events will be pending for that key.
-        // Therefore, it's safe to process them now, as the queue will remain empty afterward.
-        for key_id in newly_instantiated_network_key_ids {
+        // Drain requests parked on a network key whose public data is now
+        // locally available. LEVEL-triggered on data presence (re-checked
+        // every cycle), NOT edge-triggered on the consensus-round key
+        // instantiation: the key can materialize through paths that never
+        // emit that edge — on a fresh boot the cert-less chain-copy adoption
+        // registers the key's public data without ever passing through
+        // `poll_pending_network_key_instantiations`' newly-instantiated
+        // list. Under the old edge-triggered drain, a reshare in flight
+        // across a restart parked here forever: the session never activated,
+        // no output was ever produced, and the epoch could not close
+        // (issue #1834). Same discipline as the frozen-mpc-data queue below.
+        let ready_key_ids: Vec<ObjectID> = self
+            .requests_pending_for_network_key
+            .keys()
+            .filter(|key_id| self.network_keys.key_public_data_exists(key_id))
+            .copied()
+            .collect();
+        for key_id in ready_key_ids {
             let events_pending_for_newly_updated_network_key = self
                 .requests_pending_for_network_key
                 .remove(&key_id)
                 .unwrap_or_default();
-
+            info!(
+                network_encryption_key_id=?key_id,
+                drained = events_pending_for_newly_updated_network_key.len(),
+                "network key public data is now available; draining requests parked on it"
+            );
             for request in events_pending_for_newly_updated_network_key {
                 // We know this won't fail on a missing network key,
                 // but it could be waiting for the next committee,
@@ -619,13 +635,6 @@ impl DWalletMPCManager {
         {
             // We don't yet have the data for this network encryption key,
             // so we add it to the queue.
-            debug!(
-                session_request=?DWalletSessionRequestMetricData::from(&request.protocol_data).to_string(),
-                session_source=?request.session_type,
-                network_encryption_key_id=?network_encryption_key_id,
-                "Adding request to pending for the network key"
-            );
-
             let request_pending_for_this_network_key = self
                 .requests_pending_for_network_key
                 .entry(network_encryption_key_id)
@@ -636,6 +645,16 @@ impl DWalletMPCManager {
                 .all(|e| e.session_identifier != session_identifier)
             {
                 // Add an event with this session ID only if it doesn't exist.
+                // INFO (not debug), once per parked request: a silently
+                // stranded park here was a multi-hour diagnosis (issue
+                // #1834) — the deferral must be visible in default logs.
+                info!(
+                    session_request=?DWalletSessionRequestMetricData::from(&request.protocol_data).to_string(),
+                    session_source=?request.session_type,
+                    session_identifier=?session_identifier,
+                    network_encryption_key_id=?network_encryption_key_id,
+                    "network key public data not yet available; parking request until it is"
+                );
                 request_pending_for_this_network_key.push(request);
             }
 
@@ -645,20 +664,20 @@ impl DWalletMPCManager {
         if request.requires_next_active_committee && self.next_active_committee.is_none() {
             // We don't have the next active committee yet,
             // so we have to add this request to the pending queue until it arrives.
-            debug!(
-                session_request=?DWalletSessionRequestMetricData::from(&request.protocol_data).to_string(),
-                request=?request,
-                session_identifier=?request.session_identifier,
-                session_source=?request.session_type,
-                "Adding request to pending for the next epoch active committee"
-            );
-
             if self
                 .requests_pending_for_next_active_committee
                 .iter()
                 .all(|e| e.session_identifier != session_identifier)
             {
                 // Add a request with this session ID only if it doesn't exist.
+                // INFO, once per parked request — see the network-key park
+                // above for why these deferrals must be visible.
+                info!(
+                    session_request=?DWalletSessionRequestMetricData::from(&request.protocol_data).to_string(),
+                    session_identifier=?request.session_identifier,
+                    session_source=?request.session_type,
+                    "next-epoch active committee not yet available; parking request until it is"
+                );
                 self.requests_pending_for_next_active_committee
                     .push(request);
             }


### PR DESCRIPTION
Fixes #1834 — **release blocker**: a reshare in flight across the upgrade restart wedged the epoch permanently on the exact mainnet 1.1.8→1.2.0 atomic-swap path (reproduced twice in the `v118_upgrade` rehearsal, on plain main and main+#1821; the batch's green rehearsal runs simply didn't overlap the swap window with the mid-epoch reshare).

## Mechanism

Post-restart intake parks the reshare in `requests_pending_for_network_key` (its key's public data isn't registered yet). The queue drained only for keys in the **newly-instantiated edge list**, emitted solely by the consensus-round instantiation path — but a fresh boot materializes the key via the **cert-less chain-copy adoption**, which never emits that edge. The parked request never re-drove → the session never activated → no reshare output → `all_immediate_sessions_completed` and `all_network_encryption_keys_reconfiguration_completed` stayed false forever → the epoch could never close.

## Fix (the issue's preferred direction)

- **Level-triggered drain**: every `handle_mpc_request_batch` cycle drains any parked key whose public data now exists — same discipline as `requests_pending_for_frozen_mpc_data`, and indifferent to *which* path installed the key. Consensus-path timing is unchanged (the old edge also took effect on the next service iteration).
- **Edge plumbing removed end-to-end** (it existed only to feed this drain): the id no longer threads through `run_service_loop_iteration` → `handle_new_requests` → `handle_mpc_request_batch`; `poll_pending_network_key_instantiations` no longer collects/returns ids; the test-harness per-party threading is deleted; 51 call sites mechanically updated.
- **Observability**: both park branches (network key / next active committee) now log at **INFO** once per parked request, and the drain logs what it releases — the silence made this a multi-hour diagnosis.

## Validation

- `network_key_received_after_start_event` (the existing integration test that reproduces the exact park-then-materialize flow) — ✅ green in release, real crypto, 334s.
- **Fault-injection proof** (per `dev-docs/playbooks/test-testing.md`): forcing the drain shut (`filter(|_| false)`) makes that test **FAIL at the party-advancement cap** — the pre-fix strand — then reverted. The test genuinely guards the #1834 mechanism.
- The true end-to-end vehicle is the `v118_upgrade` rehearsal at the wedging cadence — dispatching on this branch; @ycscaly, if your local cadence reproduces deterministically, a run of your repro against this branch would be the strongest confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)