### PR TITLE
ci: gate releases on literal v1.1.8 mixed rollout

### DIFF
--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -23,3 +23,7 @@ runs:
       shell: bash
       run: |
         git config --global url."git@github.com:dwallet-labs/inkrypto".insteadOf "https://github.com/dwallet-labs/inkrypto"
+        # TEMPORARY: the crypto crates are imported from cryptography-private
+        # (PR #614) until it is published to inkrypto; the deploy key must have
+        # read access to it. Remove with the crypto dep move back to inkrypto.
+        git config --global url."git@github.com:dwallet-labs/cryptography-private".insteadOf "https://github.com/dwallet-labs/cryptography-private"

--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -23,7 +23,3 @@ runs:
       shell: bash
       run: |
         git config --global url."git@github.com:dwallet-labs/inkrypto".insteadOf "https://github.com/dwallet-labs/inkrypto"
-        # TEMPORARY: the crypto crates are imported from cryptography-private
-        # (PR #614) until it is published to inkrypto; the deploy key must have
-        # read access to it. Remove with the crypto dep move back to inkrypto.
-        git config --global url."git@github.com:dwallet-labs/cryptography-private".insteadOf "https://github.com/dwallet-labs/cryptography-private"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,6 +119,19 @@ jobs:
 
           echo "Version: $RAW  Docker tag: $DOCKER_TAG  Network: $NETWORK  Release: $IS_RELEASE"
 
+  # Release tags are blocked until the exact tagged commit survives a literal
+  # mainnet-v1.1.8/current mixed committee. This reusable call runs only the
+  # focused rollout scenario, not the expensive full upgrade matrix.
+  upgrade-compatibility-gate:
+    name: v1.1.8 mixed-rollout compatibility gate
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/upgrade-test.yaml
+    with:
+      test: v118_mixed_rollout
+      candidate_sha: ${{ github.sha }}
+      use_mocks: false
+    secrets: inherit
+
   # ---------------------------------------------------------------------------
   # Build Linux binaries in Docker (reproducible, glibc-compatible)
   # Both x64 and arm64 use the same Dockerfile with different TARGET args
@@ -411,7 +424,7 @@ jobs:
   release:
     name: Draft GitHub Release
     runs-on: ubuntu-latest
-    needs: [version, docker, upload-binaries]
+    needs: [version, docker, upload-binaries, upgrade-compatibility-gate]
     if: needs.version.outputs.is_release == 'true'
     permissions:
       contents: write

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -355,7 +355,10 @@ jobs:
               OLD_BIN_NAME=ika-node
               ;;
             cross_binary)
-              : "${OLD_REF:=$GITHUB_REF_NAME}"
+              # The old side is current source with only the protocol ceiling
+              # patched. Pin it to the same immutable candidate commit instead
+              # of a branch name that can move between setup and compilation.
+              : "${OLD_REF:=$CANDIDATE_SHA}"
               : "${OLD_BIN_NAME:=ika-validator}"
               : "${PATCH_MAX:=3}"
               ;;
@@ -430,12 +433,20 @@ jobs:
           WT="$GITHUB_WORKSPACE/old-build"
           git worktree remove --force "$WT" 2>/dev/null || true
           rm -rf "$WT"
-          # `fetch-depth: 0` fetches all tags + the triggering ref's history,
-          # but an arbitrary `old_ref` override (another branch/sha) may not be
-          # present locally — best-effort fetch it, then let worktree add fail
-          # loudly if the ref truly does not exist.
-          git fetch --no-tags origin "$OLD_REF" 2>/dev/null || true
-          git worktree add --force --detach "$WT" "$OLD_REF"
+          # Resolve the requested ref to one immutable commit before creating
+          # the worktree. A remote branch is normally present only as
+          # origin/<name>; an arbitrary SHA may need an explicit fetch.
+          if git rev-parse --verify "${OLD_REF}^{commit}" >/dev/null 2>&1; then
+            OLD_COMMIT=$(git rev-parse --verify "${OLD_REF}^{commit}")
+          elif git rev-parse --verify "origin/${OLD_REF}^{commit}" >/dev/null 2>&1; then
+            OLD_COMMIT=$(git rev-parse --verify "origin/${OLD_REF}^{commit}")
+          else
+            git fetch --no-tags origin "$OLD_REF"
+            OLD_COMMIT=$(git rev-parse --verify "FETCH_HEAD^{commit}")
+          fi
+          test -n "$OLD_COMMIT" || { echo "could not resolve old_ref '$OLD_REF' to a commit" >&2; exit 1; }
+          echo "resolved OLD_REF=$OLD_REF to immutable commit $OLD_COMMIT"
+          git worktree add --force --detach "$WT" "$OLD_COMMIT"
           if [ -n "$PATCH_MAX" ]; then
             [[ "$PATCH_MAX" =~ ^[0-9]+$ ]] || { echo "old_max_protocol_version must be numeric, got '$PATCH_MAX'" >&2; exit 1; }
             SOURCE="$WT/crates/ika-protocol-config/src/lib.rs"

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -1,6 +1,6 @@
 name: Upgrade Test
 
-# Manually triggered. Runs the out-of-process cross-binary upgrade harness
+# Release-gated and manually triggerable. Runs the out-of-process cross-binary upgrade harness
 # (`crates/ika-upgrade-test/`) on the `ika-k8s-large` self-hosted runner.
 # Unlike the in-process cluster/integration suites, this spawns REAL,
 # separately-compiled `ika-validator` child processes against an external
@@ -8,9 +8,9 @@ name: Upgrade Test
 # protocol-version upgrade contract (see
 # dev-docs/specs/cross-binary-upgrade.md).
 #
-# This is a "run it when you need it" suite — before a mainnet upgrade, or
-# when touching versioning / serialization / the epoch boundary — not a
-# per-push or nightly gate. Pick the scenario with the `test` input:
+# Manual dispatch can run any scenario. Relevant pull requests and release-tag
+# workflows run only `v118_mixed_rollout`, avoiding the full expensive matrix
+# on unrelated changes. Pick the scenario with the `test` input:
 #
 #   smoke        — go/no-go plumbing: 4 same-binary processes reach epoch 2.
 #                  Needs only the current build. Fastest.
@@ -20,15 +20,19 @@ name: Upgrade Test
 #                  wire-compatible builds: an OLD build of `old_ref` pinned
 #                  to MAX_PROTOCOL_VERSION=3 and the current build. Defaults
 #                  to old_ref=<this branch>, old_max_protocol_version=3.
-#   v118_upgrade — the atomic mainnet rehearsal: boot the literal
-#                  `mainnet-v1.1.8` binary, swap all to the current build,
+#   v118_upgrade — the full-committee mainnet rehearsal: boot the literal
+#                  `mainnet-v1.1.8` binary, sequentially swap all to current,
 #                  confirm v4 and continued serving. Defaults to
 #                  old_ref=mainnet-v1.1.8, old_bin_name=ika-node.
 #   v118_churn   — v118_upgrade + post-upgrade committee churn: after the
-#                  atomic 1.1.8 -> local swap, join a brand-new local validator
+#                  full-committee 1.1.8 -> local swap, join a new validator
 #                  so the v4 reshare of the 1.1.8-origin key includes a new
 #                  party (exercises the OCS joiner trust-anchor path from a real
 #                  1.1.8 origin). Same defaults as v118_upgrade.
+#   v118_mixed_rollout — release-blocking decentralized rollout: boot literal
+#                  mainnet-v1.1.8, upgrade exactly one validator, and keep the
+#                  other three literal old binaries through two protocol-v3
+#                  network-key reconfigurations with per-authority convergence.
 #   legacy_config — rollout-day config rehearsal: the current build on
 #                  old-style (1.1.8-shape) YAMLs — `sui-rpc-url` only, no
 #                  sui-data-source — for all validators AND the notifier
@@ -50,10 +54,75 @@ name: Upgrade Test
 # localnet (its ika system object maps to Chain::Unknown).
 
 on:
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/ika-core/Cargo.toml"
+      - "crates/ika-core/src/dwallet_mpc/**"
+      - "crates/ika-core/src/dwallet_session_request.rs"
+      - "crates/ika-core/src/request_protocol_data.rs"
+      - "crates/ika-node/Cargo.toml"
+      - "crates/dwallet-mpc-*/**"
+      - "crates/ika-types/Cargo.toml"
+      - "crates/ika-types/src/crypto.rs"
+      - "crates/ika-types/src/message.rs"
+      - "crates/ika-types/src/messages_dwallet_mpc.rs"
+      - "crates/ika-protocol-config/**"
+      - "crates/ika-upgrade-test/**"
+      - ".github/workflows/upgrade-test.yaml"
+      - ".github/workflows/release.yaml"
+  workflow_call:
+    inputs:
+      test:
+        description: "Scenario or comma-separated scenarios"
+        type: string
+        required: false
+        default: "v118_mixed_rollout"
+      candidate_sha:
+        description: "Exact release-candidate commit SHA to check out and test"
+        type: string
+        required: true
+      old_ref:
+        type: string
+        required: false
+        default: ""
+      old_bin_name:
+        type: string
+        required: false
+        default: ""
+      old_max_protocol_version:
+        type: string
+        required: false
+        default: ""
+      epoch_duration_ms:
+        type: string
+        required: false
+        default: ""
+      max_mpc_computation_cores:
+        type: string
+        required: false
+        default: ""
+      rust_log:
+        type: string
+        required: false
+        default: "info"
+      heap_profile:
+        type: boolean
+        required: false
+        default: false
+      use_mocks:
+        type: boolean
+        required: false
+        default: false
+      test_testing_fault:
+        type: boolean
+        required: false
+        default: false
   workflow_dispatch:
     inputs:
       test:
-        description: "Scenarios: 'all', or a comma-separated subset e.g. 'smoke,cross_binary,v118_churn'. Each runs as its own job on its own runner, in parallel."
+        description: "Scenarios: 'all', or a comma-separated subset e.g. 'cross_binary,v118_mixed_rollout'. Each runs as its own parallel job."
         type: string
         required: true
         # Default 'all' = every scenario. Or a comma-separated subset. Each
@@ -62,13 +131,18 @@ on:
         # apply to EVERY selected scenario, so leave them empty unless running a
         # single scenario (each scenario otherwise uses its own defaults).
         default: "all"
+      candidate_sha:
+        description: "Exact candidate SHA (empty = SHA captured when the run is dispatched)"
+        type: string
+        required: false
+        default: ""
       old_ref:
-        description: "Git ref/tag/sha/branch for the OLD binary (cross_binary & v118_upgrade; empty = per-scenario default)"
+        description: "Git ref/tag/sha/branch for the OLD binary (empty = per-scenario default; mixed rollout uses literal mainnet-v1.1.8)"
         type: string
         required: false
         default: ""
       old_bin_name:
-        description: "OLD ika-node bin name (empty = ika-node for v118_upgrade, ika-validator for cross_binary)"
+        description: "OLD ika-node bin name (empty = ika-node for v118 scenarios, ika-validator for cross_binary)"
         type: string
         required: false
         default: ""
@@ -78,7 +152,7 @@ on:
         required: false
         default: ""
       epoch_duration_ms:
-        description: "Override ika genesis epoch duration in ms (only cross_binary/v118_upgrade/v118_churn honor it; empty = scenario default)"
+        description: "Override ika genesis epoch duration in ms (mixed rollout requires >=480000; empty = scenario default)"
         type: string
         required: false
         default: ""
@@ -98,7 +172,12 @@ on:
         required: false
         default: false
       use_mocks:
-        description: "Build binaries with the INSECURE dwallet-mpc-unsafe-mock crypto (deterministic mocks). CONSTRAINT: cross-binary scenarios also build the OLD binary mocked, so old_ref MUST carry the feature; and the mock changes MPC/network-key behavior, so upgrade assertions may differ. Off by default."
+        description: "Build with INSECURE deterministic MPC mocks. Rejected for v118_mixed_rollout; other cross-binary old refs must carry the mock feature. Off by default."
+        type: boolean
+        required: false
+        default: false
+      test_testing_fault:
+        description: "TEST ONLY: build the mixed-rollout current validator with the existing test-testing reconfiguration-message fault; the zero-malicious/convergence gate must fail."
         type: boolean
         required: false
         default: false
@@ -114,6 +193,7 @@ env:
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
   RUST_LOG: ${{ inputs.rust_log || 'info' }}
+  CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
   rust_stable: "1.94"
 
 jobs:
@@ -127,10 +207,10 @@ jobs:
     steps:
       - id: pick
         env:
-          TEST: ${{ inputs.test }}
+          TEST: ${{ inputs.test || 'v118_mixed_rollout' }}
         run: |
           set -euo pipefail
-          ALL="smoke workload cross_binary v118_upgrade v118_churn legacy_config"
+          ALL="smoke workload cross_binary v118_upgrade v118_churn v118_mixed_rollout legacy_config"
           if [ "$TEST" = "all" ]; then
             SELECTED="$ALL"
           else
@@ -168,9 +248,14 @@ jobs:
           # Full history + tags: the OLD binary is built from an arbitrary
           # ref (e.g. the mainnet-v1.1.8 tag) via `git worktree add`.
           fetch-depth: 0
+          # Resolve once at trigger time; never rebuild a moving branch head.
+          ref: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
 
       - name: Runner resources
         run: |
+          ACTUAL_SHA=$(git rev-parse HEAD)
+          [ "$ACTUAL_SHA" = "$CANDIDATE_SHA" ] || { echo "checked out $ACTUAL_SHA, expected exact candidate $CANDIDATE_SHA" >&2; exit 1; }
+          echo "exact candidate SHA: $ACTUAL_SHA"
           # Surface what this pod ACTUALLY gets — the scale set advertises up
           # to 80 vCPUs, but a low cgroup quota (requests/limits mismatch) or
           # node oversubscription silently throttles the crypto workloads.
@@ -242,6 +327,7 @@ jobs:
             cross_binary) RUN_FLAG=RUN_CROSS_BINARY ;;
             v118_upgrade) RUN_FLAG=RUN_V118_UPGRADE ;;
             v118_churn)   RUN_FLAG=RUN_V118_CHURN ;;
+            v118_mixed_rollout) RUN_FLAG=RUN_V118_MIXED_ROLLOUT ;;
             legacy_config) RUN_FLAG=RUN_LEGACY_CONFIG ;;
             *) echo "unknown test: $TEST" >&2; exit 1 ;;
           esac
@@ -254,6 +340,19 @@ jobs:
             v118_upgrade | v118_churn)
               : "${OLD_REF:=mainnet-v1.1.8}"
               : "${OLD_BIN_NAME:=ika-node}"
+              ;;
+            v118_mixed_rollout)
+              [ -z "$OLD_REF" ] || [ "$OLD_REF" = "mainnet-v1.1.8" ] || {
+                echo "v118_mixed_rollout requires literal old_ref=mainnet-v1.1.8" >&2; exit 1;
+              }
+              [ -z "$OLD_BIN_NAME" ] || [ "$OLD_BIN_NAME" = "ika-node" ] || {
+                echo "v118_mixed_rollout requires the historical ika-node binary" >&2; exit 1;
+              }
+              [ -z "$PATCH_MAX" ] || {
+                echo "v118_mixed_rollout forbids MAX_PROTOCOL_VERSION patching" >&2; exit 1;
+              }
+              OLD_REF=mainnet-v1.1.8
+              OLD_BIN_NAME=ika-node
               ;;
             cross_binary)
               : "${OLD_REF:=$GITHUB_REF_NAME}"
@@ -283,8 +382,17 @@ jobs:
           CARGO_PROFILE_RELEASE_STRIP: ${{ inputs.heap_profile && 'none' || 'debuginfo' }}
           CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: ${{ inputs.heap_profile && 'off' || 'packed' }}
           USE_MOCKS: ${{ inputs.use_mocks }}
+          TEST_TESTING_FAULT: ${{ inputs.test_testing_fault }}
         run: |
           set -euo pipefail
+          if [ "$TEST_NAME" = "v118_mixed_rollout" ] && [ "$USE_MOCKS" = "true" ]; then
+            echo "v118_mixed_rollout is a release gate and must use real cryptography" >&2
+            exit 1
+          fi
+          if [ "$TEST_TESTING_FAULT" = "true" ] && [ "$TEST_NAME" != "v118_mixed_rollout" ]; then
+            echo "test_testing_fault is only supported by v118_mixed_rollout" >&2
+            exit 1
+          fi
           # `use_mocks` builds the NEW binaries with the INSECURE deterministic
           # mocks. For cross-binary scenarios the OLD binary is built with the
           # mock too (below), so its ref MUST carry the dwallet-mpc-unsafe-mock
@@ -294,6 +402,10 @@ jobs:
           if [ "$USE_MOCKS" = "true" ]; then
             NODE_FEATURES="--features dwallet-mpc-unsafe-mock"
             IKA_FEATURES="--features dwallet-mpc-unsafe-mock"
+          fi
+          if [ "$TEST_TESTING_FAULT" = "true" ]; then
+            NODE_FEATURES="--features test-testing"
+            echo "building deliberately faulty current validator; this validation run must fail closed"
           fi
           # Compilation in its own step: the Downloaded/Compiling stream is
           # the majority of this job's log volume and collapses in the UI when
@@ -305,7 +417,7 @@ jobs:
           cargo test --no-run --release -p ika-upgrade-test --test "$TEST_NAME"
 
       - name: Build OLD binary from ${{ env.OLD_REF }}
-        if: ${{ matrix.test == 'cross_binary' || matrix.test == 'v118_upgrade' || matrix.test == 'v118_churn' }}
+        if: ${{ matrix.test == 'cross_binary' || matrix.test == 'v118_upgrade' || matrix.test == 'v118_churn' || matrix.test == 'v118_mixed_rollout' }}
         env:
           USE_MOCKS: ${{ inputs.use_mocks }}
         run: |
@@ -326,10 +438,20 @@ jobs:
           git worktree add --force --detach "$WT" "$OLD_REF"
           if [ -n "$PATCH_MAX" ]; then
             [[ "$PATCH_MAX" =~ ^[0-9]+$ ]] || { echo "old_max_protocol_version must be numeric, got '$PATCH_MAX'" >&2; exit 1; }
+            SOURCE="$WT/crates/ika-protocol-config/src/lib.rs"
+            MATCHES=$(grep -cE '^const MAX_PROTOCOL_VERSION: u64 = [0-9]+;$' "$SOURCE" || true)
+            [ "$MATCHES" -eq 1 ] || { echo "expected exactly one MAX_PROTOCOL_VERSION assignment, found $MATCHES" >&2; exit 1; }
+            EXPECTED="const MAX_PROTOCOL_VERSION: u64 = ${PATCH_MAX};"
+            if grep -Fxq "$EXPECTED" "$SOURCE"; then
+              echo "MAX_PROTOCOL_VERSION already equals requested value ${PATCH_MAX}; no substitution would occur" >&2
+              exit 1
+            fi
             sed -i -E "s/^const MAX_PROTOCOL_VERSION: u64 = [0-9]+;/const MAX_PROTOCOL_VERSION: u64 = ${PATCH_MAX};/" \
-              "$WT/crates/ika-protocol-config/src/lib.rs"
+              "$SOURCE"
+            AFTER=$(grep -cFx "$EXPECTED" "$SOURCE" || true)
+            [ "$AFTER" -eq 1 ] || { echo "MAX_PROTOCOL_VERSION patch verification failed: expected '$EXPECTED' exactly once, found $AFTER" >&2; exit 1; }
             echo "patched MAX_PROTOCOL_VERSION -> ${PATCH_MAX}:"
-            grep -n 'const MAX_PROTOCOL_VERSION' "$WT/crates/ika-protocol-config/src/lib.rs"
+            grep -n 'const MAX_PROTOCOL_VERSION' "$SOURCE"
           fi
           # Build at the OLD ref's own toolchain (rustup reads the worktree's
           # rust-toolchain.toml). A ref that won't build on its own toolchain
@@ -343,7 +465,7 @@ jobs:
       - name: Run ${{ matrix.test }}
         env:
           # smoke/workload read IKA_VALIDATOR_BIN/IKA_NOTIFIER_BIN/IKA_BIN;
-          # cross_binary/v118_upgrade read NEW_BIN/NOTIFIER_BIN/OLD_BIN/IKA_BIN.
+          # Cross-binary/v1.1.8 scenarios read NEW_BIN/NOTIFIER_BIN/OLD_BIN/IKA_BIN.
           # Setting both naming sets is harmless — each test reads only its own.
           IKA_VALIDATOR_BIN: ${{ github.workspace }}/target/release/ika-validator
           NEW_BIN: ${{ github.workspace }}/target/release/ika-validator
@@ -393,6 +515,12 @@ jobs:
           set -uo pipefail
           export SUI_BIN="$HOME/.local/bin/sui"
           export "${RUN_FLAG}=1"
