### PR TITLE
fix(mpc): fail chain reads loud on a missing active-member mpc_data record

### DIFF
--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -775,36 +775,49 @@ where
         // arrives via the off-chain validator-metadata pipeline (see PR #1721)
         // and is overlaid onto Committee through a separate path. No
         // try-then-fallback decode — one shape per path.
+        //
+        // A member's record is written at candidate registration and never
+        // emptied on chain, so a missing or undecodable record is always a
+        // read defect. Dropping the member would hand the reconfiguration MPC
+        // a locally-shrunken party set that peers with healthier reads don't
+        // agree on — divergent public inputs; exclusion decisions belong to
+        // the consensus-agreed freeze, never to a local read. Error instead;
+        // the sync loop retries on the next tick.
         let class_group_encryption_keys_and_proofs: HashMap<_, _> = committee
             .iter()
-            .filter_map(|(id, (name, _))| {
-                let mpc_data = committee_mpc_data.get(id);
-
-                mpc_data.and_then(|mpc_data| {
-                    let class_groups_public_key_and_proof =
-                        bcs::from_bytes::<ClassGroupsEncryptionKeyAndProof>(
-                            &mpc_data.mpc_data_bytes(),
-                        );
-
-                    match class_groups_public_key_and_proof {
-                        Ok(key_and_proof) => Some((*name, key_and_proof)),
-                        Err(e) => {
-                            // Handled, recoverable anomaly: this validator is
-                            // dropped from the committee and construction
-                            // proceeds, so this is `warn!`, not `error!` — and
-                            // it re-runs every poll tick in legacy mode.
-                            warn!(
+            .map(|(id, (name, _))| {
+                let mpc_data = committee_mpc_data.get(id).ok_or_else(|| {
+                    error!(
+                        should_never_happen = true,
+                        authority = ?name,
+                        validator_id = ?id,
+                        "committee member has no decodable on-chain mpc_data record; \
+                         failing the chain-fallback committee build for retry"
+                    );
+                    DwalletMPCError::MissingOnChainMpcData {
+                        epoch,
+                        authority: *name,
+                    }
+                })?;
+                let key_and_proof =
+                    bcs::from_bytes::<ClassGroupsEncryptionKeyAndProof>(&mpc_data.mpc_data_bytes())
+                        .map_err(|e| {
+                            error!(
+                                should_never_happen = true,
                                 authority = ?name,
+                                validator_id = ?id,
                                 error = ?e,
                                 "failed to decode on-chain class-groups encryption key and proof; \
-                                 dropping this validator from the committee",
+                                 failing the chain-fallback committee build for retry"
                             );
-                            None
-                        }
-                    }
-                })
+                            DwalletMPCError::MissingOnChainMpcData {
+                                epoch,
+                                authority: *name,
+                            }
+                        })?;
+                Ok((*name, key_and_proof))
             })
-            .collect();
+            .collect::<DwalletMPCResult<HashMap<_, _>>>()?;
 
         // Chain fallback (legacy mode): only the bare class-groups key is on
         // chain, so there are no off-chain PVSS/VSS bundles to deliver.

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -529,13 +529,41 @@ where
                                 ))
                             })?;
                         let info = validator.verified_validator_info();
+                        // An active member's mpc_data record is written at candidate
+                        // registration and never emptied on chain, so a gap here is
+                        // always a read defect (fullnode lag, table-walk race, or a
+                        // decode failure the fetch already logged). Skipping the
+                        // member would install a committee whose class-groups map
+                        // silently diverges from peers with healthier reads — an
+                        // unagreed party-set exclusion in MPC public inputs — and
+                        // the degraded `EpochStartSystem` would be persisted and
+                        // rebuilt on every restart. Fail the whole read instead;
+                        // `must_get_epoch_start_system` retries until it completes.
+                        let Some(mpc_data) = validators_mpc_data.get(&validator.id) else {
+                            self.sui_client_metrics
+                                .sui_rpc_errors
+                                .with_label_values(&["epoch_start_missing_mpc_data"])
+                                .inc();
+                            error!(
+                                should_never_happen = true,
+                                validator_id = ?validator.id,
+                                validator_name = %info.name,
+                                "active committee member has no decodable on-chain \
+                                 mpc_data record at epoch start; failing the read for retry"
+                            );
+                            return Err(IkaError::InvalidCommittee(format!(
+                                "missing on-chain mpc_data record for active committee \
+                                 member {} ({})",
+                                info.name, validator.id
+                            )));
+                        };
                         Ok(EpochStartValidatorInfoV1 {
                             name: info.name.clone(),
                             validator_id: validator.id,
                             protocol_pubkey: info.protocol_pubkey.clone(),
                             network_pubkey: info.network_pubkey.clone(),
                             consensus_pubkey: info.consensus_pubkey.clone(),
-                            mpc_data: validators_mpc_data.get(&validator.id).cloned(),
+                            mpc_data: Some(mpc_data.clone()),
                             network_address: info.network_address.clone(),
                             p2p_address: info.p2p_address.clone(),
                             consensus_address: info.consensus_address.clone(),

--- a/crates/ika-types/src/dwallet_mpc_error.rs
+++ b/crates/ika-types/src/dwallet_mpc_error.rs
@@ -49,6 +49,16 @@ pub enum DwalletMPCError {
     )]
     OffChainAssemblyIncomplete { epoch: EpochId, missing: usize },
 
+    #[error(
+        "on-chain mpc_data record for committee member `{authority}` at epoch {epoch} is \
+         missing or undecodable — the record is written at candidate registration and never \
+         emptied, so this is a chain-read defect; retry the read"
+    )]
+    MissingOnChainMpcData {
+        epoch: EpochId,
+        authority: crate::crypto::AuthorityName,
+    },
+
     #[error("missing MPC class groups decryption shares in config")]
     MissingDwalletMPCClassGroupsDecryptionShares,
 
