### PR TITLE
fix(upgrade-test): make the v1.1.8 mixed-rollout gate deterministic for honest stragglers

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -173,6 +173,19 @@ pub struct DWalletMPCMetrics {
     /// (0 = canonical output, 1 = rejected output).
     pub(crate) session_output_rejected: IntGaugeVec,
 
+    /// A locally computed network-key reconfiguration output that returned
+    /// after the session completed via the peers' quorum, so production
+    /// discarded it without submission. The `output_digest` and
+    /// `quorum_output_digest` labels are both over RAW output bytes (before
+    /// any consensus envelope) — comparable with each other but NOT with
+    /// `session_output_info`'s envelope digests. Label equality proves the
+    /// discarded local bytes match the quorum-agreed output.
+    pub(crate) session_late_output_info: IntGaugeVec,
+
+    /// Malicious-actor count reported by the discarded late local computation
+    /// recorded in `session_late_output_info`.
+    pub(crate) session_late_output_malicious_actors: IntGaugeVec,
+
     /// Privacy-safe anomaly snapshots emitted to the validator's local log sink.
     /// Labels are fixed enums: `anomaly_kind`, `session_type` (or `unknown` when
     /// service termination has no source session), and `severity`.
@@ -505,6 +518,26 @@ impl DWalletMPCMetrics {
                 registry,
             )
             .unwrap(),
+            session_late_output_info: register_int_gauge_vec_with_registry!(
+                "ika_dwallet_mpc_session_late_output_info",
+                "Raw-bytes digest of a locally computed session output discarded after the quorum completed the session, next to the quorum output's raw-bytes digest",
+                &[
+                    "protocol_name",
+                    "session_id",
+                    "authority",
+                    "output_digest",
+                    "quorum_output_digest"
+                ],
+                registry,
+            )
+            .unwrap(),
+            session_late_output_malicious_actors: register_int_gauge_vec_with_registry!(
+                "ika_dwallet_mpc_session_late_output_malicious_actors",
+                "Malicious-actor count reported by the discarded late local computation",
+                &["protocol_name", "session_id", "authority"],
+                registry,
+            )
+            .unwrap(),
             anomaly_snapshots_total: register_int_counter_vec_with_registry!(
                 "ika_dwallet_mpc_anomaly_snapshots_total",
                 "Privacy-safe MPC anomaly snapshots emitted to the local log sink",
@@ -692,6 +725,8 @@ impl DWalletMPCMetrics {
         self.session_output_info.reset();
         self.session_reported_malicious_actors.reset();
         self.session_output_rejected.reset();
+        self.session_late_output_info.reset();
+        self.session_late_output_malicious_actors.reset();
     }
 }
 

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -18,6 +18,7 @@ use crate::dwallet_mpc::crytographic_computation::ComputationId;
 use crate::dwallet_mpc::dwallet_mpc_metrics::DWalletMPCMetrics;
 use crate::dwallet_mpc::mpc_diagnostics::{
     MpcAnomalyContext, MpcAnomalyKind, dwallet_mpc_error_diagnostic, output_digest,
+    raw_output_digest,
 };
 use crate::dwallet_mpc::mpc_manager::DWalletMPCManager;
 use crate::dwallet_mpc::mpc_session::{
@@ -1732,14 +1733,72 @@ impl DWalletMPCService {
                     ?computation_result_data,
                     "received a computation update for a non-active session"
                 );
+                let mut trigger_conditions =
+                    vec!["local_computation_update_received_after_session_became_non_active"];
+                // An honest straggler: the session completed via the peers'
+                // output quorum while this validator was still computing, so
+                // this Finalize result is correctly discarded without
+                // submission. For a network-key reconfiguration, digest the
+                // discarded raw output bytes and compare them against the
+                // quorum-agreed output recorded at quorum time — this is the
+                // only remaining byte-level cross-version compatibility
+                // evidence for this validator. Observability only: nothing
+                // is submitted and the session stays non-active.
+                if let Ok(GuaranteedOutputDeliveryRoundResult::Finalize {
+                    public_output_value,
+                    malicious_parties,
+                    ..
+                }) = &computation_result
+                    && let Some(session) = self
+                        .dwallet_mpc_manager
+                        .sessions
+                        .get_mut(&session_identifier)
+                    && session.network_key_reconfiguration
+                {
+                    let late_output_digest = raw_output_digest(public_output_value);
+                    let matches_quorum =
+                        session.record_late_output(late_output_digest, malicious_parties.len());
+                    let quorum_output_digest = session.quorum_raw_output_digest.map(hex::encode);
+                    match matches_quorum {
+                        Some(true) => {
+                            info!(
+                                ?session_identifier,
+                                validator=?validator_name,
+                                late_output_digest = %hex::encode(late_output_digest),
+                                reported_malicious_count = malicious_parties.len(),
+                                "late network-key reconfiguration output matches the quorum-agreed output; session already completed, output not submitted"
+                            );
+                            trigger_conditions.push("late_network_key_output_matched_quorum");
+                        }
+                        Some(false) => {
+                            error!(
+                                ?session_identifier,
+                                validator=?validator_name,
+                                late_output_digest = %hex::encode(late_output_digest),
+                                quorum_output_digest = ?quorum_output_digest,
+                                reported_malicious_count = malicious_parties.len(),
+                                "late network-key reconfiguration output DIVERGES from the quorum-agreed output"
+                            );
+                            trigger_conditions.push("late_network_key_output_diverged_from_quorum");
+                        }
+                        None => {
+                            warn!(
+                                ?session_identifier,
+                                validator=?validator_name,
+                                late_output_digest = %hex::encode(late_output_digest),
+                                reported_malicious_count = malicious_parties.len(),
+                                "late network-key reconfiguration output recorded without a quorum digest to compare against"
+                            );
+                            trigger_conditions.push("late_network_key_output_unverified");
+                        }
+                    }
+                }
                 self.dwallet_mpc_manager.emit_session_anomaly(
                     session_identifier,
                     MpcAnomalyKind::ComputationUpdateAfterSessionCompletion,
                     MpcAnomalyContext {
                         current_consensus_round: self.last_read_consensus_round,
-                        trigger_conditions: vec![
-                            "local_computation_update_received_after_session_became_non_active",
-                        ],
+                        trigger_conditions,
                         ..Default::default()
                     },
                 );

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -2688,7 +2688,9 @@ impl DWalletMPCService {
 
     /// Break down the key to slices because of chain transaction size limits.
     /// Limit 16 KB per Tx `pure` argument.
-    fn slice_public_output_into_messages<T>(
+    /// `pub(crate)` so compatibility tests build their fabricated output
+    /// envelopes through the real chunker instead of a copy that could drift.
+    pub(crate) fn slice_public_output_into_messages<T>(
         public_output: Vec<u8>,
         func: impl Fn(Vec<u8>, bool) -> T,
     ) -> Vec<T> {

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/late_reconfiguration_output.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/late_reconfiguration_output.rs
@@ -19,13 +19,16 @@
 //! digest is flagged as a match, and divergent bytes are flagged loudly.
 
 use crate::dwallet_mpc::crytographic_computation::ComputationId;
+use crate::dwallet_mpc::dwallet_mpc_service::DWalletMPCService;
 use crate::dwallet_mpc::integration_tests::utils;
+use crate::dwallet_mpc::integration_tests::utils::TestingSubmitToConsensus;
 use crate::dwallet_mpc::mpc_diagnostics::{
     MpcAnomalyKind, SessionDiagnosticEvent, raw_output_digest,
 };
 use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionRequestMetricData};
 use crate::request_protocol_data::{NetworkEncryptionKeyReconfigurationData, ProtocolData};
 use ika_types::crypto::AuthorityName;
+use ika_types::dwallet_mpc_error::DwalletMPCResult;
 use ika_types::message::{DWalletCheckpointMessageKind, MPCNetworkReconfigurationOutput};
 use ika_types::messages_dwallet_mpc::{
     DWalletMPCOutput, DWalletMPCOutputReport, SessionIdentifier, SessionType,
@@ -33,37 +36,37 @@ use ika_types::messages_dwallet_mpc::{
 use ika_types::noa_checkpoint::CounterpartyChainKind;
 use mpc::GuaranteedOutputDeliveryRoundResult;
 use std::collections::HashMap;
+use std::sync::Arc;
 use sui_types::base_types::ObjectID;
 
-/// A submitted network-key reconfiguration output report, chunked exactly the
-/// way production slices one output's bytes across checkpoint message kinds
-/// (`slice_public_output_into_messages` — in-order 5 KB chunks), so the
-/// raw-bytes digest of the reassembled envelope must equal the digest of the
-/// unsliced bytes.
+fn network_key_id() -> ObjectID {
+    ObjectID::from_single_byte(9)
+}
+
+/// A submitted network-key reconfiguration output report, chunked through the
+/// REAL production chunker (`slice_public_output_into_messages`), so the
+/// quorum-side raw-bytes digest is pinned against production's actual slicing
+/// rather than a test copy that could drift.
 fn reconfiguration_report(
     authority: AuthorityName,
     session_identifier: SessionIdentifier,
-    key_id: ObjectID,
     output_bytes: &[u8],
 ) -> DWalletMPCOutputReport {
-    let chunks: Vec<&[u8]> = output_bytes.chunks(5 * 1024).collect();
-    let chunk_count = chunks.len();
-    let output = chunks
-        .into_iter()
-        .enumerate()
-        .map(|(index, chunk)| {
+    let output = DWalletMPCService::slice_public_output_into_messages(
+        output_bytes.to_vec(),
+        |public_output, is_last| {
             DWalletCheckpointMessageKind::RespondDWalletMPCNetworkReconfigurationOutput(
                 MPCNetworkReconfigurationOutput {
-                    dwallet_network_encryption_key_id: key_id.to_vec(),
-                    public_output: chunk.to_vec(),
+                    dwallet_network_encryption_key_id: network_key_id().to_vec(),
+                    public_output,
                     supported_curves: vec![],
-                    is_last: index == chunk_count - 1,
+                    is_last,
                     rejected: false,
                     session_sequence_number: 3,
                 },
             )
-        })
-        .collect();
+        },
+    );
     DWalletMPCOutputReport::External(DWalletMPCOutput {
         authority,
         session_identifier,
@@ -72,10 +75,7 @@ fn reconfiguration_report(
     })
 }
 
-fn reconfiguration_request(
-    session_identifier: SessionIdentifier,
-    key_id: ObjectID,
-) -> DWalletSessionRequest {
+fn reconfiguration_request(session_identifier: SessionIdentifier) -> DWalletSessionRequest {
     DWalletSessionRequest {
         counterparty_chain: Some(CounterpartyChainKind::Sui),
         session_type: SessionType::System,
@@ -83,7 +83,7 @@ fn reconfiguration_request(
         session_sequence_number: Some(3),
         protocol_data: ProtocolData::NetworkEncryptionKeyReconfiguration {
             data: NetworkEncryptionKeyReconfigurationData {},
-            dwallet_network_encryption_key_id: key_id,
+            dwallet_network_encryption_key_id: network_key_id(),
         },
         epoch: 1,
         requires_network_key_data: true,
@@ -92,67 +92,104 @@ fn reconfiguration_request(
     }
 }
 
-fn late_finalize(
-    output_bytes: Vec<u8>,
-) -> Result<GuaranteedOutputDeliveryRoundResult, ika_types::dwallet_mpc_error::DwalletMPCError> {
-    Ok(GuaranteedOutputDeliveryRoundResult::Finalize {
-        malicious_parties: vec![],
-        private_output: vec![],
-        public_output_value: output_bytes,
-    })
+fn reconfiguration_protocol_name(request: &DWalletSessionRequest) -> String {
+    DWalletSessionRequestMetricData::from(&request.protocol_data)
+        .name()
+        .to_owned()
 }
 
-#[tokio::test]
-#[cfg(test)]
-async fn late_reconfiguration_finalize_after_quorum_records_digest_without_submitting() {
-    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
-    let (services, _, sent_consensus_messages_collectors, _, _, _, _) =
+/// Bring service 0 to the exact pre-straggler state: three peers finalized
+/// identical outputs at `quorum_round` and the quorum completed the session
+/// while this validator produced nothing. When `request_observed` the session
+/// carries the reconfiguration request metadata first (the same calls the
+/// real request-arrival path performs), which is what arms the late-output
+/// capture.
+fn setup_quorum_completed_session(
+    session_identifier: SessionIdentifier,
+    output_bytes: &[u8],
+    quorum_round: u64,
+    request_observed: bool,
+) -> (
+    Vec<DWalletMPCService>,
+    Vec<Arc<TestingSubmitToConsensus>>,
+    DWalletSessionRequest,
+) {
+    let (mut services, _, sent_consensus_messages_collectors, _, _, _, _) =
         utils::create_dwallet_mpc_services(4);
-    let mut services = services;
     let authorities: Vec<AuthorityName> = services[0].committee.names().copied().collect();
-    let session_identifier = SessionIdentifier::new(SessionType::System, [21; 32]);
-    let key_id = ObjectID::from_single_byte(9);
-    // Multiple chunks (>5 KB) so the quorum-side digest exercises in-order
-    // chunk reassembly, not just the single-chunk case.
-    let output_bytes: Vec<u8> = (0..12_000u32).map(|byte| (byte % 251) as u8).collect();
-
-    // The session request was observed earlier in the epoch — production
-    // stamps the reconfiguration metadata off it when the session is created.
-    // One below-quorum output creates the session entry; the metadata call is
-    // the same one the real request-arrival path performs.
-    services[0].dwallet_mpc_manager_mut().handle_output(
-        5_900,
-        reconfiguration_report(authorities[1], session_identifier, key_id, &output_bytes),
-    );
-    let request = reconfiguration_request(session_identifier, key_id);
-    {
+    let request = reconfiguration_request(session_identifier);
+    if request_observed {
+        // One below-quorum output creates the session entry to stamp.
+        services[0].dwallet_mpc_manager_mut().handle_output(
+            quorum_round - 2,
+            reconfiguration_report(authorities[1], session_identifier, output_bytes),
+        );
         let session = services[0]
             .dwallet_mpc_manager_mut()
             .sessions
             .get_mut(&session_identifier)
             .expect("session exists after the first output");
         session.set_request_diagnostic_metadata(&request);
-        session.set_protocol_name(
-            DWalletSessionRequestMetricData::from(&request.protocol_data)
-                .name()
-                .to_owned(),
-        );
+        session.set_protocol_name(reconfiguration_protocol_name(&request));
     }
-
-    // Three old authorities finalize with identical outputs; the quorum
-    // closes the session while this validator is still computing.
     let reports = authorities
         .iter()
         .skip(1)
         .take(3)
-        .map(|authority| {
-            reconfiguration_report(*authority, session_identifier, key_id, &output_bytes)
-        })
+        .map(|authority| reconfiguration_report(*authority, session_identifier, output_bytes))
         .collect();
     let (_, completed) = services[0]
         .dwallet_mpc_manager_mut()
-        .handle_consensus_round_outputs(5_902, reports);
+        .handle_consensus_round_outputs(quorum_round, reports);
     assert_eq!(completed, vec![session_identifier]);
+    (services, sent_consensus_messages_collectors, request)
+}
+
+/// Inject the straggler's late `Finalize` (~195ms after quorum in the
+/// observed CI failure) and assert the invariant every variant shares: a
+/// completed session's late result is never submitted to consensus.
+async fn submit_late_finalize(
+    service: &mut DWalletMPCService,
+    collector: &Arc<TestingSubmitToConsensus>,
+    session_identifier: SessionIdentifier,
+    quorum_round: u64,
+    output_bytes: Vec<u8>,
+) {
+    let result: DwalletMPCResult<GuaranteedOutputDeliveryRoundResult> =
+        Ok(GuaranteedOutputDeliveryRoundResult::Finalize {
+            malicious_parties: vec![],
+            private_output: vec![],
+            public_output_value: output_bytes,
+        });
+    collector.submitted_messages.lock().unwrap().clear();
+    service
+        .handle_computation_results_and_submit_to_consensus(HashMap::from([(
+            ComputationId {
+                session_identifier,
+                mpc_round: Some(3),
+                attempt_number: 1,
+                consensus_round: quorum_round,
+            },
+            result,
+        )]))
+        .await;
+    assert!(
+        collector.submitted_messages.lock().unwrap().is_empty(),
+        "a late finalize for a completed session must not submit anything to consensus"
+    );
+}
+
+#[tokio::test]
+#[cfg(test)]
+async fn late_reconfiguration_finalize_after_quorum_records_digest_without_submitting() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let session_identifier = SessionIdentifier::new(SessionType::System, [21; 32]);
+    // Multiple chunks (>5 KB) so the quorum-side digest exercises in-order
+    // chunk reassembly, not just the single-chunk case.
+    let output_bytes: Vec<u8> = (0..12_000u32).map(|byte| (byte % 251) as u8).collect();
+    let quorum_round = 5_902;
+    let (mut services, collectors, request) =
+        setup_quorum_completed_session(session_identifier, &output_bytes, quorum_round, true);
 
     let expected_digest = raw_output_digest(&output_bytes);
     {
@@ -167,41 +204,26 @@ async fn late_reconfiguration_finalize_after_quorum_records_digest_without_submi
             "quorum completion must stash the winning output's raw-bytes digest \
              (reassembled from the in-order chunks) before the session goes non-active"
         );
-        assert!(session.late_output_digest.is_none());
+        assert!(session.late_output.is_none());
     }
 
-    // ~195ms later: the local computation returns `Finalize` with the SAME
-    // bytes the quorum agreed on. The session is non-active, so the result is
-    // discarded — but its digest must be recorded and compared.
-    sent_consensus_messages_collectors[0]
-        .submitted_messages
-        .lock()
-        .unwrap()
-        .clear();
-    services[0]
-        .handle_computation_results_and_submit_to_consensus(HashMap::from([(
-            ComputationId {
-                session_identifier,
-                mpc_round: Some(3),
-                attempt_number: 1,
-                consensus_round: 5_902,
-            },
-            late_finalize(output_bytes.clone()),
-        )]))
-        .await;
+    // The local computation returns `Finalize` with the SAME bytes the quorum
+    // agreed on. The session is non-active, so the result is discarded — but
+    // its digest must be recorded and compared.
+    submit_late_finalize(
+        &mut services[0],
+        &collectors[0],
+        session_identifier,
+        quorum_round,
+        output_bytes.clone(),
+    )
+    .await;
 
-    assert!(
-        sent_consensus_messages_collectors[0]
-            .submitted_messages
-            .lock()
-            .unwrap()
-            .is_empty(),
-        "a late finalize for a completed session must not submit anything to consensus"
-    );
     let manager = services[0].dwallet_mpc_manager();
     let session = manager.sessions.get(&session_identifier).unwrap();
-    assert_eq!(session.late_output_digest, Some(expected_digest));
-    assert_eq!(session.late_output_reported_malicious_count, Some(0));
+    let late_output = session.late_output.as_ref().expect("late output recorded");
+    assert_eq!(late_output.digest, expected_digest);
+    assert_eq!(late_output.reported_malicious_count, 0);
     let snapshot = session
         .last_anomaly_snapshot()
         .expect("the discard site emits a ComputationUpdateAfterSessionCompletion snapshot");
@@ -231,9 +253,7 @@ async fn late_reconfiguration_finalize_after_quorum_records_digest_without_submi
         .dwallet_mpc_manager_mut()
         .refresh_observability_metrics();
     let manager = services[0].dwallet_mpc_manager();
-    let protocol_name = DWalletSessionRequestMetricData::from(&request.protocol_data)
-        .name()
-        .to_owned();
+    let protocol_name = reconfiguration_protocol_name(&request);
     let session_id_label = hex::encode(session_identifier.as_ref());
     let authority_label = services[0].name.to_string();
     let digest_label = hex::encode(expected_digest);
@@ -271,78 +291,33 @@ async fn late_reconfiguration_finalize_after_quorum_records_digest_without_submi
 #[cfg(test)]
 async fn late_reconfiguration_finalize_with_divergent_bytes_is_flagged() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
-    let (services, _, sent_consensus_messages_collectors, _, _, _, _) =
-        utils::create_dwallet_mpc_services(4);
-    let mut services = services;
-    let authorities: Vec<AuthorityName> = services[0].committee.names().copied().collect();
     let session_identifier = SessionIdentifier::new(SessionType::System, [22; 32]);
-    let key_id = ObjectID::from_single_byte(9);
     let output_bytes = vec![7u8; 6_000];
+    let quorum_round = 6_002;
+    let (mut services, collectors, request) =
+        setup_quorum_completed_session(session_identifier, &output_bytes, quorum_round, true);
 
-    services[0].dwallet_mpc_manager_mut().handle_output(
-        6_000,
-        reconfiguration_report(authorities[1], session_identifier, key_id, &output_bytes),
-    );
-    let request = reconfiguration_request(session_identifier, key_id);
-    {
-        let session = services[0]
-            .dwallet_mpc_manager_mut()
-            .sessions
-            .get_mut(&session_identifier)
-            .unwrap();
-        session.set_request_diagnostic_metadata(&request);
-        session.set_protocol_name(
-            DWalletSessionRequestMetricData::from(&request.protocol_data)
-                .name()
-                .to_owned(),
-        );
-    }
-    let reports = authorities
-        .iter()
-        .skip(1)
-        .take(3)
-        .map(|authority| {
-            reconfiguration_report(*authority, session_identifier, key_id, &output_bytes)
-        })
-        .collect();
-    services[0]
-        .dwallet_mpc_manager_mut()
-        .handle_consensus_round_outputs(6_002, reports);
-
-    // The upgraded validator really computed different bytes.
+    // The upgraded validator really did compute different bytes.
     let mut divergent_bytes = output_bytes.clone();
     divergent_bytes[100] ^= 0xFF;
-    sent_consensus_messages_collectors[0]
-        .submitted_messages
-        .lock()
-        .unwrap()
-        .clear();
-    services[0]
-        .handle_computation_results_and_submit_to_consensus(HashMap::from([(
-            ComputationId {
-                session_identifier,
-                mpc_round: Some(3),
-                attempt_number: 1,
-                consensus_round: 6_002,
-            },
-            late_finalize(divergent_bytes.clone()),
-        )]))
-        .await;
+    submit_late_finalize(
+        &mut services[0],
+        &collectors[0],
+        session_identifier,
+        quorum_round,
+        divergent_bytes.clone(),
+    )
+    .await;
 
-    assert!(
-        sent_consensus_messages_collectors[0]
-            .submitted_messages
-            .lock()
-            .unwrap()
-            .is_empty(),
-        "even a divergent late output must never be submitted"
-    );
     let quorum_digest = raw_output_digest(&output_bytes);
     let divergent_digest = raw_output_digest(&divergent_bytes);
     assert_ne!(quorum_digest, divergent_digest);
     let manager = services[0].dwallet_mpc_manager();
     let session = manager.sessions.get(&session_identifier).unwrap();
-    assert_eq!(session.late_output_digest, Some(divergent_digest));
+    assert_eq!(
+        session.late_output.as_ref().map(|late| late.digest),
+        Some(divergent_digest)
+    );
     assert_eq!(session.quorum_raw_output_digest, Some(quorum_digest));
     let snapshot = session.last_anomaly_snapshot().unwrap();
     assert!(
@@ -366,15 +341,12 @@ async fn late_reconfiguration_finalize_with_divergent_bytes_is_flagged() {
         .dwallet_mpc_manager_mut()
         .refresh_observability_metrics();
     let manager = services[0].dwallet_mpc_manager();
-    let protocol_name = DWalletSessionRequestMetricData::from(&request.protocol_data)
-        .name()
-        .to_owned();
     assert_eq!(
         manager
             .dwallet_mpc_metrics
             .session_late_output_info
             .with_label_values(&[
-                &protocol_name,
+                &reconfiguration_protocol_name(&request),
                 &hex::encode(session_identifier.as_ref()),
                 &services[0].name.to_string(),
                 &hex::encode(divergent_digest),
@@ -385,66 +357,33 @@ async fn late_reconfiguration_finalize_with_divergent_bytes_is_flagged() {
     );
 }
 
-/// A late finalize for a NON-reconfiguration session must not record or
-/// export anything — the capture is deliberately scoped to the network-key
-/// reconfiguration compatibility boundary to keep the per-session metric
-/// cardinality bounded.
+/// A late finalize for a session whose reconfiguration request was never
+/// observed must not record or export anything — the capture is deliberately
+/// scoped to the network-key reconfiguration compatibility boundary to keep
+/// the per-session metric cardinality bounded.
 #[tokio::test]
 #[cfg(test)]
 async fn late_finalize_for_non_reconfiguration_session_records_nothing() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
-    let (services, _, sent_consensus_messages_collectors, _, _, _, _) =
-        utils::create_dwallet_mpc_services(4);
-    let mut services = services;
-    let authorities: Vec<AuthorityName> = services[0].committee.names().copied().collect();
     let session_identifier = SessionIdentifier::new(SessionType::System, [23; 32]);
-    let key_id = ObjectID::from_single_byte(9);
     let output_bytes = vec![5u8; 64];
+    let quorum_round = 7_002;
+    let (mut services, collectors, _) =
+        setup_quorum_completed_session(session_identifier, &output_bytes, quorum_round, false);
 
-    // Quorum completes the session, but its request metadata was never
-    // observed — `network_key_reconfiguration` stays false, like any user
-    // protocol session would.
-    let reports = authorities
-        .iter()
-        .skip(1)
-        .take(3)
-        .map(|authority| {
-            reconfiguration_report(*authority, session_identifier, key_id, &output_bytes)
-        })
-        .collect();
-    services[0]
-        .dwallet_mpc_manager_mut()
-        .handle_consensus_round_outputs(7_002, reports);
-
-    sent_consensus_messages_collectors[0]
-        .submitted_messages
-        .lock()
-        .unwrap()
-        .clear();
-    services[0]
-        .handle_computation_results_and_submit_to_consensus(HashMap::from([(
-            ComputationId {
-                session_identifier,
-                mpc_round: Some(3),
-                attempt_number: 1,
-                consensus_round: 7_002,
-            },
-            late_finalize(output_bytes),
-        )]))
-        .await;
+    submit_late_finalize(
+        &mut services[0],
+        &collectors[0],
+        session_identifier,
+        quorum_round,
+        output_bytes,
+    )
+    .await;
 
     let session = services[0]
         .dwallet_mpc_manager()
         .sessions
         .get(&session_identifier)
         .unwrap();
-    assert!(session.late_output_digest.is_none());
-    assert!(session.late_output_reported_malicious_count.is_none());
-    assert!(
-        sent_consensus_messages_collectors[0]
-            .submitted_messages
-            .lock()
-            .unwrap()
-            .is_empty()
-    );
+    assert!(session.late_output.is_none());
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/late_reconfiguration_output.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/late_reconfiguration_output.rs
@@ -1,0 +1,450 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Regression tests for the honest-straggler ordering that made the literal
+//! v1.1.8 mixed-rollout release gate nondeterministic:
+//!
+//! 1. three old authorities finalize a network-key reconfiguration with
+//!    identical outputs;
+//! 2. this validator is still computing;
+//! 3. the quorum closes the session (`complete_mpc_session`);
+//! 4. this validator's computation returns `Finalize` shortly afterwards.
+//!
+//! Production correctly discards the late result without submitting it — but
+//! it must record the discarded output's raw-bytes digest next to the
+//! quorum-agreed output's raw-bytes digest, because that comparison is the
+//! only remaining byte-level compatibility evidence for this validator. These
+//! tests pin the whole discard-site contract: nothing is submitted, the
+//! session stays completed, the digests are recorded and exported, a matching
+//! digest is flagged as a match, and divergent bytes are flagged loudly.
+
+use crate::dwallet_mpc::crytographic_computation::ComputationId;
+use crate::dwallet_mpc::integration_tests::utils;
+use crate::dwallet_mpc::mpc_diagnostics::{
+    MpcAnomalyKind, SessionDiagnosticEvent, raw_output_digest,
+};
+use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionRequestMetricData};
+use crate::request_protocol_data::{NetworkEncryptionKeyReconfigurationData, ProtocolData};
+use ika_types::crypto::AuthorityName;
+use ika_types::message::{DWalletCheckpointMessageKind, MPCNetworkReconfigurationOutput};
+use ika_types::messages_dwallet_mpc::{
+    DWalletMPCOutput, DWalletMPCOutputReport, SessionIdentifier, SessionType,
+};
+use ika_types::noa_checkpoint::CounterpartyChainKind;
+use mpc::GuaranteedOutputDeliveryRoundResult;
+use std::collections::HashMap;
+use sui_types::base_types::ObjectID;
+
+/// A submitted network-key reconfiguration output report, chunked exactly the
+/// way production slices one output's bytes across checkpoint message kinds
+/// (`slice_public_output_into_messages` — in-order 5 KB chunks), so the
+/// raw-bytes digest of the reassembled envelope must equal the digest of the
+/// unsliced bytes.
+fn reconfiguration_report(
+    authority: AuthorityName,
+    session_identifier: SessionIdentifier,
+    key_id: ObjectID,
+    output_bytes: &[u8],
+) -> DWalletMPCOutputReport {
+    let chunks: Vec<&[u8]> = output_bytes.chunks(5 * 1024).collect();
+    let chunk_count = chunks.len();
+    let output = chunks
+        .into_iter()
+        .enumerate()
+        .map(|(index, chunk)| {
+            DWalletCheckpointMessageKind::RespondDWalletMPCNetworkReconfigurationOutput(
+                MPCNetworkReconfigurationOutput {
+                    dwallet_network_encryption_key_id: key_id.to_vec(),
+                    public_output: chunk.to_vec(),
+                    supported_curves: vec![],
+                    is_last: index == chunk_count - 1,
+                    rejected: false,
+                    session_sequence_number: 3,
+                },
+            )
+        })
+        .collect();
+    DWalletMPCOutputReport::External(DWalletMPCOutput {
+        authority,
+        session_identifier,
+        output,
+        malicious_authorities: vec![],
+    })
+}
+
+fn reconfiguration_request(
+    session_identifier: SessionIdentifier,
+    key_id: ObjectID,
+) -> DWalletSessionRequest {
+    DWalletSessionRequest {
+        counterparty_chain: Some(CounterpartyChainKind::Sui),
+        session_type: SessionType::System,
+        session_identifier,
+        session_sequence_number: Some(3),
+        protocol_data: ProtocolData::NetworkEncryptionKeyReconfiguration {
+            data: NetworkEncryptionKeyReconfigurationData {},
+            dwallet_network_encryption_key_id: key_id,
+        },
+        epoch: 1,
+        requires_network_key_data: true,
+        requires_next_active_committee: true,
+        pulled: false,
+    }
+}
+
+fn late_finalize(
+    output_bytes: Vec<u8>,
+) -> Result<GuaranteedOutputDeliveryRoundResult, ika_types::dwallet_mpc_error::DwalletMPCError> {
+    Ok(GuaranteedOutputDeliveryRoundResult::Finalize {
+        malicious_parties: vec![],
+        private_output: vec![],
+        public_output_value: output_bytes,
+    })
+}
+
+#[tokio::test]
+#[cfg(test)]
+async fn late_reconfiguration_finalize_after_quorum_records_digest_without_submitting() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (services, _, sent_consensus_messages_collectors, _, _, _, _) =
+        utils::create_dwallet_mpc_services(4);
+    let mut services = services;
+    let authorities: Vec<AuthorityName> = services[0].committee.names().copied().collect();
+    let session_identifier = SessionIdentifier::new(SessionType::System, [21; 32]);
+    let key_id = ObjectID::from_single_byte(9);
+    // Multiple chunks (>5 KB) so the quorum-side digest exercises in-order
+    // chunk reassembly, not just the single-chunk case.
+    let output_bytes: Vec<u8> = (0..12_000u32).map(|byte| (byte % 251) as u8).collect();
+
+    // The session request was observed earlier in the epoch — production
+    // stamps the reconfiguration metadata off it when the session is created.
+    // One below-quorum output creates the session entry; the metadata call is
+    // the same one the real request-arrival path performs.
+    services[0].dwallet_mpc_manager_mut().handle_output(
+        5_900,
+        reconfiguration_report(authorities[1], session_identifier, key_id, &output_bytes),
+    );
+    let request = reconfiguration_request(session_identifier, key_id);
+    {
+        let session = services[0]
+            .dwallet_mpc_manager_mut()
+            .sessions
+            .get_mut(&session_identifier)
+            .expect("session exists after the first output");
+        session.set_request_diagnostic_metadata(&request);
+        session.set_protocol_name(
+            DWalletSessionRequestMetricData::from(&request.protocol_data)
+                .name()
+                .to_owned(),
+        );
+    }
+
+    // Three old authorities finalize with identical outputs; the quorum
+    // closes the session while this validator is still computing.
+    let reports = authorities
+        .iter()
+        .skip(1)
+        .take(3)
+        .map(|authority| {
+            reconfiguration_report(*authority, session_identifier, key_id, &output_bytes)
+        })
+        .collect();
+    let (_, completed) = services[0]
+        .dwallet_mpc_manager_mut()
+        .handle_consensus_round_outputs(5_902, reports);
+    assert_eq!(completed, vec![session_identifier]);
+
+    let expected_digest = raw_output_digest(&output_bytes);
+    {
+        let session = services[0]
+            .dwallet_mpc_manager()
+            .sessions
+            .get(&session_identifier)
+            .unwrap();
+        assert_eq!(
+            session.quorum_raw_output_digest,
+            Some(expected_digest),
+            "quorum completion must stash the winning output's raw-bytes digest \
+             (reassembled from the in-order chunks) before the session goes non-active"
+        );
+        assert!(session.late_output_digest.is_none());
+    }
+
+    // ~195ms later: the local computation returns `Finalize` with the SAME
+    // bytes the quorum agreed on. The session is non-active, so the result is
+    // discarded — but its digest must be recorded and compared.
+    sent_consensus_messages_collectors[0]
+        .submitted_messages
+        .lock()
+        .unwrap()
+        .clear();
+    services[0]
+        .handle_computation_results_and_submit_to_consensus(HashMap::from([(
+            ComputationId {
+                session_identifier,
+                mpc_round: Some(3),
+                attempt_number: 1,
+                consensus_round: 5_902,
+            },
+            late_finalize(output_bytes.clone()),
+        )]))
+        .await;
+
+    assert!(
+        sent_consensus_messages_collectors[0]
+            .submitted_messages
+            .lock()
+            .unwrap()
+            .is_empty(),
+        "a late finalize for a completed session must not submit anything to consensus"
+    );
+    let manager = services[0].dwallet_mpc_manager();
+    let session = manager.sessions.get(&session_identifier).unwrap();
+    assert_eq!(session.late_output_digest, Some(expected_digest));
+    assert_eq!(session.late_output_reported_malicious_count, Some(0));
+    let snapshot = session
+        .last_anomaly_snapshot()
+        .expect("the discard site emits a ComputationUpdateAfterSessionCompletion snapshot");
+    assert_eq!(
+        snapshot.anomaly_kind,
+        MpcAnomalyKind::ComputationUpdateAfterSessionCompletion
+    );
+    assert!(
+        snapshot
+            .trigger_conditions
+            .contains(&"late_network_key_output_matched_quorum"),
+        "matching bytes must be flagged as a match: {:?}",
+        snapshot.trigger_conditions
+    );
+    assert!(snapshot.recent_trace.iter().any(|event| matches!(
+        event,
+        SessionDiagnosticEvent::LateOutputAfterCompletion {
+            matches_quorum: Some(true),
+            reported_malicious_count: 0,
+            ..
+        }
+    )));
+
+    // The digest pair must be scrapeable: this is what lets the release-gate
+    // harness accept the boundary as conclusive compatibility evidence.
+    services[0]
+        .dwallet_mpc_manager_mut()
+        .refresh_observability_metrics();
+    let manager = services[0].dwallet_mpc_manager();
+    let protocol_name = DWalletSessionRequestMetricData::from(&request.protocol_data)
+        .name()
+        .to_owned();
+    let session_id_label = hex::encode(session_identifier.as_ref());
+    let authority_label = services[0].name.to_string();
+    let digest_label = hex::encode(expected_digest);
+    assert_eq!(
+        manager
+            .dwallet_mpc_metrics
+            .session_late_output_info
+            .with_label_values(&[
+                &protocol_name,
+                &session_id_label,
+                &authority_label,
+                &digest_label,
+                &digest_label,
+            ])
+            .get(),
+        1,
+        "the late/quorum raw-digest pair must be exported for the compatibility harness"
+    );
+    assert_eq!(
+        manager
+            .dwallet_mpc_metrics
+            .session_late_output_malicious_actors
+            .with_label_values(&[&protocol_name, &session_id_label, &authority_label])
+            .get(),
+        0
+    );
+}
+
+/// Fault injection for the digest comparison itself: identical ordering, but
+/// the late computation returns DIFFERENT bytes. The discard site must flag
+/// the divergence (trigger + trace + exported digest pair with unequal
+/// labels) while still submitting nothing — the release-gate harness turns
+/// that unequal exported pair into a hard failure.
+#[tokio::test]
+#[cfg(test)]
+async fn late_reconfiguration_finalize_with_divergent_bytes_is_flagged() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (services, _, sent_consensus_messages_collectors, _, _, _, _) =
+        utils::create_dwallet_mpc_services(4);
+    let mut services = services;
+    let authorities: Vec<AuthorityName> = services[0].committee.names().copied().collect();
+    let session_identifier = SessionIdentifier::new(SessionType::System, [22; 32]);
+    let key_id = ObjectID::from_single_byte(9);
+    let output_bytes = vec![7u8; 6_000];
+
+    services[0].dwallet_mpc_manager_mut().handle_output(
+        6_000,
+        reconfiguration_report(authorities[1], session_identifier, key_id, &output_bytes),
+    );
+    let request = reconfiguration_request(session_identifier, key_id);
+    {
+        let session = services[0]
+            .dwallet_mpc_manager_mut()
+            .sessions
+            .get_mut(&session_identifier)
+            .unwrap();
+        session.set_request_diagnostic_metadata(&request);
+        session.set_protocol_name(
+            DWalletSessionRequestMetricData::from(&request.protocol_data)
+                .name()
+                .to_owned(),
+        );
+    }
+    let reports = authorities
+        .iter()
+        .skip(1)
+        .take(3)
+        .map(|authority| {
+            reconfiguration_report(*authority, session_identifier, key_id, &output_bytes)
+        })
+        .collect();
+    services[0]
+        .dwallet_mpc_manager_mut()
+        .handle_consensus_round_outputs(6_002, reports);
+
+    // The upgraded validator really computed different bytes.
+    let mut divergent_bytes = output_bytes.clone();
+    divergent_bytes[100] ^= 0xFF;
+    sent_consensus_messages_collectors[0]
+        .submitted_messages
+        .lock()
+        .unwrap()
+        .clear();
+    services[0]
+        .handle_computation_results_and_submit_to_consensus(HashMap::from([(
+            ComputationId {
+                session_identifier,
+                mpc_round: Some(3),
+                attempt_number: 1,
+                consensus_round: 6_002,
+            },
+            late_finalize(divergent_bytes.clone()),
+        )]))
+        .await;
+
+    assert!(
+        sent_consensus_messages_collectors[0]
+            .submitted_messages
+            .lock()
+            .unwrap()
+            .is_empty(),
+        "even a divergent late output must never be submitted"
+    );
+    let quorum_digest = raw_output_digest(&output_bytes);
+    let divergent_digest = raw_output_digest(&divergent_bytes);
+    assert_ne!(quorum_digest, divergent_digest);
+    let manager = services[0].dwallet_mpc_manager();
+    let session = manager.sessions.get(&session_identifier).unwrap();
+    assert_eq!(session.late_output_digest, Some(divergent_digest));
+    assert_eq!(session.quorum_raw_output_digest, Some(quorum_digest));
+    let snapshot = session.last_anomaly_snapshot().unwrap();
+    assert!(
+        snapshot
+            .trigger_conditions
+            .contains(&"late_network_key_output_diverged_from_quorum"),
+        "divergent bytes must be flagged: {:?}",
+        snapshot.trigger_conditions
+    );
+    assert!(snapshot.recent_trace.iter().any(|event| matches!(
+        event,
+        SessionDiagnosticEvent::LateOutputAfterCompletion {
+            matches_quorum: Some(false),
+            ..
+        }
+    )));
+
+    // The exported pair carries UNEQUAL digest labels — the harness-side
+    // classification fails hard on exactly this shape.
+    services[0]
+        .dwallet_mpc_manager_mut()
+        .refresh_observability_metrics();
+    let manager = services[0].dwallet_mpc_manager();
+    let protocol_name = DWalletSessionRequestMetricData::from(&request.protocol_data)
+        .name()
+        .to_owned();
+    assert_eq!(
+        manager
+            .dwallet_mpc_metrics
+            .session_late_output_info
+            .with_label_values(&[
+                &protocol_name,
+                &hex::encode(session_identifier.as_ref()),
+                &services[0].name.to_string(),
+                &hex::encode(divergent_digest),
+                &hex::encode(quorum_digest),
+            ])
+            .get(),
+        1
+    );
+}
+
+/// A late finalize for a NON-reconfiguration session must not record or
+/// export anything — the capture is deliberately scoped to the network-key
+/// reconfiguration compatibility boundary to keep the per-session metric
+/// cardinality bounded.
+#[tokio::test]
+#[cfg(test)]
+async fn late_finalize_for_non_reconfiguration_session_records_nothing() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (services, _, sent_consensus_messages_collectors, _, _, _, _) =
+        utils::create_dwallet_mpc_services(4);
+    let mut services = services;
+    let authorities: Vec<AuthorityName> = services[0].committee.names().copied().collect();
+    let session_identifier = SessionIdentifier::new(SessionType::System, [23; 32]);
+    let key_id = ObjectID::from_single_byte(9);
+    let output_bytes = vec![5u8; 64];
+
+    // Quorum completes the session, but its request metadata was never
+    // observed — `network_key_reconfiguration` stays false, like any user
+    // protocol session would.
+    let reports = authorities
+        .iter()
+        .skip(1)
+        .take(3)
+        .map(|authority| {
+            reconfiguration_report(*authority, session_identifier, key_id, &output_bytes)
+        })
+        .collect();
+    services[0]
+        .dwallet_mpc_manager_mut()
+        .handle_consensus_round_outputs(7_002, reports);
+
+    sent_consensus_messages_collectors[0]
+        .submitted_messages
+        .lock()
+        .unwrap()
+        .clear();
+    services[0]
+        .handle_computation_results_and_submit_to_consensus(HashMap::from([(
+            ComputationId {
+                session_identifier,
+                mpc_round: Some(3),
+                attempt_number: 1,
+                consensus_round: 7_002,
+            },
+            late_finalize(output_bytes),
+        )]))
+        .await;
+
+    let session = services[0]
+        .dwallet_mpc_manager()
+        .sessions
+        .get(&session_identifier)
+        .unwrap();
+    assert!(session.late_output_digest.is_none());
+    assert!(session.late_output_reported_malicious_count.is_none());
+    assert!(
+        sent_consensus_messages_collectors[0]
+            .submitted_messages
+            .lock()
+            .unwrap()
+            .is_empty()
+    );
+}

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
@@ -4,6 +4,7 @@ mod create_dwallet;
 mod encrypt_secret_share;
 mod idle_status_voting;
 mod internal_presign;
+mod late_reconfiguration_output;
 mod malicious_behavior;
 mod message_before_event;
 mod missing_network_key;

--- a/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
@@ -12,6 +12,7 @@ use fastcrypto::hash::HashFunction;
 use group::PartyID;
 use ika_types::crypto::{AuthorityName, DefaultHash};
 use ika_types::dwallet_mpc_error::DwalletMPCError;
+use ika_types::message::DWalletCheckpointMessageKind;
 use ika_types::messages_dwallet_mpc::{DWalletMPCOutputKind, SessionType};
 use serde::{Serialize, Serializer};
 use std::backtrace::{Backtrace, BacktraceStatus};
@@ -32,6 +33,42 @@ pub(crate) fn output_digest(output: &DWalletMPCOutputKind) -> Option<[u8; 32]> {
     bcs::to_bytes(output)
         .ok()
         .map(|bytes| DefaultHash::digest(&bytes).into())
+}
+
+/// Digest of raw output bytes as produced by a local computation
+/// (`GuaranteedOutputDeliveryRoundResult::Finalize::public_output_value`),
+/// before any consensus envelope is built around them. Comparable only with
+/// [`network_key_reconfiguration_raw_output_digest`] — deliberately NOT with
+/// [`output_digest`], which hashes the `DWalletMPCOutputKind` envelope.
+pub(crate) fn raw_output_digest(output: &[u8]) -> [u8; 32] {
+    DefaultHash::digest(output).into()
+}
+
+/// Digest of the raw network-key reconfiguration output bytes carried by a
+/// quorum-agreed output envelope. Non-rejected reconfiguration chunks are
+/// hashed in envelope order; chunking (`slice_public_output_into_messages`)
+/// splits one output's bytes in order, so this equals
+/// [`raw_output_digest`] of the original unsliced output. Returns `None` for
+/// envelopes carrying no non-rejected network-key reconfiguration chunk
+/// (other protocols, rejection envelopes, internal outputs).
+pub(crate) fn network_key_reconfiguration_raw_output_digest(
+    output: &DWalletMPCOutputKind,
+) -> Option<[u8; 32]> {
+    let DWalletMPCOutputKind::External { output: kinds } = output else {
+        return None;
+    };
+    let mut hasher = DefaultHash::default();
+    let mut chunk_found = false;
+    for kind in kinds {
+        if let DWalletCheckpointMessageKind::RespondDWalletMPCNetworkReconfigurationOutput(chunk) =
+            kind
+            && !chunk.rejected
+        {
+            hasher.update(&chunk.public_output);
+            chunk_found = true;
+        }
+    }
+    chunk_found.then(|| hasher.finalize().into())
 }
 
 /// Digest the exact value voted on by `weighted_majority_vote`: public output
@@ -206,6 +243,19 @@ pub(crate) enum SessionDiagnosticEvent {
     },
     QuorumOutputCached {
         without_local_output: bool,
+    },
+    /// A local network-key reconfiguration computation returned `Finalize`
+    /// after the session had already completed via the peers' output quorum.
+    /// Production correctly discards the result without submitting it; this
+    /// event preserves the raw-output digest so the discarded bytes can still
+    /// be compared against the quorum-agreed output.
+    LateOutputAfterCompletion {
+        #[serde(serialize_with = "serialize_digest")]
+        output_digest: [u8; 32],
+        #[serde(serialize_with = "serialize_optional_digest")]
+        quorum_output_digest: Option<[u8; 32]>,
+        reported_malicious_count: usize,
+        matches_quorum: Option<bool>,
     },
 }
 
@@ -478,7 +528,60 @@ impl BoundedSessionDiagnostics {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ika_types::message::MPCNetworkReconfigurationOutput;
     use std::sync::Arc;
+
+    fn reconfiguration_chunk(
+        public_output: Vec<u8>,
+        rejected: bool,
+    ) -> DWalletCheckpointMessageKind {
+        DWalletCheckpointMessageKind::RespondDWalletMPCNetworkReconfigurationOutput(
+            MPCNetworkReconfigurationOutput {
+                dwallet_network_encryption_key_id: vec![9; 32],
+                public_output,
+                supported_curves: vec![],
+                is_last: false,
+                rejected,
+                session_sequence_number: 3,
+            },
+        )
+    }
+
+    /// The whole point of the raw-bytes digest domain: hashing the winning
+    /// envelope's in-order chunks must equal hashing the unsliced
+    /// `public_output_value` a local computation returns, or the late-output
+    /// comparison would report false divergence.
+    #[test]
+    fn chunked_reconfiguration_digest_equals_unsliced_raw_digest() {
+        let output_bytes: Vec<u8> = (0..12_000u32).map(|byte| (byte % 251) as u8).collect();
+        let envelope = DWalletMPCOutputKind::External {
+            output: output_bytes
+                .chunks(5 * 1024)
+                .map(|chunk| reconfiguration_chunk(chunk.to_vec(), false))
+                .collect(),
+        };
+
+        assert_eq!(
+            network_key_reconfiguration_raw_output_digest(&envelope),
+            Some(raw_output_digest(&output_bytes))
+        );
+    }
+
+    #[test]
+    fn rejected_chunks_and_foreign_envelopes_produce_no_digest() {
+        let rejected_only = DWalletMPCOutputKind::External {
+            output: vec![reconfiguration_chunk(vec![1, 2, 3], true)],
+        };
+        assert_eq!(
+            network_key_reconfiguration_raw_output_digest(&rejected_only),
+            None
+        );
+        let no_reconfiguration_chunks = DWalletMPCOutputKind::External { output: vec![] };
+        assert_eq!(
+            network_key_reconfiguration_raw_output_digest(&no_reconfiguration_chunks),
+            None
+        );
+    }
 
     #[test]
     fn trace_is_bounded_and_anomalies_are_deduplicated() {

--- a/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
@@ -57,18 +57,22 @@ pub(crate) fn network_key_reconfiguration_raw_output_digest(
     let DWalletMPCOutputKind::External { output: kinds } = output else {
         return None;
     };
-    let mut hasher = DefaultHash::default();
-    let mut chunk_found = false;
-    for kind in kinds {
-        if let DWalletCheckpointMessageKind::RespondDWalletMPCNetworkReconfigurationOutput(chunk) =
-            kind
-            && !chunk.rejected
-        {
-            hasher.update(&chunk.public_output);
-            chunk_found = true;
-        }
-    }
-    chunk_found.then(|| hasher.finalize().into())
+    let mut chunks =
+        kinds
+            .iter()
+            .filter_map(|kind| match kind {
+                DWalletCheckpointMessageKind::RespondDWalletMPCNetworkReconfigurationOutput(
+                    chunk,
+                ) if !chunk.rejected => Some(&chunk.public_output),
+                _ => None,
+            })
+            .peekable();
+    chunks.peek()?;
+    let hasher = chunks.fold(DefaultHash::default(), |mut hasher, chunk| {
+        hasher.update(chunk);
+        hasher
+    });
+    Some(hasher.finalize().into())
 }
 
 /// Digest the exact value voted on by `weighted_majority_vote`: public output

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -708,8 +708,12 @@ impl DWalletMPCManager {
                         // finishing after that point is discarded without
                         // submission, and this digest is the only way its
                         // bytes can still be compared against the agreed
-                        // output. Returns `None` for every other protocol.
+                        // output. Gated on the session's reconfiguration flag
+                        // (set at request arrival, which necessarily precedes
+                        // any local computation) so the envelope walk never
+                        // runs for the common sign/presign outputs.
                         if !rejected
+                            && session.network_key_reconfiguration
                             && let Some(raw_digest) =
                                 network_key_reconfiguration_raw_output_digest(&output_result)
                         {
@@ -4135,9 +4139,9 @@ impl DWalletMPCManager {
                     // scenario can still check byte-equality. Both digests
                     // are over raw output bytes — NOT comparable with the
                     // `output_digest` envelope labels above.
-                    if let Some(late_output_digest) = session.late_output_digest {
+                    if let Some(late_output) = &session.late_output {
                         let authority = self.validator_name.to_string();
-                        let late_output_digest = hex::encode(late_output_digest);
+                        let output_digest = hex::encode(late_output.digest);
                         let quorum_output_digest = session
                             .quorum_raw_output_digest
                             .map(hex::encode)
@@ -4148,14 +4152,14 @@ impl DWalletMPCManager {
                                 protocol_name,
                                 &session_id,
                                 &authority,
-                                &late_output_digest,
+                                &output_digest,
                                 &quorum_output_digest,
                             ])
                             .set(1);
                         metrics
                             .session_late_output_malicious_actors
                             .with_label_values(&[protocol_name, &session_id, &authority])
-                            .set(session.late_output_reported_malicious_count.unwrap_or(0) as i64);
+                            .set(late_output.reported_malicious_count as i64);
                     }
                 }
             }

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -15,6 +15,7 @@ use crate::dwallet_mpc::dwallet_mpc_metrics::{
 use crate::dwallet_mpc::mpc_diagnostics::{
     LocalAuthorityMaliciousReason, MPC_ANOMALY_SCHEMA_VERSION, MpcAnomalyContext, MpcAnomalyKind,
     OutputReportDiagnostic, OutputVoteDiagnostics, OutputVoteGroupDiagnostic, mpc_error_diagnostic,
+    network_key_reconfiguration_raw_output_digest,
 };
 use crate::dwallet_mpc::mpc_session::{
     AddOutputResult, DWalletMPCSessionOutput, DWalletSession, PublicInput, SessionComputationType,
@@ -700,6 +701,19 @@ impl DWalletMPCManager {
                             self.dwallet_mpc_metrics
                                 .self_output_to_quorum_consensus_rounds
                                 .observe(consensus_round.saturating_sub(self_output_round) as f64);
+                        }
+                        // Stash the winning network-key reconfiguration
+                        // output's raw-bytes digest before `complete_mpc_session`
+                        // makes the session non-active: a local computation
+                        // finishing after that point is discarded without
+                        // submission, and this digest is the only way its
+                        // bytes can still be compared against the agreed
+                        // output. Returns `None` for every other protocol.
+                        if !rejected
+                            && let Some(raw_digest) =
+                                network_key_reconfiguration_raw_output_digest(&output_result)
+                        {
+                            session.record_quorum_raw_output_digest(raw_digest);
                         }
                     }
                     // Recovery net: cache quorum-agreed network-key outputs
@@ -4112,6 +4126,36 @@ impl DWalletMPCManager {
                             .session_output_rejected
                             .with_label_values(&[protocol_name, &session_id, &authority])
                             .set(observation.rejected as i64);
+                    }
+                    // A locally computed output that returned after the
+                    // session completed via the peers' quorum is discarded
+                    // without submission, so it never appears in
+                    // `output_observations`. Export its raw-bytes digest next
+                    // to the quorum's raw-bytes digest so a compatibility
+                    // scenario can still check byte-equality. Both digests
+                    // are over raw output bytes — NOT comparable with the
+                    // `output_digest` envelope labels above.
+                    if let Some(late_output_digest) = session.late_output_digest {
+                        let authority = self.validator_name.to_string();
+                        let late_output_digest = hex::encode(late_output_digest);
+                        let quorum_output_digest = session
+                            .quorum_raw_output_digest
+                            .map(hex::encode)
+                            .unwrap_or_else(|| "unknown".to_string());
+                        metrics
+                            .session_late_output_info
+                            .with_label_values(&[
+                                protocol_name,
+                                &session_id,
+                                &authority,
+                                &late_output_digest,
+                                &quorum_output_digest,
+                            ])
+                            .set(1);
+                        metrics
+                            .session_late_output_malicious_actors
+                            .with_label_values(&[protocol_name, &session_id, &authority])
+                            .set(session.late_output_reported_malicious_count.unwrap_or(0) as i64);
                     }
                 }
             }

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -174,14 +174,22 @@ pub(crate) struct DWalletSession {
     /// compared against the agreed bytes. `None` for other protocols.
     pub(super) quorum_raw_output_digest: Option<[u8; 32]>,
 
-    /// Raw-output-bytes digest of a locally computed network-key
-    /// reconfiguration output that returned after the session left `Active`
-    /// and was therefore discarded without submission. Observability only —
-    /// recording it never publishes the output or re-activates the session.
-    pub(super) late_output_digest: Option<[u8; 32]>,
-    pub(super) late_output_reported_malicious_count: Option<usize>,
+    /// A locally computed network-key reconfiguration output that returned
+    /// after the session left `Active` and was therefore discarded without
+    /// submission. Observability only — recording it never publishes the
+    /// output or re-activates the session.
+    pub(super) late_output: Option<LateLocalOutput>,
     #[cfg(test)]
     last_anomaly_snapshot: Option<MpcAnomalySnapshot>,
+}
+
+/// Raw-bytes digest and malicious report of a discarded late local
+/// computation result; one struct so the digest can never exist without its
+/// malicious count.
+#[derive(Clone, Copy)]
+pub(crate) struct LateLocalOutput {
+    pub(crate) digest: [u8; 32],
+    pub(crate) reported_malicious_count: usize,
 }
 
 /// Possible statuses of a session:
@@ -306,8 +314,7 @@ impl DWalletSession {
             local_output_submission_round: None,
             local_output_digest: None,
             quorum_raw_output_digest: None,
-            late_output_digest: None,
-            late_output_reported_malicious_count: None,
+            late_output: None,
             #[cfg(test)]
             last_anomaly_snapshot: None,
         };
@@ -778,9 +785,11 @@ impl DWalletSession {
     /// Record a locally computed output that returned after this session left
     /// `Active` and was discarded without submission. Returns whether the
     /// discarded bytes match the quorum-agreed output (`None` when no quorum
-    /// digest was recorded to compare against). Last write wins so a retried
-    /// computation attempt updates the comparison; every attempt is preserved
-    /// in the diagnostics trace.
+    /// digest was recorded to compare against). The field holds the latest
+    /// attempt, but every attempt stays visible: each is preserved in the
+    /// diagnostics trace, and superseded metric children survive until the
+    /// per-epoch reset — the release-gate harness fails closed if attempts
+    /// ever disagree on the computed bytes.
     pub(crate) fn record_late_output(
         &mut self,
         output_digest: [u8; 32],
@@ -789,8 +798,10 @@ impl DWalletSession {
         let matches_quorum = self
             .quorum_raw_output_digest
             .map(|quorum_digest| quorum_digest == output_digest);
-        self.late_output_digest = Some(output_digest);
-        self.late_output_reported_malicious_count = Some(reported_malicious_count);
+        self.late_output = Some(LateLocalOutput {
+            digest: output_digest,
+            reported_malicious_count,
+        });
         self.diagnostics
             .record(SessionDiagnosticEvent::LateOutputAfterCompletion {
                 output_digest,

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -166,6 +166,20 @@ pub(crate) struct DWalletSession {
     pub(super) local_output_submission_succeeded: Option<bool>,
     pub(super) local_output_submission_round: Option<u64>,
     pub(super) local_output_digest: Option<[u8; 32]>,
+
+    /// Raw-output-bytes digest of the quorum-agreed network-key
+    /// reconfiguration output (`mpc_diagnostics::raw_output_digest` domain,
+    /// not the `output_digest` envelope domain). Recorded at quorum so a
+    /// local computation finishing after the session completed can still be
+    /// compared against the agreed bytes. `None` for other protocols.
+    pub(super) quorum_raw_output_digest: Option<[u8; 32]>,
+
+    /// Raw-output-bytes digest of a locally computed network-key
+    /// reconfiguration output that returned after the session left `Active`
+    /// and was therefore discarded without submission. Observability only —
+    /// recording it never publishes the output or re-activates the session.
+    pub(super) late_output_digest: Option<[u8; 32]>,
+    pub(super) late_output_reported_malicious_count: Option<usize>,
     #[cfg(test)]
     last_anomaly_snapshot: Option<MpcAnomalySnapshot>,
 }
@@ -291,6 +305,9 @@ impl DWalletSession {
             local_output_submission_succeeded: None,
             local_output_submission_round: None,
             local_output_digest: None,
+            quorum_raw_output_digest: None,
+            late_output_digest: None,
+            late_output_reported_malicious_count: None,
             #[cfg(test)]
             last_anomaly_snapshot: None,
         };
@@ -749,6 +766,39 @@ impl DWalletSession {
             .record(SessionDiagnosticEvent::QuorumOutputCached {
                 without_local_output: self.self_output_consensus_round.is_none(),
             });
+    }
+
+    /// Stash the raw-output-bytes digest of the quorum-agreed network-key
+    /// reconfiguration output. First quorum wins, matching
+    /// `quorum_consensus_round` semantics.
+    pub(crate) fn record_quorum_raw_output_digest(&mut self, digest: [u8; 32]) {
+        self.quorum_raw_output_digest.get_or_insert(digest);
+    }
+
+    /// Record a locally computed output that returned after this session left
+    /// `Active` and was discarded without submission. Returns whether the
+    /// discarded bytes match the quorum-agreed output (`None` when no quorum
+    /// digest was recorded to compare against). Last write wins so a retried
+    /// computation attempt updates the comparison; every attempt is preserved
+    /// in the diagnostics trace.
+    pub(crate) fn record_late_output(
+        &mut self,
+        output_digest: [u8; 32],
+        reported_malicious_count: usize,
+    ) -> Option<bool> {
+        let matches_quorum = self
+            .quorum_raw_output_digest
+            .map(|quorum_digest| quorum_digest == output_digest);
+        self.late_output_digest = Some(output_digest);
+        self.late_output_reported_malicious_count = Some(reported_malicious_count);
+        self.diagnostics
+            .record(SessionDiagnosticEvent::LateOutputAfterCompletion {
+                output_digest,
+                quorum_output_digest: self.quorum_raw_output_digest,
+                reported_malicious_count,
+                matches_quorum,
+            });
+        matches_quorum
     }
 
     pub(crate) fn anomaly_snapshot(

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -687,23 +687,31 @@ enum NetworkKeyOutputConvergence {
     },
 }
 
-/// Whether one `expect_network_key_output_converged` boundary produced
-/// byte-level cross-version compatibility evidence for the validator(s)
-/// under test.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum NetworkKeyCompatibilityEvidence {
-    /// Every validator under test either submitted an output inside the
-    /// converged quorum or recorded a discarded late computation whose raw
-    /// output bytes match the quorum-agreed output.
-    Conclusive,
-    /// The quorum converged cleanly (correct committee, single digest, zero
-    /// malicious, zero rejected) but at least one validator under test
-    /// provided no comparable output within the window — the legitimate
-    /// straggler case: production finalizes at a Byzantine quorum and
-    /// discards a computation finishing afterwards. Not a failure of this
-    /// boundary, but it proves nothing about output compatibility, so the
-    /// scenario requires another boundary to be conclusive.
-    Inconclusive { reason: String },
+/// Per-authority byte-equality evidence from one
+/// `expect_network_key_output_converged` boundary. Tracked per validator
+/// under test (not as a boundary-wide verdict) so a scenario whose observer
+/// set changes across boundaries can still require that EVERY validator
+/// under test demonstrated byte-equality somewhere.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct NetworkKeyBoundaryEvidence {
+    /// Validators under test that demonstrated byte-equality at this
+    /// boundary: a submitted output inside the converged quorum, or a
+    /// discarded late computation whose raw output bytes match the
+    /// quorum-agreed output.
+    pub evidenced_authorities: BTreeSet<String>,
+    /// Validators under test with no comparable output at this boundary,
+    /// with the sessions/reasons. Legitimate per boundary — production
+    /// finalizes at a Byzantine quorum and discards a computation finishing
+    /// afterwards — but it proves nothing about output compatibility, so
+    /// the scenario requires each such validator to be evidenced at some
+    /// other boundary.
+    pub unevidenced_authorities: BTreeMap<String, String>,
+}
+
+impl NetworkKeyBoundaryEvidence {
+    pub fn is_conclusive(&self) -> bool {
+        self.unevidenced_authorities.is_empty()
+    }
 }
 
 fn canonical_network_key_outputs(
@@ -782,7 +790,13 @@ fn canonical_network_key_outputs(
         NETWORK_KEY_RECONFIGURATION_PROTOCOL,
     )?;
     let late_malicious = envelope_values("ika_dwallet_mpc_session_late_output_malicious_actors")?;
-    let mut late_outputs: BTreeMap<(String, String), (String, String)> = BTreeMap::new();
+    // Accumulated per (session, authority): the locally computed digest all
+    // samples must agree on, and whether any sample carries a known (and,
+    // enforced below, equal) quorum digest. Superseded gauge children survive
+    // in the registry until the epoch reset, so one key can legitimately
+    // expose an early `unknown`-quorum pair next to the later compared pair —
+    // samples only conflict when their locally computed digests differ.
+    let mut late_outputs: BTreeMap<(String, String), (String, bool)> = BTreeMap::new();
     for sample in late_samples {
         ensure!(
             sample.value == 1.0,
@@ -823,15 +837,14 @@ fn canonical_network_key_outputs(
                 "{observer}: authority {authority}'s late network-key output for session {session} reported {count} malicious actors"
             ),
         }
+        let (recorded_output_digest, matched_quorum) = late_outputs
+            .entry((session.clone(), authority.clone()))
+            .or_insert_with(|| (output_digest.clone(), false));
         ensure!(
-            late_outputs
-                .insert(
-                    (session.clone(), authority.clone()),
-                    (output_digest, quorum_output_digest),
-                )
-                .is_none(),
-            "{observer} has conflicting late-output samples for session {session} authority {authority}"
+            *recorded_output_digest == output_digest,
+            "{observer} has conflicting late-output samples for session {session} authority {authority}: the validator computed {recorded_output_digest} and {output_digest} across attempts"
         );
+        *matched_quorum |= quorum_output_digest != "unknown";
     }
 
     let mut outputs_by_session: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
@@ -919,7 +932,7 @@ fn canonical_network_key_outputs(
                 // Validated above: digest equals the quorum digest and the
                 // late malicious count is zero — byte-level evidence that the
                 // candidate computed the same output the quorum agreed on.
-                Some((_, quorum_output_digest)) if quorum_output_digest != "unknown" => {}
+                Some((_, matched_quorum)) if *matched_quorum => {}
                 Some(_) => sessions_without_candidate_evidence.push(format!(
                     "{session} (late output recorded without a quorum digest to compare against)"
                 )),
@@ -1282,7 +1295,7 @@ impl ClusterOfProcesses {
         &self,
         observer_indices: &[usize],
         timeout: Duration,
-    ) -> Result<NetworkKeyCompatibilityEvidence> {
+    ) -> Result<NetworkKeyBoundaryEvidence> {
         ensure!(
             !observer_indices.is_empty(),
             "no output-convergence observers supplied"
@@ -1303,14 +1316,24 @@ impl ClusterOfProcesses {
         // observed; success requires it to survive unchanged for the whole
         // stabilization window below.
         let mut stable: Option<(BTreeMap<String, String>, tokio::time::Instant)> = None;
+        // The last evidence observed AFTER the converged result already held
+        // through the full stabilization window. Once set, an epoch advance
+        // is normal scenario progress ending the observation window (the
+        // next epoch's metrics reset wipes these series), not a failure —
+        // return this evidence instead of racing the boundary.
+        let mut stabilized_evidence: Option<NetworkKeyBoundaryEvidence> = None;
         loop {
-            ensure!(
-                self.current_epoch().await? == expected_epoch,
-                "coordinator advanced beyond epoch {expected_epoch} before network-key output observations converged"
-            );
+            if self.current_epoch().await? != expected_epoch {
+                if let Some(evidence) = stabilized_evidence {
+                    return Ok(evidence);
+                }
+                bail!(
+                    "coordinator advanced beyond epoch {expected_epoch} before network-key output observations converged"
+                );
+            }
             let mut canonical_by_session: Option<BTreeMap<String, String>> = None;
             let mut incomplete = Vec::new();
-            let mut missing_candidate_evidence = Vec::new();
+            let mut evidence = NetworkKeyBoundaryEvidence::default();
             for index in observer_indices {
                 let validator = self
                     .validators
@@ -1349,11 +1372,20 @@ impl ClusterOfProcesses {
                         continue;
                     }
                 };
-                missing_candidate_evidence.extend(
-                    observer_missing
-                        .into_iter()
-                        .map(|session| format!("validator {}: session {session}", validator.index)),
-                );
+                if observer_missing.is_empty() {
+                    evidence
+                        .evidenced_authorities
+                        .insert(candidate_authority.clone());
+                } else {
+                    evidence.unevidenced_authorities.insert(
+                        candidate_authority.clone(),
+                        format!(
+                            "validator {}: {}",
+                            validator.index,
+                            observer_missing.join(", ")
+                        ),
+                    );
+                }
 
                 if let Some(expected) = &canonical_by_session {
                     ensure!(
@@ -1382,21 +1414,20 @@ impl ClusterOfProcesses {
                             "canonical network-key outputs changed during the stabilization window: first {expected:?}, now {canonical:?}"
                         );
                         if since.elapsed() >= NETWORK_KEY_OUTPUT_STABILIZATION {
-                            if missing_candidate_evidence.is_empty() {
-                                return Ok(NetworkKeyCompatibilityEvidence::Conclusive);
+                            if evidence.is_conclusive() {
+                                return Ok(evidence);
                             }
                             // Candidate evidence can still arrive — the
                             // straggler's computation may still be running
                             // and its discarded-output digest is recorded the
                             // moment it finishes. Keep polling (re-validating
                             // the converged result each scrape) until the
-                            // deadline before declaring the boundary
-                            // inconclusive.
+                            // deadline before returning the boundary with
+                            // unevidenced validators.
                             if tokio::time::Instant::now() >= deadline {
-                                return Ok(NetworkKeyCompatibilityEvidence::Inconclusive {
-                                    reason: missing_candidate_evidence.join("; "),
-                                });
+                                return Ok(evidence);
                             }
+                            stabilized_evidence = Some(evidence);
                         }
                     }
                     None => stable = Some((canonical, tokio::time::Instant::now())),
@@ -1404,8 +1435,10 @@ impl ClusterOfProcesses {
             } else {
                 // A fresh incomplete observation after convergence means a new
                 // network-key session surfaced; its outputs must converge and
-                // stabilize too.
+                // stabilize too — the previously stabilized evidence no longer
+                // covers the full session set.
                 stable = None;
+                stabilized_evidence = None;
                 if tokio::time::Instant::now() >= deadline {
                     bail!(
                         "network-key output observations did not become complete within {timeout:?}: {}",
@@ -2068,10 +2101,20 @@ mod tests {
         names.iter().map(|n| n.to_string()).collect()
     }
 
-    /// Late-computation evidence samples: the validator under test computed
-    /// its output after the quorum completed the session, production
-    /// discarded it, and exported the raw-bytes digest pair plus the
-    /// late-output malicious gauge.
+    /// One late-output info sample: the digest pair production exports when a
+    /// local computation returned after the quorum completed the session.
+    fn late_output_info_sample(
+        authority: &str,
+        output_digest: &str,
+        quorum_output_digest: &str,
+    ) -> String {
+        format!(
+            "ika_dwallet_mpc_session_late_output_info{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"{authority}\",output_digest=\"{output_digest}\",quorum_output_digest=\"{quorum_output_digest}\"}} 1\n"
+        )
+    }
+
+    /// Late-computation evidence samples: the info digest pair plus the
+    /// late-output malicious gauge (one series per session/authority).
     fn late_output_metrics(
         authority: &str,
         output_digest: &str,
@@ -2079,7 +2122,8 @@ mod tests {
         malicious: u64,
     ) -> String {
         format!(
-            "ika_dwallet_mpc_session_late_output_info{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"{authority}\",output_digest=\"{output_digest}\",quorum_output_digest=\"{quorum_output_digest}\"}} 1\nika_dwallet_mpc_session_late_output_malicious_actors{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"{authority}\"}} {malicious}\n"
+            "{}ika_dwallet_mpc_session_late_output_malicious_actors{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"{authority}\"}} {malicious}\n",
+            late_output_info_sample(authority, output_digest, quorum_output_digest)
         )
     }
 
@@ -2194,6 +2238,40 @@ mod tests {
         let error = canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0")
             .expect_err("a late output reporting malicious actors must fail closed");
         assert!(error.to_string().contains("2 malicious actors"));
+    }
+
+    #[test]
+    fn superseded_unknown_quorum_sample_next_to_compared_sample_is_conclusive() {
+        // A late output recorded before the quorum digest was stashed leaves
+        // a superseded `unknown`-quorum gauge child in the registry until the
+        // epoch reset; the later compared pair for the SAME locally computed
+        // bytes lands as a second child. That is one honest validator, not a
+        // conflict — evidence comes from the compared pair.
+        let committee = committee_of(&["a", "b", "c", "d"]);
+        let mut body = network_key_metrics(&[("b", "same"), ("c", "same"), ("d", "same")]);
+        body.push_str(&late_output_info_sample("a", "rawdigest", "unknown"));
+        body.push_str(&late_output_metrics("a", "rawdigest", "rawdigest", 0));
+        let NetworkKeyOutputConvergence::Converged {
+            sessions_without_candidate_evidence,
+            ..
+        } = canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0").unwrap()
+        else {
+            panic!("a superseded unknown-quorum child must not block convergence");
+        };
+        assert!(sessions_without_candidate_evidence.is_empty());
+    }
+
+    #[test]
+    fn late_samples_with_conflicting_local_digests_fail_closed() {
+        // Two attempts of the same computation produced DIFFERENT bytes —
+        // nondeterministic output is release-blocking however it surfaces.
+        let committee = committee_of(&["a", "b", "c", "d"]);
+        let mut body = network_key_metrics(&[("b", "same"), ("c", "same"), ("d", "same")]);
+        body.push_str(&late_output_info_sample("a", "firstdigest", "unknown"));
+        body.push_str(&late_output_metrics("a", "seconddigest", "seconddigest", 0));
+        let error = canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0")
+            .expect_err("cross-attempt output disagreement must fail closed");
+        assert!(error.to_string().contains("across attempts"));
     }
 
     #[test]

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -674,13 +674,42 @@ fn metric_samples_for_protocol(
 #[derive(Debug)]
 enum NetworkKeyOutputConvergence {
     Incomplete(String),
-    Converged(BTreeMap<String, String>),
+    Converged {
+        /// Canonical (converged) submitted-output digest per session.
+        canonical: BTreeMap<String, String>,
+        /// Sessions where the validator under test neither appeared in the
+        /// converged submitted-output set nor recorded matching
+        /// late-computation evidence. Quorum convergence alone cannot prove
+        /// this validator's cross-version compatibility, so the caller keeps
+        /// polling for evidence and, failing that, reports the boundary
+        /// inconclusive rather than passing it silently.
+        sessions_without_candidate_evidence: Vec<String>,
+    },
+}
+
+/// Whether one `expect_network_key_output_converged` boundary produced
+/// byte-level cross-version compatibility evidence for the validator(s)
+/// under test.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum NetworkKeyCompatibilityEvidence {
+    /// Every validator under test either submitted an output inside the
+    /// converged quorum or recorded a discarded late computation whose raw
+    /// output bytes match the quorum-agreed output.
+    Conclusive,
+    /// The quorum converged cleanly (correct committee, single digest, zero
+    /// malicious, zero rejected) but at least one validator under test
+    /// provided no comparable output within the window — the legitimate
+    /// straggler case: production finalizes at a Byzantine quorum and
+    /// discards a computation finishing afterwards. Not a failure of this
+    /// boundary, but it proves nothing about output compatibility, so the
+    /// scenario requires another boundary to be conclusive.
+    Inconclusive { reason: String },
 }
 
 fn canonical_network_key_outputs(
     body: &str,
     committee_authorities: &BTreeSet<String>,
-    required_authorities: &BTreeSet<String>,
+    candidate_authority: &str,
     quorum: usize,
     observer: &str,
 ) -> Result<NetworkKeyOutputConvergence> {
@@ -738,6 +767,73 @@ fn canonical_network_key_outputs(
         )));
     };
 
+    // Late-computation evidence: a local output the observer computed after
+    // the quorum already completed the session. Production discards it
+    // without submission and exports its raw-output-bytes digest next to the
+    // quorum output's raw-output-bytes digest. Both label values live in the
+    // raw-bytes domain — comparable with each other, deliberately NOT with
+    // the envelope `output_digest` labels parsed above. Every sample is
+    // validated fail-closed regardless of whether it ends up used as
+    // evidence: a divergent or malicious-reporting late output is
+    // release-blocking information wherever it appears.
+    let late_samples = metric_samples_for_protocol(
+        body,
+        "ika_dwallet_mpc_session_late_output_info",
+        NETWORK_KEY_RECONFIGURATION_PROTOCOL,
+    )?;
+    let late_malicious = envelope_values("ika_dwallet_mpc_session_late_output_malicious_actors")?;
+    let mut late_outputs: BTreeMap<(String, String), (String, String)> = BTreeMap::new();
+    for sample in late_samples {
+        ensure!(
+            sample.value == 1.0,
+            "{observer} late-output sample has value {}, expected 1",
+            sample.value
+        );
+        let label = |name: &str| -> Result<String> {
+            sample
+                .labels
+                .get(name)
+                .cloned()
+                .with_context(|| format!("late-output sample missing {name} label"))
+        };
+        let session = label("session_id")?;
+        let authority = label("authority")?;
+        let output_digest = label("output_digest")?;
+        let quorum_output_digest = label("quorum_output_digest")?;
+        if quorum_output_digest != "unknown" {
+            ensure!(
+                output_digest == quorum_output_digest,
+                "{observer}: authority {authority} computed a late network-key output for session {session} that DIVERGES from the quorum-agreed output: local raw-output digest {output_digest} vs quorum raw-output digest {quorum_output_digest}"
+            );
+        }
+        let malicious_count = late_malicious
+            .as_ref()
+            .and_then(|values| values.get(&(session.clone(), authority.clone())))
+            .copied();
+        match malicious_count {
+            // The info and malicious gauges are exported together; a scrape
+            // can only race the refresh, so retry rather than failing.
+            None => {
+                return Ok(NetworkKeyOutputConvergence::Incomplete(format!(
+                    "{observer} has a late-output sample for session {session} authority {authority} without its malicious-actor gauge yet"
+                )));
+            }
+            Some(0) => {}
+            Some(count) => bail!(
+                "{observer}: authority {authority}'s late network-key output for session {session} reported {count} malicious actors"
+            ),
+        }
+        ensure!(
+            late_outputs
+                .insert(
+                    (session.clone(), authority.clone()),
+                    (output_digest, quorum_output_digest),
+                )
+                .is_none(),
+            "{observer} has conflicting late-output samples for session {session} authority {authority}"
+        );
+    }
+
     let mut outputs_by_session: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
     for sample in output_samples {
         ensure!(
@@ -770,7 +866,13 @@ fn canonical_network_key_outputs(
         );
     }
 
+    ensure!(
+        committee_authorities.contains(candidate_authority),
+        "validator under test {candidate_authority} is not a committee member: {committee_authorities:?}"
+    );
+
     let mut canonical = BTreeMap::new();
+    let mut sessions_without_candidate_evidence = Vec::new();
     for (session, outputs) in outputs_by_session {
         let observed_authorities = outputs.keys().cloned().collect::<BTreeSet<_>>();
         // A validator submitting a network-key output for a session whose
@@ -779,19 +881,19 @@ fn canonical_network_key_outputs(
             observed_authorities.is_subset(committee_authorities),
             "{observer} observed out-of-committee authorities for network-key session {session}: observed={observed_authorities:?}, committee={committee_authorities:?}"
         );
-        // Reconfiguration finalizes at a Byzantine quorum and does not wait: a
-        // validator still computing when quorum forms marks its session
+        // Reconfiguration finalizes at a Byzantine quorum and does not wait:
+        // a validator still computing when quorum forms marks its session
         // complete (on seeing the quorum in consensus) and discards its own
-        // still-in-flight output, so an honest straggler legitimately never
-        // submits. Requiring the whole committee here would race that
-        // finalization. Require instead every validator under test (the
-        // upgraded observers) plus a finalizing quorum — enough to prove the
-        // upgraded node's output agrees with a quorum of peers.
-        if !required_authorities.is_subset(&observed_authorities)
-            || observed_authorities.len() < quorum
-        {
+        // still-in-flight output, so ANY honest validator — including the
+        // one under test — legitimately never submits. Completeness therefore
+        // requires only a finalizing quorum; the validator under test's
+        // byte-equality is tracked separately below, via its submitted
+        // output when present or its discarded late computation's digest
+        // otherwise, and the boundary is reported inconclusive (never
+        // silently passed, never failed) when neither exists.
+        if observed_authorities.len() < quorum {
             return Ok(NetworkKeyOutputConvergence::Incomplete(format!(
-                "{observer} has not yet observed a quorum including every validator under test for network-key session {session}: observed={observed_authorities:?}, required={required_authorities:?}, quorum={quorum}"
+                "{observer} has not yet observed a finalizing quorum for network-key session {session}: observed={observed_authorities:?}, quorum={quorum}"
             )));
         }
         let digests: BTreeSet<_> = outputs.values().cloned().collect();
@@ -812,6 +914,20 @@ fn canonical_network_key_outputs(
                 rejected.get(&key)
             );
         }
+        if !outputs.contains_key(candidate_authority) {
+            match late_outputs.get(&(session.clone(), candidate_authority.to_string())) {
+                // Validated above: digest equals the quorum digest and the
+                // late malicious count is zero — byte-level evidence that the
+                // candidate computed the same output the quorum agreed on.
+                Some((_, quorum_output_digest)) if quorum_output_digest != "unknown" => {}
+                Some(_) => sessions_without_candidate_evidence.push(format!(
+                    "{session} (late output recorded without a quorum digest to compare against)"
+                )),
+                None => sessions_without_candidate_evidence.push(format!(
+                    "{session} (no submitted output and no late-computation digest yet)"
+                )),
+            }
+        }
         canonical.insert(
             session,
             digests
@@ -820,7 +936,10 @@ fn canonical_network_key_outputs(
                 .expect("one digest after length check"),
         );
     }
-    Ok(NetworkKeyOutputConvergence::Converged(canonical))
+    Ok(NetworkKeyOutputConvergence::Converged {
+        canonical,
+        sessions_without_candidate_evidence,
+    })
 }
 
 impl ClusterOfProcesses {
@@ -1131,11 +1250,25 @@ impl ClusterOfProcesses {
         Ok(())
     }
 
-    /// Assert every authority submitted the same canonical network-key
-    /// reconfiguration output for every observed session. The current-binary
-    /// observer records individual consensus reports from all committee
-    /// members, including literal historical binaries; this catches a 3-vs-1
-    /// split even when the majority result lets the chain keep advancing.
+    /// Assert every authority that submitted a network-key reconfiguration
+    /// output submitted the same canonical bytes for every observed session.
+    /// The current-binary observer records individual consensus reports from
+    /// all committee members, including literal historical binaries; this
+    /// catches a 3-vs-1 split even when the majority result lets the chain
+    /// keep advancing.
+    ///
+    /// Completeness requires a finalizing quorum, not the whole committee:
+    /// production finalizes at a Byzantine quorum and discards a local
+    /// computation that finishes afterwards, so ANY honest validator —
+    /// including the one under test — can legitimately end a session with no
+    /// submitted output. The validator under test's byte-equality is
+    /// therefore evidenced either by its submitted output inside the
+    /// converged set, or by the raw-bytes digest production records when it
+    /// discards that validator's late `Finalize` result. When neither exists
+    /// by the deadline the boundary returns
+    /// [`NetworkKeyCompatibilityEvidence::Inconclusive`] — it neither fails
+    /// (the ordering is legitimate) nor counts as compatibility proof (the
+    /// scenario requires at least one conclusive boundary).
     ///
     /// The observation set is open when convergence is first reached:
     /// finalization happens at a Byzantine quorum, so a validator's output
@@ -1149,7 +1282,7 @@ impl ClusterOfProcesses {
         &self,
         observer_indices: &[usize],
         timeout: Duration,
-    ) -> Result<()> {
+    ) -> Result<NetworkKeyCompatibilityEvidence> {
         ensure!(
             !observer_indices.is_empty(),
             "no output-convergence observers supplied"
@@ -1177,6 +1310,7 @@ impl ClusterOfProcesses {
             );
             let mut canonical_by_session: Option<BTreeMap<String, String>> = None;
             let mut incomplete = Vec::new();
+            let mut missing_candidate_evidence = Vec::new();
             for index in observer_indices {
                 let validator = self
                     .validators
@@ -1189,33 +1323,37 @@ impl ClusterOfProcesses {
                     validator.metrics_endpoint()
                 );
                 // Each observer is a validator under test (the upgraded
-                // binary); require it to have observed its own output within a
-                // converged quorum. That is the compatibility signal — the
-                // upgraded node's reconfiguration output matching a quorum of
-                // v1.1.8 peers — without racing the straggler that finalization
-                // legitimately drops.
-                let required_authorities: BTreeSet<String> = std::iter::once(
-                    self.validator_authorities
-                        .get(*index)
-                        .with_context(|| format!("validator index {index} out of range"))?
-                        .to_string(),
-                )
-                .collect();
-                let observer_canonical = match canonical_network_key_outputs(
+                // binary); its own authority is the candidate whose
+                // byte-equality with the v1.1.8 quorum this boundary tries
+                // to witness.
+                let candidate_authority = self
+                    .validator_authorities
+                    .get(*index)
+                    .with_context(|| format!("validator index {index} out of range"))?
+                    .to_string();
+                let (observer_canonical, observer_missing) = match canonical_network_key_outputs(
                     &body,
                     &committee_authorities,
-                    &required_authorities,
+                    &candidate_authority,
                     quorum,
                     &observer,
                 )
                 .with_context(|| format!("validate network-key convergence from {observer}"))?
                 {
-                    NetworkKeyOutputConvergence::Converged(canonical) => canonical,
+                    NetworkKeyOutputConvergence::Converged {
+                        canonical,
+                        sessions_without_candidate_evidence,
+                    } => (canonical, sessions_without_candidate_evidence),
                     NetworkKeyOutputConvergence::Incomplete(reason) => {
                         incomplete.push(reason);
                         continue;
                     }
                 };
+                missing_candidate_evidence.extend(
+                    observer_missing
+                        .into_iter()
+                        .map(|session| format!("validator {}: session {session}", validator.index)),
+                );
 
                 if let Some(expected) = &canonical_by_session {
                     ensure!(
@@ -1244,7 +1382,21 @@ impl ClusterOfProcesses {
                             "canonical network-key outputs changed during the stabilization window: first {expected:?}, now {canonical:?}"
                         );
                         if since.elapsed() >= NETWORK_KEY_OUTPUT_STABILIZATION {
-                            return Ok(());
+                            if missing_candidate_evidence.is_empty() {
+                                return Ok(NetworkKeyCompatibilityEvidence::Conclusive);
+                            }
+                            // Candidate evidence can still arrive — the
+                            // straggler's computation may still be running
+                            // and its discarded-output digest is recorded the
+                            // moment it finishes. Keep polling (re-validating
+                            // the converged result each scrape) until the
+                            // deadline before declaring the boundary
+                            // inconclusive.
+                            if tokio::time::Instant::now() >= deadline {
+                                return Ok(NetworkKeyCompatibilityEvidence::Inconclusive {
+                                    reason: missing_candidate_evidence.join("; "),
+                                });
+                            }
                         }
                     }
                     None => stable = Some((canonical, tokio::time::Instant::now())),
@@ -1916,62 +2068,178 @@ mod tests {
         names.iter().map(|n| n.to_string()).collect()
     }
 
+    /// Late-computation evidence samples: the validator under test computed
+    /// its output after the quorum completed the session, production
+    /// discarded it, and exported the raw-bytes digest pair plus the
+    /// late-output malicious gauge.
+    fn late_output_metrics(
+        authority: &str,
+        output_digest: &str,
+        quorum_output_digest: &str,
+        malicious: u64,
+    ) -> String {
+        format!(
+            "ika_dwallet_mpc_session_late_output_info{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"{authority}\",output_digest=\"{output_digest}\",quorum_output_digest=\"{quorum_output_digest}\"}} 1\nika_dwallet_mpc_session_late_output_malicious_actors{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"{authority}\"}} {malicious}\n"
+        )
+    }
+
     #[test]
     fn accepts_four_authority_network_key_output_convergence() {
         let committee = committee_of(&["a", "b", "c", "d"]);
-        let required = committee_of(&["a"]);
         let mut body =
             network_key_metrics(&[("a", "same"), ("b", "same"), ("c", "same"), ("d", "same")]);
         body.push_str(
             "ika_dwallet_mpc_session_output_info{protocol_name=\"Sign\",session_id=\"unrelated\",authority=\"a\",output_digest=\"different\"} 1\n",
         );
-        let NetworkKeyOutputConvergence::Converged(canonical) =
-            canonical_network_key_outputs(&body, &committee, &required, 3, "validator 0").unwrap()
+        let NetworkKeyOutputConvergence::Converged {
+            canonical,
+            sessions_without_candidate_evidence,
+        } = canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0").unwrap()
         else {
             panic!("four matching authorities must converge");
         };
         assert_eq!(canonical["session"], "same");
+        assert!(
+            sessions_without_candidate_evidence.is_empty(),
+            "a submitted candidate output is conclusive evidence"
+        );
     }
 
     #[test]
-    fn accepts_quorum_when_straggler_absent() {
+    fn accepts_quorum_when_non_candidate_straggler_absent() {
         // The 4th validator finalized on quorum before its own output was
         // submitted (it discards a post-quorum result). A 3-of-4 converged
         // quorum that includes the validator under test still passes — the
         // full-committee requirement would race that finalization.
         let committee = committee_of(&["a", "b", "c", "d"]);
-        let required = committee_of(&["a"]);
         let body = network_key_metrics(&[("a", "same"), ("b", "same"), ("c", "same")]);
-        let NetworkKeyOutputConvergence::Converged(canonical) =
-            canonical_network_key_outputs(&body, &committee, &required, 3, "validator 0").unwrap()
+        let NetworkKeyOutputConvergence::Converged {
+            canonical,
+            sessions_without_candidate_evidence,
+        } = canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0").unwrap()
         else {
             panic!("a converged quorum including the validator under test must pass");
         };
         assert_eq!(canonical["session"], "same");
+        assert!(sessions_without_candidate_evidence.is_empty());
     }
 
     #[test]
-    fn incomplete_when_validator_under_test_absent() {
-        // A quorum that excludes the upgraded validator proves nothing about
-        // its compatibility — keep polling (fail-closed on the caller timeout).
+    fn candidate_straggler_without_late_evidence_converges_but_is_flagged() {
+        // The exact release-gate flake ordering: three v1.1.8 authorities
+        // finalize with identical outputs, the quorum closes the session, and
+        // the upgraded validator's own computation has produced nothing
+        // comparable yet. The quorum itself converged (this must NOT fail),
+        // but the session is flagged so the boundary can only be conclusive
+        // once evidence arrives — or reported inconclusive, never silently
+        // passed as compatibility proof.
         let committee = committee_of(&["a", "b", "c", "d"]);
-        let required = committee_of(&["a"]);
         let body = network_key_metrics(&[("b", "same"), ("c", "same"), ("d", "same")]);
-        let NetworkKeyOutputConvergence::Incomplete(reason) =
-            canonical_network_key_outputs(&body, &committee, &required, 3, "validator 0").unwrap()
+        let NetworkKeyOutputConvergence::Converged {
+            canonical,
+            sessions_without_candidate_evidence,
+        } = canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0").unwrap()
         else {
-            panic!("a quorum missing the validator under test must be incomplete");
+            panic!("a clean 3-of-4 quorum without the candidate must still converge");
         };
-        assert!(reason.contains("validator under test"));
+        assert_eq!(canonical["session"], "same");
+        assert_eq!(sessions_without_candidate_evidence.len(), 1);
+        assert!(sessions_without_candidate_evidence[0].contains("no submitted output"));
+    }
+
+    #[test]
+    fn candidate_straggler_with_matching_late_evidence_is_conclusive() {
+        // Same ordering, ~200ms later: the upgraded validator's computation
+        // returned `finalize` after the session completed; production
+        // discarded the output but recorded its raw-bytes digest, which
+        // matches the quorum's raw-bytes digest. That is byte-level
+        // compatibility evidence — the boundary is conclusive.
+        let committee = committee_of(&["a", "b", "c", "d"]);
+        let mut body = network_key_metrics(&[("b", "same"), ("c", "same"), ("d", "same")]);
+        body.push_str(&late_output_metrics("a", "rawdigest", "rawdigest", 0));
+        let NetworkKeyOutputConvergence::Converged {
+            canonical,
+            sessions_without_candidate_evidence,
+        } = canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0").unwrap()
+        else {
+            panic!("matching late-computation evidence must converge");
+        };
+        assert_eq!(canonical["session"], "same");
+        assert!(
+            sessions_without_candidate_evidence.is_empty(),
+            "a matching late-output digest is conclusive candidate evidence"
+        );
+    }
+
+    #[test]
+    fn candidate_late_evidence_with_divergent_bytes_fails_closed() {
+        // The upgraded validator really did compute different bytes — the
+        // quorum discarding its output must not hide the divergence.
+        let committee = committee_of(&["a", "b", "c", "d"]);
+        let mut body = network_key_metrics(&[("b", "same"), ("c", "same"), ("d", "same")]);
+        body.push_str(&late_output_metrics("a", "localdigest", "quorumdigest", 0));
+        let error = canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0")
+            .expect_err("a divergent late output must fail closed");
+        let error = error.to_string();
+        assert!(error.contains("DIVERGES"));
+        assert!(error.contains("localdigest"));
+        assert!(error.contains("quorumdigest"));
+    }
+
+    #[test]
+    fn candidate_late_evidence_reporting_malicious_actors_fails_closed() {
+        let committee = committee_of(&["a", "b", "c", "d"]);
+        let mut body = network_key_metrics(&[("b", "same"), ("c", "same"), ("d", "same")]);
+        body.push_str(&late_output_metrics("a", "rawdigest", "rawdigest", 2));
+        let error = canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0")
+            .expect_err("a late output reporting malicious actors must fail closed");
+        assert!(error.to_string().contains("2 malicious actors"));
+    }
+
+    #[test]
+    fn candidate_late_evidence_without_quorum_digest_is_not_evidence() {
+        // "unknown" means production had no quorum digest to compare against
+        // (the session left Active through a non-quorum path). The digest
+        // alone proves nothing — the session stays flagged, the boundary can
+        // at best be inconclusive, and nothing fails.
+        let committee = committee_of(&["a", "b", "c", "d"]);
+        let mut body = network_key_metrics(&[("b", "same"), ("c", "same"), ("d", "same")]);
+        body.push_str(&late_output_metrics("a", "rawdigest", "unknown", 0));
+        let NetworkKeyOutputConvergence::Converged {
+            sessions_without_candidate_evidence,
+            ..
+        } = canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0").unwrap()
+        else {
+            panic!("an unverifiable late output must not block convergence");
+        };
+        assert_eq!(sessions_without_candidate_evidence.len(), 1);
+        assert!(sessions_without_candidate_evidence[0].contains("without a quorum digest"));
+    }
+
+    #[test]
+    fn late_evidence_missing_malicious_gauge_is_incomplete() {
+        // The info sample and the malicious gauge are exported in the same
+        // refresh; only a scrape racing that refresh can see one without the
+        // other — retry, don't fail and don't accept.
+        let committee = committee_of(&["a", "b", "c", "d"]);
+        let mut body = network_key_metrics(&[("b", "same"), ("c", "same"), ("d", "same")]);
+        body.push_str(&format!(
+            "ika_dwallet_mpc_session_late_output_info{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"a\",output_digest=\"rawdigest\",quorum_output_digest=\"rawdigest\"}} 1\n"
+        ));
+        let NetworkKeyOutputConvergence::Incomplete(reason) =
+            canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0").unwrap()
+        else {
+            panic!("a late-output sample without its malicious gauge must be incomplete");
+        };
+        assert!(reason.contains("malicious-actor gauge"));
     }
 
     #[test]
     fn incomplete_below_quorum() {
         let committee = committee_of(&["a", "b", "c", "d"]);
-        let required = committee_of(&["a"]);
         let body = network_key_metrics(&[("a", "same"), ("b", "same")]);
         let NetworkKeyOutputConvergence::Incomplete(_) =
-            canonical_network_key_outputs(&body, &committee, &required, 3, "validator 0").unwrap()
+            canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0").unwrap()
         else {
             panic!("a below-quorum observation must be incomplete");
         };
@@ -1982,14 +2250,13 @@ mod tests {
         // A non-member submitting a network-key output is a hard fault, not a
         // propagation delay.
         let committee = committee_of(&["a", "b", "c"]);
-        let required = committee_of(&["a"]);
         let body = network_key_metrics(&[
             ("a", "same"),
             ("b", "same"),
             ("c", "same"),
             ("rogue", "same"),
         ]);
-        let error = canonical_network_key_outputs(&body, &committee, &required, 3, "validator 0")
+        let error = canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0")
             .expect_err("an out-of-committee authority must fail closed");
         assert!(error.to_string().contains("out-of-committee"));
     }
@@ -1997,14 +2264,13 @@ mod tests {
     #[test]
     fn rejects_one_divergent_network_key_output() {
         let committee = committee_of(&["a", "b", "c", "d"]);
-        let required = committee_of(&["a"]);
         let body = network_key_metrics(&[
             ("a", "different"),
             ("b", "majority"),
             ("c", "majority"),
             ("d", "majority"),
         ]);
-        let error = canonical_network_key_outputs(&body, &committee, &required, 3, "validator 0")
+        let error = canonical_network_key_outputs(&body, &committee, "a", 3, "validator 0")
             .expect_err("3-vs-1 output split must fail closed");
         assert!(
             error
@@ -2016,7 +2282,6 @@ mod tests {
     #[test]
     fn missing_network_key_envelope_metric_is_incomplete_not_converged() {
         let committee = committee_of(&["a"]);
-        let required = committee_of(&["a"]);
         let body = format!(
             "ika_dwallet_mpc_session_output_info{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"a\",output_digest=\"same\"}} 1\nika_dwallet_mpc_session_output_rejected{{protocol_name=\"{NETWORK_KEY_RECONFIGURATION_PROTOCOL}\",session_id=\"session\",authority=\"a\"}} 0\n"
         );
@@ -2024,7 +2289,7 @@ mod tests {
         // the observer keeps polling (and the caller ultimately times out —
         // still fail-closed), rather than declaring a hard divergence.
         let NetworkKeyOutputConvergence::Incomplete(reason) =
-            canonical_network_key_outputs(&body, &committee, &required, 1, "validator 0").unwrap()
+            canonical_network_key_outputs(&body, &committee, "a", 1, "validator 0").unwrap()
         else {
             panic!("a missing envelope metric must be reported as incomplete");
         };

--- a/crates/ika-upgrade-test/src/scenario.rs
+++ b/crates/ika-upgrade-test/src/scenario.rs
@@ -16,7 +16,7 @@
 //!     .run().await?;
 //! ```
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -27,7 +27,7 @@ use tokio::time::sleep;
 
 use crate::DEFAULT_EPOCH_DURATION_MS;
 use crate::binary::{BinaryResolver, BinarySpec};
-use crate::cluster::{ClusterBuilder, ClusterOfProcesses, NetworkKeyCompatibilityEvidence};
+use crate::cluster::{ClusterBuilder, ClusterOfProcesses, NetworkKeyBoundaryEvidence};
 use crate::mpc_timings::{self, TimingSnapshot};
 use crate::workload::WorkloadDriver;
 
@@ -554,14 +554,14 @@ impl Scenario {
         // the direct path through a `stop_and_swap` (no point flipping a node
         // that's leaving) instead of being auto-mirrored.
         let mut removed_indices: HashSet<usize> = HashSet::new();
-        // Per-boundary outcome of every ExpectNetworkKeyOutputConverged step.
-        // Each boundary tolerates the legitimate straggler ordering (quorum
-        // finalizes, the validator under test's output is discarded, no
-        // comparable evidence appears in time) as inconclusive — but the
-        // scenario as a whole must witness byte-equality between the
-        // validator under test and a finalizing quorum on at least one
-        // boundary, enforced after the step loop.
-        let mut network_key_evidence: Vec<NetworkKeyCompatibilityEvidence> = Vec::new();
+        // Per-boundary, per-authority outcome of every
+        // ExpectNetworkKeyOutputConverged step. Each boundary tolerates the
+        // legitimate straggler ordering (quorum finalizes, the validator
+        // under test's output is discarded, no comparable evidence appears in
+        // time) — but the scenario as a whole must witness byte-equality
+        // between EVERY validator under test and a finalizing quorum on at
+        // least one boundary each, enforced after the step loop.
+        let mut network_key_evidence: Vec<NetworkKeyBoundaryEvidence> = Vec::new();
 
         let total = self.steps.len();
         for (index, step) in self.steps.iter().enumerate() {
@@ -841,16 +841,16 @@ impl Scenario {
                                 .min(NETWORK_KEY_OUTPUT_OBSERVATION_TIMEOUT),
                         )
                         .await?;
-                    match &evidence {
-                        NetworkKeyCompatibilityEvidence::Conclusive => tracing::info!(
+                    if evidence.is_conclusive() {
+                        tracing::info!(
+                            evidenced = ?evidence.evidenced_authorities,
                             "network-key output convergence: byte-level candidate evidence witnessed at this boundary"
-                        ),
-                        NetworkKeyCompatibilityEvidence::Inconclusive { reason } => {
-                            tracing::warn!(
-                                %reason,
-                                "network-key output convergence: quorum converged cleanly but the validator under test provided no byte-equality evidence at this boundary (production legitimately discarded its straggling output); at least one boundary in this scenario must be conclusive"
-                            )
-                        }
+                        );
+                    } else {
+                        tracing::warn!(
+                            unevidenced = ?evidence.unevidenced_authorities,
+                            "network-key output convergence: quorum converged cleanly but validator(s) under test provided no byte-equality evidence at this boundary (production legitimately discarded a straggling output); each must be evidenced at some boundary in this scenario"
+                        );
                     }
                     network_key_evidence.push(evidence);
                 }
@@ -946,36 +946,51 @@ impl Scenario {
     }
 }
 
-/// Scenario-level cross-version compatibility gate over the per-boundary
-/// outcomes of every `expect_network_key_output_converged` step.
+/// Scenario-level cross-version compatibility gate over the per-boundary,
+/// per-authority outcomes of every `expect_network_key_output_converged`
+/// step.
 ///
-/// A single boundary where the validator under test produced no comparable
-/// output is legitimate (production finalizes at a Byzantine quorum and
-/// discards a computation that finishes afterwards) — but quorum-only
-/// convergence proves nothing about the validator under test's bytes, so a
-/// scenario in which EVERY boundary ended that way has not demonstrated
-/// cross-version output compatibility and must fail rather than pass
-/// vacuously. Scenarios without convergence steps are unaffected.
-fn require_cross_version_output_evidence(
-    outcomes: &[NetworkKeyCompatibilityEvidence],
-) -> Result<()> {
-    if outcomes.is_empty() || outcomes.contains(&NetworkKeyCompatibilityEvidence::Conclusive) {
-        return Ok(());
-    }
-    let reasons: Vec<&str> = outcomes
+/// A boundary where a validator under test produced no comparable output is
+/// legitimate (production finalizes at a Byzantine quorum and discards a
+/// computation that finishes afterwards) — but quorum-only convergence proves
+/// nothing about that validator's bytes, so every validator that was ever
+/// under test must have demonstrated byte-equality with a finalizing quorum
+/// at SOME boundary, or the scenario has not demonstrated cross-version
+/// output compatibility for it and must fail rather than pass vacuously.
+/// Scenarios without convergence steps are unaffected.
+fn require_cross_version_output_evidence(boundaries: &[NetworkKeyBoundaryEvidence]) -> Result<()> {
+    let never_evidenced: Vec<String> = boundaries
         .iter()
-        .map(|outcome| match outcome {
-            NetworkKeyCompatibilityEvidence::Conclusive => unreachable!("filtered above"),
-            NetworkKeyCompatibilityEvidence::Inconclusive { reason } => reason.as_str(),
+        .flat_map(|boundary| boundary.unevidenced_authorities.keys())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .filter(|authority| {
+            !boundaries
+                .iter()
+                .any(|boundary| boundary.evidenced_authorities.contains(*authority))
+        })
+        .map(|authority| {
+            let reasons: Vec<&str> = boundaries
+                .iter()
+                .filter_map(|boundary| {
+                    boundary
+                        .unevidenced_authorities
+                        .get(authority)
+                        .map(String::as_str)
+                })
+                .collect();
+            format!("{authority}: {}", reasons.join(" / "))
         })
         .collect();
-    bail!(
-        "insufficient cross-version compatibility evidence: every network-key reconfiguration \
-         boundary was inconclusive — the validator(s) under test never demonstrated \
-         byte-equality with a finalizing quorum (no submitted output inside the converged set \
-         and no matching late-computation digest at any boundary): {}",
-        reasons.join("; ")
-    )
+    ensure!(
+        never_evidenced.is_empty(),
+        "insufficient cross-version compatibility evidence: validator(s) under test never \
+         demonstrated byte-equality with a finalizing quorum at any network-key \
+         reconfiguration boundary (no submitted output inside the converged set and no \
+         matching late-computation digest): {}",
+        never_evidenced.join("; ")
+    );
+    Ok(())
 }
 
 /// Resolve a spec to a binary path on a blocking thread (a git-ref spec triggers
@@ -991,10 +1006,22 @@ async fn resolve(resolver: &BinaryResolver, spec: &BinarySpec) -> Result<PathBuf
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
-    fn inconclusive(reason: &str) -> NetworkKeyCompatibilityEvidence {
-        NetworkKeyCompatibilityEvidence::Inconclusive {
-            reason: reason.to_string(),
+    fn evidenced(authorities: &[&str]) -> NetworkKeyBoundaryEvidence {
+        NetworkKeyBoundaryEvidence {
+            evidenced_authorities: authorities.iter().map(|a| a.to_string()).collect(),
+            unevidenced_authorities: BTreeMap::new(),
+        }
+    }
+
+    fn unevidenced(authorities_and_reasons: &[(&str, &str)]) -> NetworkKeyBoundaryEvidence {
+        NetworkKeyBoundaryEvidence {
+            evidenced_authorities: BTreeSet::new(),
+            unevidenced_authorities: authorities_and_reasons
+                .iter()
+                .map(|(authority, reason)| (authority.to_string(), reason.to_string()))
+                .collect(),
         }
     }
 
@@ -1004,31 +1031,48 @@ mod tests {
     }
 
     #[test]
-    fn one_conclusive_boundary_satisfies_the_scenario() {
+    fn one_evidenced_boundary_per_validator_satisfies_the_scenario() {
         // The straggler ordering at one boundary is legitimate as long as the
         // other boundary witnessed byte-equality — in either order.
         require_cross_version_output_evidence(&[
-            NetworkKeyCompatibilityEvidence::Conclusive,
-            inconclusive("validator 0: session s (no submitted output)"),
+            evidenced(&["a"]),
+            unevidenced(&[("a", "session s (no submitted output)")]),
         ])
         .unwrap();
         require_cross_version_output_evidence(&[
-            inconclusive("validator 0: session s (no submitted output)"),
-            NetworkKeyCompatibilityEvidence::Conclusive,
+            unevidenced(&[("a", "session s (no submitted output)")]),
+            evidenced(&["a"]),
         ])
         .unwrap();
     }
 
     #[test]
-    fn all_inconclusive_boundaries_fail_the_scenario() {
+    fn all_boundaries_unevidenced_fail_the_scenario() {
         let error = require_cross_version_output_evidence(&[
-            inconclusive("validator 0: session s1 (no submitted output)"),
-            inconclusive("validator 0: session s2 (no submitted output)"),
+            unevidenced(&[("a", "validator 0: session s1 (no submitted output)")]),
+            unevidenced(&[("a", "validator 0: session s2 (no submitted output)")]),
         ])
         .expect_err("quorum-only convergence at every boundary must not pass the gate");
         let error = error.to_string();
         assert!(error.contains("insufficient cross-version compatibility evidence"));
         assert!(error.contains("session s1"));
         assert!(error.contains("session s2"));
+    }
+
+    #[test]
+    fn a_validator_only_ever_unevidenced_fails_even_if_another_is_conclusive() {
+        // Evidence is per validator under test, not per boundary: a rolling
+        // scenario whose observer set grows must still byte-check every
+        // upgraded validator somewhere.
+        let mut second_boundary = evidenced(&["a"]);
+        second_boundary.unevidenced_authorities.insert(
+            "b".to_string(),
+            "session s (no submitted output)".to_string(),
+        );
+        let error = require_cross_version_output_evidence(&[evidenced(&["a"]), second_boundary])
+            .expect_err("an upgraded validator that was never byte-checked must fail the gate");
+        let error = error.to_string();
+        assert!(error.contains("b:"));
+        assert!(!error.contains("a:"));
     }
 }

--- a/crates/ika-upgrade-test/src/scenario.rs
+++ b/crates/ika-upgrade-test/src/scenario.rs
@@ -27,7 +27,7 @@ use tokio::time::sleep;
 
 use crate::DEFAULT_EPOCH_DURATION_MS;
 use crate::binary::{BinaryResolver, BinarySpec};
-use crate::cluster::{ClusterBuilder, ClusterOfProcesses};
+use crate::cluster::{ClusterBuilder, ClusterOfProcesses, NetworkKeyCompatibilityEvidence};
 use crate::mpc_timings::{self, TimingSnapshot};
 use crate::workload::WorkloadDriver;
 
@@ -554,6 +554,14 @@ impl Scenario {
         // the direct path through a `stop_and_swap` (no point flipping a node
         // that's leaving) instead of being auto-mirrored.
         let mut removed_indices: HashSet<usize> = HashSet::new();
+        // Per-boundary outcome of every ExpectNetworkKeyOutputConverged step.
+        // Each boundary tolerates the legitimate straggler ordering (quorum
+        // finalizes, the validator under test's output is discarded, no
+        // comparable evidence appears in time) as inconclusive — but the
+        // scenario as a whole must witness byte-equality between the
+        // validator under test and a finalizing quorum on at least one
+        // boundary, enforced after the step loop.
+        let mut network_key_evidence: Vec<NetworkKeyCompatibilityEvidence> = Vec::new();
 
         let total = self.steps.len();
         for (index, step) in self.steps.iter().enumerate() {
@@ -825,13 +833,26 @@ impl Scenario {
                     // The system session has already completed before normal
                     // scenarios reach this assertion. Allow metrics propagation
                     // some slack, but do not reuse a multi-minute epoch timeout:
-                    // a missing authority output is itself release-blocking.
-                    c.expect_network_key_output_converged(
-                        observer_indices,
-                        self.epoch_timeout
-                            .min(NETWORK_KEY_OUTPUT_OBSERVATION_TIMEOUT),
-                    )
-                    .await?;
+                    // an incomplete quorum observation is itself release-blocking.
+                    let evidence = c
+                        .expect_network_key_output_converged(
+                            observer_indices,
+                            self.epoch_timeout
+                                .min(NETWORK_KEY_OUTPUT_OBSERVATION_TIMEOUT),
+                        )
+                        .await?;
+                    match &evidence {
+                        NetworkKeyCompatibilityEvidence::Conclusive => tracing::info!(
+                            "network-key output convergence: byte-level candidate evidence witnessed at this boundary"
+                        ),
+                        NetworkKeyCompatibilityEvidence::Inconclusive { reason } => {
+                            tracing::warn!(
+                                %reason,
+                                "network-key output convergence: quorum converged cleanly but the validator under test provided no byte-equality evidence at this boundary (production legitimately discarded its straggling output); at least one boundary in this scenario must be conclusive"
+                            )
+                        }
+                    }
+                    network_key_evidence.push(evidence);
                 }
                 Step::ExpectNoPendingNetworkKeyReconfiguration {
                     epoch,
@@ -917,11 +938,44 @@ impl Scenario {
                 step_started.elapsed().as_secs_f64()
             );
         }
+        require_cross_version_output_evidence(&network_key_evidence)?;
         if timing_snapshots.len() >= 2 {
             println!("{}", mpc_timings::render_comparison(&timing_snapshots));
         }
         Ok(ScenarioReport { timing_snapshots })
     }
+}
+
+/// Scenario-level cross-version compatibility gate over the per-boundary
+/// outcomes of every `expect_network_key_output_converged` step.
+///
+/// A single boundary where the validator under test produced no comparable
+/// output is legitimate (production finalizes at a Byzantine quorum and
+/// discards a computation that finishes afterwards) — but quorum-only
+/// convergence proves nothing about the validator under test's bytes, so a
+/// scenario in which EVERY boundary ended that way has not demonstrated
+/// cross-version output compatibility and must fail rather than pass
+/// vacuously. Scenarios without convergence steps are unaffected.
+fn require_cross_version_output_evidence(
+    outcomes: &[NetworkKeyCompatibilityEvidence],
+) -> Result<()> {
+    if outcomes.is_empty() || outcomes.contains(&NetworkKeyCompatibilityEvidence::Conclusive) {
+        return Ok(());
+    }
+    let reasons: Vec<&str> = outcomes
+        .iter()
+        .map(|outcome| match outcome {
+            NetworkKeyCompatibilityEvidence::Conclusive => unreachable!("filtered above"),
+            NetworkKeyCompatibilityEvidence::Inconclusive { reason } => reason.as_str(),
+        })
+        .collect();
+    bail!(
+        "insufficient cross-version compatibility evidence: every network-key reconfiguration \
+         boundary was inconclusive — the validator(s) under test never demonstrated \
+         byte-equality with a finalizing quorum (no submitted output inside the converged set \
+         and no matching late-computation digest at any boundary): {}",
+        reasons.join("; ")
+    )
 }
 
 /// Resolve a spec to a binary path on a blocking thread (a git-ref spec triggers
@@ -932,4 +986,49 @@ async fn resolve(resolver: &BinaryResolver, spec: &BinarySpec) -> Result<PathBuf
     tokio::task::spawn_blocking(move || resolver.resolve(&spec))
         .await
         .context("binary resolver task panicked")?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inconclusive(reason: &str) -> NetworkKeyCompatibilityEvidence {
+        NetworkKeyCompatibilityEvidence::Inconclusive {
+            reason: reason.to_string(),
+        }
+    }
+
+    #[test]
+    fn no_convergence_steps_need_no_evidence() {
+        require_cross_version_output_evidence(&[]).unwrap();
+    }
+
+    #[test]
+    fn one_conclusive_boundary_satisfies_the_scenario() {
+        // The straggler ordering at one boundary is legitimate as long as the
+        // other boundary witnessed byte-equality — in either order.
+        require_cross_version_output_evidence(&[
+            NetworkKeyCompatibilityEvidence::Conclusive,
+            inconclusive("validator 0: session s (no submitted output)"),
+        ])
+        .unwrap();
+        require_cross_version_output_evidence(&[
+            inconclusive("validator 0: session s (no submitted output)"),
+            NetworkKeyCompatibilityEvidence::Conclusive,
+        ])
+        .unwrap();
+    }
+
+    #[test]
+    fn all_inconclusive_boundaries_fail_the_scenario() {
+        let error = require_cross_version_output_evidence(&[
+            inconclusive("validator 0: session s1 (no submitted output)"),
+            inconclusive("validator 0: session s2 (no submitted output)"),
+        ])
+        .expect_err("quorum-only convergence at every boundary must not pass the gate");
+        let error = error.to_string();
+        assert!(error.contains("insufficient cross-version compatibility evidence"));
+        assert!(error.contains("session s1"));
+        assert!(error.contains("session s2"));
+    }
 }

--- a/crates/ika-upgrade-test/tests/v118_mixed_rollout.rs
+++ b/crates/ika-upgrade-test/tests/v118_mixed_rollout.rs
@@ -171,6 +171,19 @@ async fn v118_single_validator_rollout_survives_v3_network_key_resharing() {
         .expect_all_validators_healthy()
         .expect_protocol_version_at_most(3)
         .expect_all_validators_protocol_version_at_most(3)
+        // Whole-run backstop for the late-output comparison: a discarded
+        // straggler output whose bytes diverge from the quorum is logged at
+        // error level the moment it is recorded, even if it lands after a
+        // boundary's observation window closed (its metric series would be
+        // wiped at the next epoch's reset). The upgraded validator's log
+        // persists across epochs (no restart after the swap), so this catches
+        // a divergence anywhere in the run.
+        .expect_log_line_absent("late network-key reconfiguration output DIVERGES")
+        // Late-computation evidence proves the upgraded validator COMPUTES
+        // the same bytes, not that it can get an output into consensus. When
+        // it does win the race and submits, a submission failure must not
+        // hide behind the peers' quorum completing the session anyway.
+        .expect_log_line_absent("failed to submit an MPC output message to consensus")
         .run()
         .await
         .expect(

--- a/crates/ika-upgrade-test/tests/v118_mixed_rollout.rs
+++ b/crates/ika-upgrade-test/tests/v118_mixed_rollout.rs
@@ -15,6 +15,17 @@
 //! states and checks local epoch, liveness, malicious reporting, pending work,
 //! logs, and per-authority output digests before allowing the next boundary.
 //!
+//! The upgraded validator's own output is weighed without racing production:
+//! reconfiguration finalizes at a Byzantine quorum, and a validator whose
+//! computation finishes afterwards — legitimately including the upgraded one —
+//! has its result discarded without submission. A boundary is conclusive when
+//! the upgraded validator either submitted its output inside the converged
+//! quorum or recorded a discarded late computation whose raw-bytes digest
+//! matches the quorum output; divergent bytes fail hard either way. A boundary
+//! where it produced nothing comparable is inconclusive (not a failure, not
+//! proof), and the scenario fails unless at least one of the two
+//! reconfiguration boundaries is conclusive.
+//!
 //! Beyond the reshare itself, each reconfiguration is followed by a full user
 //! **DKG → Presign → ECDSA Sign → Taproot Sign** lifecycle driven through the
 //! `ika` CLI, so the gate also proves the mixed committee keeps *serving users*

--- a/dev-docs/playbooks/mpc-anomaly-diagnostics.md
+++ b/dev-docs/playbooks/mpc-anomaly-diagnostics.md
@@ -43,6 +43,24 @@ observes any of these conditions:
 The ordinary `ThresholdNotReached` result is not anomalous. It remains silent
 because it is the expected state while reports accumulate.
 
+One update-after-completion case carries extra evidence: when a network-key
+reconfiguration computation returns `Finalize` after the session already
+completed via the peers' output quorum, production still discards the result
+(nothing is submitted, the session stays completed), but it digests the
+discarded raw output bytes and compares them against the quorum-agreed
+output's raw-bytes digest recorded at quorum time. The comparison lands in the
+snapshot trigger (`late_network_key_output_matched_quorum` /
+`late_network_key_output_diverged_from_quorum` /
+`late_network_key_output_unverified`), in the session trace as a
+late-output-after-completion event, and in two scrapeable gauges:
+`ika_dwallet_mpc_session_late_output_info{...,output_digest,quorum_output_digest}`
+and `ika_dwallet_mpc_session_late_output_malicious_actors`. Both digest labels
+are over raw output bytes — comparable with each other, not with
+`ika_dwallet_mpc_session_output_info`'s envelope digests. This is what lets
+the mixed-rollout release gate treat an honest straggler (any validator whose
+computation legitimately finishes after quorum) as byte-level compatibility
+evidence instead of a nondeterministic failure.
+
 ## How the trace is collected
 
 This feature's "trace" is not OpenTelemetry tracing and does not depend on

--- a/dev-docs/specs/cross-binary-upgrade.md
+++ b/dev-docs/specs/cross-binary-upgrade.md
@@ -199,6 +199,36 @@ drives them across epochs:
   with every validator healthy and locally current, zero reported malicious
   actors, no stranded work, and identical canonical per-authority outputs.
 
+How the mixed-rollout gate weighs the upgraded validator's output: production
+finalizes a reconfiguration at a Byzantine quorum and does not wait for
+stragglers — a validator whose computation finishes after it processed the
+quorum discards its own result without submitting it, and ANY honest
+validator (including the upgraded one) can be that straggler. Requiring the
+upgraded validator's submitted output at every boundary therefore made the
+gate nondeterministic (the same candidate SHA passed or failed on a
+scheduling race). The gate instead classifies each boundary:
+
+- the upgraded validator's output appears inside the converged quorum set →
+  conclusive byte-level evidence;
+- the quorum discarded its late `Finalize`, but the node recorded the
+  discarded output's raw-bytes digest equal to the quorum output's raw-bytes
+  digest (`ika_dwallet_mpc_session_late_output_info`, zero late malicious
+  actors) → equally conclusive;
+- the digests differ, the late output reports malicious actors, or any
+  submitted output diverges / is rejected / reports malicious actors → hard
+  release-blocking failure;
+- clean quorum convergence with no comparable candidate output at all →
+  the boundary is *inconclusive*: it does not fail (the ordering is
+  legitimate), but quorum-only progress is never accepted as compatibility
+  proof.
+
+The scenario as a whole must witness conclusive candidate byte-equality on at
+least one reconfiguration boundary or it fails with "insufficient
+cross-version compatibility evidence". Every boundary still requires healthy
+validators, correct local epochs, protocol v3, quorum output convergence,
+zero malicious actors, zero rejected envelopes, no self-malicious logs, and
+no stranded sessions.
+
 The current validator's per-authority output observations and pending-session
 counts are collected protocol-generically and labeled by protocol name. This
 scenario filters that data to network-key reconfiguration because that is the
@@ -207,7 +237,10 @@ only for an allow-listed set of protocols (`OUTPUT_OBSERVATION_EXPORT_PROTOCOLS`
 in `mpc_manager.rs`, currently just network-key reconfiguration) to keep their
 session-id/authority cardinality bounded on production validators; a future DKG,
 presign, sign, or verification compatibility scenario adds its protocol to that
-allow-list rather than adding protocol-specific node instrumentation.
+allow-list rather than adding protocol-specific node instrumentation. The
+late-output digest capture is scoped the same way (reconfiguration sessions
+only) and is observability-only: it never publishes the discarded output,
+delays finalization, or re-activates a completed session.
 
 Run them on CI via the **Upgrade Test** workflow
 (`.github/workflows/upgrade-test.yaml`); see

--- a/dev-docs/specs/cross-binary-upgrade.md
+++ b/dev-docs/specs/cross-binary-upgrade.md
@@ -237,10 +237,14 @@ only for an allow-listed set of protocols (`OUTPUT_OBSERVATION_EXPORT_PROTOCOLS`
 in `mpc_manager.rs`, currently just network-key reconfiguration) to keep their
 session-id/authority cardinality bounded on production validators; a future DKG,
 presign, sign, or verification compatibility scenario adds its protocol to that
-allow-list rather than adding protocol-specific node instrumentation. The
-late-output digest capture is scoped the same way (reconfiguration sessions
-only) and is observability-only: it never publishes the discarded output,
-delays finalization, or re-activates a completed session.
+allow-list rather than adding protocol-specific node instrumentation — and, if
+it also wants straggler evidence, must extend the late-output capture too: the
+quorum raw-digest stash and the discard-site recording are separately gated on
+the session being a network-key reconfiguration (the raw-bytes digest is
+computed from that protocol's output chunks), so an allow-list entry alone
+yields submitted-output observations but no late-computation evidence. The
+late-output digest capture is observability-only: it never publishes the
+discarded output, delays finalization, or re-activates a completed session.
 
 Run them on CI via the **Upgrade Test** workflow
 (`.github/workflows/upgrade-test.yaml`); see


### PR DESCRIPTION
## Problem

The literal v1.1.8/current mixed-rollout release gate (#1841) produced contradictory results for the **same candidate SHA** `73e0121a26c30ff37cb1cf2a1b9cf51dc35df9d4`:

- Failed: https://github.com/dwallet-labs/ika/actions/runs/29508605742
- Passed: https://github.com/dwallet-labs/ika/actions/runs/29509220785

The diagnostics added in #1842 pinpointed the failing run precisely: the three literal v1.1.8 validators submitted the same canonical network-key reconfiguration output and a quorum finalized at consensus round 5902 (`local_authority_malicious=false`, zero malicious sets, zero rejections, `quorum_reached_without_local_output=true`, `local_computation_pending=true`). Roughly 195 ms later the upgraded validator's computation returned `finalize`, but the session was already non-active, so production discarded the result and never submitted it. The gate's `expect_network_key_output_converged` then waited 60 s for the upgraded authority to appear in the submitted-output set — which could never happen.

## Why this is a gate defect, not a compatibility failure

Production finalizes a reconfiguration at a Byzantine quorum and does not wait for stragglers: a validator whose computation finishes after it processed the quorum marks the session complete and discards its own result. **Any honest validator — including the upgraded one — can be that straggler.** Requiring the upgraded validator's submitted output at every boundary therefore races a ~200 ms scheduling window, which is exactly the same-SHA pass/fail behavior observed. The existing 10 s stabilization drain only covers submitted-but-still-propagating outputs; it cannot help an output production intentionally never submits.

At the same time, a missing candidate output **cannot itself prove compatibility**: quorum-only convergence is three v1.1.8 validators agreeing with each other, which says nothing about the upgraded binary's bytes. Passing on that alone would make the gate vacuous.

## Fix

**Node side — observability only** (no consensus, output-submission, session-lifecycle, or timing change; nothing is published, finalization is not delayed, the completed session is never re-activated):

- At quorum, `handle_consensus_round_outputs` stashes the winning network-key reconfiguration output's **raw-bytes digest** on the session before `complete_mpc_session` makes it non-active (reassembled from the in-order output chunks, so it equals the digest of the unsliced `public_output_value`; gated on the session's reconfiguration flag so the walk never runs for sign/presign outputs).
- At the discard site, a late `Finalize` for a completed reconfiguration session has its raw output bytes digested and compared with the stashed quorum digest. The verdict lands in the existing `computation_update_after_session_completion` anomaly (new trigger conditions), in the session trace, and in two scrapeable gauges: `ika_dwallet_mpc_session_late_output_info{output_digest,quorum_output_digest}` and `ika_dwallet_mpc_session_late_output_malicious_actors`. Scoped to reconfiguration sessions to keep the per-session cardinality bounded.

**Harness side — explicit per-validator evidence model.** Each boundary now distinguishes, for every validator under test:

1. candidate submitted inside the converged quorum and matched → **conclusive**;
2. candidate legitimately finished after quorum, discarded output's digest **equals** the quorum digest (zero late malicious) → **conclusive**;
3. candidate's bytes diverge (submitted or late, including cross-attempt disagreement) → **hard failure**;
4. candidate malicious/rejected (submitted envelopes or late malicious report) → **hard failure**;
5. clean quorum convergence with no comparable candidate output → **inconclusive**: not a failure (the ordering is legitimate), but never accepted as compatibility proof.

Every boundary still requires healthy validators, correct local epochs, protocol v3, quorum output convergence, zero malicious actors, zero rejected envelopes, no self-malicious logs, no stranded sessions; the existing 10 s stabilization drain for late-propagating **submitted** outputs is preserved unchanged. The scenario fails with "insufficient cross-version compatibility evidence" unless **every validator under test** is conclusively evidenced at **at least one** boundary — quorum-only progress can never pass the gate vacuously. Two whole-run log backstops close the metric-lifetime gaps: a divergent late output landing after a boundary's observation window still fails the run (its error line outlives the per-epoch metric reset), and an output consensus-submission failure on the candidate cannot hide behind the peers' quorum completing the session.

No historical binary is replaced, no mocks are introduced, and the rollout topology (1 current + 3 literal v1.1.8) is unchanged.

**Known residual (accepted, documented):** late-digest evidence proves the candidate *computes* identical bytes; it does not exercise the candidate's output-submission path when the candidate loses the race at every boundary (partially covered by the submission-failure log backstop), and a candidate whose computation hangs or errors *after* quorum at exactly one boundary is forgiven if the other boundary is conclusive (a deterministic cross-version computation failure hits both boundaries and fails the evidence gate; an error while the session is still Active submits a rejection and fails hard). Watch signal for operators: `ika_dwallet_mpc_anomaly_snapshots_total{anomaly_kind="local_computation_failed"}` on the upgraded validator.

## Regression tests

- `crates/ika-core/.../integration_tests/late_reconfiguration_output.rs` reproduces the exact ordering (three authorities finalize identical outputs → quorum closes the session → local `finalize` arrives afterwards) with envelopes built through the **real production chunker**, and asserts: nothing is submitted to consensus, the digest pair is recorded and exported, matching bytes are flagged as a match. A fault-injected variant returns **different** bytes and asserts the divergence trigger, trace event, and unequal exported digest pair; a third test proves sessions without the reconfiguration request record nothing.
- `mpc_diagnostics` unit tests pin the digest-domain invariant (in-order chunk reassembly ≡ unsliced raw bytes; rejected/foreign envelopes produce no digest).
- `cluster.rs` unit tests cover the full classification: straggler-without-evidence converges but is flagged; matching late evidence is conclusive; divergent late digest, late malicious report, cross-attempt digest disagreement, divergent submitted output, rejected envelope, and out-of-committee authority all fail hard; superseded `unknown`-quorum gauge children next to the compared pair are tolerated; racing scrapes stay retry-not-fail.
- `scenario.rs` unit tests pin the per-validator aggregate gate (every validator under test must be evidenced at some boundary, in either order; all-unevidenced fails; a validator only ever unevidenced fails even when another is conclusive).

## Validation

- Local: `cargo test --release -p ika-core --lib late_reconfiguration` → 3 passed; `mpc_diagnostics` → 8 passed; `cargo test --release -p ika-upgrade-test --lib` → 26 passed; `cargo fmt --all`; `cargo clippy --release -p ika-core -p ika-upgrade-test --all-targets` clean. Reviewed by the consensus-determinism checklist: no consensus message, submission, session-lifecycle, epoch-close, or malicious-accounting change; the quorum-stash input is the consensus majority vote and nothing derived from the new state feeds back into consensus.
- Literal v1.1.8/current mixed rollout on `ika-k8s-large` at the final SHA, three runs (same-SHA repeatability):
  - https://github.com/dwallet-labs/ika/actions/runs/29526059600
  - https://github.com/dwallet-labs/ika/actions/runs/29526061077
  - https://github.com/dwallet-labs/ika/actions/runs/29526063190
- Fault-injection run at the final SHA (`test_testing_fault=true`, deliberately faulty current validator — the gate must fail closed): https://github.com/dwallet-labs/ika/actions/runs/29526064935
- An earlier fault-injection run at the pre-hardening commit already failed closed as required, at the convergence assertion itself (incomplete quorum observations under the corrupted-message fault, flow 17/46): https://github.com/dwallet-labs/ika/actions/runs/29523299380

Results will be posted here when the runs conclude.

Related: #1841 (the gate), #1842 (the diagnostics that exposed the failing run's exact state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)