### PR TITLE
ci(release): fix the gate's concurrency self-deadlock + gate-log artifact pollution; network-qualify non-mainnet asset names

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,10 +81,14 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/release/}"
           NETWORK="${TAG%%-*}"
+          # Tag convention: release/{network}-v{version} (the "v" is
+          # stripped here; bare release/{network}-{version} tags from before
+          # the convention change still parse).
           VERSION="${TAG#*-}"
+          VERSION="${VERSION#v}"
 
           if [[ "$NETWORK" != "mainnet" && "$NETWORK" != "testnet" && "$NETWORK" != "devnet" ]]; then
-            echo "::error::Invalid network '$NETWORK' in tag. Must be mainnet, testnet, or devnet. Tag format: release/{network}-{version}"
+            echo "::error::Invalid network '$NETWORK' in tag. Must be mainnet, testnet, or devnet. Tag format: release/{network}-v{version}"
             exit 1
           fi
 
@@ -451,7 +455,7 @@ jobs:
           VERSION="v${{ needs.version.outputs.version }}"
           # Mainnet mints the bare v-tag: the Homebrew formula's download URL
           # and asset glob interpolate it. Other networks attach the release
-          # to the TRIGGER tag itself (release/<network>-<version>, already
+          # to the TRIGGER tag itself (release/<network>-v<version>, already
           # pointing at this run's commit) — publishing a release on an
           # existing tag creates no tag and fires no push event, so it cannot
           # re-trigger this workflow. Asset filenames use the network-qualified

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - "release/*-*"
+      # Exclude the minted release tags (release/<network>-v<version>, note
+      # the "v") so publishing a draft release does not re-trigger this
+      # workflow. Only the bare-version trigger tags
+      # (release/<network>-<version>) start a build.
+      - "!release/*-v*"
   workflow_dispatch:
     inputs:
       network:
@@ -449,25 +454,29 @@ jobs:
       - name: Package release assets
         run: |
           VERSION="v${{ needs.version.outputs.version }}"
-          # Mainnet keeps the bare v-name: the Homebrew formula's download URL
-          # and asset glob interpolate it. Other networks qualify BOTH the
-          # release tag and the asset filenames with the network, so pushing
-          # release/mainnet-X and release/testnet-X for the same version
-          # collides on neither the release name (as happened for 1.1.8) nor
-          # the downloaded tarball filenames.
+          # Mainnet keeps the bare v-name everywhere: the Homebrew formula's
+          # download URL and asset glob interpolate it. Other networks get a
+          # network-qualified asset stem and mint their release tag inside the
+          # release/ namespace (release/<network>-v<version>); the on.push.tags
+          # filter excludes "-v" tags so publishing the draft does not
+          # re-trigger this workflow. Asset filenames always use the slash-free
+          # stem — GitHub asset names cannot contain '/'.
           NETWORK="${{ needs.version.outputs.network }}"
           if [ "$NETWORK" = "mainnet" ]; then
+            ASSET_STEM="$VERSION"
             RELEASE_TAG="$VERSION"
           else
-            RELEASE_TAG="${NETWORK}-${VERSION}"
+            ASSET_STEM="${NETWORK}-${VERSION}"
+            RELEASE_TAG="release/${NETWORK}-${VERSION}"
           fi