@@ -356,6 +366,7 @@ impl DwalletMPCError {
                 "invalid_centralized_party_imported_dwallet_public_output_version"
             }
             DwalletMPCError::OffChainAssemblyIncomplete { .. } => "off_chain_assembly_incomplete",
+            DwalletMPCError::MissingOnChainMpcData { .. } => "missing_on_chain_mpc_data",
             DwalletMPCError::PresignAlreadyUsed(_) => "presign_already_used",
         }
     }

--- a/crates/ika-types/src/sui/epoch_start_system.rs
+++ b/crates/ika-types/src/sui/epoch_start_system.rs
@@ -149,6 +149,14 @@ impl EpochStartSystemTrait for EpochStartSystemV1 {
                         bcs::from_bytes::<ClassGroupsEncryptionKeyAndProof>(
                             &mpc_data.mpc_data_bytes(),
                         )
+                        .map_err(|e| {
+                            error!(
+                                authority = ?validator.authority_name(),
+                                error = ?e,
+                                "Failed to decode mainnet-v1.1.8 ClassGroupsEncryptionKeyAndProof \
+                                 from Move-side mpc_data"
+                            );
+                        })
                         .ok()
                     });
 
@@ -186,7 +194,23 @@ impl EpochStartSystemTrait for EpochStartSystemV1 {
             .active_validators
             .iter()
             .filter_map(|validator| {
-                let mpc_data = validator.mpc_data.as_ref()?;
+                let Some(mpc_data) = validator.mpc_data.as_ref() else {
+                    // The fetch (`get_epoch_start_system`) fails the whole read
+                    // when an active member's record is missing, so this arm is
+                    // reachable only from a degraded `EpochStartSystem` persisted
+                    // before that gate existed. Loud because the built committee
+                    // then silently drops this member from every MPC public input
+                    // seeded from it (the class-groups map must never be partial
+                    // for a non-excluded member).
+                    error!(
+                        should_never_happen = true,
+                        authority = ?validator.authority_name(),
+                        "active committee member has no mpc_data record in the \
+                         persisted EpochStartSystem; its class-groups key is \
+                         missing from the committee"
+                    );
+                    return None;
+                };
                 match bcs::from_bytes::<ClassGroupsEncryptionKeyAndProof>(
                     &mpc_data.mpc_data_bytes(),
                 ) {

--- a/dev-docs/specs/validator-mpc-data-announcements.md
+++ b/dev-docs/specs/validator-mpc-data-announcements.md
@@ -202,7 +202,27 @@ which bytes* deterministic in consensus order.
    fetch, assembly decode).
 3. `Committee.class_groups_public_keys_and_proofs` is load-bearing for
    the reconfiguration MPC: it is never populated partially and never
-   left empty for a non-excluded member.
+   left empty for a non-excluded member. This binds every builder of
+   the map, not only the off-chain assembly. The chain-view builders —
+   `get_epoch_start_system` in `ika-sui-client` (feeding
+   `EpochStartSystem::get_ika_committee`, the epoch store's committee
+   and, pre-v4, the MPC manager's validator-key seed) and the
+   sui_syncer legacy chain fallback (`new_committee`, feeding the
+   reconfiguration MPC under pre-v4 protocol versions) — enforce it at
+   the read boundary: an active member whose on-chain `mpc_data`
+   record is missing or undecodable fails the WHOLE read (retried by
+   `must_get_epoch_start_system` / the next sync tick), never a silent
+   member skip. Chain state cannot legitimately lack the record (it is
+   written at candidate registration and never emptied; under v4 chain
+   writes remain), so absence is always a read defect — and each
+   validator reads through its own fullnode, so a tolerated local gap
+   would be an unagreed party-set exclusion: divergent MPC public
+   inputs across honest validators. Exclusion decisions belong
+   exclusively to the consensus-agreed freeze. The completeness check
+   lives at the read boundary, NOT on `Committee` construction — a
+   post-freeze assembled committee legitimately omits *excluded*
+   members, so a type-level "map covers all members" invariant would
+   be wrong.
 4. Post-freeze, all mpc-data decisions read the frozen set only.
 
 Code anchors: `crates/ika-types/src/validator_metadata.rs` (types),
@@ -210,4 +230,7 @@ Code anchors: `crates/ika-types/src/validator_metadata.rs` (types),
 `crates/ika-core/src/authority/authority_per_epoch_store.rs` (freeze
 decision, signal tables), `crates/ika-core/src/epoch_tasks/`
 (announcement sender, joiner announcements, peer blob fetcher),
-`crates/ika-network/src/mpc_artifacts/` (blob store + hash).
+`crates/ika-network/src/mpc_artifacts/` (blob store + hash),
+`crates/ika-sui-client/src/lib.rs` +
+`crates/ika-core/src/sui_connector/sui_syncer.rs` (chain-read
+completeness gates, invariant 3).


### PR DESCRIPTION
## Problem

Both chain-view committee builders tolerated a missing/undecodable on-chain `mpc_data` record for an **active committee member** as a silent member skip:

- `EpochStartSystem::get_ika_committee` (`epoch_start_system.rs`) — a silent `filter_map` skip building `Committee.class_groups_public_keys_and_proofs`, which seeds the MPC manager's validator keys pre-v4 (`class_groups_keys_by_party_id`, live on every deployed network today since `network_encryption_key_version = 3` only arrives with protocol v4);
- the sui_syncer legacy chain fallback (`new_committee`) — the same shape building the **next** committee that feeds the reconfiguration MPC every epoch under deployed protocol versions, where the missing-record case was dropped with no log at all.

A record cannot legitimately be absent: it is written at candidate registration (`validator_info.move` fills `mpc_data_bytes` at creation) and rotation never empties it — under v4 chain writes remain. So every gap is a read defect (fullnode lag, table-walk race, decode failure). Because each validator reads through its **own** fullnode, the tolerated gap became an *unagreed party-set exclusion*: a locally-shrunken class-groups map producing divergent MPC public inputs across honest validators (the crypto layer deliberately accepts partial key maps and deals only to present parties, so nothing fails locally). Exclusion decisions belong exclusively to the consensus-agreed freeze — this was the follow-up flagged in #1846's investigation (spec invariant 3), and the transient chain-read gap was the mechanism behind the issue-#1772 epoch-boundary flake.

## Fix

Fail the read, not just the log — retry infrastructure already existed:

- **`get_epoch_start_system`** (`ika-sui-client`): an active member absent from the fetched mpc_data map fails the whole read with `InvalidCommittee`, a `should_never_happen` error log, and a dedicated `sui_rpc_errors{epoch_start_missing_mpc_data}` label. All callers go through `must_get_epoch_start_system`, which retries until the chain view is complete — and since `EpochStartSystem` is persisted in the epoch-start configuration, a degraded snapshot can no longer be persisted and rebuilt on every restart. The gate sits above both `SuiClientInner` transports.
- **`new_committee` chain fallback** (`sui_syncer`): a missing or undecodable record errors the committee build (new `DwalletMPCError::MissingOnChainMpcData`, wired into the `kind()` metric-label match); the sync loop retries on the next tick instead of shipping a shrunken reconfiguration party set.
- **Builders stay defensive**: the `None` arm in `get_ika_committee` (reachable only from a snapshot persisted before the fetch gate) now logs at `error!`; `get_ika_committee_with_network_metadata` no longer swallows decode errors with `.ok()`.
- **Deliberately NOT enforced on `Committee::new`**: a post-freeze assembled committee legitimately omits *excluded* members, so a type-level "map covers all members" invariant would be wrong — the completeness check belongs at the chain-read boundary, where no exclusion concept exists.

Spec `dev-docs/specs/validator-mpc-data-announcements.md` invariant 3 updated in the same PR: it now binds every builder of the map, documents the read-boundary gates and the unagreed-exclusion rationale, and the code anchors point at both gates.

Trade-off, considered and accepted: a persistently inconsistent fullnode now stalls epoch entry visibly (warn + metric per retry) instead of letting the validator enter with divergent MPC input. Stuck-loudly is diagnosable in minutes; divergent-input failures historically surfaced as false-malicious convictions and took days.

## Validation

- `cargo check --release --workspace --all-targets` clean (caught the one exhaustive-match site needing the new error variant's arm); clippy clean on the three touched crates.
- Test Cluster suite green — run [29533696866](https://github.com/dwallet-labs/ika/actions/runs/29533696866) (includes `test_joiner_lands_in_next_committee_class_groups` from #1846, which exercises exactly this epoch-boundary read).
- Rust integration suite green — run [29533694710](https://github.com/dwallet-labs/ika/actions/runs/29533694710).
- TS integration suite green — run [29533698830](https://github.com/dwallet-labs/ika/actions/runs/29533698830).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
