### PR TITLE
test(cluster): assert off-chain freeze capture of a joiner via the handoff cert (#1772)

### DIFF
--- a/crates/ika-test-cluster/src/lib.rs
+++ b/crates/ika-test-cluster/src/lib.rs
@@ -41,6 +41,7 @@ use ika_swarm_config::validator_initialization_config::{
     ValidatorInitializationConfig, ValidatorInitializationConfigBuilder,
 };
 use ika_types::crypto::AuthorityPublicKeyBytes;
+use ika_types::handoff::HandoffItemKey;
 use ika_types::messages_dwallet_mpc::{IkaNetworkConfig, SessionIdentifier, SessionType};
 use ika_types::supported_protocol_versions::SupportedProtocolVersions;
 use rand::rngs::OsRng;
@@ -806,16 +807,6 @@ impl IkaTestCluster {
         })
     }
 
-    /// Poll the chain until the `DWallet` at `dwallet_id` transitions
-    /// out of the in-flight DKG states (`DKGRequested`,
-    /// `AwaitingNetworkDKGVerification`, etc.) into a terminal one
-    /// (`Active` / equivalent on success, `NetworkRejected*` on
-    /// failure). Returns `Ok` on success terminal state, `Err` on
-    /// rejection or timeout.
-    ///
-    /// Events-based detection (`DWalletSessionResultEvent` emitted
-    /// by `sessions_manager`) doesn't surface reliably through the
-    /// Sui SDK's `MoveEventModule` / `MoveModule` filters in this
     /// Return the set of epochs for which the given node has a
     /// persisted `CertifiedHandoffAttestation` in its perpetual
     /// tables. Use this to verify the off-chain handoff pipeline
@@ -835,6 +826,50 @@ impl IkaTestCluster {
         })
     }
 
+    /// Authority names pinned by the `ValidatorMpcData` items of the
+    /// node's persisted handoff cert for `source_epoch` — the durable,
+    /// consensus-anchored record of that epoch's frozen off-chain
+    /// mpc_data input set. Unlike the chain-view committee's
+    /// class-groups map (which stays populated for a member the
+    /// off-chain freeze excluded, because chain writes remain under
+    /// v4), absence here means the frozen set really did not carry the
+    /// validator's mpc_data. `None` while the node has no cert for
+    /// that epoch: cert persistence trails the epoch switch by the
+    /// quorum aggregation of consensus-ordered handoff signatures, so
+    /// callers should poll.
+    pub fn handoff_cert_mpc_data_validators_for_node(
+        &self,
+        node_handle: &IkaNodeHandle,
+        source_epoch: ika_types::committee::EpochId,
+    ) -> Option<Vec<ika_types::crypto::AuthorityName>> {
+        node_handle.with(|node| {
+            node.state()
+                .perpetual_tables()
+                .get_certified_handoff_attestation(source_epoch)
+                .expect("read certified handoff attestation from perpetual tables")
+                .map(|cert| {
+                    cert.attestation
+                        .items
+                        .into_iter()
+                        .filter_map(|(key, _digest)| match key {
+                            HandoffItemKey::ValidatorMpcData { validator } => Some(validator),
+                            _ => None,
+                        })
+                        .collect()
+                })
+        })
+    }
+
+    /// Poll the chain until the `DWallet` at `dwallet_id` transitions
+    /// out of the in-flight DKG states (`DKGRequested`,
+    /// `AwaitingNetworkDKGVerification`, etc.) into a terminal one
+    /// (`Active` / equivalent on success, `NetworkRejected*` on
+    /// failure). Returns `Ok` on success terminal state, `Err` on
+    /// rejection or timeout.
+    ///
+    /// Events-based detection (`DWalletSessionResultEvent` emitted
+    /// by `sessions_manager`) doesn't surface reliably through the
+    /// Sui SDK's `MoveEventModule` / `MoveModule` filters in this
     /// in-process setup, so we query the on-chain object state
     /// instead. The `DWalletCoordinator` stores each dWallet as a
     /// dynamic object field of its `dwallets: ObjectTable<ID,

--- a/crates/ika-test-cluster/tests/joiner.rs
+++ b/crates/ika-test-cluster/tests/joiner.rs
@@ -23,8 +23,10 @@
 //! coordination tests, not scheduling-dependent. Real parallel crypto + no
 //! msim slowdown.
 