+          # Keep production pool sizing/timing for the release gate. The
+          # reduced-pool override remains a resource concession for the wider
+          # workload/churn matrix, not compatibility evidence.
+          if [ "$TEST_NAME" = "v118_mixed_rollout" ]; then
+            unset IKA_ENABLE_SMALL_PRESIGN_POOLS
+          fi
           mkdir -p "$UPGRADE_TEST_DIR"
           echo "running $TEST_NAME (flag $RUN_FLAG); sui=$SUI_BIN old_bin=${OLD_BIN:-<none>}"
           # Resource sampler (CPU + MEMORY) -> resource-sampler.log, BACKGROUNDED

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,7 +3253,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "class_groups"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
 dependencies = [
  "bcs",
  "commitment",
@@ -3344,7 +3344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3353,7 +3353,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3369,7 +3369,7 @@ dependencies = [
 [[package]]
 name = "commitment"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
 dependencies = [
  "crypto-bigint 0.7.0-rc.9",
  "group 0.2.0",
@@ -5084,7 +5084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5349,7 +5349,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5865,7 +5865,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
 dependencies = [
  "blake2b_simd",
  "crypto-bigint 0.7.0-rc.9",
@@ -6178,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "homomorphic_encryption"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
 dependencies = [
  "criterion",
  "crypto-bigint 0.7.0-rc.9",
@@ -7330,7 +7330,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7970,7 +7970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8365,7 +8365,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 [[package]]
 name = "maurer"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
 dependencies = [
  "commitment",
  "crypto-bigint 0.7.0-rc.9",
@@ -9534,7 +9534,7 @@ dependencies = [
 [[package]]
 name = "mpc"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
 dependencies = [
  "aead 0.5.2",
  "bcs",
@@ -11241,7 +11241,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
 dependencies = [
  "commitment",
  "crypto-bigint 0.7.0-rc.9",
@@ -11258,7 +11258,7 @@ dependencies = [
 [[package]]
 name = "proof_aggregation"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
 dependencies = [
  "commitment",
  "crypto-bigint 0.7.0-rc.9",
@@ -11572,7 +11572,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.8",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12301,7 +12301,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12314,7 +12314,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12382,7 +12382,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13305,7 +13305,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16010,7 +16010,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -17111,7 +17111,7 @@ dependencies = [
 [[package]]
 name = "twopc_mpc"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
 dependencies = [
  "class_groups",
  "commitment",
@@ -17844,7 +17844,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-classgroups-types"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bcs",
  "class_groups",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-rng"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "commitment",
  "fastcrypto",
@@ -6548,7 +6548,7 @@ dependencies = [
 
 [[package]]
 name = "ika"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6592,7 +6592,7 @@ dependencies = [
 
 [[package]]
 name = "ika-archival"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6762,7 +6762,7 @@ dependencies = [
 
 [[package]]
 name = "ika-node"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6830,7 +6830,7 @@ dependencies = [
 
 [[package]]
 name = "ika-proxy"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -6979,7 +6979,7 @@ dependencies = [
 
 [[package]]
 name = "ika-test-cluster"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7064,7 +7064,7 @@ dependencies = [
 
 [[package]]
 name = "ika-upgrade-test"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,7 +3253,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "class_groups"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "bcs",
  "commitment",
@@ -3369,7 +3369,7 @@ dependencies = [
 [[package]]
 name = "commitment"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "crypto-bigint 0.7.0-rc.9",
  "group 0.2.0",
@@ -5865,7 +5865,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "blake2b_simd",
  "crypto-bigint 0.7.0-rc.9",
@@ -6178,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "homomorphic_encryption"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "criterion",
  "crypto-bigint 0.7.0-rc.9",
@@ -8365,7 +8365,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 [[package]]
 name = "maurer"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "commitment",
  "crypto-bigint 0.7.0-rc.9",
@@ -9534,7 +9534,7 @@ dependencies = [
 [[package]]
 name = "mpc"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "aead 0.5.2",
  "bcs",
@@ -11241,7 +11241,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "commitment",
  "crypto-bigint 0.7.0-rc.9",
@@ -11258,7 +11258,7 @@ dependencies = [
 [[package]]
 name = "proof_aggregation"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "commitment",
  "crypto-bigint 0.7.0-rc.9",
@@ -17111,7 +17111,7 @@ dependencies = [
 [[package]]
 name = "twopc_mpc"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/cryptography-private?rev=eeb6e68f#eeb6e68f6bc7fe243dc0307611431485987d5972"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "class_groups",
  "commitment",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 [workspace.package]
 # This version string will be inherited by ika-core, ika-node, ika-tools, ika-sdk, and ika crates.
-version = "1.2.0"
+version = "1.2.1"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,18 +79,18 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 [workspace.dependencies]
 crypto-bigint = { version = "0.7.0-pre.9", default-features = false, features = ["serde"] }
 
-mpc = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "eeb6e68f"}
-proof = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "eeb6e68f"}
+mpc = { git = "https://github.com/dwallet-labs/inkrypto", rev = "c3c20ac6"}
+proof = { git = "https://github.com/dwallet-labs/inkrypto", rev = "c3c20ac6"}
 # NOTE: the `parallel` (rayon) feature on class_groups/twopc_mpc is enabled per
 # crate under `[target.'cfg(not(msim))'.dependencies]` (see dwallet-classgroups-types
 # and ika-core), NOT here — workspace-dependency features are inherited regardless of
 # cfg, so enabling `parallel` here would leak rayon into `cargo simtest` (cfg msim),
 # whose rayon workers have no msim node context and break determinism / panic.
-class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "eeb6e68f", features = ["threshold"] }
-commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "eeb6e68f" }
-twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "eeb6e68f"}
-group = { git = "https://github.com/dwallet-labs/cryptography-private", features = ["os_rng"], rev = "eeb6e68f"}
-homomorphic_encryption = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "eeb6e68f"}
+class_groups = { git = "https://github.com/dwallet-labs/inkrypto", rev = "c3c20ac6", features = ["threshold"] }
+commitment = { git = "https://github.com/dwallet-labs/inkrypto", rev = "c3c20ac6" }
+twopc_mpc = { git = "https://github.com/dwallet-labs/inkrypto", rev = "c3c20ac6"}
+group = { git = "https://github.com/dwallet-labs/inkrypto", features = ["os_rng"], rev = "c3c20ac6"}
+homomorphic_encryption = { git = "https://github.com/dwallet-labs/inkrypto", rev = "c3c20ac6"}
 
 k256 = { version = "0.14.0-pre.11", default-features = false }
 p256 = { version = "0.14.0-pre.11", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,18 +79,18 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 [workspace.dependencies]
 crypto-bigint = { version = "0.7.0-pre.9", default-features = false, features = ["serde"] }
 
-mpc = { git = "https://github.com/dwallet-labs/inkrypto", rev = "1d8b5a9"}
-proof = { git = "https://github.com/dwallet-labs/inkrypto", rev = "1d8b5a9"}
+mpc = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "eeb6e68f"}
+proof = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "eeb6e68f"}
 # NOTE: the `parallel` (rayon) feature on class_groups/twopc_mpc is enabled per
 # crate under `[target.'cfg(not(msim))'.dependencies]` (see dwallet-classgroups-types
 # and ika-core), NOT here — workspace-dependency features are inherited regardless of
 # cfg, so enabling `parallel` here would leak rayon into `cargo simtest` (cfg msim),
 # whose rayon workers have no msim node context and break determinism / panic.
-class_groups = { git = "https://github.com/dwallet-labs/inkrypto", rev = "1d8b5a9", features = ["threshold"] }
-commitment = { git = "https://github.com/dwallet-labs/inkrypto", rev = "1d8b5a9" }
-twopc_mpc = { git = "https://github.com/dwallet-labs/inkrypto", rev = "1d8b5a9"}
-group = { git = "https://github.com/dwallet-labs/inkrypto", features = ["os_rng"], rev = "1d8b5a9"}
-homomorphic_encryption = { git = "https://github.com/dwallet-labs/inkrypto", rev = "1d8b5a9"}
+class_groups = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "eeb6e68f", features = ["threshold"] }
+commitment = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "eeb6e68f" }
+twopc_mpc = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "eeb6e68f"}
+group = { git = "https://github.com/dwallet-labs/cryptography-private", features = ["os_rng"], rev = "eeb6e68f"}
+homomorphic_encryption = { git = "https://github.com/dwallet-labs/cryptography-private", rev = "eeb6e68f"}
 
 k256 = { version = "0.14.0-pre.11", default-features = false }
 p256 = { version = "0.14.0-pre.11", default-features = false }

--- a/crates/dwallet-classgroups-types/Cargo.toml
+++ b/crates/dwallet-classgroups-types/Cargo.toml
@@ -18,7 +18,7 @@ twopc_mpc.workspace = true
 default = []
 # INSECURE test-only mock: replaces the expensive validator class-groups/PVSS
 # keygen (`from_seed`) with neutral keys + default proofs — consumed only by the
-# mocked protocol rounds. Never enable in production. See cryptography-private
+# mocked protocol rounds. Never enable in production. See inkrypto
 # `unsafe_mock`.
 dwallet-mpc-unsafe-mock = ["class_groups/unsafe_mock", "twopc_mpc/unsafe_mock"]
 

--- a/crates/dwallet-mpc-centralized-party/Cargo.toml
+++ b/crates/dwallet-mpc-centralized-party/Cargo.toml
@@ -29,8 +29,8 @@ crypto-bigint.workspace = true
 # No default features: the INSECURE `dwallet-mpc-unsafe-mock` below must be opt-in only.
 default = []
 wasm_js = ["group/wasm_js", "dep:getrandom"]
-# INSECURE test-only mock: forwards to the deterministic cryptography-private protocol mocks.
-# Never enable in production. See cryptography-private `unsafe_mock`.
+# INSECURE test-only mock: forwards to the deterministic inkrypto protocol mocks.
+# Never enable in production. See inkrypto `unsafe_mock`.
 dwallet-mpc-unsafe-mock = [
     "twopc_mpc/unsafe_mock",
     "dwallet-mpc-types/dwallet-mpc-unsafe-mock",

--- a/crates/dwallet-mpc-types/Cargo.toml
+++ b/crates/dwallet-mpc-types/Cargo.toml
@@ -24,8 +24,8 @@ curve25519-dalek.workspace = true
 [features]
 # No default features: the INSECURE `dwallet-mpc-unsafe-mock` below must be opt-in only.
 default = []
-# INSECURE test-only mock: enable the deterministic protocol mocks in the cryptography-private
-# crates. Must never be enabled in production builds. See cryptography-private `unsafe_mock`.
+# INSECURE test-only mock: enable the deterministic protocol mocks in the inkrypto
+# crates. Must never be enabled in production builds. See inkrypto `unsafe_mock`.
 dwallet-mpc-unsafe-mock = ["twopc_mpc/unsafe_mock"]
 
 [lints]

--- a/crates/ika-core/Cargo.toml
+++ b/crates/ika-core/Cargo.toml
@@ -112,8 +112,8 @@ twopc_mpc = { workspace = true, features = ["parallel"] }
 default = []
 test-utils = []
 enforce-minimum-cpu = []
-# INSECURE test-only mock: forwards to the deterministic cryptography-private protocol mocks.
-# Never enable in production. See cryptography-private `unsafe_mock`.
+# INSECURE test-only mock: forwards to the deterministic inkrypto protocol mocks.
+# Never enable in production. See inkrypto `unsafe_mock`.
 dwallet-mpc-unsafe-mock = [
     "dwallet-mpc-types/dwallet-mpc-unsafe-mock",
     "dwallet-classgroups-types/dwallet-mpc-unsafe-mock",

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -850,6 +850,12 @@ pub(crate) fn network_dkg_v2_public_input(
         PartyID,
         ika_types::committee::RistrettoPvssEncryptionKeyAndProof,
     >,
+    // Selects the equality-of-coefficients discrete-log bound: `true` picks the
+    // `-10` relaxed (+519) bound the deployed network transcribes, `false` the
+    // strict (+529) bound reserved for a future, not-yet-deployed format. Derived
+    // from the protocol version (`is_network_encryption_key_version_v3()`) at the
+    // call site; TEMPORARY until the network migrates off the relaxed bound.
+    backward_compatible: bool,
 ) -> DwalletMPCResult<<dkg::Party as mpc::Party>::PublicInput> {
     let public_input = <dkg::Party as mpc::Party>::PublicInput::new(
         access_structure,
@@ -857,6 +863,7 @@ pub(crate) fn network_dkg_v2_public_input(
         secp256k1_pvss_encryption_keys_and_proofs,
         ristretto_pvss_encryption_keys_and_proofs,
         secp256r1_pvss_encryption_keys_and_proofs,
+        backward_compatible,
     )
     .map_err(|e| DwalletMPCError::InvalidMPCPartyType(e.to_string()))?;
 

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/reconfiguration.rs
@@ -52,6 +52,11 @@ pub(crate) trait ReconfigurationPartyPublicInputGenerator: Party {
         upcoming_validator_mpc_keys: ValidatorMpcKeysByPartyId,
         network_dkg_public_output: VersionedNetworkDkgOutput,
         latest_reconfiguration_public_output: Option<VersionedDecryptionKeyReconfigurationOutput>,
+        // Equality-of-coefficients discrete-log bound selector: `true` = `-10`
+        // relaxed (+519) bound the deployed network transcribes, `false` = strict
+        // (+529) reserved for a future format. Derived from the protocol version
+        // (`is_reconfiguration_message_version_v3()`) at the call site.
+        backward_compatible: bool,
     ) -> DwalletMPCResult<<ReconfigurationParty as mpc::Party>::PublicInput>;
 }
 
@@ -63,6 +68,7 @@ impl ReconfigurationPartyPublicInputGenerator for ReconfigurationParty {
         upcoming_validator_mpc_keys: ValidatorMpcKeysByPartyId,
         network_dkg_public_output: VersionedNetworkDkgOutput,
         latest_reconfiguration_public_output: Option<VersionedDecryptionKeyReconfigurationOutput>,
+        backward_compatible: bool,
     ) -> DwalletMPCResult<<ReconfigurationParty as Party>::PublicInput> {
         let current_committee = current_committee.clone();
         // Committees supply ONLY the access structures (voting weights /
@@ -192,6 +198,7 @@ impl ReconfigurationPartyPublicInputGenerator for ReconfigurationParty {
                                 upcoming_validators_pvss_hpke_keys_by_party_id.secp256k1_pvss.clone(),
                                 upcoming_validators_pvss_hpke_keys_by_party_id.ristretto_pvss.clone(),
                                 upcoming_validators_pvss_hpke_keys_by_party_id.secp256r1_pvss.clone(),
+                                backward_compatible,
                             )
                                 .map_err(DwalletMPCError::from)?;
 
@@ -235,6 +242,7 @@ impl ReconfigurationPartyPublicInputGenerator for ReconfigurationParty {
                                 upcoming_validators_pvss_hpke_keys_by_party_id.secp256k1_pvss.clone(),
                                 upcoming_validators_pvss_hpke_keys_by_party_id.ristretto_pvss.clone(),
                                 upcoming_validators_pvss_hpke_keys_by_party_id.secp256r1_pvss.clone(),
+                                backward_compatible,
                             )
                                 .map_err(DwalletMPCError::from)?;
 
@@ -261,6 +269,7 @@ impl ReconfigurationPartyPublicInputGenerator for ReconfigurationParty {
                                 upcoming_validators_pvss_hpke_keys_by_party_id.secp256k1_pvss.clone(),
                                 upcoming_validators_pvss_hpke_keys_by_party_id.ristretto_pvss.clone(),
                                 upcoming_validators_pvss_hpke_keys_by_party_id.secp256r1_pvss.clone(),
+                                backward_compatible,
                             )
                                 .map_err(DwalletMPCError::from)?;
 

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -154,6 +154,27 @@ pub struct DWalletMPCMetrics {
     /// assert exclusion programmatically instead of grepping logs.
     pub(crate) malicious_actors_count: IntGauge,
 
+    /// Number of network-key reconfiguration sessions that are still
+    /// non-terminal on this validator. This is deliberately unlabeled and
+    /// always exported so a release-gate assertion can distinguish a clean
+    /// zero from a missing metric.
+    pub(crate) network_key_reconfiguration_sessions_pending: IntGauge,
+
+    /// Per-authority network-key reconfiguration outputs observed through
+    /// consensus. The digest is over canonical BCS output bytes and excludes
+    /// the sender/malicious envelope. A current validator therefore exposes
+    /// the literal previous-release validators' submitted results without
+    /// requiring instrumentation in the historical binary.
+    pub(crate) network_key_reconfiguration_output_info: IntGaugeVec,
+
+    /// Malicious-actor count carried in each authority's network-key
+    /// reconfiguration output report.
+    pub(crate) network_key_reconfiguration_reported_malicious_actors: IntGaugeVec,
+
+    /// Whether each authority's network-key reconfiguration output report was
+    /// rejected (0 = canonical output, 1 = rejected output).
+    pub(crate) network_key_reconfiguration_output_rejected: IntGaugeVec,
+
     /// Histogram-by-bucket of how long each currently-Active session has been
     /// tracked for. Labels: `session_type` (`user` / `system` /
     /// `internal_presign` / `noa_sign`), `age_bucket` (`<30s`, `<5m`, `<30m`,
@@ -445,6 +466,34 @@ impl DWalletMPCMetrics {
                 registry
             )
             .unwrap(),
+            network_key_reconfiguration_sessions_pending: register_int_gauge_with_registry!(
+                "ika_dwallet_mpc_network_key_reconfiguration_sessions_pending",
+                "Network-key reconfiguration sessions still non-terminal on this validator",
+                registry,
+            )
+            .unwrap(),
+            network_key_reconfiguration_output_info: register_int_gauge_vec_with_registry!(
+                "ika_dwallet_mpc_network_key_reconfiguration_output_info",
+                "Per-authority canonical network-key reconfiguration output digest observed through consensus",
+                &["session_id", "authority", "output_digest"],
+                registry,
+            )
+            .unwrap(),
+            network_key_reconfiguration_reported_malicious_actors:
+                register_int_gauge_vec_with_registry!(
+                    "ika_dwallet_mpc_network_key_reconfiguration_reported_malicious_actors",
+                    "Malicious-actor count carried in each authority's network-key reconfiguration output report",
+                    &["session_id", "authority"],
+                    registry,
+                )
+                .unwrap(),
+            network_key_reconfiguration_output_rejected: register_int_gauge_vec_with_registry!(
+                "ika_dwallet_mpc_network_key_reconfiguration_output_rejected",
+                "Whether each authority's network-key reconfiguration output report was rejected",
+                &["session_id", "authority"],
+                registry,
+            )
+            .unwrap(),
             active_sessions_by_age: register_int_gauge_vec_with_registry!(
                 "ika_dwallet_mpc_active_sessions_by_age",
                 "Active session count by session type and age bucket",
@@ -607,6 +656,10 @@ impl DWalletMPCMetrics {
         self.user_session_local_output_rejected.reset();
         self.user_session_output_received_from.reset();
         self.user_session_distinct_output_digests.reset();
+        self.network_key_reconfiguration_output_info.reset();
+        self.network_key_reconfiguration_reported_malicious_actors
+            .reset();
+        self.network_key_reconfiguration_output_rejected.reset();
     }
 }
 

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -154,26 +154,24 @@ pub struct DWalletMPCMetrics {
     /// assert exclusion programmatically instead of grepping logs.
     pub(crate) malicious_actors_count: IntGauge,
 
-    /// Number of network-key reconfiguration sessions that are still
-    /// non-terminal on this validator. This is deliberately unlabeled and
-    /// always exported so a release-gate assertion can distinguish a clean
-    /// zero from a missing metric.
-    pub(crate) network_key_reconfiguration_sessions_pending: IntGauge,
+    /// Number of sessions still non-terminal on this validator, grouped by
+    /// protocol name. Completed protocols are exported with zero while their
+    /// session remains tracked, distinguishing a clean zero from a missing
+    /// observation.
+    pub(crate) protocol_sessions_pending: IntGaugeVec,
 
-    /// Per-authority network-key reconfiguration outputs observed through
-    /// consensus. The digest is over canonical BCS output bytes and excludes
-    /// the sender/malicious envelope. A current validator therefore exposes
-    /// the literal previous-release validators' submitted results without
-    /// requiring instrumentation in the historical binary.
-    pub(crate) network_key_reconfiguration_output_info: IntGaugeVec,
+    /// Per-authority session outputs observed through consensus. The digest is
+    /// over canonical BCS output bytes and excludes the sender/malicious
+    /// envelope. Labels identify the protocol and concrete session, allowing
+    /// targeted compatibility tests without protocol-specific instrumentation.
+    pub(crate) session_output_info: IntGaugeVec,
 
-    /// Malicious-actor count carried in each authority's network-key
-    /// reconfiguration output report.
-    pub(crate) network_key_reconfiguration_reported_malicious_actors: IntGaugeVec,
+    /// Malicious-actor count carried in each authority's session output report.
+    pub(crate) session_reported_malicious_actors: IntGaugeVec,
 
-    /// Whether each authority's network-key reconfiguration output report was
-    /// rejected (0 = canonical output, 1 = rejected output).
-    pub(crate) network_key_reconfiguration_output_rejected: IntGaugeVec,
+    /// Whether each authority's session output report was rejected
+    /// (0 = canonical output, 1 = rejected output).
+    pub(crate) session_output_rejected: IntGaugeVec,
 
     /// Histogram-by-bucket of how long each currently-Active session has been
     /// tracked for. Labels: `session_type` (`user` / `system` /
@@ -466,31 +464,31 @@ impl DWalletMPCMetrics {
                 registry
             )
             .unwrap(),
-            network_key_reconfiguration_sessions_pending: register_int_gauge_with_registry!(
-                "ika_dwallet_mpc_network_key_reconfiguration_sessions_pending",
-                "Network-key reconfiguration sessions still non-terminal on this validator",
+            protocol_sessions_pending: register_int_gauge_vec_with_registry!(
+                "ika_dwallet_mpc_protocol_sessions_pending",
+                "Sessions still non-terminal on this validator, grouped by protocol",
+                &["protocol_name"],
                 registry,
             )
             .unwrap(),
-            network_key_reconfiguration_output_info: register_int_gauge_vec_with_registry!(
-                "ika_dwallet_mpc_network_key_reconfiguration_output_info",
-                "Per-authority canonical network-key reconfiguration output digest observed through consensus",
-                &["session_id", "authority", "output_digest"],
+            session_output_info: register_int_gauge_vec_with_registry!(
+                "ika_dwallet_mpc_session_output_info",
+                "Per-authority canonical session output digest observed through consensus",
+                &["protocol_name", "session_id", "authority", "output_digest"],
                 registry,
             )
             .unwrap(),
-            network_key_reconfiguration_reported_malicious_actors:
-                register_int_gauge_vec_with_registry!(
-                    "ika_dwallet_mpc_network_key_reconfiguration_reported_malicious_actors",
-                    "Malicious-actor count carried in each authority's network-key reconfiguration output report",
-                    &["session_id", "authority"],
-                    registry,
-                )
-                .unwrap(),
-            network_key_reconfiguration_output_rejected: register_int_gauge_vec_with_registry!(
-                "ika_dwallet_mpc_network_key_reconfiguration_output_rejected",
-                "Whether each authority's network-key reconfiguration output report was rejected",
-                &["session_id", "authority"],
+            session_reported_malicious_actors: register_int_gauge_vec_with_registry!(
+                "ika_dwallet_mpc_session_reported_malicious_actors",
+                "Malicious-actor count carried in each authority's session output report",
+                &["protocol_name", "session_id", "authority"],
+                registry,
+            )
+            .unwrap(),
+            session_output_rejected: register_int_gauge_vec_with_registry!(
+                "ika_dwallet_mpc_session_output_rejected",
+                "Whether each authority's session output report was rejected",
+                &["protocol_name", "session_id", "authority"],
                 registry,
             )
             .unwrap(),
@@ -656,10 +654,10 @@ impl DWalletMPCMetrics {
         self.user_session_local_output_rejected.reset();
         self.user_session_output_received_from.reset();
         self.user_session_distinct_output_digests.reset();
-        self.network_key_reconfiguration_output_info.reset();
-        self.network_key_reconfiguration_reported_malicious_actors
-            .reset();
-        self.network_key_reconfiguration_output_rejected.reset();
+        self.protocol_sessions_pending.reset();
+        self.session_output_info.reset();
+        self.session_reported_malicious_actors.reset();
+        self.session_output_rejected.reset();
     }
 }
 

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -3501,9 +3501,19 @@ impl DWalletMPCManager {
                 let pending = protocol_sessions_pending
                     .entry(protocol_name.clone())
                     .or_default();
+                // `ComputationCompleted` means this validator finished the
+                // computation and submitted its output — no pending work. It
+                // isn't `Completed` (that awaits the quorum transition, tracked
+                // separately by `sessions_with_self_output_no_quorum`), and a
+                // session reloaded from the DB as already-computed
+                // (`complete_computation_mpc_session_and_create_if_not_exists`)
+                // lingers in this state until epoch-end pruning. Counting it as
+                // pending would keep this gauge from ever draining to zero.
                 if !matches!(
                     session.status,
-                    SessionStatus::Completed | SessionStatus::Failed
+                    SessionStatus::Completed
+                        | SessionStatus::Failed
+                        | SessionStatus::ComputationCompleted
                 ) {
                     *pending += 1;
                 }

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -73,6 +73,15 @@ use ika_types::noa_checkpoint::{
 };
 
 use crate::dwallet_mpc::NetworkOwnedAddressSignOutput;
+use crate::request_protocol_data::NETWORK_KEY_RECONFIGURATION_PROTOCOL_NAME;
+
+/// Protocols whose per-authority output observations are exported as
+/// `ika_dwallet_mpc_session_output_*` metrics. Restricted deliberately: those
+/// series are labeled by session id and authority, so exporting every protocol
+/// would add one series per sign/presign session on production validators.
+/// Extend this only when a compatibility scenario actually scrapes another
+/// protocol's per-authority outputs.
+const OUTPUT_OBSERVATION_EXPORT_PROTOCOLS: &[&str] = &[NETWORK_KEY_RECONFIGURATION_PROTOCOL_NAME];
 
 /// Compute the agreed chain context for any `CounterpartyChain` implementation.
 /// Updates `current_context` in place if a new context is agreed upon.
@@ -3498,29 +3507,34 @@ impl DWalletMPCManager {
                 ) {
                     *pending += 1;
                 }
-                let session_id = hex::encode(session.session_identifier.as_ref());
-                for (authority, observation) in &session.output_observations {
-                    let authority = authority.to_string();
-                    for digest in &observation.digests {
-                        let output_digest = hex::encode(digest);
+                // The per-authority, per-session output digests are
+                // high-cardinality (session id x authority); only export them
+                // for the protocols a compatibility scenario scrapes.
+                if OUTPUT_OBSERVATION_EXPORT_PROTOCOLS.contains(&protocol_name.as_str()) {
+                    let session_id = hex::encode(session.session_identifier.as_ref());
+                    for (authority, observation) in &session.output_observations {
+                        let authority = authority.to_string();
+                        for digest in &observation.digests {
+                            let output_digest = hex::encode(digest);
+                            metrics
+                                .session_output_info
+                                .with_label_values(&[
+                                    protocol_name,
+                                    &session_id,
+                                    &authority,
+                                    &output_digest,
+                                ])
+                                .set(1);
+                        }
                         metrics
-                            .session_output_info
-                            .with_label_values(&[
-                                protocol_name,
-                                &session_id,
-                                &authority,
-                                &output_digest,
-                            ])
-                            .set(1);
+                            .session_reported_malicious_actors
+                            .with_label_values(&[protocol_name, &session_id, &authority])
+                            .set(observation.malicious_actor_count as i64);
+                        metrics
+                            .session_output_rejected
+                            .with_label_values(&[protocol_name, &session_id, &authority])
+                            .set(observation.rejected as i64);
                     }
-                    metrics
-                        .session_reported_malicious_actors
-                        .with_label_values(&[protocol_name, &session_id, &authority])
-                        .set(observation.malicious_actor_count as i64);
-                    metrics
-                        .session_output_rejected
-                        .with_label_values(&[protocol_name, &session_id, &authority])
-                        .set(observation.rejected as i64);
                 }
             }
         }

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -2022,6 +2022,9 @@ impl DWalletMPCManager {
             Ok((public_input, private_input)) => {
                 let session_sequence_number = request.session_sequence_number;
                 let session_type = request.session_type;
+                let protocol_name = DWalletSessionRequestMetricData::from(&request.protocol_data)
+                    .name()
+                    .to_owned();
                 let status = SessionStatus::Active {
                     public_input,
                     private_input,
@@ -2037,6 +2040,7 @@ impl DWalletMPCManager {
                 if let Some(session) = self.sessions.get_mut(&session_identifier) {
                     session.status = status;
                     session.set_request_metadata(session_sequence_number, session_type);
+                    session.set_protocol_name(protocol_name);
                 } else {
                     self.new_session(
                         &session_identifier,
@@ -3460,7 +3464,7 @@ impl DWalletMPCManager {
         let mut state_counts: HashMap<&str, i64> = HashMap::new();
         let mut age_bucket_counts: HashMap<(&str, &str), i64> = HashMap::new();
         let mut sessions_with_self_output_no_quorum = 0i64;
-        let mut network_key_reconfiguration_sessions_pending = 0i64;
+        let mut protocol_sessions_pending: HashMap<String, i64> = HashMap::new();
         for session in self.sessions.values() {
             *state_counts
                 .entry(session_state_label(&session.status))
@@ -3484,39 +3488,48 @@ impl DWalletMPCManager {
             {
                 sessions_with_self_output_no_quorum += 1;
             }
-            if session.is_network_key_reconfiguration {
+            if let Some(protocol_name) = &session.protocol_name {
+                let pending = protocol_sessions_pending
+                    .entry(protocol_name.clone())
+                    .or_default();
                 if !matches!(
                     session.status,
                     SessionStatus::Completed | SessionStatus::Failed
                 ) {
-                    network_key_reconfiguration_sessions_pending += 1;
+                    *pending += 1;
                 }
                 let session_id = hex::encode(session.session_identifier.as_ref());
-                for (authority, observation) in
-                    &session.network_key_reconfiguration_output_observations
-                {
+                for (authority, observation) in &session.output_observations {
                     let authority = authority.to_string();
                     for digest in &observation.digests {
                         let output_digest = hex::encode(digest);
                         metrics
-                            .network_key_reconfiguration_output_info
-                            .with_label_values(&[&session_id, &authority, &output_digest])
+                            .session_output_info
+                            .with_label_values(&[
+                                protocol_name,
+                                &session_id,
+                                &authority,
+                                &output_digest,
+                            ])
                             .set(1);
                     }
                     metrics
-                        .network_key_reconfiguration_reported_malicious_actors
-                        .with_label_values(&[&session_id, &authority])
+                        .session_reported_malicious_actors
+                        .with_label_values(&[protocol_name, &session_id, &authority])
                         .set(observation.malicious_actor_count as i64);
                     metrics
-                        .network_key_reconfiguration_output_rejected
-                        .with_label_values(&[&session_id, &authority])
+                        .session_output_rejected
+                        .with_label_values(&[protocol_name, &session_id, &authority])
                         .set(observation.rejected as i64);
                 }
             }
         }
-        metrics
-            .network_key_reconfiguration_sessions_pending
-            .set(network_key_reconfiguration_sessions_pending);
+        for (protocol_name, pending) in protocol_sessions_pending {
+            metrics
+                .protocol_sessions_pending
+                .with_label_values(&[&protocol_name])
+                .set(pending);
+        }
         for state in ALL_SESSION_STATES.iter().copied() {
             metrics
                 .session_state_count

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -3460,6 +3460,7 @@ impl DWalletMPCManager {
         let mut state_counts: HashMap<&str, i64> = HashMap::new();
         let mut age_bucket_counts: HashMap<(&str, &str), i64> = HashMap::new();
         let mut sessions_with_self_output_no_quorum = 0i64;
+        let mut network_key_reconfiguration_sessions_pending = 0i64;
         for session in self.sessions.values() {
             *state_counts
                 .entry(session_state_label(&session.status))
@@ -3483,7 +3484,39 @@ impl DWalletMPCManager {
             {
                 sessions_with_self_output_no_quorum += 1;
             }
+            if session.is_network_key_reconfiguration {
+                if !matches!(
+                    session.status,
+                    SessionStatus::Completed | SessionStatus::Failed
+                ) {
+                    network_key_reconfiguration_sessions_pending += 1;
+                }
+                let session_id = hex::encode(session.session_identifier.as_ref());
+                for (authority, observation) in
+                    &session.network_key_reconfiguration_output_observations
+                {
+                    let authority = authority.to_string();
+                    for digest in &observation.digests {
+                        let output_digest = hex::encode(digest);
+                        metrics
+                            .network_key_reconfiguration_output_info
+                            .with_label_values(&[&session_id, &authority, &output_digest])
+                            .set(1);
+                    }
+                    metrics
+                        .network_key_reconfiguration_reported_malicious_actors
+                        .with_label_values(&[&session_id, &authority])
+                        .set(observation.malicious_actor_count as i64);
+                    metrics
+                        .network_key_reconfiguration_output_rejected
+                        .with_label_values(&[&session_id, &authority])
+                        .set(observation.rejected as i64);
+                }
+            }
         }
+        metrics
+            .network_key_reconfiguration_sessions_pending
+            .set(network_key_reconfiguration_sessions_pending);
         for state in ALL_SESSION_STATES.iter().copied() {
             metrics
                 .session_state_count

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -37,6 +37,13 @@ pub(crate) struct DWalletMPCSessionOutput {
     pub(crate) malicious_authorities: Vec<AuthorityName>,
 }
 
+#[derive(Clone)]
+pub(crate) struct NetworkKeyReconfigurationOutputObservation {
+    pub(crate) digests: HashSet<[u8; 32]>,
+    pub(crate) malicious_actor_count: usize,
+    pub(crate) rejected: bool,
+}
+
 /// A dWallet session. Encapsulates computation done by validators,
 /// whose output is being agreed upon in consensus,
 /// then being transmitted onto the Sui chain as part of a checkpoint,
@@ -113,6 +120,18 @@ pub(crate) struct DWalletSession {
     /// envelope excluded), so identical outputs from different validators collapse to one
     /// digest.
     pub(super) distinct_output_digests: HashSet<[u8; 32]>,
+
+    /// Set once the on-chain request identifies this as a network-key
+    /// reconfiguration session. Outputs can arrive before the request, so the
+    /// per-authority observations below are collected while the request kind
+    /// is unknown and exposed only after this flag becomes true.
+    pub(super) is_network_key_reconfiguration: bool,
+
+    /// Canonical submitted output observed from each authority through
+    /// consensus. This preserves the individual votes that a later weighted
+    /// majority would otherwise hide.
+    pub(super) network_key_reconfiguration_output_observations:
+        HashMap<AuthorityName, NetworkKeyReconfigurationOutputObservation>,
 }
 
 /// Possible statuses of a session:
@@ -189,11 +208,17 @@ impl DWalletSession {
     ) -> Self {
         // If the new session is created with an Active status the request is right there;
         // pull seq/type out of it so they survive any later transition to a unit variant.
-        let (session_sequence_number, session_type) = match &status {
-            SessionStatus::Active { request, .. } => {
-                (request.session_sequence_number, Some(request.session_type))
-            }
-            _ => (None, None),
+        let (session_sequence_number, session_type, is_network_key_reconfiguration) = match &status
+        {
+            SessionStatus::Active { request, .. } => (
+                request.session_sequence_number,
+                Some(request.session_type),
+                matches!(
+                    &request.protocol_data,
+                    ProtocolData::NetworkEncryptionKeyReconfiguration { .. }
+                ),
+            ),
+            _ => (None, None, false),
         };
         Self {
             status,
@@ -212,6 +237,8 @@ impl DWalletSession {
             distinct_output_authorities: HashSet::new(),
             local_output_rejected: None,
             distinct_output_digests: HashSet::new(),
+            is_network_key_reconfiguration,
+            network_key_reconfiguration_output_observations: HashMap::new(),
         }
     }
 
@@ -225,6 +252,16 @@ impl DWalletSession {
     ) {
         self.session_sequence_number = self.session_sequence_number.or(session_sequence_number);
         self.session_type = Some(session_type);
+    }
+
+    pub(crate) fn mark_network_key_reconfiguration(&mut self) {
+        self.is_network_key_reconfiguration = true;
+    }
+
+    pub(crate) fn discard_unclassified_output_observations(&mut self) {
+        if !self.is_network_key_reconfiguration {
+            self.network_key_reconfiguration_output_observations.clear();
+        }
     }
 
     pub(crate) fn clear_data(&mut self) {
@@ -329,6 +366,11 @@ impl DWalletSession {
         sender_party_id: PartyID,
         output: DWalletMPCOutputReport,
     ) {
+        let may_be_network_key_reconfiguration = self.is_network_key_reconfiguration
+            || matches!(&self.status, SessionStatus::WaitingForSessionRequest)
+            || !self
+                .network_key_reconfiguration_output_observations
+                .is_empty();
         debug!(
             session_identifier=?output.session_identifier(),
             from_authority=?output.authority(),
@@ -373,6 +415,8 @@ impl DWalletSession {
             .entry(consensus_round)
             .or_default();
 
+        let authority = output.authority();
+        let rejected = output.rejected();
         let malicious_authorities = output.malicious_authorities();
         if let Ok(output) = output.output() {
             // Hash the output content (sender + malicious-authorities envelope excluded) so
@@ -381,6 +425,22 @@ impl DWalletSession {
             if let Ok(output_bytes) = bcs::to_bytes(&output) {
                 let digest: [u8; 32] = DefaultHash::digest(&output_bytes).into();
                 self.distinct_output_digests.insert(digest);
+                if may_be_network_key_reconfiguration {
+                    self.network_key_reconfiguration_output_observations
+                        .entry(authority)
+                        .and_modify(|observation| {
+                            observation.digests.insert(digest);
+                            observation.malicious_actor_count = observation
+                                .malicious_actor_count
+                                .max(malicious_authorities.len());
+                            observation.rejected |= rejected;
+                        })
+                        .or_insert_with(|| NetworkKeyReconfigurationOutputObservation {
+                            digests: HashSet::from([digest]),
+                            malicious_actor_count: malicious_authorities.len(),
+                            rejected,
+                        });
+                }
             }
             if let Vacant(e) = consensus_round_output_map.entry(sender_party_id) {
                 e.insert(DWalletMPCSessionOutput {
@@ -786,6 +846,10 @@ impl DWalletMPCManager {
         }
 
         let status = self.session_status_from_request(request.clone(), false);
+        let is_network_key_reconfiguration = matches!(
+            &request.protocol_data,
+            ProtocolData::NetworkEncryptionKeyReconfiguration { .. }
+        );
 
         self.dwallet_mpc_metrics
             .add_received_request_start(&(&request.protocol_data).into());
@@ -799,6 +863,11 @@ impl DWalletMPCManager {
             // unit-variant states (ComputationCompleted/Completed/Failed) which would
             // otherwise discard this information.
             session.set_request_metadata(request.session_sequence_number, request.session_type);
+            if is_network_key_reconfiguration {
+                session.mark_network_key_reconfiguration();
+            } else {
+                session.discard_unclassified_output_observations();
+            }
 
             // We only trust the session type that we deduce ourselves from the session request.
             // However, it is not safe to override the session status in all cases.
@@ -824,6 +893,11 @@ impl DWalletMPCManager {
             // explicit set covers the non-Active creation path (e.g. Failed).
             if let Some(session) = self.sessions.get_mut(&session_identifier) {
                 session.set_request_metadata(request.session_sequence_number, request.session_type);
+                if is_network_key_reconfiguration {
+                    session.mark_network_key_reconfiguration();
+                } else {
+                    session.discard_unclassified_output_observations();
+                }
             }
         }
         Some(status)

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -38,7 +38,7 @@ pub(crate) struct DWalletMPCSessionOutput {
 }
 
 #[derive(Clone)]
-pub(crate) struct NetworkKeyReconfigurationOutputObservation {
+pub(crate) struct SessionOutputObservation {
     pub(crate) digests: HashSet<[u8; 32]>,
     pub(crate) malicious_actor_count: usize,
     pub(crate) rejected: bool,
@@ -88,6 +88,11 @@ pub(crate) struct DWalletSession {
     /// Same idea — set to `Some(_)` once we've seen a request, preserved across transitions.
     pub(super) session_type: Option<SessionType>,
 
+    /// Stable protocol name from the session request. Outputs can arrive before
+    /// their request, so this remains `None` until the request is observed and
+    /// is then preserved across terminal status transitions.
+    pub(super) protocol_name: Option<String>,
+
     // -------- per-session timing/diagnostic counters --------
     // All of these are populated in this process's lifetime only — pre-restart events
     // do not contribute. They feed the `ika_dwallet_mpc_user_session_*` per-seq gauges.
@@ -121,17 +126,10 @@ pub(crate) struct DWalletSession {
     /// digest.
     pub(super) distinct_output_digests: HashSet<[u8; 32]>,
 
-    /// Set once the on-chain request identifies this as a network-key
-    /// reconfiguration session. Outputs can arrive before the request, so the
-    /// per-authority observations below are collected while the request kind
-    /// is unknown and exposed only after this flag becomes true.
-    pub(super) is_network_key_reconfiguration: bool,
-
     /// Canonical submitted output observed from each authority through
-    /// consensus. This preserves the individual votes that a later weighted
-    /// majority would otherwise hide.
-    pub(super) network_key_reconfiguration_output_observations:
-        HashMap<AuthorityName, NetworkKeyReconfigurationOutputObservation>,
+    /// consensus. This is protocol-agnostic and preserves individual votes
+    /// that a later weighted majority would otherwise hide.
+    pub(super) output_observations: HashMap<AuthorityName, SessionOutputObservation>,
 }
 
 /// Possible statuses of a session:
@@ -208,17 +206,17 @@ impl DWalletSession {
     ) -> Self {
         // If the new session is created with an Active status the request is right there;
         // pull seq/type out of it so they survive any later transition to a unit variant.
-        let (session_sequence_number, session_type, is_network_key_reconfiguration) = match &status
-        {
+        let (session_sequence_number, session_type, protocol_name) = match &status {
             SessionStatus::Active { request, .. } => (
                 request.session_sequence_number,
                 Some(request.session_type),
-                matches!(
-                    &request.protocol_data,
-                    ProtocolData::NetworkEncryptionKeyReconfiguration { .. }
+                Some(
+                    DWalletSessionRequestMetricData::from(&request.protocol_data)
+                        .name()
+                        .to_owned(),
                 ),
             ),
-            _ => (None, None, false),
+            _ => (None, None, None),
         };
         Self {
             status,
@@ -231,14 +229,14 @@ impl DWalletSession {
             created_at: Instant::now(),
             session_sequence_number,
             session_type,
+            protocol_name,
             first_output_consensus_round: None,
             self_output_consensus_round: None,
             quorum_consensus_round: None,
             distinct_output_authorities: HashSet::new(),
             local_output_rejected: None,
             distinct_output_digests: HashSet::new(),
-            is_network_key_reconfiguration,
-            network_key_reconfiguration_output_observations: HashMap::new(),
+            output_observations: HashMap::new(),
         }
     }
 
@@ -254,13 +252,9 @@ impl DWalletSession {
         self.session_type = Some(session_type);
     }
 
-    pub(crate) fn mark_network_key_reconfiguration(&mut self) {
-        self.is_network_key_reconfiguration = true;
-    }
-
-    pub(crate) fn discard_unclassified_output_observations(&mut self) {
-        if !self.is_network_key_reconfiguration {
-            self.network_key_reconfiguration_output_observations.clear();
+    pub(crate) fn set_protocol_name(&mut self, protocol_name: String) {
+        if self.protocol_name.is_none() {
+            self.protocol_name = Some(protocol_name);
         }
     }
 
@@ -366,11 +360,6 @@ impl DWalletSession {
         sender_party_id: PartyID,
         output: DWalletMPCOutputReport,
     ) {
-        let may_be_network_key_reconfiguration = self.is_network_key_reconfiguration
-            || matches!(&self.status, SessionStatus::WaitingForSessionRequest)
-            || !self
-                .network_key_reconfiguration_output_observations
-                .is_empty();
         debug!(
             session_identifier=?output.session_identifier(),
             from_authority=?output.authority(),
@@ -425,22 +414,20 @@ impl DWalletSession {
             if let Ok(output_bytes) = bcs::to_bytes(&output) {
                 let digest: [u8; 32] = DefaultHash::digest(&output_bytes).into();
                 self.distinct_output_digests.insert(digest);
-                if may_be_network_key_reconfiguration {
-                    self.network_key_reconfiguration_output_observations
-                        .entry(authority)
-                        .and_modify(|observation| {
-                            observation.digests.insert(digest);
-                            observation.malicious_actor_count = observation
-                                .malicious_actor_count
-                                .max(malicious_authorities.len());
-                            observation.rejected |= rejected;
-                        })
-                        .or_insert_with(|| NetworkKeyReconfigurationOutputObservation {
-                            digests: HashSet::from([digest]),
-                            malicious_actor_count: malicious_authorities.len(),
-                            rejected,
-                        });
-                }
+                self.output_observations
+                    .entry(authority)
+                    .and_modify(|observation| {
+                        observation.digests.insert(digest);
+                        observation.malicious_actor_count = observation
+                            .malicious_actor_count
+                            .max(malicious_authorities.len());
+                        observation.rejected |= rejected;
+                    })
+                    .or_insert_with(|| SessionOutputObservation {
+                        digests: HashSet::from([digest]),
+                        malicious_actor_count: malicious_authorities.len(),
+                        rejected,
+                    });
             }
             if let Vacant(e) = consensus_round_output_map.entry(sender_party_id) {
                 e.insert(DWalletMPCSessionOutput {
@@ -846,10 +833,9 @@ impl DWalletMPCManager {
         }
 
         let status = self.session_status_from_request(request.clone(), false);
-        let is_network_key_reconfiguration = matches!(
-            &request.protocol_data,
-            ProtocolData::NetworkEncryptionKeyReconfiguration { .. }
-        );
+        let protocol_name = DWalletSessionRequestMetricData::from(&request.protocol_data)
+            .name()
+            .to_owned();
 
         self.dwallet_mpc_metrics
             .add_received_request_start(&(&request.protocol_data).into());
@@ -863,11 +849,7 @@ impl DWalletMPCManager {
             // unit-variant states (ComputationCompleted/Completed/Failed) which would
             // otherwise discard this information.
             session.set_request_metadata(request.session_sequence_number, request.session_type);
-            if is_network_key_reconfiguration {
-                session.mark_network_key_reconfiguration();
-            } else {
-                session.discard_unclassified_output_observations();
-            }
+            session.set_protocol_name(protocol_name.clone());
 
             // We only trust the session type that we deduce ourselves from the session request.
             // However, it is not safe to override the session status in all cases.
@@ -893,11 +875,7 @@ impl DWalletMPCManager {
             // explicit set covers the non-Active creation path (e.g. Failed).
             if let Some(session) = self.sessions.get_mut(&session_identifier) {
                 session.set_request_metadata(request.session_sequence_number, request.session_type);
-                if is_network_key_reconfiguration {
-                    session.mark_network_key_reconfiguration();
-                } else {
-                    session.discard_unclassified_output_observations();
-                }
+                session.set_protocol_name(protocol_name);
             }
         }
         Some(status)

--- a/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
@@ -231,6 +231,7 @@ pub(crate) fn session_input_from_request(
                     validator_mpc_keys_by_party_id.secp256k1_pvss,
                     validator_mpc_keys_by_party_id.secp256r1_pvss,
                     validator_mpc_keys_by_party_id.ristretto_pvss,
+                    protocol_config.is_network_encryption_key_version_v3(),
                 )?)
             } else {
                 PublicInput::NetworkEncryptionKeyDkgBwdCompat(network_dkg_bwd_compat_public_input(
@@ -278,6 +279,7 @@ pub(crate) fn session_input_from_request(
                         upcoming_validator_mpc_keys,
                         network_dkg_public_output,
                         latest_reconfiguration_public_output,
+                        protocol_config.is_reconfiguration_message_version_v3(),
                     )?,
                 )
             } else {

--- a/crates/ika-core/src/request_protocol_data.rs
+++ b/crates/ika-core/src/request_protocol_data.rs
@@ -103,6 +103,14 @@ impl From<&NetworkOwnedAddressSignData> for SignData {
 #[display("Network Encryption Key DKG")]
 pub struct NetworkEncryptionKeyDkgData {}
 
+/// Canonical protocol name for network-key reconfiguration sessions, as
+/// produced by `NetworkEncryptionKeyReconfigurationData`'s `Display`. Named
+/// because it labels the `ika_dwallet_mpc_session_*` metrics that a release-gate
+/// compatibility test filters on and that we allow-list for export; the
+/// `mod tests` below fails if this constant and the `Display` string diverge.
+pub const NETWORK_KEY_RECONFIGURATION_PROTOCOL_NAME: &str =
+    "Network Encryption Key Reconfiguration";
+
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, derive_more::Display)]
 #[display("Network Encryption Key Reconfiguration")]
 pub struct NetworkEncryptionKeyReconfigurationData {}
@@ -552,5 +560,27 @@ impl ProtocolData {
                 ..
             } => Some(*dwallet_network_encryption_key_id),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dwallet_session_request::DWalletSessionRequestMetricData;
+
+    /// The metric label a release-gate compatibility test filters on is the
+    /// protocol `Display` string, surfaced through `name()`. Anchor them so a
+    /// cosmetic rename of the `Display` fails here instead of silently making
+    /// the gate observe nothing.
+    #[test]
+    fn network_key_reconfiguration_protocol_name_matches_metric_label() {
+        let protocol_data = ProtocolData::NetworkEncryptionKeyReconfiguration {
+            data: NetworkEncryptionKeyReconfigurationData {},
+            dwallet_network_encryption_key_id: ObjectID::ZERO,
+        };
+        assert_eq!(
+            DWalletSessionRequestMetricData::from(&protocol_data).name(),
+            NETWORK_KEY_RECONFIGURATION_PROTOCOL_NAME,
+        );
     }
 }

--- a/crates/ika-node/Cargo.toml
+++ b/crates/ika-node/Cargo.toml
@@ -82,8 +82,8 @@ default = ["enforce-minimum-cpu", "jemalloc"]
 # validator on the ika testnet or mainnet networks (identified by the deployed
 # ika system object, not the Sui settlement chain — see ika-core's runtime.rs).
 enforce-minimum-cpu = ["ika-core/enforce-minimum-cpu"]
-# INSECURE test-only mock: forwards to the deterministic cryptography-private protocol mocks.
-# Never enable in production. See cryptography-private `unsafe_mock`.
+# INSECURE test-only mock: forwards to the deterministic inkrypto protocol mocks.
+# Never enable in production. See inkrypto `unsafe_mock`.
 dwallet-mpc-unsafe-mock = ["ika-core/dwallet-mpc-unsafe-mock"]
 # Compiled-in jemalloc as the global allocator (mirrors sui-node) — better
 # fragmentation behavior than glibc malloc for long-running RocksDB-heavy

--- a/crates/ika-test-cluster/Cargo.toml
+++ b/crates/ika-test-cluster/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 [features]
 # No default features: the INSECURE `dwallet-mpc-unsafe-mock` below must be opt-in only.
 default = []
-# INSECURE test-only mock: forwards to the deterministic cryptography-private protocol mocks so
+# INSECURE test-only mock: forwards to the deterministic inkrypto protocol mocks so
 # dwallet-mpc integration tests run without real class-group crypto. Never enable in production.
 # Run e.g. `cargo test -p ika-test-cluster --features dwallet-mpc-unsafe-mock`.
 dwallet-mpc-unsafe-mock = [

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -669,7 +669,9 @@ enum NetworkKeyOutputConvergence {
 
 fn canonical_network_key_outputs(
     body: &str,
-    expected_authorities: &BTreeSet<String>,
+    committee_authorities: &BTreeSet<String>,
+    required_authorities: &BTreeSet<String>,
+    quorum: usize,
     observer: &str,
 ) -> Result<NetworkKeyOutputConvergence> {
     let output_samples = metric_samples_for_protocol(
@@ -761,9 +763,25 @@ fn canonical_network_key_outputs(
     let mut canonical = BTreeMap::new();
     for (session, outputs) in outputs_by_session {
         let observed_authorities = outputs.keys().cloned().collect::<BTreeSet<_>>();
-        if &observed_authorities != expected_authorities {
+        // A validator submitting a network-key output for a session whose
+        // committee it isn't in is a real fault, not a propagation delay.
+        ensure!(
+            observed_authorities.is_subset(committee_authorities),
+            "{observer} observed out-of-committee authorities for network-key session {session}: observed={observed_authorities:?}, committee={committee_authorities:?}"
+        );
+        // Reconfiguration finalizes at a Byzantine quorum and does not wait: a
+        // validator still computing when quorum forms marks its session
+        // complete (on seeing the quorum in consensus) and discards its own
+        // still-in-flight output, so an honest straggler legitimately never
+        // submits. Requiring the whole committee here would race that
+        // finalization. Require instead every validator under test (the
+        // upgraded observers) plus a finalizing quorum — enough to prove the
+        // upgraded node's output agrees with a quorum of peers.
+        if !required_authorities.is_subset(&observed_authorities)
+            || observed_authorities.len() < quorum
+        {
             return Ok(NetworkKeyOutputConvergence::Incomplete(format!(
-                "{observer} observed the wrong authority set for network-key session {session}: observed={observed_authorities:?}, expected={expected_authorities:?}"
+                "{observer} has not yet observed a quorum including every validator under test for network-key session {session}: observed={observed_authorities:?}, required={required_authorities:?}, quorum={quorum}"
             )));
         }
         let digests: BTreeSet<_> = outputs.values().cloned().collect();
@@ -1117,11 +1135,15 @@ impl ClusterOfProcesses {
             !observer_indices.is_empty(),
             "no output-convergence observers supplied"
         );
-        let expected_authorities: BTreeSet<_> = self
+        let committee_authorities: BTreeSet<_> = self
             .validator_authorities
             .iter()
             .map(ToString::to_string)
             .collect();
+        // Byzantine quorum of the committee. These scenarios run an
+        // equal-weight committee, so a plain member count matches the
+        // access-structure threshold (n - floor((n-1)/3)).
+        let quorum = committee_authorities.len() - committee_authorities.len().saturating_sub(1) / 3;
         let expected_epoch = self.current_epoch().await?;
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
@@ -1142,11 +1164,28 @@ impl ClusterOfProcesses {
                     validator.index,
                     validator.metrics_endpoint()
                 );
-                let observer_canonical =
-                    match canonical_network_key_outputs(&body, &expected_authorities, &observer)
-                        .with_context(|| {
-                            format!("validate network-key convergence from {observer}")
-                        })? {
+                // Each observer is a validator under test (the upgraded
+                // binary); require it to have observed its own output within a
+                // converged quorum. That is the compatibility signal — the
+                // upgraded node's reconfiguration output matching a quorum of
+                // v1.1.8 peers — without racing the straggler that finalization
+                // legitimately drops.
+                let required_authorities: BTreeSet<String> = std::iter::once(
+                    self.validator_authorities
+                        .get(*index)
+                        .with_context(|| format!("validator index {index} out of range"))?
+                        .to_string(),
+                )
+                .collect();
+                let observer_canonical = match canonical_network_key_outputs(
+                    &body,
+                    &committee_authorities,
+                    &required_authorities,
+                    quorum,
+                    &observer,
+                )
+                .with_context(|| format!("validate network-key convergence from {observer}"))?
+                {
                         NetworkKeyOutputConvergence::Converged(canonical) => canonical,
                         NetworkKeyOutputConvergence::Incomplete(reason) => {
                             incomplete.push(reason);
@@ -1225,11 +1264,6 @@ impl ClusterOfProcesses {
 
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
-            let current_epoch = self.current_epoch().await?;
-            ensure!(
-                current_epoch == epoch,
-                "coordinator advanced to epoch {current_epoch} before epoch {epoch} local network-key work drained"
-            );
             let mut pending = Vec::new();
             for index in observer_indices {
                 let validator = self
@@ -1267,6 +1301,14 @@ impl ClusterOfProcesses {
             if pending.is_empty() {
                 return Ok(());
             }
+            // Check the epoch guard AFTER computing pending so the diagnostic
+            // names the gauge that never drained, not just "advanced".
+            let current_epoch = self.current_epoch().await?;
+            ensure!(
+                current_epoch == epoch,
+                "coordinator advanced to epoch {current_epoch} before epoch {epoch} local network-key work drained; still pending: {}",
+                pending.join("; ")
+            );
             if tokio::time::Instant::now() >= deadline {
                 bail!(
                     "network-key reconfiguration remained pending within {timeout:?}: {}",
@@ -1822,19 +1864,21 @@ mod tests {
         assert_eq!(parse_labelless_gauge(body, "ika_current_epoch"), Some(4));
     }
 
+    fn committee_of(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|n| n.to_string()).collect()
+    }
+
     #[test]
     fn accepts_four_authority_network_key_output_convergence() {
-        let expected = ["a", "b", "c", "d"]
-            .into_iter()
-            .map(str::to_string)
-            .collect();
+        let committee = committee_of(&["a", "b", "c", "d"]);
+        let required = committee_of(&["a"]);
         let mut body =
             network_key_metrics(&[("a", "same"), ("b", "same"), ("c", "same"), ("d", "same")]);
         body.push_str(
             "ika_dwallet_mpc_session_output_info{protocol_name=\"Sign\",session_id=\"unrelated\",authority=\"a\",output_digest=\"different\"} 1\n",
         );
         let NetworkKeyOutputConvergence::Converged(canonical) =
-            canonical_network_key_outputs(&body, &expected, "validator 0").unwrap()
+            canonical_network_key_outputs(&body, &committee, &required, 3, "validator 0").unwrap()
         else {
             panic!("four matching authorities must converge");
         };
@@ -1842,18 +1886,73 @@ mod tests {
     }
 
     #[test]
+    fn accepts_quorum_when_straggler_absent() {
+        // The 4th validator finalized on quorum before its own output was
+        // submitted (it discards a post-quorum result). A 3-of-4 converged
+        // quorum that includes the validator under test still passes — the
+        // full-committee requirement would race that finalization.
+        let committee = committee_of(&["a", "b", "c", "d"]);
+        let required = committee_of(&["a"]);
+        let body = network_key_metrics(&[("a", "same"), ("b", "same"), ("c", "same")]);
+        let NetworkKeyOutputConvergence::Converged(canonical) =
+            canonical_network_key_outputs(&body, &committee, &required, 3, "validator 0").unwrap()
+        else {
+            panic!("a converged quorum including the validator under test must pass");
+        };
+        assert_eq!(canonical["session"], "same");
+    }
+
+    #[test]
+    fn incomplete_when_validator_under_test_absent() {
+        // A quorum that excludes the upgraded validator proves nothing about
+        // its compatibility — keep polling (fail-closed on the caller timeout).
+        let committee = committee_of(&["a", "b", "c", "d"]);
+        let required = committee_of(&["a"]);
+        let body = network_key_metrics(&[("b", "same"), ("c", "same"), ("d", "same")]);
+        let NetworkKeyOutputConvergence::Incomplete(reason) =
+            canonical_network_key_outputs(&body, &committee, &required, 3, "validator 0").unwrap()
+        else {
+            panic!("a quorum missing the validator under test must be incomplete");
+        };
+        assert!(reason.contains("validator under test"));
+    }
+
+    #[test]
+    fn incomplete_below_quorum() {
+        let committee = committee_of(&["a", "b", "c", "d"]);
+        let required = committee_of(&["a"]);
+        let body = network_key_metrics(&[("a", "same"), ("b", "same")]);
+        let NetworkKeyOutputConvergence::Incomplete(_) =
+            canonical_network_key_outputs(&body, &committee, &required, 3, "validator 0").unwrap()
+        else {
+            panic!("a below-quorum observation must be incomplete");
+        };
+    }
+
+    #[test]
+    fn rejects_out_of_committee_authority() {
+        // A non-member submitting a network-key output is a hard fault, not a
+        // propagation delay.
+        let committee = committee_of(&["a", "b", "c"]);
+        let required = committee_of(&["a"]);
+        let body =
+            network_key_metrics(&[("a", "same"), ("b", "same"), ("c", "same"), ("rogue", "same")]);
+        let error = canonical_network_key_outputs(&body, &committee, &required, 3, "validator 0")
+            .expect_err("an out-of-committee authority must fail closed");
+        assert!(error.to_string().contains("out-of-committee"));
+    }
+
+    #[test]
     fn rejects_one_divergent_network_key_output() {
-        let expected = ["a", "b", "c", "d"]
-            .into_iter()
-            .map(str::to_string)
-            .collect();
+        let committee = committee_of(&["a", "b", "c", "d"]);
+        let required = committee_of(&["a"]);
         let body = network_key_metrics(&[
             ("a", "different"),
             ("b", "majority"),
             ("c", "majority"),
             ("d", "majority"),
         ]);
-        let error = canonical_network_key_outputs(&body, &expected, "validator 0")
+        let error = canonical_network_key_outputs(&body, &committee, &required, 3, "validator 0")
             .expect_err("3-vs-1 output split must fail closed");
         assert!(
             error
@@ -1864,7 +1963,8 @@ mod tests {
 
     #[test]
     fn missing_network_key_envelope_metric_is_incomplete_not_converged() {
-        let expected = ["a"].into_iter().map(str::to_string).collect();
+        let committee = committee_of(&["a"]);
+        let required = committee_of(&["a"]);
         let body = format!(
             "ika_dwallet_mpc_session_output_info{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"a\",output_digest=\"same\"}} 1\nika_dwallet_mpc_session_output_rejected{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"a\"}} 0\n"
         );
@@ -1872,7 +1972,7 @@ mod tests {
         // the observer keeps polling (and the caller ultimately times out —
         // still fail-closed), rather than declaring a hard divergence.
         let NetworkKeyOutputConvergence::Incomplete(reason) =
-            canonical_network_key_outputs(&body, &expected, "validator 0").unwrap()
+            canonical_network_key_outputs(&body, &committee, &required, 1, "validator 0").unwrap()
         else {
             panic!("a missing envelope metric must be reported as incomplete");
         };

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -49,6 +49,10 @@ use crate::process::ValidatorProcess;
 use crate::sui::SuiLocalnet;
 use crate::{DEFAULT_EPOCH_DURATION_MS, DEFAULT_NUM_VALIDATORS};
 
+// Must equal `NetworkEncryptionKeyReconfigurationData`'s `Display` in ika-core
+// (`request_protocol_data.rs`), which labels the metrics scraped below. ika-core
+// has no dep edge here, so a `mod tests` there anchors that string to its own
+// `NETWORK_KEY_RECONFIGURATION_PROTOCOL_NAME` constant and trips if it drifts.
 const NETWORK_KEY_RECONFIGURATION_PROTOCOL: &str = "Network Encryption Key Reconfiguration";
 
 /// A running out-of-process cluster. Owns the Sui localnet, the validator
@@ -650,28 +654,43 @@ fn metric_samples_for_protocol(
         .collect()
 }
 
+/// Outcome of inspecting one observer's network-key output metrics.
+///
+/// `Incomplete` means the observer has not recorded enough yet and the caller
+/// should keep polling; a hard `Err` (divergent digests, a malicious/rejected
+/// report, or malformed metrics) is release-blocking and must not be retried.
+/// Distinguishing the two by type keeps the retry/fail decision off fragile
+/// error-string matching.
+#[derive(Debug)]
+enum NetworkKeyOutputConvergence {
+    Incomplete(String),
+    Converged(BTreeMap<String, String>),
+}
+
 fn canonical_network_key_outputs(
     body: &str,
     expected_authorities: &BTreeSet<String>,
     observer: &str,
-) -> Result<BTreeMap<String, String>> {
+) -> Result<NetworkKeyOutputConvergence> {
     let output_samples = metric_samples_for_protocol(
         body,
         "ika_dwallet_mpc_session_output_info",
         NETWORK_KEY_RECONFIGURATION_PROTOCOL,
     )?;
-    ensure!(
-        !output_samples.is_empty(),
-        "{observer} is missing network-key output observations"
-    );
+    if output_samples.is_empty() {
+        return Ok(NetworkKeyOutputConvergence::Incomplete(format!(
+            "{observer} is missing network-key output observations"
+        )));
+    }
 
-    let envelope_values = |metric: &str| {
+    // An absent envelope gauge means the observer has not recorded the full
+    // report yet (retry). Malformed or duplicated samples are hard failures.
+    let envelope_values = |metric: &str| -> Result<Option<BTreeMap<(String, String), u64>>> {
         let samples =
             metric_samples_for_protocol(body, metric, NETWORK_KEY_RECONFIGURATION_PROTOCOL)?;
-        ensure!(
-            !samples.is_empty(),
-            "{observer} is missing required {metric} samples"
-        );
+        if samples.is_empty() {
+            return Ok(None);
+        }
         let mut values = BTreeMap::new();
         for sample in samples {
             let session = sample
@@ -696,10 +715,16 @@ fn canonical_network_key_outputs(
                 "{observer} has duplicate {metric} samples for session {session} authority {authority}"
             );
         }
-        Ok::<_, anyhow::Error>(values)
+        Ok(Some(values))
     };
-    let malicious = envelope_values("ika_dwallet_mpc_session_reported_malicious_actors")?;
-    let rejected = envelope_values("ika_dwallet_mpc_session_output_rejected")?;
+    let (Some(malicious), Some(rejected)) = (
+        envelope_values("ika_dwallet_mpc_session_reported_malicious_actors")?,
+        envelope_values("ika_dwallet_mpc_session_output_rejected")?,
+    ) else {
+        return Ok(NetworkKeyOutputConvergence::Incomplete(format!(
+            "{observer} is missing required network-key envelope samples"
+        )));
+    };
 
     let mut outputs_by_session: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
     for sample in output_samples {
@@ -736,10 +761,11 @@ fn canonical_network_key_outputs(
     let mut canonical = BTreeMap::new();
     for (session, outputs) in outputs_by_session {
         let observed_authorities = outputs.keys().cloned().collect::<BTreeSet<_>>();
-        ensure!(
-            &observed_authorities == expected_authorities,
-            "{observer} observed the wrong authority set for network-key session {session}: observed={observed_authorities:?}, expected={expected_authorities:?}"
-        );
+        if &observed_authorities != expected_authorities {
+            return Ok(NetworkKeyOutputConvergence::Incomplete(format!(
+                "{observer} observed the wrong authority set for network-key session {session}: observed={observed_authorities:?}, expected={expected_authorities:?}"
+            )));
+        }
         let digests: BTreeSet<_> = outputs.values().cloned().collect();
         ensure!(
             digests.len() == 1,
@@ -766,7 +792,7 @@ fn canonical_network_key_outputs(
                 .expect("one digest after length check"),
         );
     }
-    Ok(canonical)
+    Ok(NetworkKeyOutputConvergence::Converged(canonical))
 }
 
 impl ClusterOfProcesses {
@@ -1117,20 +1143,14 @@ impl ClusterOfProcesses {
                     validator.metrics_endpoint()
                 );
                 let observer_canonical =
-                    match canonical_network_key_outputs(&body, &expected_authorities, &observer) {
-                        Ok(canonical) => canonical,
-                        Err(error)
-                            if error.to_string().contains("missing network-key")
-                                || error.to_string().contains("missing required")
-                                || error.to_string().contains("wrong authority set") =>
-                        {
-                            incomplete.push(error.to_string());
+                    match canonical_network_key_outputs(&body, &expected_authorities, &observer)
+                        .with_context(|| {
+                            format!("validate network-key convergence from {observer}")
+                        })? {
+                        NetworkKeyOutputConvergence::Converged(canonical) => canonical,
+                        NetworkKeyOutputConvergence::Incomplete(reason) => {
+                            incomplete.push(reason);
                             continue;
-                        }
-                        Err(error) => {
-                            return Err(error).with_context(|| {
-                                format!("validate network-key convergence from {observer}")
-                            });
                         }
                     };
 
@@ -1813,7 +1833,11 @@ mod tests {
         body.push_str(
             "ika_dwallet_mpc_session_output_info{protocol_name=\"Sign\",session_id=\"unrelated\",authority=\"a\",output_digest=\"different\"} 1\n",
         );
-        let canonical = canonical_network_key_outputs(&body, &expected, "validator 0").unwrap();
+        let NetworkKeyOutputConvergence::Converged(canonical) =
+            canonical_network_key_outputs(&body, &expected, "validator 0").unwrap()
+        else {
+            panic!("four matching authorities must converge");
+        };
         assert_eq!(canonical["session"], "same");
     }
 
@@ -1839,13 +1863,19 @@ mod tests {
     }
 
     #[test]
-    fn rejects_missing_network_key_envelope_metric() {
+    fn missing_network_key_envelope_metric_is_incomplete_not_converged() {
         let expected = ["a"].into_iter().map(str::to_string).collect();
         let body = format!(
             "ika_dwallet_mpc_session_output_info{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"a\",output_digest=\"same\"}} 1\nika_dwallet_mpc_session_output_rejected{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"a\"}} 0\n"
         );
-        let error = canonical_network_key_outputs(&body, &expected, "validator 0")
-            .expect_err("missing malicious envelope metric must fail closed");
-        assert!(error.to_string().contains("missing required"));
+        // A missing malicious-actor envelope is a not-yet-recorded observation:
+        // the observer keeps polling (and the caller ultimately times out —
+        // still fail-closed), rather than declaring a hard divergence.
+        let NetworkKeyOutputConvergence::Incomplete(reason) =
+            canonical_network_key_outputs(&body, &expected, "validator 0").unwrap()
+        else {
+            panic!("a missing envelope metric must be reported as incomplete");
+        };
+        assert!(reason.contains("missing required"));
     }
 }

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -49,6 +49,8 @@ use crate::process::ValidatorProcess;
 use crate::sui::SuiLocalnet;
 use crate::{DEFAULT_EPOCH_DURATION_MS, DEFAULT_NUM_VALIDATORS};
 
+const NETWORK_KEY_RECONFIGURATION_PROTOCOL: &str = "Network Encryption Key Reconfiguration";
+
 /// A running out-of-process cluster. Owns the Sui localnet, the validator
 /// processes, and the notifier; tears everything down on `Drop` (each child has
 /// `kill_on_drop`).
@@ -595,14 +597,68 @@ fn required_unlabeled_metric(
     )
 }
 
+fn required_labeled_metric(
+    body: &str,
+    metric: &str,
+    expected_labels: &[(&str, &str)],
+    validator: &ValidatorProcess,
+) -> Result<u64> {
+    let samples = parse_metric_samples(body, metric)?;
+    let matching = samples
+        .into_iter()
+        .filter(|sample| {
+            expected_labels.iter().all(|(name, value)| {
+                sample
+                    .labels
+                    .get(*name)
+                    .is_some_and(|actual| actual == value)
+            })
+        })
+        .collect::<Vec<_>>();
+    ensure!(
+        matching.len() == 1,
+        "validator {} metrics endpoint {} returned {} samples for {metric} with labels {expected_labels:?}; expected exactly one",
+        validator.index,
+        validator.metrics_endpoint(),
+        matching.len()
+    );
+    let value = matching[0].value;
+    ensure!(
+        value.is_finite() && value >= 0.0 && value.fract() == 0.0,
+        "validator {} metrics endpoint {} returned invalid {metric} value {value} with labels {expected_labels:?}",
+        validator.index,
+        validator.metrics_endpoint()
+    );
+    Ok(value as u64)
+}
+
+fn metric_samples_for_protocol(
+    body: &str,
+    metric: &str,
+    protocol_name: &str,
+) -> Result<Vec<PrometheusSample>> {
+    parse_metric_samples(body, metric)?
+        .into_iter()
+        .map(|sample| {
+            let sample_protocol = sample
+                .labels
+                .get("protocol_name")
+                .with_context(|| format!("{metric} sample missing protocol_name label"))?;
+            Ok((sample_protocol == protocol_name).then_some(sample))
+        })
+        .filter_map(Result::transpose)
+        .collect()
+}
+
 fn canonical_network_key_outputs(
     body: &str,
     expected_authorities: &BTreeSet<String>,
     observer: &str,
 ) -> Result<BTreeMap<String, String>> {
-    let output_samples = parse_metric_samples(
+    let output_samples = metric_samples_for_protocol(
         body,
-        "ika_dwallet_mpc_network_key_reconfiguration_output_info",
+        "ika_dwallet_mpc_session_output_info",
+        NETWORK_KEY_RECONFIGURATION_PROTOCOL,
     )?;
     ensure!(
         !output_samples.is_empty(),
@@ -610,7 +666,8 @@ fn canonical_network_key_outputs(
     );
 
     let envelope_values = |metric: &str| {
-        let samples = parse_metric_samples(body, metric)?;
+        let samples =
+            metric_samples_for_protocol(body, metric, NETWORK_KEY_RECONFIGURATION_PROTOCOL)?;
         ensure!(
             !samples.is_empty(),
             "{observer} is missing required {metric} samples"
@@ -641,9 +698,8 @@ fn canonical_network_key_outputs(
         }
         Ok::<_, anyhow::Error>(values)
     };
-    let malicious =
-        envelope_values("ika_dwallet_mpc_network_key_reconfiguration_reported_malicious_actors")?;
-    let rejected = envelope_values("ika_dwallet_mpc_network_key_reconfiguration_output_rejected")?;
+    let malicious = envelope_values("ika_dwallet_mpc_session_reported_malicious_actors")?;
+    let rejected = envelope_values("ika_dwallet_mpc_session_output_rejected")?;
 
     let mut outputs_by_session: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
     for sample in output_samples {
@@ -1161,11 +1217,24 @@ impl ClusterOfProcesses {
                     .get(*index)
                     .with_context(|| format!("validator index {index} out of range"))?;
                 let body = validator.metrics().await?;
-                for metric in [
-                    "ika_dwallet_mpc_network_key_reconfiguration_sessions_pending",
-                    "ika_dwallet_mpc_network_key_instantiations_in_flight",
+                let protocol_pending = required_labeled_metric(
+                    &body,
+                    "ika_dwallet_mpc_protocol_sessions_pending",
+                    &[("protocol_name", NETWORK_KEY_RECONFIGURATION_PROTOCOL)],
+                    validator,
+                )?;
+                let instantiations = required_unlabeled_metric(
+                    &body,
+                    &["ika_dwallet_mpc_network_key_instantiations_in_flight"],
+                    validator,
+                )?;
+                for (metric, value) in [
+                    (
+                        "network-key reconfiguration sessions pending",
+                        protocol_pending,
+                    ),
+                    ("network-key instantiations in flight", instantiations),
                 ] {
-                    let value = required_unlabeled_metric(&body, &[metric], validator)?;
                     if value != 0 {
                         pending.push(format!(
                             "validator {} at {} reports {metric}={value}",
@@ -1646,13 +1715,13 @@ mod tests {
             .flat_map(|(authority, digest)| {
                 [
                     format!(
-                        "ika_dwallet_mpc_network_key_reconfiguration_output_info{{session_id=\"session\",authority=\"{authority}\",output_digest=\"{digest}\"}} 1\n"
+                        "ika_dwallet_mpc_session_output_info{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"{authority}\",output_digest=\"{digest}\"}} 1\n"
                     ),
                     format!(
-                        "ika_dwallet_mpc_network_key_reconfiguration_reported_malicious_actors{{session_id=\"session\",authority=\"{authority}\"}} 0\n"
+                        "ika_dwallet_mpc_session_reported_malicious_actors{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"{authority}\"}} 0\n"
                     ),
                     format!(
-                        "ika_dwallet_mpc_network_key_reconfiguration_output_rejected{{session_id=\"session\",authority=\"{authority}\"}} 0\n"
+                        "ika_dwallet_mpc_session_output_rejected{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"{authority}\"}} 0\n"
                     ),
                 ]
             })
@@ -1690,6 +1759,22 @@ mod tests {
         assert!(error.contains("http://127.0.0.1:0/metrics"));
     }
 
+    #[test]
+    fn labeled_metric_requires_the_requested_protocol() {
+        let validator = stopped_validator();
+        let body = "ika_dwallet_mpc_protocol_sessions_pending{protocol_name=\"Sign\"} 0\n";
+        let error = required_labeled_metric(
+            body,
+            "ika_dwallet_mpc_protocol_sessions_pending",
+            &[("protocol_name", NETWORK_KEY_RECONFIGURATION_PROTOCOL)],
+            &validator,
+        )
+        .expect_err("missing requested protocol must fail closed")
+        .to_string();
+        assert!(error.contains("validator 2"));
+        assert!(error.contains("http://127.0.0.1:0/metrics"));
+    }
+
     #[tokio::test]
     async fn stopped_validator_health_and_metrics_fail_closed() {
         let validator = stopped_validator();
@@ -1723,8 +1808,11 @@ mod tests {
             .into_iter()
             .map(str::to_string)
             .collect();
-        let body =
+        let mut body =
             network_key_metrics(&[("a", "same"), ("b", "same"), ("c", "same"), ("d", "same")]);
+        body.push_str(
+            "ika_dwallet_mpc_session_output_info{protocol_name=\"Sign\",session_id=\"unrelated\",authority=\"a\",output_digest=\"different\"} 1\n",
+        );
         let canonical = canonical_network_key_outputs(&body, &expected, "validator 0").unwrap();
         assert_eq!(canonical["session"], "same");
     }
@@ -1753,11 +1841,10 @@ mod tests {
     #[test]
     fn rejects_missing_network_key_envelope_metric() {
         let expected = ["a"].into_iter().map(str::to_string).collect();
-        let body = concat!(
-            "ika_dwallet_mpc_network_key_reconfiguration_output_info{session_id=\"session\",authority=\"a\",output_digest=\"same\"} 1\n",
-            "ika_dwallet_mpc_network_key_reconfiguration_output_rejected{session_id=\"session\",authority=\"a\"} 0\n",
+        let body = format!(
+            "ika_dwallet_mpc_session_output_info{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"a\",output_digest=\"same\"}} 1\nika_dwallet_mpc_session_output_rejected{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"a\"}} 0\n"
         );
-        let error = canonical_network_key_outputs(body, &expected, "validator 0")
+        let error = canonical_network_key_outputs(&body, &expected, "validator 0")
             .expect_err("missing malicious envelope metric must fail closed");
         assert!(error.to_string().contains("missing required"));
     }

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -12,11 +12,12 @@
 //! YAML on a persistent data dir and hand it to a real binary via
 //! `--config-path`, instead of starting `IkaNode` in-process.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::time::Duration;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, bail, ensure};
 use ika_config::initiation::InitiationParameters;
 use ika_config::node::{NodeConfig, SuiDataSource};
 use ika_protocol_config::ProtocolVersion;
@@ -33,9 +34,11 @@ use ika_swarm_config::sui_client::{
 use ika_swarm_config::validator_initialization_config::{
     ValidatorInitializationConfig, ValidatorInitializationConfigBuilder,
 };
-use ika_types::crypto::KeypairTraits;
-use ika_types::messages_dwallet_mpc::IkaNetworkConfig;
-use ika_types::sui::SystemInner;
+use ika_types::crypto::{AuthorityPublicKeyBytes, KeypairTraits};
+use ika_types::messages_dwallet_mpc::{
+    DWalletNetworkEncryptionKey, DWalletNetworkEncryptionKeyState, IkaNetworkConfig,
+};
+use ika_types::sui::{DWalletCoordinatorInner, SystemInner};
 use rand::rngs::OsRng;
 use sui_sdk::SuiClientBuilder;
 use sui_sdk::wallet_context::WalletContext;
@@ -67,6 +70,10 @@ pub struct ClusterOfProcesses {
     /// aligned with `validators` by index; joiners append. A mirrored
     /// validator's `sui_state_mirror_peers` is built from these.
     validator_peer_ids: Vec<String>,
+    /// Protocol authorities aligned with `validators`. The convergence check
+    /// compares exact identities, not just a count that a missing validator
+    /// and an unexpected sender could accidentally satisfy.
+    validator_authorities: Vec<AuthorityPublicKeyBytes>,
     /// Bootstrap package state (`ika_supply_id` funds joiner stakes).
     packages: PublishedIkaPackages,
     /// Bootstrap system state (`init_system_shared_version` is needed by
@@ -297,6 +304,10 @@ impl ClusterBuilder {
             .iter()
             .map(|init| hex::encode(init.network_key_pair.public().0.to_bytes()))
             .collect();
+        let validator_authorities = validator_init_configs
+            .iter()
+            .map(|init| init.key_pair.public().into())
+            .collect();
 
         // OCS verified-reads path (protocol v4): a validator with `sui-data-source`
         // set refuses to boot without a Sui trust anchor. Seed every validator
@@ -422,6 +433,7 @@ impl ClusterBuilder {
             publisher_keypair,
             committee,
             validator_peer_ids,
+            validator_authorities,
             packages: bootstrap.packages,
             system: bootstrap.system,
             wallet: bootstrap.wallet_context,
@@ -493,6 +505,214 @@ fn parse_labelless_gauge(body: &str, metric: &str) -> Option<u64> {
         })
 }
 
+#[derive(Clone, Debug, PartialEq)]
+struct PrometheusSample {
+    labels: BTreeMap<String, String>,
+    value: f64,
+}
+
+/// Parse exact Prometheus samples for one metric name. Prefix collisions are
+/// rejected (`metric_other` is not `metric`); labels used by this harness are
+/// hex/identifier strings and therefore never contain escaped commas.
+fn parse_metric_samples(body: &str, metric: &str) -> Result<Vec<PrometheusSample>> {
+    body.lines()
+        .filter(|line| !line.starts_with('#'))
+        .filter_map(|line| {
+            let rest = line.strip_prefix(metric)?;
+            if !rest.starts_with(' ') && !rest.starts_with('{') {
+                return None;
+            }
+            Some(rest)
+        })
+        .map(|rest| {
+            let (labels, value) = if let Some(rest) = rest.strip_prefix('{') {
+                let (raw_labels, value) = rest
+                    .split_once("} ")
+                    .with_context(|| format!("malformed labeled sample for {metric}: {rest}"))?;
+                let labels = raw_labels
+                    .split(',')
+                    .map(|pair| {
+                        let (name, value) = pair.split_once('=').with_context(|| {
+                            format!("malformed label in sample for {metric}: {pair}")
+                        })?;
+                        let value = value
+                            .strip_prefix('"')
+                            .and_then(|value| value.strip_suffix('"'))
+                            .with_context(|| {
+                                format!("unquoted label in sample for {metric}: {pair}")
+                            })?;
+                        Ok((name.to_string(), value.to_string()))
+                    })
+                    .collect::<Result<BTreeMap<_, _>>>()?;
+                (labels, value)
+            } else {
+                (BTreeMap::new(), rest.trim())
+            };
+            let value = value
+                .parse::<f64>()
+                .with_context(|| format!("non-numeric sample for {metric}: {value}"))?;
+            Ok(PrometheusSample { labels, value })
+        })
+        .collect()
+}
+
+fn required_unlabeled_metric(
+    body: &str,
+    metric_names: &[&str],
+    validator: &ValidatorProcess,
+) -> Result<u64> {
+    for metric in metric_names {
+        let samples = parse_metric_samples(body, metric)?;
+        if samples.is_empty() {
+            continue;
+        }
+        if samples.len() != 1 || !samples[0].labels.is_empty() {
+            bail!(
+                "validator {} metrics endpoint {} returned {} non-canonical samples for {}",
+                validator.index,
+                validator.metrics_endpoint(),
+                samples.len(),
+                metric
+            );
+        }
+        let value = samples[0].value;
+        if !value.is_finite() || value < 0.0 || value.fract() != 0.0 {
+            bail!(
+                "validator {} metrics endpoint {} returned invalid {} value {}",
+                validator.index,
+                validator.metrics_endpoint(),
+                metric,
+                value
+            );
+        }
+        return Ok(value as u64);
+    }
+    bail!(
+        "validator {} metrics endpoint {} is missing required metric (accepted names: {})",
+        validator.index,
+        validator.metrics_endpoint(),
+        metric_names.join(", ")
+    )
+}
+
+fn canonical_network_key_outputs(
+    body: &str,
+    expected_authorities: &BTreeSet<String>,
+    observer: &str,
+) -> Result<BTreeMap<String, String>> {
+    let output_samples = parse_metric_samples(
+        body,
+        "ika_dwallet_mpc_network_key_reconfiguration_output_info",
+    )?;
+    ensure!(
+        !output_samples.is_empty(),
+        "{observer} is missing network-key output observations"
+    );
+
+    let envelope_values = |metric: &str| {
+        let samples = parse_metric_samples(body, metric)?;
+        ensure!(
+            !samples.is_empty(),
+            "{observer} is missing required {metric} samples"
+        );
+        let mut values = BTreeMap::new();
+        for sample in samples {
+            let session = sample
+                .labels
+                .get("session_id")
+                .cloned()
+                .with_context(|| format!("{metric} sample missing session_id label"))?;
+            let authority = sample
+                .labels
+                .get("authority")
+                .cloned()
+                .with_context(|| format!("{metric} sample missing authority label"))?;
+            ensure!(
+                sample.value.is_finite() && sample.value >= 0.0 && sample.value.fract() == 0.0,
+                "{metric} sample for session {session} authority {authority} has invalid value {}",
+                sample.value
+            );
+            ensure!(
+                values
+                    .insert((session.clone(), authority.clone()), sample.value as u64)
+                    .is_none(),
+                "{observer} has duplicate {metric} samples for session {session} authority {authority}"
+            );
+        }
+        Ok::<_, anyhow::Error>(values)
+    };
+    let malicious =
+        envelope_values("ika_dwallet_mpc_network_key_reconfiguration_reported_malicious_actors")?;
+    let rejected = envelope_values("ika_dwallet_mpc_network_key_reconfiguration_output_rejected")?;
+
+    let mut outputs_by_session: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+    for sample in output_samples {
+        ensure!(
+            sample.value == 1.0,
+            "{observer} output-info sample has value {}, expected 1",
+            sample.value
+        );
+        let session = sample
+            .labels
+            .get("session_id")
+            .cloned()
+            .context("output-info sample missing session_id label")?;
+        let authority = sample
+            .labels
+            .get("authority")
+            .cloned()
+            .context("output-info sample missing authority label")?;
+        let digest = sample
+            .labels
+            .get("output_digest")
+            .cloned()
+            .context("output-info sample missing output_digest label")?;
+        let previous = outputs_by_session
+            .entry(session.clone())
+            .or_default()
+            .insert(authority.clone(), digest.clone());
+        ensure!(
+            previous.as_ref().is_none_or(|previous| previous == &digest),
+            "{observer} observed conflicting digests for session {session} authority {authority}"
+        );
+    }
+
+    let mut canonical = BTreeMap::new();
+    for (session, outputs) in outputs_by_session {
+        let observed_authorities = outputs.keys().cloned().collect::<BTreeSet<_>>();
+        ensure!(
+            &observed_authorities == expected_authorities,
+            "{observer} observed the wrong authority set for network-key session {session}: observed={observed_authorities:?}, expected={expected_authorities:?}"
+        );
+        let digests: BTreeSet<_> = outputs.values().cloned().collect();
+        ensure!(
+            digests.len() == 1,
+            "{observer} observed divergent per-authority outputs for network-key session {session}: {outputs:?}"
+        );
+        for authority in outputs.keys() {
+            let key = (session.clone(), authority.clone());
+            ensure!(
+                malicious.get(&key) == Some(&0),
+                "{observer} observed authority {authority} report a non-zero or missing malicious set for session {session}: {:?}",
+                malicious.get(&key)
+            );
+            ensure!(
+                rejected.get(&key) == Some(&0),
+                "{observer} observed authority {authority} submit a rejected or missing output for session {session}: {:?}",
+                rejected.get(&key)
+            );
+        }
+        canonical.insert(
+            session,
+            digests
+                .into_iter()
+                .next()
+                .expect("one digest after length check"),
+        );
+    }
+    Ok(canonical)
+}
+
 impl ClusterOfProcesses {
     /// Current on-chain ika epoch (read from the system object).
     pub async fn current_epoch(&self) -> Result<u64> {
@@ -512,6 +732,460 @@ impl ClusterOfProcesses {
             .await
             .map_err(|e| anyhow::anyhow!("get_system_inner: {e}"))?;
         Ok(inner.protocol_version)
+    }
+
+    async fn coordinator_snapshot(
+        &self,
+    ) -> Result<(
+        ika_types::sui::system_inner_v1::DWalletCoordinatorInnerV1,
+        BTreeMap<ObjectID, DWalletNetworkEncryptionKey>,
+    )> {
+        let (_, coordinator) = self
+            .ika_client
+            .get_dwallet_coordinator_inner()
+            .await
+            .map_err(|error| anyhow::anyhow!("get_dwallet_coordinator_inner: {error}"))?;
+        let keys = self
+            .ika_client
+            .get_dwallet_mpc_network_keys(&coordinator)
+            .await
+            .map_err(|error| anyhow::anyhow!("get_dwallet_mpc_network_keys: {error}"))?;
+        let DWalletCoordinatorInner::V1(inner) = coordinator;
+        Ok((inner, keys.into_iter().collect()))
+    }
+
+    /// Assert every expected validator process is still running and its admin
+    /// endpoint is reachable. This intentionally does not filter to running
+    /// processes: a dead expected validator is the failure being tested.
+    pub async fn expect_all_validators_healthy(&self) -> Result<()> {
+        for validator in &self.validators {
+            validator.expect_healthy().await?;
+        }
+        Ok(())
+    }
+
+    /// Wait until every validator's local epoch-store has entered `target`.
+    /// On-chain epoch progress is insufficient: a quorum can advance while one
+    /// validator remains on the previous epoch. v1.1.8 exported
+    /// `current_epoch`; current builds export the renamed `ika_current_epoch`.
+    pub async fn wait_for_all_validators_local_epoch(
+        &self,
+        target: u64,
+        timeout: Duration,
+    ) -> Result<()> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let mut lagging = Vec::new();
+            for validator in &self.validators {
+                if !validator.is_running() {
+                    bail!(
+                        "validator {} is not running while waiting for local epoch {} (metrics endpoint {})",
+                        validator.index,
+                        target,
+                        validator.metrics_endpoint()
+                    );
+                }
+                let body = validator.metrics().await?;
+                let epoch = required_unlabeled_metric(
+                    &body,
+                    &["ika_current_epoch", "current_epoch"],
+                    validator,
+                )?;
+                if epoch != target {
+                    lagging.push((validator.index, validator.metrics_endpoint(), epoch));
+                }
+            }
+            if lagging.is_empty() {
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                bail!(
+                    "validators did not all enter local epoch {target} within {timeout:?}: {lagging:?}"
+                );
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    /// Fail if any validator locally reports a protocol version above the
+    /// supplied ceiling. The metric exists under the same name in v1.1.8 and
+    /// current builds.
+    pub async fn expect_all_validators_protocol_version_at_most(&self, ceiling: u64) -> Result<()> {
+        for validator in &self.validators {
+            let body = validator.metrics().await?;
+            let version =
+                required_unlabeled_metric(&body, &["ika_current_protocol_version"], validator)?;
+            if version > ceiling {
+                bail!(
+                    "validator {} at {} reports protocol version {}, above ceiling {}",
+                    validator.index,
+                    validator.metrics_endpoint(),
+                    version,
+                    ceiling
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Assert the epoch's mid-epoch network-key reconfiguration has not been
+    /// initiated yet. A key may still be `NetworkReconfigurationCompleted`
+    /// from the previous epoch, so the epoch-scoped next-committee marker and
+    /// completion counter are the deterministic witnesses.
+    pub async fn expect_network_key_reconfiguration_not_started(&self, epoch: u64) -> Result<()> {
+        let (coordinator, keys) = self.coordinator_snapshot().await?;
+        ensure!(
+            coordinator.current_epoch == epoch,
+            "expected coordinator epoch {epoch} before network-key reconfiguration, got {}",
+            coordinator.current_epoch
+        );
+        ensure!(
+            !keys.is_empty(),
+            "coordinator epoch {epoch} has no network encryption keys"
+        );
+        ensure!(
+            coordinator.next_epoch_active_committee.is_none(),
+            "epoch {epoch} mid-epoch reconfiguration was already initiated"
+        );
+        ensure!(
+            coordinator.epoch_dwallet_network_encryption_keys_reconfiguration_completed == 0,
+            "epoch {epoch} already reports {} completed network-key reconfigurations",
+            coordinator.epoch_dwallet_network_encryption_keys_reconfiguration_completed
+        );
+        Ok(())
+    }
+
+    /// Wait until the requested epoch's network keys are visibly in the
+    /// `AwaitingNetworkReconfiguration` state. This makes the mixed-version
+    /// overlap deterministic: the binary swap is complete before the harness
+    /// witnesses the real on-chain reshare request.
+    pub async fn wait_for_network_key_reconfiguration_started(
+        &self,
+        epoch: u64,
+        timeout: Duration,
+    ) -> Result<()> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let (coordinator, keys) = self.coordinator_snapshot().await?;
+            ensure!(
+                coordinator.current_epoch == epoch,
+                "expected coordinator epoch {epoch} while waiting for network-key reconfiguration start, got {}",
+                coordinator.current_epoch
+            );
+            ensure!(
+                !keys.is_empty(),
+                "coordinator epoch {epoch} has no network encryption keys"
+            );
+            let awaiting = keys
+                .values()
+                .filter(|key| {
+                    key.state == DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration
+                })
+                .count();
+            if awaiting == keys.len() {
+                tracing::info!(
+                    epoch,
+                    keys = keys.len(),
+                    "network-key reconfiguration started"
+                );
+                return Ok(());
+            }
+            if coordinator.next_epoch_active_committee.is_some()
+                && coordinator.epoch_dwallet_network_encryption_keys_reconfiguration_completed > 0
+            {
+                bail!(
+                    "network-key reconfiguration in epoch {epoch} completed before the harness observed every key in the started state"
+                );
+            }
+            if tokio::time::Instant::now() >= deadline {
+                bail!(
+                    "network-key reconfiguration did not start in epoch {epoch} within {timeout:?}; states={:?}",
+                    keys.values().map(|key| &key.state).collect::<Vec<_>>()
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    }
+
+    /// Wait for the same epoch's on-chain network-key reconfiguration and all
+    /// system sessions to complete. Observing this before the epoch boundary
+    /// prevents quorum progress in the next epoch from masking a stranded
+    /// minority validator.
+    pub async fn wait_for_network_key_reconfiguration_completed(
+        &self,
+        epoch: u64,
+        timeout: Duration,
+    ) -> Result<()> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let (coordinator, keys) = self.coordinator_snapshot().await?;
+            ensure!(
+                coordinator.current_epoch == epoch,
+                "coordinator advanced to epoch {} before the harness observed epoch {epoch} network-key reconfiguration completion",
+                coordinator.current_epoch
+            );
+            let all_keys_completed = !keys.is_empty()
+                && keys.values().all(|key| {
+                    key.state == DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted
+                });
+            let expected = coordinator.dwallet_network_encryption_keys.size;
+            let completed =
+                coordinator.epoch_dwallet_network_encryption_keys_reconfiguration_completed;
+            let system = &coordinator.sessions_manager.system_sessions_keeper;
+            if all_keys_completed
+                && completed == expected
+                && system.started_sessions_count == system.completed_sessions_count
+            {
+                tracing::info!(
+                    epoch,
+                    completed,
+                    system_sessions = system.completed_sessions_count,
+                    "network-key reconfiguration completed"
+                );
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                bail!(
+                    "network-key reconfiguration did not complete in epoch {epoch} within {timeout:?}: key_states={:?}, completed={completed}/{expected}, system_sessions={}/{}",
+                    keys.values().map(|key| &key.state).collect::<Vec<_>>(),
+                    system.completed_sessions_count,
+                    system.started_sessions_count
+                );
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    /// Assert the malicious-actor gauge exactly on the specified validator
+    /// observers. Historical v1.1.8 does not export this gauge, so callers name
+    /// the current-binary observer(s); missing metrics still fail closed.
+    pub async fn expect_malicious_actors_exactly(
+        &self,
+        observer_indices: &[usize],
+        expected: u64,
+    ) -> Result<()> {
+        ensure!(
+            !observer_indices.is_empty(),
+            "no malicious-metric observers supplied"
+        );
+        for index in observer_indices {
+            let validator = self
+                .validators
+                .get(*index)
+                .with_context(|| format!("validator index {index} out of range"))?;
+            let body = validator.metrics().await?;
+            let actual = required_unlabeled_metric(
+                &body,
+                &["ika_dwallet_mpc_malicious_actors_count"],
+                validator,
+            )?;
+            ensure!(
+                actual == expected,
+                "validator {} at {} reports {} malicious actors; expected exactly {}",
+                validator.index,
+                validator.metrics_endpoint(),
+                actual,
+                expected
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn expect_malicious_actors_at_least(
+        &self,
+        observer_indices: &[usize],
+        minimum: u64,
+    ) -> Result<()> {
+        ensure!(
+            !observer_indices.is_empty(),
+            "no malicious-metric observers supplied"
+        );
+        let mut maximum = 0;
+        for index in observer_indices {
+            let validator = self
+                .validators
+                .get(*index)
+                .with_context(|| format!("validator index {index} out of range"))?;
+            let body = validator.metrics().await?;
+            let actual = required_unlabeled_metric(
+                &body,
+                &["ika_dwallet_mpc_malicious_actors_count"],
+                validator,
+            )?;
+            maximum = maximum.max(actual);
+        }
+        ensure!(
+            maximum >= minimum,
+            "malicious-metric observers {observer_indices:?} reported maximum {maximum}; expected at least {minimum}"
+        );
+        Ok(())
+    }
+
+    /// Assert every authority submitted the same canonical network-key
+    /// reconfiguration output for every observed session. The current-binary
+    /// observer records individual consensus reports from all committee
+    /// members, including literal historical binaries; this catches a 3-vs-1
+    /// split even when the majority result lets the chain keep advancing.
+    pub async fn expect_network_key_output_converged(
+        &self,
+        observer_indices: &[usize],
+        timeout: Duration,
+    ) -> Result<()> {
+        ensure!(
+            !observer_indices.is_empty(),
+            "no output-convergence observers supplied"
+        );
+        let expected_authorities: BTreeSet<_> = self
+            .validator_authorities
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        let expected_epoch = self.current_epoch().await?;
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            ensure!(
+                self.current_epoch().await? == expected_epoch,
+                "coordinator advanced beyond epoch {expected_epoch} before network-key output observations converged"
+            );
+            let mut canonical_by_session: Option<BTreeMap<String, String>> = None;
+            let mut incomplete = Vec::new();
+            for index in observer_indices {
+                let validator = self
+                    .validators
+                    .get(*index)
+                    .with_context(|| format!("validator index {index} out of range"))?;
+                let body = validator.metrics().await?;
+                let observer = format!(
+                    "validator {} metrics endpoint {}",
+                    validator.index,
+                    validator.metrics_endpoint()
+                );
+                let observer_canonical =
+                    match canonical_network_key_outputs(&body, &expected_authorities, &observer) {
+                        Ok(canonical) => canonical,
+                        Err(error)
+                            if error.to_string().contains("missing network-key")
+                                || error.to_string().contains("missing required")
+                                || error.to_string().contains("wrong authority set") =>
+                        {
+                            incomplete.push(error.to_string());
+                            continue;
+                        }
+                        Err(error) => {
+                            return Err(error).with_context(|| {
+                                format!("validate network-key convergence from {observer}")
+                            });
+                        }
+                    };
+
+                if let Some(expected) = &canonical_by_session {
+                    ensure!(
+                        expected == &observer_canonical,
+                        "network-key observers disagree: expected {expected:?}, validator {} at {} reported {observer_canonical:?}",
+                        validator.index,
+                        validator.metrics_endpoint()
+                    );
+                } else {
+                    canonical_by_session = Some(observer_canonical);
+                }
+            }
+            if incomplete.is_empty() {
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                bail!(
+                    "network-key output observations did not become complete within {timeout:?}: {}",
+                    incomplete.join("; ")
+                );
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    /// Assert both chain and local-observer views have no stranded network-key
+    /// work for `epoch`. The chain checks system-session accounting and every
+    /// key state; the current observer checks always-present pending and
+    /// instantiation gauges.
+    pub async fn expect_no_pending_network_key_reconfiguration(
+        &self,
+        epoch: u64,
+        observer_indices: &[usize],
+        timeout: Duration,
+    ) -> Result<()> {
+        ensure!(
+            !observer_indices.is_empty(),
+            "no network-key pending-state observers supplied"
+        );
+        let (coordinator, keys) = self.coordinator_snapshot().await?;
+        ensure!(
+            coordinator.current_epoch == epoch,
+            "expected coordinator epoch {epoch}, got {}",
+            coordinator.current_epoch
+        );
+        ensure!(
+            !keys.is_empty(),
+            "coordinator epoch {epoch} has no network encryption keys"
+        );
+        ensure!(
+            keys.values().all(|key| key.state
+                == DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted),
+            "epoch {epoch} has non-completed network-key states: {:?}",
+            keys.values().map(|key| &key.state).collect::<Vec<_>>()
+        );
+        ensure!(
+            coordinator.epoch_dwallet_network_encryption_keys_reconfiguration_completed
+                == coordinator.dwallet_network_encryption_keys.size,
+            "epoch {epoch} completed network-key count {}/{}",
+            coordinator.epoch_dwallet_network_encryption_keys_reconfiguration_completed,
+            coordinator.dwallet_network_encryption_keys.size
+        );
+        let system = &coordinator.sessions_manager.system_sessions_keeper;
+        ensure!(
+            system.started_sessions_count == system.completed_sessions_count,
+            "epoch {epoch} has stranded immediate/system sessions: completed {}/started {}",
+            system.completed_sessions_count,
+            system.started_sessions_count
+        );
+
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let current_epoch = self.current_epoch().await?;
+            ensure!(
+                current_epoch == epoch,
+                "coordinator advanced to epoch {current_epoch} before epoch {epoch} local network-key work drained"
+            );
+            let mut pending = Vec::new();
+            for index in observer_indices {
+                let validator = self
+                    .validators
+                    .get(*index)
+                    .with_context(|| format!("validator index {index} out of range"))?;
+                let body = validator.metrics().await?;
+                for metric in [
+                    "ika_dwallet_mpc_network_key_reconfiguration_sessions_pending",
+                    "ika_dwallet_mpc_network_key_instantiations_in_flight",
+                ] {
+                    let value = required_unlabeled_metric(&body, &[metric], validator)?;
+                    if value != 0 {
+                        pending.push(format!(
+                            "validator {} at {} reports {metric}={value}",
+                            validator.index,
+                            validator.metrics_endpoint()
+                        ));
+                    }
+                }
+            }
+            if pending.is_empty() {
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                bail!(
+                    "network-key reconfiguration remained pending within {timeout:?}: {}",
+                    pending.join("; ")
+                );
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
     }
 
     /// The minimum canonical network DKG output version reported across all
@@ -761,6 +1435,8 @@ impl ClusterOfProcesses {
         });
         self.validator_peer_ids
             .push(hex::encode(init.network_key_pair.public().0.to_bytes()));
+        self.validator_authorities
+            .push(init.key_pair.public().into());
         Ok(index)
     }
 
@@ -945,4 +1621,144 @@ fn rayon_threads_per_node(node_count: usize) -> usize {
         "upgrade-test rayon budget: available_parallelism vs cgroup cpu.max"
     );
     threads
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stopped_validator() -> ValidatorProcess {
+        ValidatorProcess::new(
+            2,
+            PathBuf::from("validator"),
+            PathBuf::from("config.yaml"),
+            PathBuf::from("data"),
+            "127.0.0.1:9002".parse().unwrap(),
+            0,
+            PathBuf::from("node.log"),
+            1,
+        )
+    }
+
+    fn network_key_metrics(outputs: &[(&str, &str)]) -> String {
+        outputs
+            .iter()
+            .flat_map(|(authority, digest)| {
+                [
+                    format!(
+                        "ika_dwallet_mpc_network_key_reconfiguration_output_info{{session_id=\"session\",authority=\"{authority}\",output_digest=\"{digest}\"}} 1\n"
+                    ),
+                    format!(
+                        "ika_dwallet_mpc_network_key_reconfiguration_reported_malicious_actors{{session_id=\"session\",authority=\"{authority}\"}} 0\n"
+                    ),
+                    format!(
+                        "ika_dwallet_mpc_network_key_reconfiguration_output_rejected{{session_id=\"session\",authority=\"{authority}\"}} 0\n"
+                    ),
+                ]
+            })
+            .collect()
+    }
+
+    #[test]
+    fn parses_exact_labeled_metric_without_prefix_collision() {
+        let body = concat!(
+            "# TYPE ika_output_info gauge\n",
+            "ika_output_info{session_id=\"abc\",authority=\"k#01\",output_digest=\"deadbeef\"} 1\n",
+            "ika_output_info_extra{session_id=\"wrong\"} 7\n",
+        );
+        let samples = parse_metric_samples(body, "ika_output_info").unwrap();
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].labels["session_id"], "abc");
+        assert_eq!(samples[0].labels["authority"], "k#01");
+        assert_eq!(samples[0].labels["output_digest"], "deadbeef");
+        assert_eq!(samples[0].value, 1.0);
+    }
+
+    #[test]
+    fn rejects_malformed_labeled_metric() {
+        let body = "ika_output_info{session_id=abc} 1\n";
+        assert!(parse_metric_samples(body, "ika_output_info").is_err());
+    }
+
+    #[test]
+    fn missing_required_metric_names_validator_and_endpoint() {
+        let validator = stopped_validator();
+        let error = required_unlabeled_metric("", &["ika_required"], &validator)
+            .expect_err("missing metric must fail closed");
+        let error = error.to_string();
+        assert!(error.contains("validator 2"));
+        assert!(error.contains("http://127.0.0.1:0/metrics"));
+    }
+
+    #[tokio::test]
+    async fn stopped_validator_health_and_metrics_fail_closed() {
+        let validator = stopped_validator();
+        let health = validator
+            .expect_healthy()
+            .await
+            .expect_err("stopped validator must be unhealthy")
+            .to_string();
+        assert!(health.contains("validator 2"));
+        assert!(health.contains("http://127.0.0.1:9002"));
+
+        let metrics = validator
+            .metrics()
+            .await
+            .expect_err("unreachable metrics endpoint must fail")
+            .to_string();
+        assert!(metrics.contains("validator 2"));
+        assert!(metrics.contains("http://127.0.0.1:0/metrics"));
+    }
+
+    #[test]
+    fn parses_historical_and_current_labelless_gauges_exactly() {
+        let body = "current_epoch 3\nika_current_epoch 4\nika_current_epoch_extra 9\n";
+        assert_eq!(parse_labelless_gauge(body, "current_epoch"), Some(3));
+        assert_eq!(parse_labelless_gauge(body, "ika_current_epoch"), Some(4));
+    }
+
+    #[test]
+    fn accepts_four_authority_network_key_output_convergence() {
+        let expected = ["a", "b", "c", "d"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let body =
+            network_key_metrics(&[("a", "same"), ("b", "same"), ("c", "same"), ("d", "same")]);
+        let canonical = canonical_network_key_outputs(&body, &expected, "validator 0").unwrap();
+        assert_eq!(canonical["session"], "same");
+    }
+
+    #[test]
+    fn rejects_one_divergent_network_key_output() {
+        let expected = ["a", "b", "c", "d"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let body = network_key_metrics(&[
+            ("a", "different"),
+            ("b", "majority"),
+            ("c", "majority"),
+            ("d", "majority"),
+        ]);
+        let error = canonical_network_key_outputs(&body, &expected, "validator 0")
+            .expect_err("3-vs-1 output split must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("divergent per-authority outputs")
+        );
+    }
+
+    #[test]
+    fn rejects_missing_network_key_envelope_metric() {
+        let expected = ["a"].into_iter().map(str::to_string).collect();
+        let body = concat!(
+            "ika_dwallet_mpc_network_key_reconfiguration_output_info{session_id=\"session\",authority=\"a\",output_digest=\"same\"} 1\n",
+            "ika_dwallet_mpc_network_key_reconfiguration_output_rejected{session_id=\"session\",authority=\"a\"} 0\n",
+        );
+        let error = canonical_network_key_outputs(body, &expected, "validator 0")
+            .expect_err("missing malicious envelope metric must fail closed");
+        assert!(error.to_string().contains("missing required"));
+    }
 }

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -1143,7 +1143,8 @@ impl ClusterOfProcesses {
         // Byzantine quorum of the committee. These scenarios run an
         // equal-weight committee, so a plain member count matches the
         // access-structure threshold (n - floor((n-1)/3)).
-        let quorum = committee_authorities.len() - committee_authorities.len().saturating_sub(1) / 3;
+        let quorum =
+            committee_authorities.len() - committee_authorities.len().saturating_sub(1) / 3;
         let expected_epoch = self.current_epoch().await?;
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
@@ -1186,12 +1187,12 @@ impl ClusterOfProcesses {
                 )
                 .with_context(|| format!("validate network-key convergence from {observer}"))?
                 {
-                        NetworkKeyOutputConvergence::Converged(canonical) => canonical,
-                        NetworkKeyOutputConvergence::Incomplete(reason) => {
-                            incomplete.push(reason);
-                            continue;
-                        }
-                    };
+                    NetworkKeyOutputConvergence::Converged(canonical) => canonical,
+                    NetworkKeyOutputConvergence::Incomplete(reason) => {
+                        incomplete.push(reason);
+                        continue;
+                    }
+                };
 
                 if let Some(expected) = &canonical_by_session {
                     ensure!(
@@ -1935,8 +1936,12 @@ mod tests {
         // propagation delay.
         let committee = committee_of(&["a", "b", "c"]);
         let required = committee_of(&["a"]);
-        let body =
-            network_key_metrics(&[("a", "same"), ("b", "same"), ("c", "same"), ("rogue", "same")]);
+        let body = network_key_metrics(&[
+            ("a", "same"),
+            ("b", "same"),
+            ("c", "same"),
+            ("rogue", "same"),
+        ]);
         let error = canonical_network_key_outputs(&body, &committee, &required, 3, "validator 0")
             .expect_err("an out-of-committee authority must fail closed");
         assert!(error.to_string().contains("out-of-committee"));

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -55,6 +55,16 @@ use crate::{DEFAULT_EPOCH_DURATION_MS, DEFAULT_NUM_VALIDATORS};
 // `NETWORK_KEY_RECONFIGURATION_PROTOCOL_NAME` constant and trips if it drifts.
 const NETWORK_KEY_RECONFIGURATION_PROTOCOL: &str = "Network Encryption Key Reconfiguration";
 
+/// How long a fully-converged network-key output observation must hold
+/// unchanged before `expect_network_key_output_converged` accepts it. The
+/// observation set is open at first convergence (an output submitted to
+/// consensus just before its author saw the quorum can still be propagating),
+/// and no production watermark proves the set closed; the drain bounds that
+/// propagation window with repeated re-validation instead. Consensus commit
+/// latency in these clusters is well under a second, so ten seconds of
+/// repeated scrapes is orders of magnitude past the in-flight window.
+const NETWORK_KEY_OUTPUT_STABILIZATION: Duration = Duration::from_secs(10);
+
 /// A running out-of-process cluster. Owns the Sui localnet, the validator
 /// processes, and the notifier; tears everything down on `Drop` (each child has
 /// `kill_on_drop`).
@@ -1126,6 +1136,15 @@ impl ClusterOfProcesses {
     /// observer records individual consensus reports from all committee
     /// members, including literal historical binaries; this catches a 3-vs-1
     /// split even when the majority result lets the chain keep advancing.
+    ///
+    /// The observation set is open when convergence is first reached:
+    /// finalization happens at a Byzantine quorum, so a validator's output
+    /// submitted to consensus just before it saw the quorum can still be
+    /// propagating. Observers keep recording (and exporting) such late
+    /// outputs after session completion, so instead of returning on the
+    /// first converged scrape this holds the converged result through a
+    /// stabilization window, re-validating every scrape — a late-arriving
+    /// divergent output fails the run instead of landing after success.
     pub async fn expect_network_key_output_converged(
         &self,
         observer_indices: &[usize],
@@ -1147,6 +1166,10 @@ impl ClusterOfProcesses {
             committee_authorities.len() - committee_authorities.len().saturating_sub(1) / 3;
         let expected_epoch = self.current_epoch().await?;
         let deadline = tokio::time::Instant::now() + timeout;
+        // First fully-converged canonical result and when it was first
+        // observed; success requires it to survive unchanged for the whole
+        // stabilization window below.
+        let mut stable: Option<(BTreeMap<String, String>, tokio::time::Instant)> = None;
         loop {
             ensure!(
                 self.current_epoch().await? == expected_epoch,
@@ -1206,13 +1229,37 @@ impl ClusterOfProcesses {
                 }
             }
             if incomplete.is_empty() {
-                return Ok(());
-            }
-            if tokio::time::Instant::now() >= deadline {
-                bail!(
-                    "network-key output observations did not become complete within {timeout:?}: {}",
-                    incomplete.join("; ")
-                );
+                let canonical = canonical_by_session
+                    .context("converged with no observers — observer list cannot be empty here")?;
+                match &stable {
+                    Some((expected, since)) => {
+                        // Late outputs that agree grow the observed set without
+                        // changing the canonical digests; a late divergent
+                        // output already failed hard inside
+                        // `canonical_network_key_outputs` (digest-equality is a
+                        // hard error). A changed canonical map here means a
+                        // session appeared or changed mid-drain — fail closed.
+                        ensure!(
+                            expected == &canonical,
+                            "canonical network-key outputs changed during the stabilization window: first {expected:?}, now {canonical:?}"
+                        );
+                        if since.elapsed() >= NETWORK_KEY_OUTPUT_STABILIZATION {
+                            return Ok(());
+                        }
+                    }
+                    None => stable = Some((canonical, tokio::time::Instant::now())),
+                }
+            } else {
+                // A fresh incomplete observation after convergence means a new
+                // network-key session surfaced; its outputs must converge and
+                // stabilize too.
+                stable = None;
+                if tokio::time::Instant::now() >= deadline {
+                    bail!(
+                        "network-key output observations did not become complete within {timeout:?}: {}",
+                        incomplete.join("; ")
+                    );
+                }
             }
             tokio::time::sleep(Duration::from_secs(1)).await;
         }

--- a/crates/ika-upgrade-test/src/mpc_timings.rs
+++ b/crates/ika-upgrade-test/src/mpc_timings.rs
@@ -4,8 +4,8 @@
 //! Rough MPC-protocol timing collection for the cross-binary tests.
 //!
 //! Scrapes each validator's Prometheus endpoint for the dwallet-MPC duration
-//! metrics (`dwallet_mpc_computation_duration_avg` /
-//! `dwallet_mpc_advance_completions`, both labeled by protocol + curve +
+//! metrics (`ika_dwallet_mpc_computation_duration_avg` /
+//! `ika_dwallet_mpc_advance_completions`, both labeled by protocol + curve +
 //! round) and aggregates them into per-protocol-round rows. Snapshots taken
 //! at different points of a scenario (e.g. before and after a binary swap)
 //! are compared at the end of the run; large ratios are flagged in the
@@ -96,46 +96,6 @@ pub async fn record_snapshot(
     let snapshot = TimingSnapshot { label, rows };
     println!("{}", render_snapshot(&snapshot));
     Ok(snapshot)
-}
-
-/// Scrape every running validator's `ika_dwallet_mpc_malicious_actors_count` gauge
-/// and return the maximum across the cluster. Used by the cross-binary
-/// malicious-detection test to assert programmatically that at least one honest
-/// validator recorded a malicious actor — instead of grepping node logs. A
-/// stopped/unreachable validator is skipped (it can't report, and the faulty
-/// one we want excluded anyway).
-pub async fn max_malicious_actors_count(cluster: &ClusterOfProcesses) -> Result<u64> {
-    let http = reqwest::Client::new();
-    let mut max_count = 0u64;
-    for proc in cluster.validators.iter().filter(|p| p.is_running()) {
-        let url = format!("http://127.0.0.1:{}/metrics", proc.metrics_port());
-        let body = match http.get(&url).send().await {
-            Ok(resp) => resp.text().await.context("read metrics body")?,
-            Err(e) => {
-                tracing::warn!(index = proc.index, error = %e, "metrics scrape failed; skipping validator");
-                continue;
-            }
-        };
-        if let Some(count) = parse_unlabeled_gauge(&body, "ika_dwallet_mpc_malicious_actors_count")
-        {
-            tracing::info!(index = proc.index, count, "scraped malicious-actors gauge");
-            max_count = max_count.max(count);
-        }
-    }
-    Ok(max_count)
-}
-
-/// Parse a single unlabeled gauge line (`<metric> <value>`) from Prometheus
-/// text-format exposition, ignoring `# HELP` / `# TYPE` comment lines.
-fn parse_unlabeled_gauge(body: &str, metric: &str) -> Option<u64> {
-    body.lines()
-        .filter(|line| !line.starts_with('#'))
-        .find_map(|line| {
-            let rest = line.strip_prefix(metric)?;
-            // Reject labeled samples (`metric{...}`) — this gauge has no labels.
-            let value = rest.strip_prefix(' ')?.trim();
-            value.parse::<f64>().ok().map(|v| v as u64)
-        })
 }
 
 /// Render one snapshot as a fixed-width table.
@@ -300,10 +260,10 @@ mod tests {
     #[test]
     fn parses_round_labeled_metric_lines() {
         let body = concat!(
-            "# HELP dwallet_mpc_computation_duration_avg Average duration of MPC computations in milliseconds\n",
-            "# TYPE dwallet_mpc_computation_duration_avg gauge\n",
-            "dwallet_mpc_computation_duration_avg{curve=\"Secp256k1\",hash_scheme=\"\",mpc_round=\"first_round\",protocol_name=\"Presign\",signature_algorithm=\"ECDSA\"} 321.5\n",
-            "dwallet_mpc_computation_duration_avg{curve=\"Secp256k1\",hash_scheme=\"\",mpc_round=\"second_round\",protocol_name=\"Presign\",signature_algorithm=\"ECDSA\"} 100\n",
+            "# HELP ika_dwallet_mpc_computation_duration_avg Average duration of MPC computations in milliseconds\n",
+            "# TYPE ika_dwallet_mpc_computation_duration_avg gauge\n",
+            "ika_dwallet_mpc_computation_duration_avg{curve=\"Secp256k1\",hash_scheme=\"\",mpc_round=\"first_round\",protocol_name=\"Presign\",signature_algorithm=\"ECDSA\"} 321.5\n",
+            "ika_dwallet_mpc_computation_duration_avg{curve=\"Secp256k1\",hash_scheme=\"\",mpc_round=\"second_round\",protocol_name=\"Presign\",signature_algorithm=\"ECDSA\"} 100\n",
             "other_metric{mpc_round=\"x\"} 5\n",
         );
         let parsed = parse_metric(body, "ika_dwallet_mpc_computation_duration_avg");

--- a/crates/ika-upgrade-test/src/process.rs
+++ b/crates/ika-upgrade-test/src/process.rs
@@ -100,6 +100,14 @@ impl ValidatorProcess {
         self.metrics_port
     }
 
+    pub fn admin_endpoint(&self) -> String {
+        format!("http://{}", self.admin_addr)
+    }
+
+    pub fn metrics_endpoint(&self) -> String {
+        format!("http://127.0.0.1:{}/metrics", self.metrics_port)
+    }
+
     /// Spawn the process and block until its admin server answers, i.e. the
     /// node has booted far enough to serve `GET /node-config`.
     pub async fn start(&mut self) -> Result<()> {
@@ -277,6 +285,53 @@ impl ValidatorProcess {
 
     pub fn log_path(&self) -> &PathBuf {
         &self.log_path
+    }
+
+    /// Fail-closed liveness check for an already-started validator. Unlike the
+    /// startup poll, this is an assertion: a missing child or one unreachable
+    /// admin endpoint is an immediate failure with the validator index and
+    /// endpoint in the error.
+    pub async fn expect_healthy(&self) -> Result<()> {
+        if !self.is_running() {
+            bail!(
+                "validator {} is not running (admin endpoint {})",
+                self.index,
+                self.admin_endpoint()
+            );
+        }
+        self.admin_get("node-config").await.with_context(|| {
+            format!(
+                "validator {} unreachable at admin endpoint {}",
+                self.index,
+                self.admin_endpoint()
+            )
+        })?;
+        Ok(())
+    }
+
+    /// Scrape this validator's Prometheus endpoint. Assertions use this
+    /// instead of open-coded reqwest calls so HTTP errors, non-2xx responses,
+    /// and body-read failures all retain the validator index and endpoint.
+    pub async fn metrics(&self) -> Result<String> {
+        let url = self.metrics_endpoint();
+        let response = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("validator {} metrics GET {url}", self.index))?;
+        if !response.status().is_success() {
+            bail!(
+                "validator {} metrics endpoint {} returned {}",
+                self.index,
+                url,
+                response.status()
+            );
+        }
+        response
+            .text()
+            .await
+            .with_context(|| format!("validator {} read metrics body from {url}", self.index))
     }
 
     async fn wait_until_healthy(&self, timeout: Duration) -> Result<()> {

--- a/crates/ika-upgrade-test/src/scenario.rs
+++ b/crates/ika-upgrade-test/src/scenario.rs
@@ -31,6 +31,8 @@ use crate::cluster::{ClusterBuilder, ClusterOfProcesses};
 use crate::mpc_timings::{self, TimingSnapshot};
 use crate::workload::WorkloadDriver;
 
+const NETWORK_KEY_OUTPUT_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(60);
+
 /// One ordered step in a scenario.
 #[derive(Clone, Debug)]
 pub enum Step {
@@ -820,8 +822,16 @@ impl Scenario {
                     let c = cluster
                         .as_ref()
                         .context("ExpectNetworkKeyOutputConverged before StartAll")?;
-                    c.expect_network_key_output_converged(observer_indices, self.epoch_timeout)
-                        .await?;
+                    // The system session has already completed before normal
+                    // scenarios reach this assertion. Allow metrics propagation
+                    // some slack, but do not reuse a multi-minute epoch timeout:
+                    // a missing authority output is itself release-blocking.
+                    c.expect_network_key_output_converged(
+                        observer_indices,
+                        self.epoch_timeout
+                            .min(NETWORK_KEY_OUTPUT_OBSERVATION_TIMEOUT),
+                    )
+                    .await?;
                 }
                 Step::ExpectNoPendingNetworkKeyReconfiguration {
                     epoch,

--- a/crates/ika-upgrade-test/src/scenario.rs
+++ b/crates/ika-upgrade-test/src/scenario.rs
@@ -36,6 +36,8 @@ use crate::workload::WorkloadDriver;
 pub enum Step {
     StartAll(BinarySpec),
     WaitForEpoch(u64),
+    WaitForAllValidatorsLocalEpoch(u64),
+    ExpectAllValidatorsHealthy,
     StopAndSwap {
         validators: Vec<usize>,
         to: BinarySpec,
@@ -53,6 +55,10 @@ pub enum Step {
     /// and the workload degrades into an ordinary post-upgrade test while the
     /// run stays green.
     ExpectProtocolVersionAtMost(u64),
+    ExpectAllValidatorsProtocolVersionAtMost(u64),
+    ExpectNetworkKeyReconfigurationNotStarted(u64),
+    WaitForNetworkKeyReconfigurationStarted(u64),
+    WaitForNetworkKeyReconfigurationCompleted(u64),
     /// Poll until every running validator reports a canonical network DKG
     /// output version `>= at_least` (via its `/metrics`), or time out. Confirms
     /// the off-chain handoff migrated the DKG output (e.g. 2 -> 3 after the v4
@@ -96,13 +102,25 @@ pub enum Step {
     RunWorkload {
         label: String,
     },
-    /// Assert that at least one running validator's
-    /// `ika_dwallet_mpc_malicious_actors_count` gauge is `>= min_total` — i.e.
-    /// malicious detection actually fired. Scrapes metrics, no log grep.
+    /// Assert that at least one explicitly selected validator's
+    /// `ika_dwallet_mpc_malicious_actors_count` gauge is `>= min_total`.
+    /// Every selected scrape and metric is required; there is no skip path.
     ExpectMaliciousActorsAtLeast {
+        observer_indices: Vec<usize>,
         min_total: u64,
     },
-    /// Assert every running validator's `node.log` does (`present: true`) or
+    ExpectMaliciousActorsExactly {
+        observer_indices: Vec<usize>,
+        expected: u64,
+    },
+    ExpectNetworkKeyOutputConverged {
+        observer_indices: Vec<usize>,
+    },
+    ExpectNoPendingNetworkKeyReconfiguration {
+        epoch: u64,
+        observer_indices: Vec<usize>,
+    },
+    /// Assert every expected validator's `node.log` does (`present: true`) or
     /// does not (`present: false`) contain `needle`. Logs are truncated on
     /// each (re)start, so after a swap this sees only the new binary's
     /// output. For invariants observable only in logs (e.g. the one-time
@@ -119,6 +137,10 @@ impl std::fmt::Display for Step {
         match self {
             Step::StartAll(spec) => write!(f, "start_all({})", spec.label()),
             Step::WaitForEpoch(e) => write!(f, "wait_for_epoch({e})"),
+            Step::WaitForAllValidatorsLocalEpoch(e) => {
+                write!(f, "wait_for_all_validators_local_epoch({e})")
+            }
+            Step::ExpectAllValidatorsHealthy => write!(f, "expect_all_validators_healthy"),
             Step::StopAndSwap { validators, to } => {
                 write!(f, "stop_and_swap({validators:?} -> {})", to.label())
             }
@@ -128,6 +150,18 @@ impl std::fmt::Display for Step {
             }
             Step::ExpectProtocolVersionAtMost(v) => {
                 write!(f, "expect_protocol_version_at_most({v})")
+            }
+            Step::ExpectAllValidatorsProtocolVersionAtMost(v) => {
+                write!(f, "expect_all_validators_protocol_version_at_most({v})")
+            }
+            Step::ExpectNetworkKeyReconfigurationNotStarted(epoch) => {
+                write!(f, "expect_network_key_reconfiguration_not_started({epoch})")
+            }
+            Step::WaitForNetworkKeyReconfigurationStarted(epoch) => {
+                write!(f, "wait_for_network_key_reconfiguration_started({epoch})")
+            }
+            Step::WaitForNetworkKeyReconfigurationCompleted(epoch) => {
+                write!(f, "wait_for_network_key_reconfiguration_completed({epoch})")
             }
             Step::ExpectNetworkDkgOutputVersionAtLeast(v) => {
                 write!(f, "expect_network_dkg_output_version_at_least({v})")
@@ -142,9 +176,31 @@ impl std::fmt::Display for Step {
             Step::SetGlobalPresignConfig => write!(f, "set_global_presign_config"),
             Step::RecordMpcTimings { label } => write!(f, "record_mpc_timings({label:?})"),
             Step::RunWorkload { label } => write!(f, "run_workload({label:?})"),
-            Step::ExpectMaliciousActorsAtLeast { min_total } => {
-                write!(f, "expect_malicious_actors_at_least({min_total})")
-            }
+            Step::ExpectMaliciousActorsAtLeast {
+                observer_indices,
+                min_total,
+            } => write!(
+                f,
+                "expect_malicious_actors_at_least({observer_indices:?}, {min_total})"
+            ),
+            Step::ExpectMaliciousActorsExactly {
+                observer_indices,
+                expected,
+            } => write!(
+                f,
+                "expect_malicious_actors_exactly({observer_indices:?}, {expected})"
+            ),
+            Step::ExpectNetworkKeyOutputConverged { observer_indices } => write!(
+                f,
+                "expect_network_key_output_converged({observer_indices:?})"
+            ),
+            Step::ExpectNoPendingNetworkKeyReconfiguration {
+                epoch,
+                observer_indices,
+            } => write!(
+                f,
+                "expect_no_pending_network_key_reconfiguration({epoch}, {observer_indices:?})"
+            ),
             Step::ExpectLogLine { needle, present } => {
                 let polarity = if *present { "present" } else { "absent" };
                 write!(f, "expect_log_line_{polarity}({needle:?})")
@@ -263,7 +319,20 @@ impl Scenario {
         self
     }
 
+    pub fn wait_for_all_validators_local_epoch(mut self, epoch: u64) -> Self {
+        self.steps.push(Step::WaitForAllValidatorsLocalEpoch(epoch));
+        self
+    }
+
+    pub fn expect_all_validators_healthy(mut self) -> Self {
+        self.steps.push(Step::ExpectAllValidatorsHealthy);
+        self
+    }
+
     pub fn stop_and_swap(mut self, validators: &[usize], to: BinarySpec) -> Self {
+        // Intentionally sequential: each validator is stopped, restarted, and
+        // health-checked before the next index. Passing the full committee is
+        // a coordinated full-committee rollout, not an atomic restart.
         self.steps.push(Step::StopAndSwap {
             validators: validators.to_vec(),
             to,
@@ -289,6 +358,30 @@ impl Scenario {
     /// early fails loudly instead of silently voiding the workload's purpose.
     pub fn expect_protocol_version_at_most(mut self, version: u64) -> Self {
         self.steps.push(Step::ExpectProtocolVersionAtMost(version));
+        self
+    }
+
+    pub fn expect_all_validators_protocol_version_at_most(mut self, version: u64) -> Self {
+        self.steps
+            .push(Step::ExpectAllValidatorsProtocolVersionAtMost(version));
+        self
+    }
+
+    pub fn expect_network_key_reconfiguration_not_started(mut self, epoch: u64) -> Self {
+        self.steps
+            .push(Step::ExpectNetworkKeyReconfigurationNotStarted(epoch));
+        self
+    }
+
+    pub fn wait_for_network_key_reconfiguration_started(mut self, epoch: u64) -> Self {
+        self.steps
+            .push(Step::WaitForNetworkKeyReconfigurationStarted(epoch));
+        self
+    }
+
+    pub fn wait_for_network_key_reconfiguration_completed(mut self, epoch: u64) -> Self {
+        self.steps
+            .push(Step::WaitForNetworkKeyReconfigurationCompleted(epoch));
         self
     }
 
@@ -362,9 +455,47 @@ impl Scenario {
     /// Assert at least one running validator recorded `>= min_total` malicious
     /// actors this epoch (scrapes the `ika_dwallet_mpc_malicious_actors_count`
     /// gauge).
-    pub fn expect_malicious_actors_at_least(mut self, min_total: u64) -> Self {
+    pub fn expect_malicious_actors_at_least(
+        mut self,
+        observer_indices: &[usize],
+        min_total: u64,
+    ) -> Self {
+        self.steps.push(Step::ExpectMaliciousActorsAtLeast {
+            observer_indices: observer_indices.to_vec(),
+            min_total,
+        });
+        self
+    }
+
+    pub fn expect_malicious_actors_exactly(
+        mut self,
+        observer_indices: &[usize],
+        expected: u64,
+    ) -> Self {
+        self.steps.push(Step::ExpectMaliciousActorsExactly {
+            observer_indices: observer_indices.to_vec(),
+            expected,
+        });
+        self
+    }
+
+    pub fn expect_network_key_output_converged(mut self, observer_indices: &[usize]) -> Self {
+        self.steps.push(Step::ExpectNetworkKeyOutputConverged {
+            observer_indices: observer_indices.to_vec(),
+        });
+        self
+    }
+
+    pub fn expect_no_pending_network_key_reconfiguration(
+        mut self,
+        epoch: u64,
+        observer_indices: &[usize],
+    ) -> Self {
         self.steps
-            .push(Step::ExpectMaliciousActorsAtLeast { min_total });
+            .push(Step::ExpectNoPendingNetworkKeyReconfiguration {
+                epoch,
+                observer_indices: observer_indices.to_vec(),
+            });
         self
     }
 
@@ -456,6 +587,19 @@ impl Scenario {
                     let c = cluster.as_ref().context("WaitForEpoch before StartAll")?;
                     c.wait_for_epoch(*epoch, self.epoch_timeout).await?;
                 }
+                Step::WaitForAllValidatorsLocalEpoch(epoch) => {
+                    let c = cluster
+                        .as_ref()
+                        .context("WaitForAllValidatorsLocalEpoch before StartAll")?;
+                    c.wait_for_all_validators_local_epoch(*epoch, self.epoch_timeout)
+                        .await?;
+                }
+                Step::ExpectAllValidatorsHealthy => {
+                    let c = cluster
+                        .as_ref()
+                        .context("ExpectAllValidatorsHealthy before StartAll")?;
+                    c.expect_all_validators_healthy().await?;
+                }
                 Step::StopAndSwap { validators, to } => {
                     let new_binary = resolve(&resolver, to).await?;
                     let split_configured = !self.direct_validators.is_empty();
@@ -544,6 +688,34 @@ impl Scenario {
                         "protocol version ceiling assertion passed"
                     );
                 }
+                Step::ExpectAllValidatorsProtocolVersionAtMost(version) => {
+                    let c = cluster
+                        .as_ref()
+                        .context("ExpectAllValidatorsProtocolVersionAtMost before StartAll")?;
+                    c.expect_all_validators_protocol_version_at_most(*version)
+                        .await?;
+                }
+                Step::ExpectNetworkKeyReconfigurationNotStarted(epoch) => {
+                    let c = cluster
+                        .as_ref()
+                        .context("ExpectNetworkKeyReconfigurationNotStarted before StartAll")?;
+                    c.expect_network_key_reconfiguration_not_started(*epoch)
+                        .await?;
+                }
+                Step::WaitForNetworkKeyReconfigurationStarted(epoch) => {
+                    let c = cluster
+                        .as_ref()
+                        .context("WaitForNetworkKeyReconfigurationStarted before StartAll")?;
+                    c.wait_for_network_key_reconfiguration_started(*epoch, self.epoch_timeout)
+                        .await?;
+                }
+                Step::WaitForNetworkKeyReconfigurationCompleted(epoch) => {
+                    let c = cluster
+                        .as_ref()
+                        .context("WaitForNetworkKeyReconfigurationCompleted before StartAll")?;
+                    c.wait_for_network_key_reconfiguration_completed(*epoch, self.epoch_timeout)
+                        .await?;
+                }
                 Step::ExpectNetworkDkgOutputVersionAtLeast(at_least) => {
                     let c = cluster
                         .as_ref()
@@ -624,26 +796,50 @@ impl Scenario {
                     let snapshot = mpc_timings::record_snapshot(c, label.clone()).await?;
                     timing_snapshots.push(snapshot);
                 }
-                Step::ExpectMaliciousActorsAtLeast { min_total } => {
+                Step::ExpectMaliciousActorsAtLeast {
+                    observer_indices,
+                    min_total,
+                } => {
                     let c = cluster
                         .as_ref()
                         .context("ExpectMaliciousActorsAtLeast before StartAll")?;
-                    let got = mpc_timings::max_malicious_actors_count(c).await?;
-                    if got < *min_total {
-                        bail!(
-                            "expected at least {min_total} malicious actor(s) recorded, \
-                             but the max across running validators was {got}"
-                        );
-                    }
-                    tracing::info!(
-                        got,
-                        expected = *min_total,
-                        "malicious-actors assertion passed (scraped from metrics)"
-                    );
+                    c.expect_malicious_actors_at_least(observer_indices, *min_total)
+                        .await?;
+                }
+                Step::ExpectMaliciousActorsExactly {
+                    observer_indices,
+                    expected,
+                } => {
+                    let c = cluster
+                        .as_ref()
+                        .context("ExpectMaliciousActorsExactly before StartAll")?;
+                    c.expect_malicious_actors_exactly(observer_indices, *expected)
+                        .await?;
+                }
+                Step::ExpectNetworkKeyOutputConverged { observer_indices } => {
+                    let c = cluster
+                        .as_ref()
+                        .context("ExpectNetworkKeyOutputConverged before StartAll")?;
+                    c.expect_network_key_output_converged(observer_indices, self.epoch_timeout)
+                        .await?;
+                }
+                Step::ExpectNoPendingNetworkKeyReconfiguration {
+                    epoch,
+                    observer_indices,
+                } => {
+                    let c = cluster
+                        .as_ref()
+                        .context("ExpectNoPendingNetworkKeyReconfiguration before StartAll")?;
+                    c.expect_no_pending_network_key_reconfiguration(
+                        *epoch,
+                        observer_indices,
+                        self.epoch_timeout,
+                    )
+                    .await?;
                 }
                 Step::ExpectLogLine { needle, present } => {
                     let c = cluster.as_ref().context("ExpectLogLine before StartAll")?;
-                    for proc in c.validators.iter().filter(|p| p.is_running()) {
+                    for proc in &c.validators {
                         let log = std::fs::read_to_string(proc.log_path()).with_context(|| {
                             format!("read validator log {}", proc.log_path().display())
                         })?;
@@ -660,7 +856,7 @@ impl Scenario {
                     tracing::info!(
                         needle = needle.as_str(),
                         present = *present,
-                        "log-line assertion passed on every running validator"
+                        "log-line assertion passed on every expected validator"
                     );
                 }
                 Step::RunWorkload { label } => {

--- a/crates/ika-upgrade-test/tests/cross_binary.rs
+++ b/crates/ika-upgrade-test/tests/cross_binary.rs
@@ -40,9 +40,8 @@
 //! exchanging consensus + MPC messages. The literal `mainnet-v1.1.8` binary
 //! also boots and runs in this harness (the harness registers the bare
 //! v1.1.8 class-groups key shape at genesis) — see `v118_upgrade.rs` for
-//! that rehearsal, which swaps *atomically* instead: mixed 1.1.8/local
-//! committees are not guaranteed MPC-wire-compatible, so the rolling-swap
-//! variant is only valid between builds of the same branch.
+//! that full-committee rehearsal. `v118_mixed_rollout.rs` separately tests
+//! the production one-current/three-literal-v1.1.8 topology through real MPC.
 //!
 //! Genesis writes an **empty** `GlobalPresignConfig` — a harness
 //! arrangement, *not* the mainnet state (mainnet's config is populated; the

--- a/crates/ika-upgrade-test/tests/malicious_cross_binary.rs
+++ b/crates/ika-upgrade-test/tests/malicious_cross_binary.rs
@@ -21,7 +21,8 @@
 //! malicious actor and reconfigure without it (committee dips to 3), so the
 //! network still reaches epoch 3. The test asserts detection **programmatically**
 //! by scraping the honest validators' `ika_dwallet_mpc_malicious_actors_count`
-//! gauge (`expect_malicious_actors_at_least(1)`) — no log grep. A green run
+//! gauge on the deliberately faulty current-binary observer
+//! (`expect_malicious_actors_at_least(&[3], 1)`) — no log grep. A green run
 //! means the harness/protocol catches a cross-binary misbehaving validator —
 //! i.e. malicious detection is not vacuous. This is NOT a production test; it
 //! exists to validate the test infrastructure (see `.claude/skills/test-testing`).
@@ -120,7 +121,7 @@ async fn honest_committee_marks_faulty_local_validator_malicious() {
         // recorded a malicious actor. The exit code alone is not the assertion —
         // the network could reach epoch 3 without ever flagging anyone, which is
         // exactly the vacuous-pass this guards against.
-        .expect_malicious_actors_at_least(1)
+        .expect_malicious_actors_at_least(&[3], 1)
         .run()
         .await
         .expect("honest committee should reconfigure past a faulty cross-binary validator");

--- a/crates/ika-upgrade-test/tests/v118_churn.rs
+++ b/crates/ika-upgrade-test/tests/v118_churn.rs
@@ -3,7 +3,7 @@
 
 //! Literal mainnet-v1.1.8 upgrade rehearsal **with post-upgrade committee
 //! churn**: boot a 4-validator committee on the actual `mainnet-v1.1.8`
-//! `ika-node` binary at protocol v3, swap **all validators atomically** to the
+//! `ika-node` binary at protocol v3, sequentially swap **all validators** to the
 //! local build and confirm the upgrade to v4 — then, on the now all-local
 //! committee, **join a brand-new validator** (candidate → stake → activate) so
 //! the v4 reshare encrypts the network key (originally DKG'd by 1.1.8's crypto)
@@ -15,13 +15,10 @@
 //! (`cross_binary`'s `add_joiner_validator`, which seeds the joiner's
 //! `sui_unsafe_genesis_committee` so a v4/OCS validator boots).
 //!
-//! The churn runs **only after** the atomic swap, so every validator is the
-//! local build — there is never a mixed 1.1.8/local committee. That is
-//! required: this branch single-pins `cryptography-private`, so mixed
-//! committees can't exchange MPC messages; the swap must be atomic, and any
-//! churn must follow it. (A *rolling* 1.1.8 swap — `cross_binary` from 1.1.8 —
-//! is therefore invalid; this scenario is how to get churn from a 1.1.8
-//! origin.)
+//! The churn runs only after every validator has been replaced, so its tested
+//! reshare has no mixed 1.1.8/current committee. The sequential replacement
+//! has transient mixed states but intentionally avoids an MPC boundary; the
+//! separate `v118_mixed_rollout` scenario tests real MPC in that topology.
 //!
 //! Opt-in, via `RUN_V118_CHURN=1` (same binaries as `v118_upgrade`):
 //!
@@ -47,7 +44,7 @@ fn bin_from_env(var: &str, default: &str) -> PathBuf {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn v118_atomic_upgrade_then_committee_churn() {
+async fn v118_full_committee_upgrade_then_churn() {
     if std::env::var("RUN_V118_CHURN").is_err() {
         eprintln!(
             "skipping: set RUN_V118_CHURN=1 (needs OLD_BIN/NEW_BIN/NOTIFIER_BIN/IKA_BIN/SUI_BIN)"
@@ -94,7 +91,7 @@ async fn v118_atomic_upgrade_then_committee_churn() {
         .with_ika_cli(ika_cli)
         // OCS read topology: keep validators 0 and 1 on the direct gRPC path
         // (serving the SuiStateMirror relay); flip validators 2 and 3 to
-        // peer-only SuiStateMirrored at the atomic swap and bring the joiner up
+        // peer-only SuiStateMirrored during the full-committee swap and bring the joiner up
         // mirrored, all reading verified Sui state through 0 and 1. The split
         // materializes at the 1.1.8->local swap (the 1.1.8 phase stays direct on
         // legacy JSON-RPC), giving a stable 5-member committee of 2 direct + 3
@@ -106,9 +103,9 @@ async fn v118_atomic_upgrade_then_committee_churn() {
         // network DKG (1.1.8 crypto) completed before the swap.
         .start_all(old)
         .wait_for_epoch(2)
-        // ATOMIC swap every validator to the local build (rolling is impossible
-        // on this branch's single crypto pin). The local v4 binaries inherit
-        // and reshare the completed 1.1.8-crypto network key.
+        // Sequentially swap every validator to the local build before the
+        // tested boundary. The local v4 binaries inherit and reshare the
+        // completed 1.1.8-crypto network key.
         .stop_and_swap(&[0, 1, 2, 3], new.clone())
         // n=4: drop the buffer to a bare quorum so the capability vote tallies.
         .set_buffer_stake(0)
@@ -137,7 +134,7 @@ async fn v118_atomic_upgrade_then_committee_churn() {
         .record_mpc_timings("v4-with-joiner")
         .run()
         .await
-        .expect("v1.1.8 -> local atomic upgrade + committee churn");
+        .expect("v1.1.8 -> local full-committee upgrade + committee churn");
 
     tracing::info!(
         "v118 churn rehearsal PASSED: mainnet-v1.1.8 -> local, v3 -> v4, joiner added to a \

--- a/crates/ika-upgrade-test/tests/v118_mixed_rollout.rs
+++ b/crates/ika-upgrade-test/tests/v118_mixed_rollout.rs
@@ -14,6 +14,14 @@
 //! therefore witnesses each reconfiguration's on-chain started/completed
 //! states and checks local epoch, liveness, malicious reporting, pending work,
 //! logs, and per-authority output digests before allowing the next boundary.
+//!
+//! Beyond the reshare itself, each reconfiguration is followed by a full user
+//! **DKG → Presign → ECDSA Sign → Taproot Sign** lifecycle driven through the
+//! `ika` CLI, so the gate also proves the mixed committee keeps *serving users*
+//! at v3, not only that the system reshare converges. The workloads run in the
+//! settled window after a reshare's assertions and before the next epoch — not
+//! between the timed reconfiguration start/completed observations, which a
+//! multi-minute lifecycle would otherwise perturb.
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -31,7 +39,7 @@ async fn v118_single_validator_rollout_survives_v3_network_key_resharing() {
     if std::env::var("RUN_V118_MIXED_ROLLOUT").is_err() {
         eprintln!(
             "skipping: set RUN_V118_MIXED_ROLLOUT=1 \
-             (needs OLD_BIN/NEW_BIN/NOTIFIER_BIN/SUI_BIN)"
+             (needs OLD_BIN/NEW_BIN/NOTIFIER_BIN/IKA_BIN/SUI_BIN)"
         );
         return;
     }
@@ -46,6 +54,7 @@ async fn v118_single_validator_rollout_survives_v3_network_key_resharing() {
     ));
     let current = BinarySpec::Path(bin_from_env("NEW_BIN", "target/release/ika-validator"));
     let notifier = bin_from_env("NOTIFIER_BIN", "target/release/ika-notifier");
+    let ika_cli = bin_from_env("IKA_BIN", "target/release/ika");
     let sui = bin_from_env("SUI_BIN", "sui");
     let repo = std::env::current_dir()
         .expect("cwd")
@@ -77,6 +86,8 @@ async fn v118_single_validator_rollout_survives_v3_network_key_resharing() {
         .with_epoch_duration_ms(epoch_duration_ms)
         .with_epoch_timeout(Duration::from_secs(1200))
         .with_genesis_global_presign_config(GenesisGlobalPresignConfig::Full)
+        // Drives DKG/Presign/Sign through the `ika` CLI after each reshare.
+        .with_ika_cli(ika_cli)
         .start_all(old)
         // Epoch 2 guarantees the all-v1.1.8 committee completed genesis
         // network DKG. Require every node's local epoch, not just the on-chain
@@ -116,6 +127,13 @@ async fn v118_single_validator_rollout_survives_v3_network_key_resharing() {
         .expect_log_line_absent("recognized_self_as_malicious")
         .expect_protocol_version_at_most(3)
         .expect_all_validators_protocol_version_at_most(3)
+        // The mixed committee must also keep serving users, not just converge on
+        // the system reshare. Run a full user lifecycle in the settled window
+        // after the reshare's assertions — a fresh dWallet DKG, a global presign,
+        // and an ECDSA + Taproot sign, all across the 1-current/3-v1.1.8
+        // committee at v3. Placed here (not between the timed reshare
+        // observations) so the ~minutes-long lifecycle cannot perturb them.
+        .run_workload("mixed-v3-after-first-reshare")
         .wait_for_epoch(3)
         .wait_for_all_validators_local_epoch(3)
         .expect_all_validators_healthy()
@@ -134,6 +152,9 @@ async fn v118_single_validator_rollout_survives_v3_network_key_resharing() {
         .expect_log_line_absent("recognized_self_as_malicious")
         .expect_protocol_version_at_most(3)
         .expect_all_validators_protocol_version_at_most(3)
+        // Serve a second full user lifecycle after the second reshare, proving
+        // continued user-facing service is not a one-off of the first boundary.
+        .run_workload("mixed-v3-after-second-reshare")
         .wait_for_epoch(4)
         .wait_for_all_validators_local_epoch(4)
         .expect_all_validators_healthy()
@@ -147,6 +168,7 @@ async fn v118_single_validator_rollout_survives_v3_network_key_resharing() {
 
     tracing::info!(
         "v1.1.8 mixed rollout PASSED: one current + three literal v1.1.8 validators \
-         completed two protocol-v3 network-key reconfigurations with identical outputs"
+         completed two protocol-v3 network-key reconfigurations with identical outputs \
+         and served a full DKG/Presign/Sign user lifecycle after each"
     );
 }

--- a/crates/ika-upgrade-test/tests/v118_mixed_rollout.rs
+++ b/crates/ika-upgrade-test/tests/v118_mixed_rollout.rs
@@ -106,8 +106,11 @@ async fn v118_single_validator_rollout_survives_v3_network_key_resharing() {
         .wait_for_network_key_reconfiguration_completed(2)
         .expect_all_validators_healthy()
         .wait_for_all_validators_local_epoch(2)
-        .expect_malicious_actors_exactly(&current_observer, 0)
+        // Check the individual authority outputs first so a compatibility
+        // failure reports the exact 3-vs-1 digest split before the aggregate
+        // malicious-actor gauge stops the scenario.
         .expect_network_key_output_converged(&current_observer)
+        .expect_malicious_actors_exactly(&current_observer, 0)
         .expect_no_pending_network_key_reconfiguration(2, &current_observer)
         .expect_log_line_absent("node recognized itself as malicious")
         .expect_log_line_absent("recognized_self_as_malicious")
@@ -124,8 +127,8 @@ async fn v118_single_validator_rollout_survives_v3_network_key_resharing() {
         .wait_for_network_key_reconfiguration_completed(3)
         .expect_all_validators_healthy()
         .wait_for_all_validators_local_epoch(3)
-        .expect_malicious_actors_exactly(&current_observer, 0)
         .expect_network_key_output_converged(&current_observer)
+        .expect_malicious_actors_exactly(&current_observer, 0)
         .expect_no_pending_network_key_reconfiguration(3, &current_observer)
         .expect_log_line_absent("node recognized itself as malicious")
         .expect_log_line_absent("recognized_self_as_malicious")

--- a/crates/ika-upgrade-test/tests/v118_mixed_rollout.rs
+++ b/crates/ika-upgrade-test/tests/v118_mixed_rollout.rs
@@ -1,0 +1,149 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Literal mainnet-v1.1.8/current single-validator rollout gate.
+//!
+//! A four-validator committee boots on the actual `mainnet-v1.1.8` binary,
+//! completes genesis network DKG, then upgrades exactly validator 0 to the
+//! release candidate. The other three validators remain on v1.1.8 while the
+//! mixed committee completes two protocol-v3 network-key reconfigurations.
+//!
+//! Epoch advancement alone is not evidence: three matching old validators can
+//! preserve quorum while the upgraded validator submits different bytes,
+//! records itself malicious, or never enters the new epoch. The scenario
+//! therefore witnesses each reconfiguration's on-chain started/completed
+//! states and checks local epoch, liveness, malicious reporting, pending work,
+//! logs, and per-authority output digests before allowing the next boundary.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ika_swarm_config::sui_client::GenesisGlobalPresignConfig;
+use ika_upgrade_test::binary::BinarySpec;
+use ika_upgrade_test::scenario::Scenario;
+
+fn bin_from_env(var: &str, default: &str) -> PathBuf {
+    PathBuf::from(std::env::var(var).unwrap_or_else(|_| default.to_string()))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn v118_single_validator_rollout_survives_v3_network_key_resharing() {
+    if std::env::var("RUN_V118_MIXED_ROLLOUT").is_err() {
+        eprintln!(
+            "skipping: set RUN_V118_MIXED_ROLLOUT=1 \
+             (needs OLD_BIN/NEW_BIN/NOTIFIER_BIN/SUI_BIN)"
+        );
+        return;
+    }
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
+        .with_log_level("info")
+        .with_env()
+        .init();
+
+    let old = BinarySpec::Path(bin_from_env(
+        "OLD_BIN",
+        "/tmp/ika-v118/target/release/ika-node",
+    ));
+    let current = BinarySpec::Path(bin_from_env("NEW_BIN", "target/release/ika-validator"));
+    let notifier = bin_from_env("NOTIFIER_BIN", "target/release/ika-notifier");
+    let sui = bin_from_env("SUI_BIN", "sui");
+    let repo = std::env::current_dir()
+        .expect("cwd")
+        .ancestors()
+        .nth(2)
+        .expect("workspace root")
+        .to_path_buf();
+    let base = PathBuf::from(
+        std::env::var("UPGRADE_TEST_DIR")
+            .unwrap_or_else(|_| "/mnt/nvme0n1p1/tmp/ika-v118-mixed-rollout".to_string()),
+    );
+    let _ = std::fs::remove_dir_all(&base);
+    let epoch_duration_ms = std::env::var("EPOCH_DURATION_MS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(600_000);
+    assert!(
+        epoch_duration_ms >= 480_000,
+        "v118 mixed rollout requires an epoch of at least 480000ms so the bounded sequential restart completes before the mid-epoch reconfiguration"
+    );
+
+    // Validator 0 is the sole current-binary observer. It records every
+    // authority's consensus-submitted reconfiguration output, including the
+    // three literal historical validators, using canonical BCS digests.
+    let current_observer = [0];
+
+    Scenario::new(4, repo, sui, notifier)
+        .with_base_dir(base)
+        .with_epoch_duration_ms(epoch_duration_ms)
+        .with_epoch_timeout(Duration::from_secs(1200))
+        .with_genesis_global_presign_config(GenesisGlobalPresignConfig::Full)
+        .start_all(old)
+        // Epoch 2 guarantees the all-v1.1.8 committee completed genesis
+        // network DKG. Require every node's local epoch, not just the on-chain
+        // counter that quorum progress can advance without a lagging member.
+        .wait_for_epoch(2)
+        .wait_for_all_validators_local_epoch(2)
+        .expect_all_validators_healthy()
+        .expect_protocol_version_at_most(3)
+        .expect_all_validators_protocol_version_at_most(3)
+        // Prove this epoch's reshare has not started. With a >=8-minute epoch,
+        // the midpoint is at least 4 minutes away; one graceful stop (bounded
+        // at 60s) plus startup health wait (bounded at 120s) completes before
+        // it, so success does not depend on racing a restart into active MPC.
+        .expect_network_key_reconfiguration_not_started(2)
+        // Upgrade exactly one validator. stop_and_swap is sequential, but a
+        // one-element set makes the rollout topology unambiguous: 1 current +
+        // 3 literal v1.1.8 for the rest of the scenario.
+        .stop_and_swap(&[0], current)
+        .expect_all_validators_healthy()
+        .wait_for_all_validators_local_epoch(2)
+        .expect_protocol_version_at_most(3)
+        .expect_all_validators_protocol_version_at_most(3)
+        // First real mixed-version v3 reshare. Witness start explicitly after
+        // the swap, then inspect every invariant before the epoch can hide a
+        // minority failure behind quorum progress.
+        .wait_for_network_key_reconfiguration_started(2)
+        .wait_for_network_key_reconfiguration_completed(2)
+        .expect_all_validators_healthy()
+        .wait_for_all_validators_local_epoch(2)
+        .expect_malicious_actors_exactly(&current_observer, 0)
+        .expect_network_key_output_converged(&current_observer)
+        .expect_no_pending_network_key_reconfiguration(2, &current_observer)
+        .expect_log_line_absent("node recognized itself as malicious")
+        .expect_log_line_absent("recognized_self_as_malicious")
+        .expect_protocol_version_at_most(3)
+        .expect_all_validators_protocol_version_at_most(3)
+        .wait_for_epoch(3)
+        .wait_for_all_validators_local_epoch(3)
+        .expect_all_validators_healthy()
+        .expect_protocol_version_at_most(3)
+        .expect_all_validators_protocol_version_at_most(3)
+        // Repeat at the next boundary. This proves the first success was not a
+        // one-off transition artifact and keeps the committee mixed throughout.
+        .wait_for_network_key_reconfiguration_started(3)
+        .wait_for_network_key_reconfiguration_completed(3)
+        .expect_all_validators_healthy()
+        .wait_for_all_validators_local_epoch(3)
+        .expect_malicious_actors_exactly(&current_observer, 0)
+        .expect_network_key_output_converged(&current_observer)
+        .expect_no_pending_network_key_reconfiguration(3, &current_observer)
+        .expect_log_line_absent("node recognized itself as malicious")
+        .expect_log_line_absent("recognized_self_as_malicious")
+        .expect_protocol_version_at_most(3)
+        .expect_all_validators_protocol_version_at_most(3)
+        .wait_for_epoch(4)
+        .wait_for_all_validators_local_epoch(4)
+        .expect_all_validators_healthy()
+        .expect_protocol_version_at_most(3)
+        .expect_all_validators_protocol_version_at_most(3)
+        .run()
+        .await
+        .expect(
+            "literal v1.1.8/current mixed committee must converge across v3 network-key resharing",
+        );
+
+    tracing::info!(
+        "v1.1.8 mixed rollout PASSED: one current + three literal v1.1.8 validators \
+         completed two protocol-v3 network-key reconfigurations with identical outputs"
+    );
+}

--- a/crates/ika-upgrade-test/tests/v118_upgrade.rs
+++ b/crates/ika-upgrade-test/tests/v118_upgrade.rs
@@ -3,8 +3,8 @@
 
 //! Literal mainnet-v1.1.8 upgrade rehearsal: boot a 4-validator committee on
 //! the **actual `mainnet-v1.1.8` `ika-node` binary** (built from the tag),
-//! run the mainnet user flow at protocol v3, swap **all validators
-//! atomically** to the local build, and verify the network upgrades to v4
+//! run the mainnet user flow at protocol v3, sequentially swap **all
+//! validators** to the local build, and verify the network upgrades to v4
 //! and keeps serving — including through the rollout's presign stall window.
 //!
 //! ## The mainnet state this reproduces (verified on-chain at epoch 315)
@@ -60,10 +60,10 @@
 //! - global presigns requested at v3 on the local build are served via the
 //!   pre-activation fallback (no deadlock in the upgrade window).
 //!
-//! The swap is **atomic** (all validators at once), not rolling: this branch
-//! single-pins `cryptography-private`, and mixed 1.1.8/local committees
-//! cannot exchange MPC messages. The rehearsal mirrors a coordinated
-//! full-network restart.
+//! `stop_and_swap([0, 1, 2, 3])` is sequential: each validator restarts and
+//! passes its health check before the next is stopped. This scenario replaces
+//! the full committee before intentionally crossing the tested reshare; it
+//! does not verify that the transient mixed committee can run MPC.
 //!
 //! Per-component binary choices (each verified against the tag):
 //!
@@ -110,7 +110,7 @@ fn bin_from_env(var: &str, default: &str) -> PathBuf {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn v118_atomic_upgrade_to_local_build() {
+async fn v118_full_committee_upgrade_to_local_build() {
     if std::env::var("RUN_V118_UPGRADE").is_err() {
         eprintln!(
             "skipping: set RUN_V118_UPGRADE=1 (needs OLD_BIN/NEW_BIN/NOTIFIER_BIN/IKA_BIN/SUI_BIN)"
@@ -240,7 +240,7 @@ async fn v118_atomic_upgrade_to_local_build() {
         .record_mpc_timings("local-v4-settled")
         .run()
         .await
-        .expect("v1.1.8 -> local atomic upgrade rehearsal");
+        .expect("v1.1.8 -> local full-committee upgrade rehearsal");
 
     tracing::info!(
         "v118 upgrade rehearsal PASSED: literal mainnet-v1.1.8 -> local build, v3 -> v4, \

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -72,16 +72,17 @@ cross-binary malicious-detection test asserts exclusion programmatically
 instead of matching a log line. Log-level discipline itself lives in
 [`logging.md`](logging.md).
 
-The literal previous-release rollout gate also exports per-authority
-network-key reconfiguration observations from its current-binary validator.
-`ika_dwallet_mpc_network_key_reconfiguration_output_info` carries the session,
+Per-authority output observations are protocol-generic.
+`ika_dwallet_mpc_session_output_info` carries the protocol name, session,
 authority, and canonical BCS-output digest; the paired
-`_reported_malicious_actors` and `_output_rejected` gauges preserve each
-authority's report envelope. This lets one instrumented current validator
-verify all consensus-submitted outputs, including reports from an unmodified
-historical binary. The series reset with the per-epoch manager. The unlabeled,
-always-present `_sessions_pending` gauge makes a clean zero distinguishable
-from a missing scrape.
+`ika_dwallet_mpc_session_reported_malicious_actors` and
+`ika_dwallet_mpc_session_output_rejected` gauges preserve each authority's
+report envelope. This lets one instrumented validator verify
+consensus-submitted outputs from any protocol, including reports from an
+unmodified historical binary. The series reset with the per-epoch manager.
+`ika_dwallet_mpc_protocol_sessions_pending{protocol_name=...}` emits zero for a
+completed protocol while its session remains tracked, so tests can distinguish
+a clean zero from a missing protocol observation.
 
 ## Inventory (generated)
 
@@ -148,13 +149,10 @@ ika_dwallet_mpc_network_key_instantiation_failures_total
 ika_dwallet_mpc_network_key_instantiation_sub_call_duration_seconds
 ika_dwallet_mpc_network_key_instantiations_in_flight
 ika_dwallet_mpc_network_key_loaded_epoch
-ika_dwallet_mpc_network_key_reconfiguration_output_info
-ika_dwallet_mpc_network_key_reconfiguration_output_rejected
-ika_dwallet_mpc_network_key_reconfiguration_reported_malicious_actors
-ika_dwallet_mpc_network_key_reconfiguration_sessions_pending
 ika_dwallet_mpc_number_of_expected_sign_sessions
 ika_dwallet_mpc_number_of_unexpected_sign_sessions
 ika_dwallet_mpc_protocol_data_generation_errors_total
+ika_dwallet_mpc_protocol_sessions_pending
 ika_dwallet_mpc_ready_to_advance_result_total
 ika_dwallet_mpc_received_requests_start_count
 ika_dwallet_mpc_requests_pending_for_frozen_mpc_data
@@ -163,6 +161,9 @@ ika_dwallet_mpc_requests_pending_for_next_active_committee
 ika_dwallet_mpc_self_output_to_quorum_consensus_rounds
 ika_dwallet_mpc_service_end_of_publish_local
 ika_dwallet_mpc_session_start_count
+ika_dwallet_mpc_session_output_info
+ika_dwallet_mpc_session_output_rejected
+ika_dwallet_mpc_session_reported_malicious_actors
 ika_dwallet_mpc_session_state_count
 ika_dwallet_mpc_sessions_rejected_total
 ika_dwallet_mpc_sessions_with_self_output_no_quorum

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -72,6 +72,17 @@ cross-binary malicious-detection test asserts exclusion programmatically
 instead of matching a log line. Log-level discipline itself lives in
 [`logging.md`](logging.md).
 
+The literal previous-release rollout gate also exports per-authority
+network-key reconfiguration observations from its current-binary validator.
+`ika_dwallet_mpc_network_key_reconfiguration_output_info` carries the session,
+authority, and canonical BCS-output digest; the paired
+`_reported_malicious_actors` and `_output_rejected` gauges preserve each
+authority's report envelope. This lets one instrumented current validator
+verify all consensus-submitted outputs, including reports from an unmodified
+historical binary. The series reset with the per-epoch manager. The unlabeled,
+always-present `_sessions_pending` gauge makes a clean zero distinguishable
+from a missing scrape.
+
 ## Inventory (generated)
 
 Regenerate with: `./scripts/check-metric-names.sh --list`
@@ -137,6 +148,10 @@ ika_dwallet_mpc_network_key_instantiation_failures_total
 ika_dwallet_mpc_network_key_instantiation_sub_call_duration_seconds
 ika_dwallet_mpc_network_key_instantiations_in_flight
 ika_dwallet_mpc_network_key_loaded_epoch
+ika_dwallet_mpc_network_key_reconfiguration_output_info
+ika_dwallet_mpc_network_key_reconfiguration_output_rejected
+ika_dwallet_mpc_network_key_reconfiguration_reported_malicious_actors
+ika_dwallet_mpc_network_key_reconfiguration_sessions_pending
 ika_dwallet_mpc_number_of_expected_sign_sessions
 ika_dwallet_mpc_number_of_unexpected_sign_sessions
 ika_dwallet_mpc_protocol_data_generation_errors_total

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -72,17 +72,23 @@ cross-binary malicious-detection test asserts exclusion programmatically
 instead of matching a log line. Log-level discipline itself lives in
 [`logging.md`](logging.md).
 
-Per-authority output observations are protocol-generic.
+Per-authority output observations are collected protocol-generically but
+**exported only for an allow-listed set of protocols** (currently network-key
+reconfiguration; see `OUTPUT_OBSERVATION_EXPORT_PROTOCOLS` in `mpc_manager.rs`).
 `ika_dwallet_mpc_session_output_info` carries the protocol name, session,
 authority, and canonical BCS-output digest; the paired
 `ika_dwallet_mpc_session_reported_malicious_actors` and
 `ika_dwallet_mpc_session_output_rejected` gauges preserve each authority's
 report envelope. This lets one instrumented validator verify
-consensus-submitted outputs from any protocol, including reports from an
-unmodified historical binary. The series reset with the per-epoch manager.
-`ika_dwallet_mpc_protocol_sessions_pending{protocol_name=...}` emits zero for a
-completed protocol while its session remains tracked, so tests can distinguish
-a clean zero from a missing protocol observation.
+consensus-submitted outputs, including reports from an unmodified historical
+binary. The allow-list is deliberate: these series are labeled by session id
+and authority, so exporting every protocol would add one series per
+sign/presign session on production validators — extend it only when a scenario
+actually scrapes another protocol's outputs. The series reset with the
+per-epoch manager. `ika_dwallet_mpc_protocol_sessions_pending{protocol_name=...}`
+is exported for every protocol (it is bounded — one series per protocol name)
+and emits zero for a completed protocol while its session remains tracked, so
+tests can distinguish a clean zero from a missing protocol observation.
 
 ## Inventory (generated)
 

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -58,15 +58,18 @@ gh run watch <run-id>
 gh run download <run-id> -n <artifact>   # localnet-logs / cluster-tests-log-<attempt> / rust-tests-log
 ```
 
-## Upgrade test (run-when-needed, not in the nightly fan-out)
+## Upgrade test (release gate and focused PR check)
 
 `.github/workflows/upgrade-test.yaml` runs the out-of-process cross-binary
 upgrade harness (`crates/ika-upgrade-test/`) — real, separately-compiled
 `ika-validator` child processes against an external `sui` localnet, swapped
-across epochs. It is `workflow_dispatch`-only and deliberately NOT part of
-`scheduled-all-suites.yaml`: it is a pre-mainnet-upgrade rehearsal and a
-check for changes to versioning / serialization / the epoch boundary, not a
-per-push gate. The contract it verifies is
+across epochs. Manual dispatch remains available. Pull requests that touch
+MPC, crypto dependencies, serialization, protocol configuration, the upgrade
+harness, or `Cargo.lock` automatically run the focused literal-v1.1.8 mixed
+rollout rather than the entire matrix. The release workflow calls the same
+reusable workflow with the exact candidate SHA and blocks tag publication on
+that scenario. It is not part of `scheduled-all-suites.yaml`. The contract it
+verifies is
 [`../specs/cross-binary-upgrade.md`](../specs/cross-binary-upgrade.md).
 
 ```bash
@@ -98,11 +101,24 @@ gh workflow run upgrade-test.yaml --ref <branch> -f test=cross_binary
 #   override the old side, e.g. a specific commit kept at v3:
 #   -f old_ref=<sha-or-branch> -f old_max_protocol_version=3 -f old_bin_name=ika-validator
 
-# Atomic mainnet rehearsal: boot the literal mainnet-v1.1.8 binary, swap all
-# to the current build, confirm v4 and continued serving. Pick it explicitly
+# Coordinated full-committee rehearsal: boot literal mainnet-v1.1.8, then
+# sequentially swap all validators to current before the tested reshare.
 # before a mainnet upgrade (builds the tag at its own old toolchain).
 gh workflow run upgrade-test.yaml --ref <branch> -f test=v118_upgrade
 #   override the old tag:  -f old_ref=tag-or-sha  (defaults to mainnet-v1.1.8)
+
+# Release-blocking decentralized rollout: one current validator and three
+# literal v1.1.8 validators remain mixed through two protocol-v3 network-key
+# reconfigurations. Real crypto and production presign-pool sizing are forced;
+# its >=8-minute epoch reserves the bounded restart before the midpoint.
+gh workflow run upgrade-test.yaml --ref <branch> -f test=v118_mixed_rollout \
+  -f candidate_sha=<exact-candidate-sha>
+
+# Test-test the release gate with the repository's compiled-in, feature-gated
+# one-validator reconfiguration-message fault. This run is expected to fail;
+# its logs must show the exact zero-malicious or output-convergence assertion.
+gh workflow run upgrade-test.yaml --ref <branch> -f test=v118_mixed_rollout \
+  -f candidate_sha=<exact-candidate-sha> -f test_testing_fault=true
 
 # Loaded runner slack: bump epochs for the upgrade scenarios.
 #   -f epoch_duration_ms=600000
@@ -113,31 +129,37 @@ gh workflow run upgrade-test.yaml --ref <branch> -f test=v118_upgrade
 # runs that FINISH — a runner death drops it like every other artifact).
 ```
 
-### Scenario differences — `cross_binary` vs `v118_upgrade` (and the rest)
+### Scenario differences
 
-All four scenarios genesis at **protocol v3** (a v4 *genesis* DKG is rejected
+All scenarios genesis at **protocol v3** (a v4 *genesis* DKG is rejected
 forever — the network must upgrade *into* v4) with one notifier + a validator
 committee. They differ in the OLD binary, how it is swapped, and what
 continuity they prove:
 
-| | `smoke` | `workload` | `cross_binary` | `v118_upgrade` |
-|---|---|---|---|---|
-| OLD binary | current build | current build | **this branch pinned to `MAX_PROTOCOL_VERSION=3`** (one-line patch, current toolchain) | **the literal `mainnet-v1.1.8` `ika-node`** from the tag (old toolchain, `--no-default-features`) |
-| Binary swap | none | none | **rolling** — one at a time; mixed-binary committees exchange consensus + MPC mid-epoch | **atomic** — all validators at once |
-| Committee churn | no | no | **yes** — 4 → 3 → 5 → 4 across epochs (remove, join 2 brand-new validators, remove); a real reshare to a different party set at every boundary | **no** — fixed 4 |
-| `GlobalPresignConfig` | n/a | full | **empty** (harness arrangement → routes presign per-dWallet; exercises targeted-presign) | **populated** (mainnet-faithful → global presign; exercises the pre-activation fallback / upgrade-window deadlock guard) |
-| Proves | 4 validators reach epoch 2 | one full DKG→Presign→Sign lifecycle | wire-compat + on-disk compat + reshare/churn **between two builds of the same branch** | the **real mainnet 1.1.8 → current upgrade**: local boots against RocksDB **written by 1.1.8**, reshares a key whose DKG bytes were **produced by 1.1.8's crypto**, 1.1.8 dWallets stay usable, global-presign pre-activation fallback (no deadlock) |
+| Scenario | Binary topology at tested reshare | Protocol transition | Primary invariant |
+|---|---|---|---|
+| `smoke` | current only | none | process harness reaches epoch 2 |
+| `workload` | current only | v3 → v4 | user DKG → Presign → Sign survives activation |
+| `cross_binary` | current source plus current source pinned to max v3 | v3 → v4 | current-source wire compatibility and multi-epoch churn |
+| `v118_upgrade` | literal v1.1.8, then every validator sequentially restarted onto current before the tested reshare | v3 → v4 | historical RocksDB/key continuity and pre-activation global presign |
+| `v118_churn` | current only by the tested churn reshare | v3 → v4 | v1.1.8-origin key reshared to a new post-upgrade validator |
+| `v118_mixed_rollout` | **one current + three literal v1.1.8** for two reshares | held at v3 | exact production rollout topology, zero false-malicious results, no stranded validator/session, canonical 4-of-4 output convergence |
+| `legacy_config` | current only | v3 → v4 | old JSON-RPC-only configuration remains accepted |
 
-**Why the swap style differs:** `cross_binary`'s two binaries are the same
-branch differing only in advertised protocol version, so they are
-MPC-wire-compatible and a *rolling* swap with mixed committees is valid.
-`v118_upgrade` can't do that — this branch single-pins `cryptography-private`,
-so a mixed 1.1.8/local committee can't exchange MPC messages; it must swap
-**atomically** (a coordinated full-network restart). A *rolling* `cross_binary`
-from 1.1.8 is therefore invalid; to get churn from a real 1.1.8 origin you swap
-atomically first, then churn — which is exactly **`v118_churn`** (`v118_upgrade`
-+ one post-swap joiner: the v4 reshare of the 1.1.8-origin network key then
-includes a party that never held it, with no mixed committee).
+`stop_and_swap([0, 1, 2, 3])` is sequential: it restarts and health-checks
+each process before moving to the next. Therefore `v118_upgrade` and
+`v118_churn` are coordinated full-committee replacement tests, not atomic
+restart tests, and they replace every validator before intentionally crossing
+their tested reshare. `v118_mixed_rollout` closes that gap by swapping only
+validator 0, explicitly witnessing the reconfiguration start after the swap,
+and retaining the other three literal historical processes through completion.
+
+On-chain epoch advancement is deliberately not a success criterion for the
+mixed scenario. A 3-of-4 old-binary majority can continue while the upgraded
+validator is divergent or self-convicted. The test additionally requires local
+epoch and health on all four processes, exact protocol-v3 ceilings, zero
+malicious reports and self-malicious logs, completed on-chain and local session
+accounting, and the same canonical output digest from all four authorities.
 
 **Which to use:** `v118_upgrade` is the pre-mainnet-upgrade rehearsal (real
 release, real on-disk + crypto continuity); `v118_churn` is the same plus one

--- a/dev-docs/specs/cross-binary-upgrade.md
+++ b/dev-docs/specs/cross-binary-upgrade.md
@@ -200,11 +200,14 @@ drives them across epochs:
   actors, no stranded work, and identical canonical per-authority outputs.
 
 The current validator's per-authority output observations and pending-session
-counts are protocol-generic and labeled by protocol name. This scenario filters
-that shared data to network-key reconfiguration because that is the deployment
-boundary it specifies; other protocol compatibility scenarios can apply the
-same evidence to DKG, presign, sign, or verification sessions without adding
-protocol-specific node instrumentation.
+counts are collected protocol-generically and labeled by protocol name. This
+scenario filters that data to network-key reconfiguration because that is the
+deployment boundary it specifies. The per-authority output series are exported
+only for an allow-listed set of protocols (`OUTPUT_OBSERVATION_EXPORT_PROTOCOLS`
+in `mpc_manager.rs`, currently just network-key reconfiguration) to keep their
+session-id/authority cardinality bounded on production validators; a future DKG,
+presign, sign, or verification compatibility scenario adds its protocol to that
+allow-list rather than adding protocol-specific node instrumentation.
 
 Run them on CI via the **Upgrade Test** workflow
 (`.github/workflows/upgrade-test.yaml`); see

--- a/dev-docs/specs/cross-binary-upgrade.md
+++ b/dev-docs/specs/cross-binary-upgrade.md
@@ -74,14 +74,18 @@ serialization/schema change, MUST preserve all of the following.
    [`epoch-close-session-lock.md`](epoch-close-session-lock.md) for the
    completion-target / close-predicate rules this builds on.
 
-4. **Wire compatibility.** A vN binary MUST correctly deserialize the
-   consensus messages and MPC messages produced by vN−1 peers, and vice
-   versa. The versioned-enum payloads are the trap: adding a variant in
-   vN+1 breaks vN deserialization unless vN was written to tolerate it.
-   Wire compatibility is what makes a **rolling** swap (mixed committee,
-   peers exchanging consensus + MPC messages mid-epoch) valid at all — it
-   is only valid between builds that are mutually wire-compatible (see
-   the crypto-boundary exception below).
+4. **Wire and cryptographic-output compatibility.** A vN binary MUST
+   correctly deserialize the consensus and MPC messages produced by vN−1
+   peers, and vice versa. It MUST also construct the same canonical MPC
+   transcript and output while both select the same on-chain protocol
+   version. Matching `protocol_version` values are not enough: dependency
+   behavior, transcript construction, serialization, and output finalization
+   are compiled into each binary. A validator-by-validator rollout therefore
+   requires a literal previous-release/current mixed committee to exchange
+   real MPC messages and agree on output bytes. A dependency boundary that
+   cannot do so blocks the release; it is not grounds to replace the
+   historical binary with current source pinned to an older advertised
+   version.
 
 5. **On-disk compatibility.** `AuthorityPerpetualTables` written by a
    vN−1 binary MUST reopen under vN. A validator stopped on vN−1 and
@@ -137,37 +141,38 @@ next-committee assembly, which by construction never serves the genesis
 requirement (4/4 class-groups keys, 0/4 PVSS). This is also the path
 mainnet itself takes, so upgrade testing must follow it.
 
-## The crypto-boundary exception: a naive rolling swap is NOT always valid
+## Literal previous-release compatibility is a release gate
 
-A rolling, mixed-committee swap is valid **only between builds that share
-the same crypto and differ solely in the protocol version they
-advertise**. Across a crypto-library boundary it is not, and the upgrade
-must instead be an **atomic, coordinated full-network restart**.
+The decentralized rollout topology is one release-candidate validator and
+the rest of the committee on the literal previous release. That topology must
+remain valid through a network-key reconfiguration while the on-chain
+protocol version remains v3. Operational instructions cannot turn a
+validator-by-validator deployment into an atomic restart, and quorum progress
+cannot establish compatibility: three matching old validators can advance the
+chain while the upgraded validator produces different bytes, falls behind, or
+records itself as malicious.
 
-The concrete instance that defines this rule (`mainnet-v1.1.8` → current
-`dev`):
+The `mainnet-v1.1.8` → current boundary is especially important because
+v1.1.8 links the former `class_groups`/`inkrypto` dependency while current
+source links `cryptography-private`. The prior assumption was that their MPC
+wire formats were not interchangeable and therefore that every validator had
+to be replaced before the next MPC boundary. That assumption conflicts with
+the deployment contract. The release gate must run the literal binaries with
+real cryptography and either prove compatible canonical output or expose a
+release blocker.
 
-- v1.1.8 links `class_groups` from the `inkrypto` crypto library; `dev`
-  links `cryptography-private` (the migration between the two). Their MPC
-  wire formats are not interchangeable, so a mixed v1.1.8/`dev` committee
-  cannot exchange MPC messages.
-- v4 also changed validator-key publication from the bare
-  `ClassGroupsEncryptionKeyAndProof` shape to the combined
-  `ValidatorEncryptionKeysAndProofs`. A v1.1.8 binary booted into a
-  committee whose validator records were registered in the new shape
-  fails to decode the on-chain record (`class groups public key …
-  remaining input`) and panics on the key-mismatch check at startup.
-- The current build carries **backward** compatibility for the v1.1.8
-  key shape, so it can read state v1.1.8 wrote; v1.1.8 has no **forward**
-  compatibility for the new shape. Compatibility across this boundary is
-  therefore one-directional, which is exactly why the swap must be atomic
-  (every validator restarts onto the new binary together) rather than
-  rolling.
+Protocol v4 also changes validator-key publication from the bare
+`ClassGroupsEncryptionKeyAndProof` shape to the combined
+`ValidatorEncryptionKeysAndProofs`. Current code can read the historical key
+shape; v1.1.8 cannot read the new shape. The mixed-rollout gate deliberately
+holds v3 and does not register new-shape validators during its mixed phase.
+Forward-only v4 state therefore does not excuse incompatibility for the v3
+network-key reshare.
 
-A change that introduces a new crypto-library or validator-key-shape
-boundary inherits this constraint: it MUST document whether mixed
-committees remain wire-compatible, and if not, that its rollout is an
-atomic restart, not a rolling swap.
+Any crypto-library, transcript, validator-key, or serialization change MUST
+state how the literal previous release interoperates during a rolling rollout.
+If it cannot, the candidate is not releasable until compatibility is restored
+or the decentralized rollout contract is explicitly changed outside this test.
 
 ## How this is verified
 
@@ -183,11 +188,16 @@ drives them across epochs:
   two wire-compatible builds (an OLD build of the current branch pinned
   to `MAX_PROTOCOL_VERSION = 3`, and the current `dev`): the vote
   advances v3 → v4 while the committee reshapes 4 → 3 → 5 → 4.
-- `tests/v118_upgrade.rs` — the atomic mainnet rehearsal: boot the literal
-  `mainnet-v1.1.8` binary, run the mainnet user flow at v3, swap all
-  validators at once to the current build, and confirm the network
-  upgrades to v4 and keeps serving through the pre-activation presign
-  window.
+- `tests/v118_upgrade.rs` — the coordinated full-committee mainnet
+  rehearsal: boot the literal `mainnet-v1.1.8` binary, run the mainnet user
+  flow at v3, sequentially restart all validators onto the current build
+  before the tested reshare, and confirm the network upgrades to v4 and keeps
+  serving through the pre-activation presign window.
+- `tests/v118_mixed_rollout.rs` — the release-blocking deployment topology:
+  upgrade exactly one member of a four-validator literal v1.1.8 committee,
+  hold protocol v3, and require two network-key reconfigurations to complete
+  with every validator healthy and locally current, zero reported malicious
+  actors, no stranded work, and identical canonical per-authority outputs.
 
 Run them on CI via the **Upgrade Test** workflow
 (`.github/workflows/upgrade-test.yaml`); see

--- a/dev-docs/specs/cross-binary-upgrade.md
+++ b/dev-docs/specs/cross-binary-upgrade.md
@@ -199,6 +199,13 @@ drives them across epochs:
   with every validator healthy and locally current, zero reported malicious
   actors, no stranded work, and identical canonical per-authority outputs.
 
+The current validator's per-authority output observations and pending-session
+counts are protocol-generic and labeled by protocol name. This scenario filters
+that shared data to network-key reconfiguration because that is the deployment
+boundary it specifies; other protocol compatibility scenarios can apply the
+same evidence to DKG, presign, sign, or verification sessions without adding
+protocol-specific node instrumentation.
+
 Run them on CI via the **Upgrade Test** workflow
 (`.github/workflows/upgrade-test.yaml`); see
 [`../playbooks/ci-suites.md`](../playbooks/ci-suites.md).

--- a/sdk/ika-wasm/Cargo.lock
+++ b/sdk/ika-wasm/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "bcs",

--- a/sdk/ika-wasm/Cargo.lock
+++ b/sdk/ika-wasm/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "class_groups"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "bcs",
  "commitment",
@@ -241,7 +241,7 @@ dependencies = [
 [[package]]
 name = "commitment"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "crypto-bigint",
  "group 0.2.0",
@@ -644,7 +644,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "blake2b_simd",
  "crypto-bigint",
@@ -715,7 +715,7 @@ dependencies = [
 [[package]]
 name = "homomorphic_encryption"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "crypto-bigint",
  "group 0.2.0",
@@ -858,7 +858,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "maurer"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "mpc"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "aead 0.5.2",
  "bcs",
@@ -1064,7 +1064,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -1080,7 +1080,7 @@ dependencies = [
 [[package]]
 name = "proof_aggregation"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "commitment",
  "crypto-bigint",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "twopc_mpc"
 version = "0.2.0"
-source = "git+https://github.com/dwallet-labs/inkrypto?rev=1d8b5a9#1d8b5a9052b30851aef1a26df946465cabe35bad"
+source = "git+https://github.com/dwallet-labs/inkrypto?rev=c3c20ac6#c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d"
 dependencies = [
  "class_groups",
  "commitment",


### PR DESCRIPTION
## Why

The upgrade suite did not reproduce a decentralized validator rollout. `cross_binary` built the candidate twice and only pinned one copy to protocol v3, while the literal-v1.1.8 scenarios replaced every validator before intentionally crossing their tested network-key reshare. Because `stop_and_swap([0, 1, 2, 3])` is sequential and on-chain epoch advancement needs only quorum, those green runs could not detect one upgraded validator producing different MPC output bytes, lagging locally, or recognizing itself as malicious while three old validators kept the network moving.

This matters because the testnet v1.1.8 -> v1.2.0 incident happened with both binaries selecting protocol config v3. A shared protocol number is not evidence that cryptography implementation, transcript construction, serialization, or output finalization is wire-compatible.

## What changed

- Adds `v118_mixed_rollout`: boot four validators from the literal `mainnet-v1.1.8` tag, complete genesis DKG, upgrade exactly validator 0 to the exact candidate SHA, then keep the 1-current/3-old committee mixed through two protocol-v3 network-key reconfigurations using real cryptography and production presign sizing.
- Adds deterministic DSL witnesses for reconfiguration-not-started, started, and completed state, plus fail-closed local epoch, health, protocol ceiling, malicious count, log absence, output convergence, and pending-session assertions.
- Adds protocol-generic MPC session observations for every identified protocol: per-authority canonical output digests, malicious-actor counts, rejected envelopes, and pending-session counts. The mixed-rollout gate filters these reusable metrics to `Network Encryption Key Reconfiguration`; future upgrade scenarios can apply the same machinery to DKG, presign, sign, or other protocols. Digests cover canonical BCS output bytes, exclude the sender/malicious envelope, preserve multiple digests per authority, and therefore fail on a 3-vs-1 split even if the majority result advances the chain.
- Makes metric reads fail closed on dead/unreachable validators and missing/malformed samples, with validator index and endpoint in every error. The intentionally-malicious scenario now uses the same scraper.
- Makes historical `MAX_PROTOCOL_VERSION` patching fail if the assignment is absent, duplicated, already equal (no substitution), or not exactly the requested value afterward. Old refs are resolved to immutable commits before worktree creation.
- Adds focused PR path filters, a reusable `workflow_call`, and a tag-release dependency that tests the exact candidate SHA. Manual dispatch and every existing scenario remain available; `test=all` now includes the mixed rollout.
- Bumps the workspace release version to `1.2.1` and refreshes both the root and independent WASM lockfiles.
- Updates the upgrade contract, CI playbook, metric inventory, and the misleading “atomic swap” documentation.

## Coverage flow

| Scenario | Binary topology at tested reshare | Protocol behavior | What it proves |
|---|---|---|---|
| `smoke` | current only | no upgrade | same-binary process plumbing |
| `workload` | current only | v3 -> v4 | DKG/Presign/Sign across activation |
| `cross_binary` | current source + current source max-v3 pinned | v3 -> v4 | current-source wire compatibility and churn |
| `v118_upgrade` | literal v1.1.8, then all validators sequentially current | v3 -> v4 | historical RocksDB/key continuity and pre-activation global presign |
| `v118_churn` | current only by churn reshare | v3 -> v4 | v1.1.8-origin key reshared to a new validator |
| **`v118_mixed_rollout`** | **1 exact candidate + 3 literal v1.1.8** | **held at v3 for two reshares** | **production rollout topology; canonical output convergence (upgraded validator + finalizing quorum, hard digest equality), zero false-malicious, no stranded member/session** |
| `legacy_config` | current only | v3 -> v4 | legacy JSON-RPC configuration |

## Mixed-rollout invariants

For both network-key reconfigurations, the test requires:

- all four expected validator processes running, admin-reachable, and locally in the expected epoch;
- on-chain and per-process protocol version at most 3;
- explicit on-chain start and completion of the epoch's reconfiguration;
- exactly zero malicious actors on the current observer and no self-malicious log marker on any validator;
- one identical canonical network-key output digest across every observed authority, where the observed set must include the upgraded validator and at least a finalizing quorum (reconfiguration finalizes at quorum and discards a still-computing straggler's output, so an honest old-binary straggler may legitimately never submit); any submitted divergent digest is a hard failure, with zero malicious actors and no rejected envelope in every report;
- no incomplete on-chain immediate/system session, no local pending reconfiguration session, and no in-flight network-key instantiation.

Epoch advancement and successful quorum workloads are intentionally insufficient assertions.

## Validation

Local:

- `cargo fmt --all -- --check`
- `cargo test --release -p ika-upgrade-test --lib` (11 passed)
- `cargo test --release -p ika-upgrade-test --tests -- --test-threads=1` (all test targets compiled/executed; external scenarios remain environment-gated)
- `cargo test --release -p ika-core dwallet_mpc::integration_tests::session::test_handle_mpc_request_with_invalid_protocol_data_returns_failed -- --test-threads=1` (real cryptography; 1 passed)
- `cargo clippy -p ika-upgrade-test --all-targets --all-features -- -D warnings`
- `cargo clippy -p ika-core --lib --all-features -- -D warnings`
- `cargo check --release -p ika-core --lib`
- `./scripts/check-metric-names.sh`
- workflow YAML parse and `git diff --check`
- after the release bump: `cargo check -p ika-upgrade-test --tests` plus locked root and independent-WASM metadata resolution at workspace version `1.2.1`

Large-runner evidence:

- Required literal/history batch (`v118_upgrade` and `v118_churn` passed; the mixed rollout reproduced the blocker): https://github.com/dwallet-labs/ika/actions/runs/29410941527
- Corrected `cross_binary` rerun (`1 passed; 0 ignored`): https://github.com/dwallet-labs/ika/actions/runs/29411679357
- Deliberate output-mutation run proving the convergence guard fails closed: https://github.com/dwallet-labs/ika/actions/runs/29426981676
- First unfaulted literal v1.1.8/current mixed rollout after the compatibility fix (`1 passed; 0 ignored`, two protocol-v3 network-key reshares and MPC workloads): https://github.com/dwallet-labs/ika/actions/runs/29481354745
- Exact `1.2.1` candidate SHA `4306469d06940ee632fe98b261ea64f601514748` release gate (queued): https://github.com/dwallet-labs/ika/actions/runs/29485803984

## Compatibility defect and fix

The first literal mixed-committee run reproduced the incident: the upgraded authority sent its first-round network-key reconfiguration message, all three v1.1.8 validators rejected its proof, the old-validator quorum advanced while marking the upgraded authority malicious, and the upgraded validator logged `recognized_self_as_malicious`.

The failure was after message deserialization and before output adoption. The incompatible transcript came from the backward-compatible reconfiguration proof using `SECRET_KEY_SHARE_LIMBS` where v1.1.8 used `SECRET_KEY_SHARE_WITNESS_LIMBS`. The fix is published in public `inkrypto` commit [`c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d`](https://github.com/dwallet-labs/inkrypto/commit/c3c20ac67baa862c38dfc0f43dcbd6b0e94ab92d), which this PR pins.

The passing mixed-rollout run above demonstrates the compatibility fix against the literal historical binary with real cryptography. The exact `1.2.1` candidate run is still queued, so merge readiness remains gated on that result.

Related: #1736, #1834, and #1835.

