### PR TITLE
fix(sui-connector): re-derive epoch-switch step gauges from chain state

### DIFF
--- a/crates/ika-core/src/sui_connector/metrics.rs
+++ b/crates/ika-core/src/sui_connector/metrics.rs
@@ -209,7 +209,7 @@ impl SuiConnectorMetrics {
             .unwrap(),
             epoch_switch_step_done: register_int_gauge_vec_with_registry!(
                 "ika_sui_connector_epoch_switch_step_done",
-                "Per-step gauge (0/1) for epoch-switch progress within the current epoch",
+                "Per-step gauge (0/1) for epoch-switch progress within the current epoch, re-derived from chain state each tick (restart-proof for all steps except request_advance_epoch)",
                 &["step"],
                 registry,
             )

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -581,16 +581,29 @@ where
         // gauges.
         let mid_epoch_done_on_chain = system_inner_v1.validator_set.next_epoch_committee.is_some();
         let keys_total = coordinator_inner.dwallet_network_encryption_keys.size;
-        // Requested (every key parked awaiting reconfiguration) or already fully
-        // completed this epoch (keys leave the awaiting state on completion).
+        // Every key is either not-yet-requested, parked awaiting reconfiguration
+        // (requested, incomplete), or counted in the per-epoch completed counter
+        // (keys leave the awaiting state on completion; `advance_epoch` asserts
+        // completed == total before zeroing, so the counter cannot leak across
+        // epochs). completed + awaiting == total therefore holds exactly when
+        // every key has been requested this epoch — including the mixed window
+        // where some completions already landed while others are still awaiting.
+        let awaiting_keys = network_encryption_keys
+            .values()
+            .filter(|key| {
+                key.state == DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration
+            })
+            .count() as u64;
+        // The bare completed-counter arm stays independent of the local key map
+        // so a lagging map read cannot suppress a fully-completed epoch.
         let reconfig_done_on_chain = keys_total > 0
             && (coordinator_inner.epoch_dwallet_network_encryption_keys_reconfiguration_completed
                 == keys_total
                 || (network_encryption_keys.len() as u64 == keys_total
-                    && network_encryption_keys.values().all(|key| {
-                        key.state
-                            == DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration
-                    })));
+                    && coordinator_inner
+                        .epoch_dwallet_network_encryption_keys_reconfiguration_completed
+                        + awaiting_keys
+                        == keys_total));
         // Votes are opened at mid-epoch (alongside the next active committee) and
         // consumed by the pricing calculation, so Some(committee) + no open votes
         // means the calculation already ran this epoch.

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -569,6 +569,62 @@ where
                  holding advance_epoch this tick",
             );
         }
