### PR TITLE
fix(committee): marker-guarded one-time legacy migration — unbreaks msim/debug store reopens (#1836)

### DIFF
--- a/crates/ika-core/src/epoch/committee_store.rs
+++ b/crates/ika-core/src/epoch/committee_store.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use sui_types::base_types::ObjectID;
-use tracing::info;
+use tracing::{info, warn};
 use typed_store::rocks::{DBMap, DBOptions, MetricConf, ReadWriteOptions, default_db_options};
 use typed_store::rocksdb::Options;
 
@@ -27,7 +27,21 @@ pub struct CommitteeStoreTables {
     /// Map from each epoch ID to the committee information.
     #[default_options_override_fn = "committee_table_default_config"]
     committee_map: DBMap<EpochId, Committee>,
+    /// Singleton marker: the `committee_map` value-schema generation this
+    /// store was last opened under (see `COMMITTEE_SCHEMA_VERSION_CURRENT`).
+    /// Present-and-current ⇒ every record is current-layout and the legacy
+    /// migration scan is skipped at open. Absent ⇒ the CF may hold
+    /// mainnet-v1.1.8 records (or is brand new) and the one-time scan runs.
+    /// Its own column family, so consulting it never decodes a committee
+    /// value under a possibly-mismatched schema.
+    committee_schema_version: DBMap<(), u64>,
 }
+
+/// `committee_map` value-schema generations: the mainnet-v1.1.8 layout
+/// (pre-`consensus_keys`) is generation 1; the current layout is 2. Only
+/// the current value is ever written; the constant exists so the marker
+/// is self-describing when inspected.
+const COMMITTEE_SCHEMA_VERSION_CURRENT: u64 = 2;
 
 // These functions are used to initialize the DB tables
 fn committee_table_default_config() -> DBOptions {
@@ -54,12 +68,37 @@ impl CommitteeStore {
     /// One-time migration: rewrite `committee_map` records persisted by
     /// mainnet-v1.1.8 (pre-`consensus_keys` layout, which the current
     /// `Committee` cannot decode — bcs is positional) in the current layout,
-    /// so every later read is a plain decode. Idempotent and crash-safe: a
-    /// record is rewritten only if it fails the current decode AND succeeds
-    /// the legacy one, so re-running skips already-migrated records. Remove
-    /// together with `LegacyCommittee` once no fleet upgrades directly from
-    /// 1.1.8 data dirs.
+    /// so every later read is a plain decode. Runs at most once per data
+    /// dir, guarded by the schema-version marker; crash-safe (a crash
+    /// before the marker re-scans on the next open, and re-migrating a
+    /// legacy record is a no-op rewrite). Remove together with
+    /// `LegacyCommittee` once no fleet upgrades directly from 1.1.8 data
+    /// dirs.
     fn migrate_legacy_records(tables: &CommitteeStoreTables) {
+        // Marker present: this store was already opened (and, if needed,
+        // migrated) by a current-schema binary, so every record decodes
+        // under the current layout — skip the scan. The skip is what makes
+        // REOPENS safe under debug assertions: the pinned typed-store
+        // `debug_fatal!`s — a PANIC in debug/msim builds — on any record
+        // that fails the reading view's schema, so scanning a
+        // current-layout CF under the LEGACY view (as every reopen did
+        // before the marker) panicked every msim node restart (issue
+        // #1836). Release builds log-and-skip instead, which is why the
+        // real-binary upgrade rehearsal never saw it.
+        match tables.committee_schema_version.get(&()) {
+            Ok(Some(version)) if version >= COMMITTEE_SCHEMA_VERSION_CURRENT => return,
+            Ok(_) => {}
+            Err(e) => {
+                // A marker read error must NOT skip the migration: a
+                // genuine 1.1.8 data dir would then fail its first
+                // committee read. Fall through and scan — idempotent.
+                warn!(
+                    error = ?e,
+                    "failed to read the committee schema-version marker; \
+                     running the legacy-migration scan"
+                );
+            }
+        }
         let legacy_view: DBMap<EpochId, LegacyCommittee> = DBMap::reopen(
             &tables.committee_map.db,
             Some("committee_map"),
@@ -67,15 +106,19 @@ impl CommitteeStore {
             false,
         )
         .expect("reopening committee_map under the legacy schema cannot fail — same cf");
-        // Current-layout records fail the legacy decode (trailing bytes) and
-        // are yielded as Err items; skip them. For each legacy-decodable
-        // record, confirm the current decode really fails before rewriting,
-        // so a current record can never be misread as legacy.
+        // A record that decodes under the legacy schema IS legacy: the two
+        // layouts are mutually exclusive on decode success (a current
+        // record leaves trailing bytes under the legacy schema; a legacy
+        // record exhausts its input under the current one), so no
+        // current-decode probe is needed before rewriting — and probing
+        // would `debug_fatal!` on every genuine 1.1.8 record in debug
+        // builds. Current-layout records yield `Err` items here and are
+        // skipped. (Residual corner: a marker-less MIXED CF — reachable
+        // only by crashing mid-scan on a real 1.1.8 upgrade and reopening
+        // in a debug-assertions build — panics in the iterator; the
+        // release re-scan handles it.)
         for item in legacy_view.safe_iter() {
             let Ok((epoch, legacy)) = item else { continue };
-            if tables.committee_map.get(&epoch).is_ok() {
-                continue;
-            }
             let committee = Committee::from(legacy);
             tables
                 .committee_map
@@ -87,6 +130,13 @@ impl CommitteeStore {
                  consensus_keys is empty for this epoch"
             );
         }
+        // Written AFTER the scan completes, so a crash mid-migration
+        // re-scans on the next open instead of stranding unmigrated rows
+        // behind the marker.
+        tables
+            .committee_schema_version
+            .insert(&(), &COMMITTEE_SCHEMA_VERSION_CURRENT)
+            .expect("failed to write the committee schema-version marker");
     }
 
     pub fn new_for_testing(_genesis_committee: &Committee) -> Self {
@@ -145,27 +195,114 @@ mod tests {
     use super::*;
     use ika_types::committee::LegacyCommittee;
 
+    fn fresh_path() -> PathBuf {
+        std::env::temp_dir().join(format!("DB_{:?}", nondeterministic!(ObjectID::random())))
+    }
+
+    fn legacy_view(store: &CommitteeStore) -> DBMap<EpochId, LegacyCommittee> {
+        DBMap::reopen(
+            &store.tables.committee_map.db,
+            Some("committee_map"),
+            &ReadWriteOptions::default(),
+            false,
+        )
+        .unwrap()
+    }
+
+    /// A genuine 1.1.8 data dir: legacy records, NO marker. The first open
+    /// migrates every record and writes the marker; the second open is a
+    /// pure marker-skip and the records still read fine.
     #[tokio::test]
     async fn legacy_records_migrate_at_open() {
-        let dir = std::env::temp_dir();
-        let path = dir.join(format!("DB_{:?}", nondeterministic!(ObjectID::random())));
+        let path = fresh_path();
+        let (legacy_committee, _keys) = Committee::new_simple_test_committee_of_size(4);
+        {
+            let store = CommitteeStore::new(path.clone(), None);
+            legacy_view(&store)
+                .insert(
+                    &legacy_committee.epoch,
+                    &LegacyCommittee::mirror_of(&legacy_committee),
+                )
+                .unwrap();
+            // A 1.1.8 dir has no marker; the fresh open above wrote one, so
+            // remove it to simulate the real upgrade state.
+            store.tables.committee_schema_version.remove(&()).unwrap();
+        }
+        for reopen in 0..2 {
+            let store = CommitteeStore::new(path.clone(), None);
+            let migrated = store
+                .get_committee(&legacy_committee.epoch)
+                .unwrap()
+                .unwrap();
+            assert_eq!(migrated.epoch, legacy_committee.epoch);
+            assert_eq!(migrated.voting_rights, legacy_committee.voting_rights);
+            assert_eq!(migrated.quorum_threshold, legacy_committee.quorum_threshold);
+            assert_eq!(
+                store.tables.committee_schema_version.get(&()).unwrap(),
+                Some(COMMITTEE_SCHEMA_VERSION_CURRENT),
+                "reopen {reopen}: the marker must be present after migration"
+            );
+        }
+    }
+
+    /// The marker actually gates the scan: with the marker present, a
+    /// reopen must NOT touch the CF — proven by planting a legacy record
+    /// AFTER the marker and observing it still legacy-encoded after the
+    /// reopen (the migration would have rewritten it to the current
+    /// layout, which no longer decodes under the legacy schema). This is
+    /// the property that keeps msim node restarts panic-free (#1836): a
+    /// marker-skipped open never iterates records under a mismatched
+    /// schema.
+    #[tokio::test]
+    async fn marker_skips_the_scan_on_reopen() {
+        let path = fresh_path();
+        let (legacy_committee, _keys) = Committee::new_simple_test_committee_of_size(4);
+        {
+            let store = CommitteeStore::new(path.clone(), None);
+            assert_eq!(
+                store.tables.committee_schema_version.get(&()).unwrap(),
+                Some(COMMITTEE_SCHEMA_VERSION_CURRENT),
+                "a fresh open must write the marker"
+            );
+            legacy_view(&store)
+                .insert(
+                    &legacy_committee.epoch,
+                    &LegacyCommittee::mirror_of(&legacy_committee),
+                )
+                .unwrap();
+        }
+        let store = CommitteeStore::new(path.clone(), None);
+        // Still decodes under the LEGACY schema ⇒ the scan did not run and
+        // did not rewrite it. (Probing it under the current schema would
+        // debug_fatal-panic in debug builds — exactly what the marker skip
+        // avoids — so the negative is asserted through the legacy view.)
+        assert!(
+            legacy_view(&store)
+                .get(&legacy_committee.epoch)
+                .unwrap()
+                .is_some(),
+            "the marker-guarded reopen must not have rewritten the record"
+        );
+    }
+
+    /// Mixed marker-less CF (legacy + current + corrupt): the scan migrates
+    /// the legacy record, leaves the current one untouched, and skips the
+    /// corrupt one. Release-only: iterating a schema-mismatched record
+    /// `debug_fatal!`s (panics) under debug assertions inside the pinned
+    /// typed-store — this mixed state is only reachable in production by
+    /// crashing mid-scan during a real 1.1.8 upgrade, where the re-scan
+    /// runs on a release binary.
+    #[cfg(not(debug_assertions))]
+    #[tokio::test]
+    async fn mixed_markerless_cf_migrates_legacy_and_skips_the_rest() {
+        let path = fresh_path();
         let (legacy_committee, _keys) = Committee::new_simple_test_committee_of_size(4);
         let (mut current_committee, _keys) = Committee::new_simple_test_committee_of_size(4);
         current_committee.epoch = legacy_committee.epoch + 1;
         let corrupt_epoch = legacy_committee.epoch + 2;
         {
             let store = CommitteeStore::new(path.clone(), None);
-            // Plant a 1.1.8-layout record, as a pre-upgrade binary would have
-            // written it — alongside a current-layout record and a corrupt
-            // one, the mixed state a CF can be in at open.
-            let legacy_view: DBMap<EpochId, LegacyCommittee> = DBMap::reopen(
-                &store.tables.committee_map.db,
-                Some("committee_map"),
-                &ReadWriteOptions::default(),
-                false,
-            )
-            .unwrap();
-            legacy_view
+            legacy_view(&store)
                 .insert(
                     &legacy_committee.epoch,
                     &LegacyCommittee::mirror_of(&legacy_committee),
@@ -184,28 +321,15 @@ mod tests {
             )
             .unwrap();
             raw_view.insert(&corrupt_epoch, &vec![0xde, 0xad]).unwrap();
-            // The legacy record does not decode under the current schema —
-            // this is the state an upgraded binary opens the store in.
-            assert!(
-                store
-                    .tables
-                    .committee_map
-                    .get(&legacy_committee.epoch)
-                    .is_err()
-            );
+            store.tables.committee_schema_version.remove(&()).unwrap();
         }
-        // Reopen twice: the first migration rewrites the legacy record, the
-        // second is a no-op over already-migrated records (idempotency); the
-        // corrupt record must not abort either open.
         for _ in 0..2 {
             let store = CommitteeStore::new(path.clone(), None);
             let migrated = store
                 .get_committee(&legacy_committee.epoch)
                 .unwrap()
                 .unwrap();
-            assert_eq!(migrated.epoch, legacy_committee.epoch);
             assert_eq!(migrated.voting_rights, legacy_committee.voting_rights);
-            assert_eq!(migrated.quorum_threshold, legacy_committee.quorum_threshold);
             // The current-layout record is untouched by the migration.
             let untouched = store
                 .get_committee(&current_committee.epoch)


### PR DESCRIPTION
Fixes #1836 — main's simtest is red: `sim_two_laggards_one_epoch` panics on node restart inside `CommitteeStore::new` (`typed-store safe_iter.rs:99`, run [29325949651](https://github.com/dwallet-labs/ika/actions/runs/29325949651)).

## Root cause

The #1821 migration scanned the whole `committee_map` CF under the **legacy** schema at **every** store open, relying on schema-mismatched records being yielded as `Err` items. That contract only holds in release: the pinned typed-store `debug_fatal!`s — a **panic** under debug assertions (msim, plain `cargo test`, debug validators) — on any record failing the reading view's schema, in both `safe_iter` **and** `get()`. Any store holding current-layout records (i.e. every store after its first reconfiguration) therefore panicked on reopen under msim. Release logs-and-continues — which is why `v118_upgrade` passed while simtest fails.

## Fix

1. **Scan once, marker-guarded**: a `committee_schema_version` singleton (own CF — consulting it never decodes a committee value) skips the scan when present-and-current. Fresh dir: scans an empty CF, writes the marker. Genuine 1.1.8 dir: no marker → scans once (all records decode as legacy — no mismatch, no `debug_fatal`) → rewrites → marker written **after** the scan (crash mid-migration re-scans). Marker read error → falls through to the scan.
2. **Current-decode probe removed**: the two layouts are mutually exclusive on decode success (current leaves trailing bytes under legacy; legacy exhausts input under current), so legacy-decode success already implies the rewrite — and the probe `debug_fatal`'d on every genuine 1.1.8 record in debug builds.
3. Documented residual: a marker-less **mixed** CF (crash mid-scan on a real 1.1.8 upgrade + reopen in a debug build) still panics; the release re-scan handles it.

## Validation

- Tests restructured for marker semantics, split by profile (the mixed-CF test is release-only *because the mixed scan panics by design in debug* — that's the bug class itself). Green in **both** debug and release.
- **Fault-injection proof**: disabling the marker gate makes the debug-profile tests fail with the *exact* production signatures — `safe_iter.rs:99` / `mod.rs:1685`, `Failed to deserialize value in cf committee_map: remaining input` — the same line as main's simtest failure. Reverted.
- Dispatching simtest (the reproducing suite) + cluster on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)