+          echo "ASSET_STEM=${ASSET_STEM}" >> "$GITHUB_ENV"
           echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
           for dir in artifacts/*/; do
             platform="$(basename "$dir")"
             # download-artifact strips unix modes; restore the executable bit
             # so the tarballs (and the Homebrew install) carry runnable binaries.
             chmod +x "$dir"*
-            tar -czvf "ika-${RELEASE_TAG}-${platform}.tar.gz" -C "$dir" .
+            tar -czvf "ika-${ASSET_STEM}-${platform}.tar.gz" -C "$dir" .
           done
 
       - name: Create draft release
@@ -480,10 +489,10 @@ jobs:
           # release commit this run built.
           gh release create "$RELEASE_TAG" \
             --draft \
-            --title "$RELEASE_TAG" \
+            --title "$ASSET_STEM" \
             --target "${{ github.sha }}" \
             --generate-notes \
-            ika-${RELEASE_TAG}-*.tar.gz
+            ika-${ASSET_STEM}-*.tar.gz
 
   # ---------------------------------------------------------------------------
   # Update Homebrew formula for ika CLI

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,6 @@ on:
   push:
     tags:
       - "release/*-*"
-      # Exclude the minted release tags (release/<network>-v<version>, note
-      # the "v") so publishing a draft release does not re-trigger this
-      # workflow. Only the bare-version trigger tags
-      # (release/<network>-<version>) start a build.
-      - "!release/*-v*"
   workflow_dispatch:
     inputs:
       network:
@@ -454,20 +449,20 @@ jobs:
       - name: Package release assets
         run: |
           VERSION="v${{ needs.version.outputs.version }}"
-          # Mainnet keeps the bare v-name everywhere: the Homebrew formula's
-          # download URL and asset glob interpolate it. Other networks get a
-          # network-qualified asset stem and mint their release tag inside the
-          # release/ namespace (release/<network>-v<version>); the on.push.tags
-          # filter excludes "-v" tags so publishing the draft does not
-          # re-trigger this workflow. Asset filenames always use the slash-free
-          # stem — GitHub asset names cannot contain '/'.
+          # Mainnet mints the bare v-tag: the Homebrew formula's download URL
+          # and asset glob interpolate it. Other networks attach the release
+          # to the TRIGGER tag itself (release/<network>-<version>, already
+          # pointing at this run's commit) — publishing a release on an
+          # existing tag creates no tag and fires no push event, so it cannot
+          # re-trigger this workflow. Asset filenames use the network-qualified
+          # slash-free stem — GitHub asset names cannot contain '/'.
           NETWORK="${{ needs.version.outputs.network }}"
           if [ "$NETWORK" = "mainnet" ]; then
             ASSET_STEM="$VERSION"
             RELEASE_TAG="$VERSION"
           else
             ASSET_STEM="${NETWORK}-${VERSION}"
-            RELEASE_TAG="release/${NETWORK}-${VERSION}"
+            RELEASE_TAG="${{ github.ref_name }}"
           fi
           echo "ASSET_STEM=${ASSET_STEM}" >> "$GITHUB_ENV"
           echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
@@ -483,10 +478,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # --target pins the publish-time tag: a draft's tag is minted only
-          # when the draft is published, and without --target it would point
-          # at the default branch's HEAD at publish time — not the tagged
-          # release commit this run built.
+          # --target pins mainnet's publish-time tag mint: a draft's tag is
+          # created only when the draft is published, and without --target it
+          # would point at the default branch's HEAD at publish time — not the
+          # tagged release commit this run built. For non-mainnet the trigger
+          # tag already exists, so --target is ignored.
           gh release create "$RELEASE_TAG" \
             --draft \
             --title "$ASSET_STEM" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -474,9 +474,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # --target pins the publish-time tag: a draft's tag is minted only
+          # when the draft is published, and without --target it would point
+          # at the default branch's HEAD at publish time — not the tagged
+          # release commit this run built.
           gh release create "$RELEASE_TAG" \
             --draft \
             --title "$RELEASE_TAG" \
+            --target "${{ github.sha }}" \
             --generate-notes \
             ika-${RELEASE_TAG}-*.tar.gz
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -395,10 +395,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Download all artifacts
+      - name: Download platform binaries
         uses: actions/download-artifact@v8
         with:
           path: artifacts/
+          # Platform binaries only: the upgrade-compatibility-gate is a called
+          # workflow, so its always()-uploaded log artifacts land in THIS run's
+          # artifact namespace and would otherwise show up as fake platforms.
+          pattern: "{linux,macos,windows}-*"
 
       - name: Create build summary
         run: |
@@ -432,42 +436,49 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Download all artifacts
+      - name: Download platform binaries
         uses: actions/download-artifact@v8
         with:
           path: artifacts/
+          # Platform binaries only: the upgrade-compatibility-gate is a called
+          # workflow, so its always()-uploaded log artifacts (upgrade-test-log-*,
+          # resource-sampler-*, ...) land in THIS run's artifact namespace and
+          # would otherwise be packaged as fake platform tarballs.
+          pattern: "{linux,macos,windows}-*"
 
       - name: Package release assets
         run: |
           VERSION="v${{ needs.version.outputs.version }}"
-          for dir in artifacts/*/; do
-            platform="$(basename "$dir")"
-            # download-artifact strips unix modes; restore the executable bit
-            # so the tarballs (and the Homebrew install) carry runnable binaries.
-            chmod +x "$dir"*
-            tar -czvf "ika-${VERSION}-${platform}.tar.gz" -C "$dir" .
-          done
-
-      - name: Create draft release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="v${{ needs.version.outputs.version }}"
-          # Mainnet keeps the bare v-tag: the Homebrew formula's download URL
-          # interpolates it. Other networks get a qualified tag so pushing
-          # release/mainnet-X and release/testnet-X for the same version does
-          # not collide on one release name (as happened for 1.1.8).
+          # Mainnet keeps the bare v-name: the Homebrew formula's download URL
+          # and asset glob interpolate it. Other networks qualify BOTH the
+          # release tag and the asset filenames with the network, so pushing
+          # release/mainnet-X and release/testnet-X for the same version
+          # collides on neither the release name (as happened for 1.1.8) nor
+          # the downloaded tarball filenames.
           NETWORK="${{ needs.version.outputs.network }}"
           if [ "$NETWORK" = "mainnet" ]; then
             RELEASE_TAG="$VERSION"
           else
             RELEASE_TAG="${NETWORK}-${VERSION}"
           fi