+
+        // The per-step assignments above are process-local memos: each is set when
+        // THIS process performs a step, and all of them zero on restart. During a
+        // rolling upgrade every validator restarts and the whole fleet reports 0
+        // even for steps long completed on chain. Re-derive every step with an
+        // on-chain "done" predicate (the negation of the guard that triggers it)
+        // and OR it with the memo each tick, so a restarted validator converges on
+        // its next tick. `request_advance_epoch` stays memo-only: its chain effect
+        // is the epoch switch itself, which replaces this state and re-zeros the
+        // gauges.
+        let mid_epoch_done_on_chain = system_inner_v1.validator_set.next_epoch_committee.is_some();
+        let keys_total = coordinator_inner.dwallet_network_encryption_keys.size;
+        // Requested (every key parked awaiting reconfiguration) or already fully
+        // completed this epoch (keys leave the awaiting state on completion).
+        let reconfig_done_on_chain = keys_total > 0
+            && (coordinator_inner.epoch_dwallet_network_encryption_keys_reconfiguration_completed
+                == keys_total
+                || (network_encryption_keys.len() as u64 == keys_total
+                    && network_encryption_keys.values().all(|key| {
+                        key.state
+                            == DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration
+                    })));
+        // Votes are opened at mid-epoch (alongside the next active committee) and
+        // consumed by the pricing calculation, so Some(committee) + no open votes
+        // means the calculation already ran this epoch.
+        let pricing_done_on_chain = coordinator_inner.next_epoch_active_committee.is_some()
+            && coordinator_inner
+                .pricing_and_fee_management
+                .calculation_votes
+                .is_none();
+        let lock_done_on_chain =
+            sessions_manager.locked_last_user_initiated_session_to_complete_in_current_epoch;
+        for (step, done) in [
+            (
+                EPOCH_SWITCH_STEP_MID_EPOCH,
+                epoch_switch_state.ran_mid_epoch || mid_epoch_done_on_chain,
+            ),
+            (
+                EPOCH_SWITCH_STEP_NETWORK_KEY_RECONFIG,
+                epoch_switch_state.network_encryption_key_mid_epoch_reconfiguration
+                    || reconfig_done_on_chain,
+            ),
+            (
+                EPOCH_SWITCH_STEP_CALC_PRICING,
+                epoch_switch_state.calculated_protocol_pricing || pricing_done_on_chain,
+            ),
+            (
+                EPOCH_SWITCH_STEP_LOCK_LAST_SESSION,
+                epoch_switch_state.ran_lock_last_session || lock_done_on_chain,
+            ),
+        ] {
+            self.metrics
+                .epoch_switch_step_done
+                .with_label_values(&[step])
+                .set(i64::from(done));
+        }
     }
 
     pub async fn run_epoch(


### PR DESCRIPTION
## What

`epoch_switch_step_done{step}` gauges were process-local memos — set when *this* process performed a step, zeroed on restart. Each tick now ORs the memo with an on-chain "done" predicate (the negation of the guard that triggers the step), so a restarted validator converges on its next tick.

## Why

Observed live on testnet epoch 354: the network-key reconfiguration completed on chain (589 per-epoch output observations, on-chain completion counter equal to the key count), yet **all 24 upgraded validators reported 0 on every step gauge** — every one of them had restarted during the rolling v1.1.8→v1.2.x upgrade after the steps ran. Any dashboard/alert built on these gauges reads "nothing happened this epoch" during exactly the windows (rolling upgrades, crash-restarts) where epoch-switch visibility matters most. The infra side worked around it by switching to chain-truth signals ([infra@680062d9](https://github.com/dwallet-labs/infra/commit/680062d9)); this fixes the source.

## Chain predicates

| Step | on-chain "done" |
|---|---|
| `mid_epoch` | `system.validator_set.next_epoch_committee.is_some()` (the mid-epoch trigger's negation) |
| `network_encryption_key_mid_epoch_reconfiguration` | `completed == keys.size` (fully done, independent of the local key-map read) **or** `completed + #awaiting == keys.size` (every key requested — covers the mixed window where some completions already landed while others are still awaiting; keys leave the awaiting state on completion, and `advance_epoch` asserts completed == total before zeroing, so the counter cannot leak across epochs) |
| `calculate_protocols_pricing` | `next_epoch_active_committee.is_some() && calculation_votes.is_none()` — **exact, verified in Move**: `initiate_pricing_calculation` sets votes `Some` at mid-epoch; `calculate_pricing_votes` sets them back to `none` on `is_calculation_completed()` (`pricing_and_fee_manager.move:147-150`); and `advance_epoch` aborts while votes are in progress, so `Some` cannot linger across an epoch. Partial completion (chunked calculation) keeps votes `Some` → gauge correctly stays 0 until fully done |
| `lock_last_session` | `sessions_manager.locked_last_user_initiated_session_to_complete_in_current_epoch` |
| `request_advance_epoch` | memo-only, unchanged: its chain effect is the epoch switch itself, which replaces `EpochSwitchState` and re-zeros the gauges |

## Behavior

Observability-only. The memos still gate re-execution exactly as before; no submission decision changes. The sync runs at the end of `run_epoch_switch` on successful ticks only (early-return error paths skip it, next tick self-heals). The per-epoch zeroing at `run_epoch` start is preserved and the per-tick set is idempotent in both directions.

## Verification

- `cargo fmt --all --check`
- `cargo check --release -p ika-core`
- `cargo clippy --release -p ika-core --all-targets -- -D warnings`
- `./scripts/check-metric-names.sh` (220 literal, 3 dynamic sites skipped)
- Pricing-votes lifecycle verified against `contracts/ika_dwallet_2pc_mpc/sources/pricing_and_fee_manager.move`
- Rebased on main; review fix closed the mixed-state gap in the reconfiguration predicate (some keys completed + some awaiting previously read 0 on a restarted validator)
- Test Cluster suite: run 29577891558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