+use ika_node::IkaNodeHandle;
 use ika_protocol_config::ProtocolVersion;
-use ika_test_cluster::{IkaTestClusterBuilder, wait_for_node_epoch};
+use ika_test_cluster::{IkaTestCluster, IkaTestClusterBuilder, wait_for_node_epoch};
+use ika_types::crypto::AuthorityName;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_joiner_added_at_epoch_2() {
@@ -92,10 +94,18 @@ async fn test_joiner_added_at_epoch_2() {
 /// the joiner present in this map, because its class-groups key went
 /// on-chain at candidate registration. So this assertion covers the
 /// CHAIN view — the map `class_groups_keys_by_party_id` seeds the MPC
-/// manager's validator keys from at epoch start — while capture by the
+/// manager's validator keys from at epoch start. Capture by the
 /// off-chain freeze (which feeds the reconfiguration MPC and the
-/// handoff cert) is only indirectly exercised here and deserves its own
-/// handoff-cert-based assertion (follow-up).
+/// handoff cert) is asserted separately below, against the handoff
+/// certificate's `ValidatorMpcData` items — the durable,
+/// consensus-anchored record of the frozen set (kept forever in the
+/// perpetual tables): the joiner must appear in the epoch-1 cert
+/// (captured by the first freeze) or, tolerated with a warning, in
+/// the epoch-2 cert — the self-heal path where a joiner that
+/// legitimately missed the freeze (per the spec it is excluded, not
+/// waited for; dev-docs/specs/validator-mpc-data-announcements.md) is
+/// seated by the chain committee anyway and self-announces into
+/// consensus as an epoch-2 member.
 ///
 /// Assertion semantics (issue #1772): whether the joiner's on-chain
 /// mpc_data record is visible in the epoch-2 `EpochStartSystem` read is
@@ -146,6 +156,15 @@ async fn test_joiner_lands_in_next_committee_class_groups() {
         .expect("IkaTestClusterBuilder::build() failed");
 
     cluster.wait_for_epoch(1).await;
+    // Cert-read probe, captured BEFORE the joiner spawns so it is
+    // guaranteed to be an original committee member (the swarm's
+    // handle order is unspecified once the joiner node is in).
+    let probe = cluster
+        .swarm
+        .validator_node_handles()
+        .into_iter()
+        .next()
+        .expect("swarm has at least one validator");
     let joiner = cluster
         .add_joiner_validator()
         .await
@@ -215,55 +234,124 @@ async fn test_joiner_lands_in_next_committee_class_groups() {
          every EpochStartSystem read"
     );
 
-    if joiner_captured {
-        return;
+    if !joiner_captured {
+        // The joiner's mpc_data record wasn't visible in this node's
+        // epoch-2 chain read — the #1772 race. The record is durable, so
+        // the epoch-3 boundary read must see it. `joiner_in_voting_rights`
+        // disambiguates the miss in logs: true = selected into the epoch-2
+        // committee but its mpc_data didn't decode out of the chain read;
+        // false = registration landed after the mid-epoch committee
+        // selection, so the joiner only activates at epoch 3. Both resolve
+        // by the epoch-3 read.
+        tracing::warn!(
+            ?joiner_name,
+            joiner_in_voting_rights,
+            "joiner missing from the epoch-2 committee class-groups map \
+             (transient chain-read gap, tolerated once); asserting it is \
+             present in the epoch-3 committee"
+        );
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(300),
+            cluster.wait_for_epoch(3),
+        )
+        .await
+        .expect("cluster did not reach epoch 3 within 300s during the joiner grace window");
+        tokio::time::timeout(
+            std::time::Duration::from_secs(60),
+            wait_for_node_epoch(&joiner.node_handle, 3),
+        )
+        .await
+        .expect(
+            "joiner node did not reach epoch 3 within 60s of the cluster during the grace window",
+        );
+
+        let joiner_captured_at_epoch_3 = joiner.node_handle.with(|node| {
+            let epoch_store = node.state().epoch_store_for_testing();
+            let committee = epoch_store.committee();
+            assert_eq!(committee.epoch(), 3, "joiner node should be at epoch 3");
+            committee
+                .class_groups_public_keys_and_proofs
+                .contains_key(&joiner_name)
+        });
+        assert!(
+            joiner_captured_at_epoch_3,
+            "joiner {joiner_name:?} was missing from the epoch-2 committee \
+             class_groups_public_keys_and_proofs (tolerated once — a \
+             transient chain-read gap under load) and is STILL absent at \
+             epoch 3: its on-chain mpc_data record never became readable — \
+             a registration/lifecycle bug, not a timing race"
+        );
     }
 
-    // The joiner's mpc_data record wasn't visible in this node's
-    // epoch-2 chain read — the #1772 race. The record is durable, so
-    // the epoch-3 boundary read must see it. `joiner_in_voting_rights`
-    // disambiguates the miss in logs: true = selected into the epoch-2
-    // committee but its mpc_data didn't decode out of the chain read;
-    // false = registration landed after the mid-epoch committee
-    // selection, so the joiner only activates at epoch 3. Both resolve
-    // by the epoch-3 read.
-    tracing::warn!(
-        ?joiner_name,
-        joiner_in_voting_rights,
-        "joiner missing from the epoch-2 committee class-groups map \
-         (transient chain-read gap, tolerated once); asserting it is \
-         present in the epoch-3 committee"
-    );
+    // The chain-view checks above cannot see a freeze miss (see the
+    // test doc) — the off-chain frozen set's durable record is the
+    // handoff cert's `ValidatorMpcData` items. Assert the joiner is in
+    // the epoch-1 cert.
+    let epoch_1_cert_validators = wait_for_handoff_cert_mpc_data(&cluster, &probe, 1).await;
+    // Original members reach the frozen set by consensus
+    // self-submission — no P2P fan-out or propagation race involved —
+    // so their absence means the freeze/handoff pipeline is broken
+    // outright and must never fall into the joiner-tolerance path
+    // below.
+    for original in &cluster.validator_names {
+        assert!(
+            epoch_1_cert_validators.contains(original),
+            "original validator {original:?} missing from the epoch-1 handoff cert's \
+             ValidatorMpcData items ({epoch_1_cert_validators:?})"
+        );
+    }
+    if !epoch_1_cert_validators.contains(&joiner_name) {
+        // Legitimate per the spec: a joiner whose announcement loses
+        // the propagation race with the freeze is excluded, not waited
+        // for. The network must then self-heal — seated in epoch 2,
+        // the joiner self-announces into consensus, so the epoch-2
+        // freeze (and therefore the epoch-2 cert) must capture it.
+        tracing::warn!(
+            ?joiner_name,
+            "joiner missing from the epoch-1 handoff cert (excluded by the first freeze); \
+             falling back to the epoch-2 cert via the member self-announcement path"
+        );
+        tokio::time::timeout(
+            std::time::Duration::from_secs(120),
+            cluster.wait_for_epoch(3),
+        )
+        .await
+        .expect("epoch 3 did not arrive within 120s while waiting for the self-heal cert");
+        let epoch_2_cert_validators = wait_for_handoff_cert_mpc_data(&cluster, &probe, 2).await;
+        assert!(
+            epoch_2_cert_validators.contains(&joiner_name),
+            "joiner {joiner_name:?} missing from BOTH the epoch-1 and the epoch-2 handoff \
+             certs' ValidatorMpcData items (epoch-2: {epoch_2_cert_validators:?}) — the \
+             off-chain frozen set never captured the joiner's mpc_data"
+        );
+    }
+}
 
-    tokio::time::timeout(
-        std::time::Duration::from_secs(300),
-        cluster.wait_for_epoch(3),
-    )
-    .await
-    .expect("cluster did not reach epoch 3 within 300s during the joiner grace window");
-    tokio::time::timeout(
-        std::time::Duration::from_secs(60),
-        wait_for_node_epoch(&joiner.node_handle, 3),
-    )
-    .await
-    .expect("joiner node did not reach epoch 3 within 60s of the cluster during the grace window");
-
-    let joiner_captured_at_epoch_3 = joiner.node_handle.with(|node| {
-        let epoch_store = node.state().epoch_store_for_testing();
-        let committee = epoch_store.committee();
-        assert_eq!(committee.epoch(), 3, "joiner node should be at epoch 3");
-        committee
-            .class_groups_public_keys_and_proofs
-            .contains_key(&joiner_name)
-    });
-    assert!(
-        joiner_captured_at_epoch_3,
-        "joiner {joiner_name:?} was missing from the epoch-2 committee \
-         class_groups_public_keys_and_proofs (tolerated once — a \
-         transient chain-read gap under load) and is STILL absent at \
-         epoch 3: its on-chain mpc_data record never became readable — \
-         a registration/lifecycle bug, not a timing race"
-    );
+/// Poll `node_handle`'s perpetual tables until its handoff cert for
+/// `source_epoch` is persisted, then return the authority names pinned
+/// by the cert's `ValidatorMpcData` items. Cert persistence trails the
+/// epoch switch (quorum aggregation of the consensus-ordered handoff
+/// signatures runs at the boundary), hence the eventual semantics.
+async fn wait_for_handoff_cert_mpc_data(
+    cluster: &IkaTestCluster,
+    node_handle: &IkaNodeHandle,
+    source_epoch: u64,
+) -> Vec<AuthorityName> {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(60);
+    loop {
+        if let Some(validators) =
+            cluster.handoff_cert_mpc_data_validators_for_node(node_handle, source_epoch)
+        {
+            return validators;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "no handoff cert for source epoch {source_epoch} persisted on the probe \
+             validator within 60s"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## What

Follow-up to #1846, which proved (by fault injection) that `test_joiner_lands_in_next_committee_class_groups` only reads the CHAIN-view committee (`EpochStartSystem::get_ika_committee`) — nothing in the suite asserted the **off-chain frozen mpc_data set** captures a mid-epoch joiner. This PR adds that coverage against the durable, consensus-anchored record of the frozen set: the handoff certificate's `ValidatorMpcData` items (kept forever in the perpetual tables).

- **ika-test-cluster harness**: new `handoff_cert_mpc_data_validators_for_node(node, source_epoch)` — reads a node's persisted `CertifiedHandoffAttestation` for a source epoch and lists the authority names in its `ValidatorMpcData` items (companion to `handoff_cert_epochs_for_node`). Also rejoins the `wait_for_dwallet_dkg_complete` doc comment that an earlier insertion had split in half.
- **Test**: after the chain-view checks (whose early return is removed so this always runs), assert with eventual semantics:
  - all original members must appear in the epoch-1 cert's items (they self-submit into consensus — no propagation race — so their absence is a broken pipeline, never tolerated);
  - the joiner must appear in the epoch-1 cert (captured by the first freeze) **or**, tolerated with a `warn`, in the epoch-2 cert — the self-heal path where a joiner that legitimately missed the freeze (excluded, not waited for, per `dev-docs/specs/validator-mpc-data-announcements.md`) self-announces as a seated epoch-2 member.

## Validation (per dev-docs/playbooks/test-testing.md)

Fault run — `JoinerAnnouncementSender::run` early-returned so the joiner never fans out (a 30s delay is not enough; the freeze grace outlasts it):

- epoch-1 freeze froze 4/4 originals; the epoch-1 cert **lacked** the joiner and the tolerance warn fired, **while the chain-view map still contained it** — the exact blind spot #1846 documented; only the new cert assertion saw the divergence;
- epoch-2 freeze captured 5/5 via member self-announcement; the epoch-2 cert contained the joiner; the test passed (the predicted recoverable shape). Fault reverted; no residue.

Clean control — passed. Note: on a loaded laptop the 10s-epoch freeze organically beats the joiner fan-out (accepted ~6s after the freeze fired), so the clean local run also takes the tolerated warn path; CI timing exercises the primary path.

All three CI suites green on this branch: integration [29535518775](https://github.com/dwallet-labs/ika/actions/runs/29535518775) ✅, cluster [29535520812](https://github.com/dwallet-labs/ika/actions/runs/29535520812) ✅ (the joiner test took the primary path on CI — joiner captured by the first freeze, present in the epoch-1 cert, no tolerance warn), TS [29535522549](https://github.com/dwallet-labs/ika/actions/runs/29535522549) ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