+          echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
+          for dir in artifacts/*/; do
+            platform="$(basename "$dir")"
+            # download-artifact strips unix modes; restore the executable bit
+            # so the tarballs (and the Homebrew install) carry runnable binaries.
+            chmod +x "$dir"*
+            tar -czvf "ika-${RELEASE_TAG}-${platform}.tar.gz" -C "$dir" .
+          done
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           gh release create "$RELEASE_TAG" \
             --draft \
             --title "$RELEASE_TAG" \
             --generate-notes \
-            ika-${VERSION}-*.tar.gz
+            ika-${RELEASE_TAG}-*.tar.gz
 
   # ---------------------------------------------------------------------------
   # Update Homebrew formula for ika CLI

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -478,6 +478,77 @@ jobs:
             tar -czvf "ika-${ASSET_STEM}-${platform}.tar.gz" -C "$dir" .
           done
 
+      - name: Compose release body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="v${{ needs.version.outputs.version }}"
+          NETWORK="${{ needs.version.outputs.network }}"
+          # The auto-generated changelog goes into a collapsed section at the
+          # bottom; the curated sections above it are a scaffold the release
+          # manager fills in before publishing. Fetched via the API (instead
+          # of --generate-notes) so it can be embedded inside the template.
+          NOTES=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="$RELEASE_TAG" \
+            -f target_commitish="${GITHUB_SHA}" \
+            --jq '.body')
+          {
+            sed -e "s|__VERSION__|${VERSION}|g" \
+                -e "s|__NETWORK__|${NETWORK}|g" \
+                -e "s|__SHA__|${GITHUB_SHA}|g" \
+                -e "s|__SHA_SHORT__|${GITHUB_SHA:0:10}|g" \
+                -e "s|__REPO__|${GITHUB_REPOSITORY}|g" <<'SCAFFOLD'
+          # Ika __VERSION__ (__NETWORK__)
+
+          > **⚠️ Scaffold — the release manager fills this in before
+          > publishing.** Each section says what belongs in it; write for the
+          > reader named in its heading, delete sections that don't apply,
+          > then delete this banner. Style reference: the testnet-v1.2.1
+          > release.
+
+          ## Protocol
+
+          <!-- The protocol version this release runs and/or advertises. If a
+          new version activates after the rollout, spell out the activation
+          mechanism and timing (e.g. automatic capability tally, ~1 epoch
+          after quorum of stake upgrades) and list what the new version
+          brings, in operator-visible terms. -->
+
+          ## ⚠️ dApp developers
+
+          <!-- Client compatibility: minimum @ika.xyz/sdk version, what
+          breaks without it, and the action deadline relative to the
+          rollout/activation. Delete this section if nothing changes for
+          dApps. -->
+
+          ## Operators: read before upgrading
+
+          <!-- Link the operators upgrade guide on docs.ika.xyz, then the
+          essentials as bullets: binary/image changes, config edges, metric
+          renames, resource-profile changes, the supported rollout strategy
+          (rolling vs coordinated, and what validated it), rollback caveats.
+          Delete what doesn't apply. -->
+
+          ## Validation
+
+          Built at [`__SHA_SHORT__`](https://github.com/__REPO__/commit/__SHA__).
+          This tag passed the release-blocking v1.1.8 mixed-rollout
+          compatibility gate before this draft was created.
+
+          <!-- Add further validation evidence for this exact commit (full
+          suite runs, upgrade matrix) — only what actually ran against it. -->
+
+          <details>
+          <summary>Full changelog (auto-generated)</summary>
+
+          SCAFFOLD
+            printf '%s\n' "$NOTES"
+            cat <<'SCAFFOLD'
+
+          </details>
+          SCAFFOLD
+          } > release-body.md
+
       - name: Create draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -491,7 +562,7 @@ jobs:
             --draft \
             --title "$ASSET_STEM" \
             --target "${{ github.sha }}" \
-            --generate-notes \
+            --notes-file release-body.md \
             ika-${ASSET_STEM}-*.tar.gz
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -183,7 +183,14 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Literal prefix, NOT ${{ github.workflow }}: inside a workflow_call,
+  # github.workflow resolves to the CALLER's name, so the release gate
+  # computed the same group its caller was holding ("Release-<tag-ref>")
+  # and GitHub killed it at startup as a self-deadlock — silently skipping
+  # the release Draft job (first hit: release/testnet-1.2.1). A literal
+  # prefix keeps per-ref dedup for dispatches while never colliding with
+  # a caller's group.
+  group: upgrade-test-${{ github.ref }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
## What happened on `release/testnet-1.2.1` ([run 29517890344](https://github.com/dwallet-labs/ika/actions/runs/29517890344))

Every build/docker/GCP job succeeded, but the run is marked **failed** and **Draft GitHub Release was skipped** — and the new `upgrade-compatibility-gate` from #1841 appears nowhere in the job list.

## Root cause

Inside a reusable-workflow call, **`github.workflow` resolves to the CALLER's name**. `upgrade-test.yaml`'s concurrency group (`${{ github.workflow }}-${{ github.ref }}`) therefore evaluated to `Release-refs/tags/release/testnet-1.2.1` — the *same group the calling release run was already holding*. GitHub detects the self-deadlock and kills the called workflow at startup: zero gate jobs materialize, the run fails, and every job `needs`-ing the gate is skipped.

## Fixes

1. **Concurrency self-deadlock** (`upgrade-test.yaml`): literal `upgrade-test-` prefix in the group instead of `${{ github.workflow }}` — dispatches keep per-ref dedup; a called gate can never collide with its caller.

2. **Gate-log artifact pollution** (`release.yaml`, found auditing for more called-workflow traps): a called workflow shares the **caller's artifact namespace**, and the gate uploads logs with `if: always()` (`upgrade-test-log-*`, `resource-sampler-*`, `jeprof-*`). The Draft and Build Summary jobs downloaded ALL run artifacts and treated every directory as a platform — so the moment fix 1 lets the gate actually run, every release draft would package the gate's logs as fake platform tarballs. Both downloads now filter to `pattern: "{linux,macos,windows}-*"`.

3. **Network-qualified asset names** (`release.yaml`): non-mainnet tarballs are now `ika-<network>-v<version>-<platform>.tar.gz`, so testnet/mainnet assets of the same version no longer collide on filename. Mainnet keeps the bare `ika-v<version>-*` names the Homebrew formula's download pattern interpolates (Homebrew job untouched).

4. **Publish-time tag target** (`release.yaml`): a draft's tag is minted only when the draft is published, and `gh release create` without `--target` points it at the **default branch's HEAD at publish time** — not the tagged commit the run built. Both 1.2.x drafts needed a manual `target_commitish` PATCH for exactly this reason. The create step now passes `--target "${{ github.sha }}"` (load-bearing for mainnet's minted tag; ignored when the tag already exists).

5. **Non-mainnet releases attach to the trigger tag, and the trigger-tag convention becomes `release/<network>-v<version>`** (`release.yaml`, release-owner decision): instead of minting a second near-identical tag next to the trigger tag at the same commit, the draft now uses `github.ref_name` as its tag — publishing a release on an existing tag creates no tag and fires no push event, so publish can never re-trigger this workflow. The trigger tag now carries the `v` (so the release page reads `release/testnet-v1.2.1`); the parser strips it, and bare pre-convention tags (`release/<network>-<version>`) still parse. Asset filenames keep the slash-free network-qualified stem (GitHub asset names cannot contain `/`). Mainnet still mints the bare `v<version>` tag the Homebrew formula interpolates.

6. **Draft body scaffold** (`release.yaml`): the draft body is no longer the raw `--generate-notes` dump. The pipeline composes it from a template — a fill-me-in banner, curated sections with HTML-comment guidance (Protocol / dApp developers / Operators / Validation, modeled on the testnet-v1.2.1 body), a pre-filled built-at commit link plus the mixed-rollout-gate fact (guaranteed true — the draft job `needs` the gate), and the auto-generated changelog collapsed in a `<details>` block, fetched via the generate-notes API. The changelog is piped through `printf` as data (never shell-re-evaluated), so PR titles can't inject into the script.

## Audit of the other workflows for the same class

- `upgrade-test.yaml` is the **only** callable workflow (`workflow_call`) in the repo, and `release.yaml:128` its only caller — no other workflow can hit the `github.workflow`-in-called-context trap today.
- The call passes `secrets: inherit` ✅ and all 11 `inputs.*` names the workflow references are declared under `workflow_call` ✅.
- No `github.event_name` / `github.event.inputs` branching inside `upgrade-test.yaml` that would misfire in called context ✅.
- All other artifact downloads in `release.yaml` (docker, GCP upload) fetch by explicit `name:` ✅.

## Notes

- Workflow files are pinned at the tagged commit, so this fixes **future** tags. The `testnet-v1.2.1` draft was assembled manually (all binaries built + on GCP): assets `ika-testnet-v1.2.1-*`, attached to `release/testnet-v1.2.1` (created at `d0c9abed7d` per the new convention) — it already matches what this PR will produce, and publishing it mints nothing and triggers nothing. Pushing that tag fired one expected-red run ([29527486277](https://github.com/dwallet-labs/ika/actions/runs/29527486277)): the workflow pinned at `d0c9abed7d` predates the `v`-stripping parser, so it died at tag validation with nothing built. The pre-convention trigger tags (`release/testnet-1.2.0`, `release/testnet-1.2.1`) were deleted afterwards; `release/testnet-v1.2.1` is the only 1.2.x tag (the validated build run [29517890344](https://github.com/dwallet-labs/ika/actions/runs/29517890344) itself is unaffected).
- The called-gate path (`push` tag → `workflow_call`) has still never executed end-to-end — it deadlocked on its only real invocation, and neither `pull_request` nor `workflow_dispatch` exercises it. First real validation will be the next release tag (e.g. `release/mainnet-1.2.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
