### PR TITLE
fix(dwallet-mpc): re-instantiate network keys from chain after a mid-epoch restart (#1852)

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -30,6 +30,7 @@ use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionReques
 use crate::epoch::submit_to_consensus::DWalletMPCSubmitToConsensus;
 use crate::noa_checkpoints::NOACheckpointHandler;
 use crate::request_protocol_data::ProtocolData;
+use arc_swap::ArcSwap;
 use commitment::CommitmentSizedNumber;
 use dwallet_classgroups_types::ValidatorMPCSecrets;
 use dwallet_mpc_types::dwallet_mpc::MPCDataTrait;
@@ -72,6 +73,7 @@ use prometheus::Registry;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use sui_types::base_types::ObjectID;
 use sui_types::messages_consensus::Round;
 #[cfg(any(test, feature = "test-utils"))]
 use tokio::sync::watch;
@@ -191,6 +193,10 @@ impl DWalletMPCService {
         system_checkpoint_handler: Option<
             NOACheckpointHandler<noa_checkpoint::SuiSystemCheckpoint>,
         >,
+        // Shared set of instantiated network keys (created once at the node
+        // seam, also handed to the sui-connector syncer). The manager writes
+        // here on confirmed instantiation; the syncer reads it.
+        instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
     ) -> Self {
         let network_dkg_third_round_delay = protocol_config.network_dkg_third_round_delay();
 
@@ -227,6 +233,7 @@ impl DWalletMPCService {
             epoch_store.clone(),
             network_owned_address_sign_output_sender,
             max_mpc_computation_cores,
+            instantiated_network_keys,
         );
 
         Self {
@@ -315,6 +322,7 @@ impl DWalletMPCService {
                 epoch_store,
                 network_owned_address_sign_output_sender,
                 None,
+                Arc::new(ArcSwap::from_pointee(HashSet::new())),
             ),
             exit: watch::channel(()).1,
             end_of_publish: false,

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -193,10 +193,11 @@ impl DWalletMPCService {
         system_checkpoint_handler: Option<
             NOACheckpointHandler<noa_checkpoint::SuiSystemCheckpoint>,
         >,
-        // Shared set of instantiated network keys (created once at the node
-        // seam, also handed to the sui-connector syncer). The manager writes
-        // here on confirmed instantiation; the syncer reads it.
-        instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
+        // Shared set of restart-stranded network keys (created once at the
+        // node seam, also handed to the sui-connector syncer). The manager
+        // flags a stranded key at adoption and un-flags it on confirmed
+        // instantiation; the syncer chain-reads flagged keys.
+        stranded_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
     ) -> Self {
         let network_dkg_third_round_delay = protocol_config.network_dkg_third_round_delay();
 
@@ -233,7 +234,7 @@ impl DWalletMPCService {
             epoch_store.clone(),
             network_owned_address_sign_output_sender,
             max_mpc_computation_cores,
-            instantiated_network_keys,
+            stranded_network_keys,
         );
 
         Self {

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -709,3 +709,148 @@ async fn adopted_keys_always_resolve_a_network_key_id() {
     );
     assert_all_adopted_resolve(manager, "after the cert-less registration pass");
 }
+
+/// The mid-epoch-restart strand (#1852), manager side. Once this epoch's
+/// reconfiguration completes, its output digest is recorded under the CURRENT
+/// epoch and the off-chain overlay serves that output — which is encrypted to
+/// the NEXT committee. Adoption must skip it (a running validator already
+/// holds this epoch's parameters; adopting would fail decryption), and that
+/// skip is exactly what strands a validator that restarted mid-epoch with an
+/// empty instantiation map: nothing else re-delivers an instantiable output.
+/// The recovery contract this test pins: an overlay carrying the CURRENT
+/// epoch's output — what the syncer now sources from chain for a key the
+/// manager hasn't instantiated — must be adopted and spawn instantiation.
+#[tokio::test]
+async fn this_epoch_reconfiguration_output_is_skipped_and_current_epoch_output_recovers() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (
+        mut dwallet_mpc_services,
+        _sui_data_senders,
+        _sent_consensus_messages_collectors,
+        epoch_stores,
+        _notify_services,
+        _network_owned_address_sign_request_senders,
+        _network_owned_address_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services(1);
+    let service = dwallet_mpc_services.first_mut().unwrap();
+    let epoch_id = service.epoch;
+    let prior_epoch = epoch_id - 1;
+
+    let key_id = ObjectID::random();
+    let network_key_id = NetworkKeyId([0x71; 32]);
+    crate::network_key_id_mapping::register(key_id, network_key_id);
+    let dkg_output = b"restart strand network dkg public output".to_vec();
+    // R(M-1): produced by the PRIOR epoch's reconfiguration FOR this epoch's
+    // committee — the output this epoch's parameters derive from, and what
+    // the chain serves as the current epoch's reconfiguration output.
+    let current_epoch_output = b"reconfiguration output for the current committee".to_vec();
+    // R(M): produced by THIS epoch's reconfiguration FOR the next committee.
+    let this_epoch_output = b"reconfiguration output for the next committee".to_vec();
+
+    // Record R(M)'s digest under the current epoch, exactly as output
+    // processing does when this epoch's reconfiguration completes.
+    let perpetual_dir = tempfile::tempdir().expect("tempdir");
+    let perpetual = Arc::new(
+        crate::authority::authority_perpetual_tables::AuthorityPerpetualTables::open(
+            perpetual_dir.path(),
+            None,
+        ),
+    );
+    perpetual
+        .insert_network_reconfiguration_output_digest_for_epoch(
+            epoch_id,
+            key_id,
+            mpc_data_blob_hash(&this_epoch_output),
+        )
+        .expect("digest insert");
+    epoch_stores
+        .first()
+        .unwrap()
+        .perpetual_tables
+        .lock()
+        .unwrap()
+        .replace(perpetual);
+
+    // Phase 1 — the strand shape. The cert deliberately pins R(M) so the
+    // cert-digest gate alone would ADOPT this overlay; only the
+    // produced-this-epoch guard can be the one skipping it. (In the real
+    // restart the prior epoch's cert pins R(M-1) and both gates skip R(M);
+    // pinning R(M) here isolates the guard under test.)
+    let cert_pinning = |reconfiguration_output: &[u8]| CertifiedHandoffAttestation {
+        attestation: HandoffAttestation {
+            epoch: prior_epoch,
+            next_committee_pubkey_set_hash: [0u8; 32],
+            items: vec![
+                (
+                    HandoffItemKey::NetworkDkgOutput {
+                        key_id: network_key_id,
+                    },
+                    mpc_data_blob_hash(&dkg_output),
+                ),
+                (
+                    HandoffItemKey::NetworkReconfigurationOutput {
+                        key_id: network_key_id,
+                    },
+                    mpc_data_blob_hash(reconfiguration_output),
+                ),
+            ],
+        },
+        signatures: vec![],
+    };
+    epoch_stores
+        .first()
+        .unwrap()
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(prior_epoch, cert_pinning(&this_epoch_output));
+
+    let this_epoch_overlay = Arc::new(HashMap::from([(
+        key_id,
+        network_key_data(key_id, epoch_id, dkg_output.clone(), this_epoch_output),
+    )]));
+    let manager = service.dwallet_mpc_manager_mut();
+    manager.adopt_cert_verified_keys(&this_epoch_overlay);
+    assert!(
+        !manager.adopted_network_key_data.contains_key(&key_id),
+        "an overlay serving the reconfiguration output produced THIS epoch (for \
+         the next committee) must be skipped by the produced-this-epoch guard"
+    );
+
+    // Phase 2 — the recovery contract. The realistic prior-epoch cert pins
+    // R(M-1); the overlay now carries R(M-1) (the syncer's un-instantiated
+    // chain read). The recorded R(M) digest must not match it, so adoption
+    // proceeds and instantiation spawns.
+    epoch_stores
+        .first()
+        .unwrap()
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(prior_epoch, cert_pinning(&current_epoch_output));
+    let current_epoch_overlay = Arc::new(HashMap::from([(
+        key_id,
+        network_key_data(
+            key_id,
+            epoch_id,
+            dkg_output.clone(),
+            current_epoch_output.clone(),
+        ),
+    )]));
+    manager.adopt_cert_verified_keys(&current_epoch_overlay);
+    let adopted = manager
+        .adopted_network_key_data
+        .get(&key_id)
+        .expect("the current-epoch reconfiguration output must be adopted");
+    assert_eq!(
+        adopted.current_reconfiguration_public_output, current_epoch_output,
+        "the adopted data must carry the current epoch's output"
+    );
+    manager.instantiate_adopted_network_keys();
+    assert!(
+        manager
+            .pending_network_key_instantiations
+            .contains_key(&key_id),
+        "the adopted current-epoch output must spawn instantiation"
+    );
+}

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -717,9 +717,11 @@ async fn adopted_keys_always_resolve_a_network_key_id() {
 /// holds this epoch's parameters; adopting would fail decryption), and that
 /// skip is exactly what strands a validator that restarted mid-epoch with an
 /// empty instantiation map: nothing else re-delivers an instantiable output.
-/// The recovery contract this test pins: an overlay carrying the CURRENT
-/// epoch's output — what the syncer now sources from chain for a key the
-/// manager hasn't instantiated — must be adopted and spawn instantiation.
+/// The contracts this test pins: the manager flags such a key as stranded
+/// (the syncer's trigger to source the current epoch's output from chain),
+/// and an overlay carrying the CURRENT epoch's output — what that
+/// chain-sourced recovery read delivers — is adopted and spawns
+/// instantiation.
 #[tokio::test]
 async fn this_epoch_reconfiguration_output_is_skipped_and_current_epoch_output_recovers() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
@@ -816,9 +818,17 @@ async fn this_epoch_reconfiguration_output_is_skipped_and_current_epoch_output_r
         "an overlay serving the reconfiguration output produced THIS epoch (for \
          the next committee) must be skipped by the produced-this-epoch guard"
     );
+    // Holding nothing for the skipped key (not instantiated, nothing in
+    // flight, nothing adopted) is the restart strand: the manager must flag
+    // the key so the syncer sources the current epoch's output from chain.
+    assert!(
+        manager.stranded_network_keys.load().contains(&key_id),
+        "the skipped key must be flagged as stranded for the syncer's \
+         chain-sourced recovery read"
+    );
 
     // Phase 2 — the recovery contract. The realistic prior-epoch cert pins
-    // R(M-1); the overlay now carries R(M-1) (the syncer's un-instantiated
+    // R(M-1); the overlay now carries R(M-1) (the syncer's stranded-key
     // chain read). The recorded R(M) digest must not match it, so adoption
     // proceeds and instantiation spawns.
     epoch_stores

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -84,6 +84,12 @@ pub(crate) struct TestingAuthorityPerEpochStore {
     /// "cert absent"); tests for the cert-digest gate insert one here.
     pub(crate) certified_handoff_attestations:
         Arc<Mutex<HashMap<EpochId, CertifiedHandoffAttestation>>>,
+    /// Configurable perpetual-tables handle. `None` by default (matching
+    /// "nothing recorded"); tests for the produced-this-epoch adoption
+    /// guard open real tables in a tempdir and install them here.
+    pub(crate) perpetual_tables: Arc<
+        Mutex<Option<Arc<crate::authority::authority_perpetual_tables::AuthorityPerpetualTables>>>,
+    >,
 }
 
 pub(crate) struct IntegrationTestState {
@@ -150,6 +156,7 @@ impl TestingAuthorityPerEpochStore {
             presign_private_outputs: Arc::new(Mutex::new(HashMap::new())),
             assigned_presigns: Arc::new(Mutex::new(HashMap::new())),
             certified_handoff_attestations: Arc::new(Mutex::new(HashMap::new())),
+            perpetual_tables: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -519,12 +526,14 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
     ) -> Option<
         std::sync::Arc<crate::authority::authority_perpetual_tables::AuthorityPerpetualTables>,
     > {
-        // Tests don't install a perpetual tables handle; returning
-        // None is consistent with "freeze hasn't been populated
+        // `None` unless a test installs real tables (tempdir-backed): the
+        // default is consistent with "freeze hasn't been populated
         // either," and `local_mpc_data_ready_for_frozen_set`
         // short-circuits to `true` on an empty frozen set before
-        // it would touch this.
-        None
+        // it would touch this. The produced-this-epoch adoption-guard
+        // tests install tables here to record an epoch-keyed
+        // reconfiguration-output digest.
+        self.perpetual_tables.lock().unwrap().clone()
     }
 }
 

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -32,6 +32,7 @@ use crate::dwallet_mpc::{
 };
 use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionRequestMetricData};
 use crate::network_key_id_mapping::network_key_id_for;
+use arc_swap::ArcSwap;
 use dwallet_classgroups_types::ValidatorMPCSecrets;
 use dwallet_mpc_types::dwallet_mpc::{
     DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm, MPCPrivateInput,
@@ -323,6 +324,16 @@ pub(crate) struct DWalletMPCManager {
     /// in the process-global mapping, short-circuiting before this gate.
     pub(crate) network_key_id_derivations_spawned: HashMap<ObjectID, [u8; 32]>,
 
+    /// Set of network keys this validator has actually instantiated, shared by
+    /// `Arc` with the sui-connector network-keys sync task. A key is inserted
+    /// here (and only here) once `update_network_key` confirms it is
+    /// instantiated — never on a decrypt/epoch-mismatch failure — so the set
+    /// never claims an un-instantiated key. The syncer reads it to keep serving
+    /// the off-chain reconfiguration output for an instantiated key while
+    /// sourcing the current-epoch output from chain for a key a fresh/restart
+    /// validator has not instantiated yet (see `sync_dwallet_network_keys`).
+    pub(crate) instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
+
     /// Sessions whose protocol-cryptographic-data generation already
     /// failed and was logged. The generation re-runs every 20ms service
     /// iteration, so a stuck session would otherwise emit ~50 identical
@@ -463,6 +474,7 @@ impl DWalletMPCManager {
         epoch_store: Arc<dyn AuthorityPerEpochStoreTrait>,
         network_owned_address_sign_output_sender: Sender<NetworkOwnedAddressSignOutput>,
         max_computation_cores: Option<usize>,
+        instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
     ) -> Self {
         Self::try_new(
             validator_name,
@@ -478,6 +490,7 @@ impl DWalletMPCManager {
             epoch_store,
             network_owned_address_sign_output_sender,
             max_computation_cores,
+            instantiated_network_keys,
         )
         .unwrap_or_else(|err| {
             error!(error=?err, "Failed to create DWalletMPCManager.");
@@ -500,6 +513,7 @@ impl DWalletMPCManager {
         epoch_store: Arc<dyn AuthorityPerEpochStoreTrait>,
         network_owned_address_sign_output_sender: Sender<NetworkOwnedAddressSignOutput>,
         max_computation_cores: Option<usize>,
+        instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
     ) -> DwalletMPCResult<Self> {
         let access_structure = generate_access_structure_from_committee(&committee)?;
 
@@ -601,6 +615,7 @@ impl DWalletMPCManager {
             last_cert_read_warn: None,
             warned_cert_digest_mismatches: HashSet::new(),
             network_key_id_derivations_spawned: HashMap::new(),
+            instantiated_network_keys,
             warned_cryptographic_data_generation_failures: HashSet::new(),
             untracked_anomalies: HashSet::new(),
             last_failed_network_key_data: HashMap::new(),
@@ -1233,6 +1248,22 @@ impl DWalletMPCManager {
                     })
                     .is_some_and(|digest| digest == reconfiguration_digest);
                 if produced_this_epoch {
+                    // `already_instantiated = true` is the healthy shape (the
+                    // running validator holds the current epoch's parameters
+                    // and is only pre-staging this output for the boundary
+                    // flip). `false` means this validator holds NOTHING for
+                    // the key while the overlay serves only the next
+                    // committee's output — the mid-epoch-restart strand the
+                    // syncer's un-instantiated chain read exists to resolve.
+                    info!(
+                        ?key_id,
+                        already_instantiated = self
+                            .network_keys
+                            .network_encryption_keys
+                            .contains_key(key_id),
+                        "adoption skipping network key: the overlay's reconfiguration output \
+                         was produced this epoch (encrypted to the next committee)"
+                    );
                     continue;
                 }
             }
@@ -2982,6 +3013,17 @@ impl DWalletMPCManager {
                         }
                         // Succeeded — drop any prior failure record.
                         self.last_failed_network_key_data.remove(&key_id);
+                        // Mark the key instantiated for the sui-connector
+                        // network-keys sync task: from here it keeps serving this
+                        // key's off-chain reconfiguration output instead of
+                        // re-importing the current-epoch output from chain.
+                        // Written ONLY here (confirmed-instantiated), never on the
+                        // decrypt-fail / epoch-mismatch branches above.
+                        self.instantiated_network_keys.rcu(|keys| {
+                            let mut keys = (**keys).clone();
+                            keys.insert(key_id);
+                            Arc::new(keys)
+                        });
                     }
                 }
                 Err(err) => {

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -324,15 +324,18 @@ pub(crate) struct DWalletMPCManager {
     /// in the process-global mapping, short-circuiting before this gate.
     pub(crate) network_key_id_derivations_spawned: HashMap<ObjectID, [u8; 32]>,
 
-    /// Set of network keys this validator has actually instantiated, shared by
-    /// `Arc` with the sui-connector network-keys sync task. A key is inserted
-    /// here (and only here) once `update_network_key` confirms it is
-    /// instantiated — never on a decrypt/epoch-mismatch failure — so the set
-    /// never claims an un-instantiated key. The syncer reads it to keep serving
-    /// the off-chain reconfiguration output for an instantiated key while
-    /// sourcing the current-epoch output from chain for a key a fresh/restart
-    /// validator has not instantiated yet (see `sync_dwallet_network_keys`).
-    pub(crate) instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
+    /// Network keys stranded by a mid-epoch restart, shared by `Arc` with the
+    /// sui-connector network-keys sync task. The adoption pass inserts a key
+    /// when its produced-this-epoch guard skips the overlay while this
+    /// validator holds NOTHING for the key (not instantiated, no instantiation
+    /// in flight, nothing adopted) — the restart strand, where the off-chain
+    /// overlay serves only the next committee's output and nothing re-delivers
+    /// an instantiable one. The syncer chain-reads ONLY flagged keys (serving
+    /// the canonical current-epoch output); a confirmed instantiation removes
+    /// the key, returning it to the off-chain read path. Empty in every
+    /// healthy flow, which preserves the v4 no-steady-state-chain-read
+    /// invariant (see `sync_dwallet_network_keys`).
+    pub(crate) stranded_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
 
     /// Sessions whose protocol-cryptographic-data generation already
     /// failed and was logged. The generation re-runs every 20ms service
@@ -474,7 +477,7 @@ impl DWalletMPCManager {
         epoch_store: Arc<dyn AuthorityPerEpochStoreTrait>,
         network_owned_address_sign_output_sender: Sender<NetworkOwnedAddressSignOutput>,
         max_computation_cores: Option<usize>,
-        instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
+        stranded_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
     ) -> Self {
         Self::try_new(
             validator_name,
@@ -490,7 +493,7 @@ impl DWalletMPCManager {
             epoch_store,
             network_owned_address_sign_output_sender,
             max_computation_cores,
-            instantiated_network_keys,
+            stranded_network_keys,
         )
         .unwrap_or_else(|err| {
             error!(error=?err, "Failed to create DWalletMPCManager.");
@@ -513,7 +516,7 @@ impl DWalletMPCManager {
         epoch_store: Arc<dyn AuthorityPerEpochStoreTrait>,
         network_owned_address_sign_output_sender: Sender<NetworkOwnedAddressSignOutput>,
         max_computation_cores: Option<usize>,
-        instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
+        stranded_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
     ) -> DwalletMPCResult<Self> {
         let access_structure = generate_access_structure_from_committee(&committee)?;
 
@@ -615,7 +618,7 @@ impl DWalletMPCManager {
             last_cert_read_warn: None,
             warned_cert_digest_mismatches: HashSet::new(),
             network_key_id_derivations_spawned: HashMap::new(),
-            instantiated_network_keys,
+            stranded_network_keys,
             warned_cryptographic_data_generation_failures: HashSet::new(),
             untracked_anomalies: HashSet::new(),
             last_failed_network_key_data: HashMap::new(),
@@ -1251,19 +1254,43 @@ impl DWalletMPCManager {
                     // `already_instantiated = true` is the healthy shape (the
                     // running validator holds the current epoch's parameters
                     // and is only pre-staging this output for the boundary
-                    // flip). `false` means this validator holds NOTHING for
-                    // the key while the overlay serves only the next
-                    // committee's output — the mid-epoch-restart strand the
-                    // syncer's un-instantiated chain read exists to resolve.
+                    // flip).
+                    let already_instantiated = self
+                        .network_keys
+                        .network_encryption_keys
+                        .contains_key(key_id);
                     info!(
                         ?key_id,
-                        already_instantiated = self
-                            .network_keys
-                            .network_encryption_keys
-                            .contains_key(key_id),
+                        already_instantiated,
                         "adoption skipping network key: the overlay's reconfiguration output \
                          was produced this epoch (encrypted to the next committee)"
                     );
+                    // The mid-epoch-restart strand (#1852): this validator
+                    // holds NOTHING for the key — no instantiated parameters,
+                    // no instantiation in flight, no adopted data awaiting one
+                    // — while the overlay serves only the next committee's
+                    // output. Nothing else re-delivers an instantiable
+                    // current-epoch output, so flag the key for the syncer's
+                    // chain-sourced recovery read. The in-flight/adopted
+                    // checks keep the healthy flip out of the set: a running
+                    // validator whose FIRST instantiation is still on the
+                    // rayon pool when this epoch's reconfiguration completes
+                    // already holds the right bytes and needs no chain read.
+                    let stranded = !already_instantiated
+                        && !self.pending_network_key_instantiations.contains_key(key_id)
+                        && !self.adopted_network_key_data.contains_key(key_id);
+                    if stranded && !self.stranded_network_keys.load().contains(key_id) {
+                        info!(
+                            ?key_id,
+                            "network key stranded after a mid-epoch restart — requesting a \
+                             chain-sourced current-epoch reconfiguration output from the syncer"
+                        );
+                        self.stranded_network_keys.rcu(|keys| {
+                            let mut keys = (**keys).clone();
+                            keys.insert(*key_id);
+                            Arc::new(keys)
+                        });
+                    }
                     continue;
                 }
             }
@@ -3013,17 +3040,20 @@ impl DWalletMPCManager {
                         }
                         // Succeeded — drop any prior failure record.
                         self.last_failed_network_key_data.remove(&key_id);
-                        // Mark the key instantiated for the sui-connector
-                        // network-keys sync task: from here it keeps serving this
-                        // key's off-chain reconfiguration output instead of
-                        // re-importing the current-epoch output from chain.
-                        // Written ONLY here (confirmed-instantiated), never on the
-                        // decrypt-fail / epoch-mismatch branches above.
-                        self.instantiated_network_keys.rcu(|keys| {
-                            let mut keys = (**keys).clone();
-                            keys.insert(key_id);
-                            Arc::new(keys)
-                        });
+                        // A confirmed instantiation ends the restart-recovery
+                        // read: un-flag the key so the sui-connector sync task
+                        // returns it to the off-chain read path. Removed ONLY
+                        // here (confirmed-instantiated), never on the
+                        // decrypt-fail / epoch-mismatch branches above — a key
+                        // that still cannot instantiate keeps its
+                        // chain-sourced overlay and retries.
+                        if self.stranded_network_keys.load().contains(&key_id) {
+                            self.stranded_network_keys.rcu(|keys| {
+                                let mut keys = (**keys).clone();
+                                keys.remove(&key_id);
+                                Arc::new(keys)
+                            });
+                        }
                     }
                 }
                 Err(err) => {

--- a/crates/ika-core/src/epoch_tasks/handoff_signature_sender.rs
+++ b/crates/ika-core/src/epoch_tasks/handoff_signature_sender.rs
@@ -21,6 +21,7 @@ use crate::authority::authority_per_epoch_store::{
 use crate::consensus_adapter::SubmitToConsensus;
 use crate::validator_metadata::{HandoffItemsBuilder, next_committee_pubkey_set};
 use fastcrypto::ed25519::Ed25519KeyPair;
+use ika_network::mpc_artifacts::mpc_data_blob_hash;
 use ika_types::committee::Committee;
 use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use ika_types::messages_consensus::ConsensusTransaction;
@@ -181,54 +182,32 @@ impl HandoffSignatureSender {
     }
 
     /// For each network encryption key that has finished its initial
-    /// DKG, re-cache the canonical DKG output bytes into the per-epoch
-    /// digest table. Idempotent — re-caching the same bytes keeps the
-    /// same digest (the cache layer is content-addressed). The DKG
-    /// output is a one-time stable value, so caching it from the
-    /// (possibly-lagging) `network_keys_receiver` snapshot can't diverge
-    /// across the committee. The per-epoch reconfiguration output is
-    /// intentionally left to its consensus-ordered sources — see the
-    /// note in the loop body.
+    /// DKG and has NO locally-recorded DKG digest yet, cache the DKG
+    /// output bytes from the overlay snapshot into the per-epoch digest
+    /// table. Fill-absence ONLY: a validator that saw EndOfPublish
+    /// before its own MPC produced/cached the output would otherwise
+    /// build an attestation missing the `NetworkDkgOutput` item and
+    /// cross-reject peers as `AttestationMismatch`. The per-epoch
+    /// reconfiguration output is intentionally left to its
+    /// consensus-ordered sources — see the note in the loop body.
+    ///
+    /// NEVER overwrite an existing digest: the local mirror is written
+    /// canonically by the instantiation path (the reconstructed V3
+    /// output once the V2→V3 canonical migration flips) and by the
+    /// cert-anchored barrier install — both strictly more authoritative
+    /// than this watch snapshot, which can carry the chain's original
+    /// pre-V3 anchor whenever the syncer chain-read before the
+    /// off-chain blob source was installed (a post-restart window).
+    /// An unconditional write here clobbered the DURABLE perpetual
+    /// canonical mirror with that anchor, permanently failing the
+    /// handoff-cert DKG-digest adoption gate every later epoch — the
+    /// never-instantiated variant of issue #1852.
     fn hydrate_protocol_output_digests_from_chain(
         &self,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) {
         let snapshot = self.network_keys_receiver.borrow().clone();
-        for (key_id, data) in snapshot.iter() {
-            // DKG output: present once the key crosses out of
-            // `AwaitingNetworkDKG`. Always cache if we have non-empty
-            // bytes — re-caching with the same canonical bytes is a
-            // no-op for the digest.
-            if !data.network_dkg_public_output.is_empty()
-                && !matches!(
-                    data.state,
-                    DWalletNetworkEncryptionKeyState::AwaitingNetworkDKG
-                )
-                && let Err(e) =
-                    epoch_store.cache_network_dkg_output(*key_id, &data.network_dkg_public_output)
-            {
-                warn!(
-                    error = ?e,
-                    key_id = ?key_id,
-                    "failed to hydrate network DKG digest from chain bytes"
-                );
-            }
-            // NOTE: the *reconfiguration* output is deliberately NOT
-            // hydrated here. Unlike the one-time DKG output, it is
-            // epoch-specific, and this `network_keys_receiver` snapshot
-            // is a non-consensus watch channel that can surface the
-            // *prior* epoch's output (via the perpetual mirror) a round
-            // behind. The reconfiguration digest is written solely by
-            // this validator's local reconfiguration MPC in
-            // `dwallet_mpc_service`, keyed by the reconfiguration
-            // session's own epoch, and both the handoff items builder and
-            // `snapshot_ready_for_signing` read it from that epoch-keyed
-            // slice (`get_network_reconfiguration_output_digests_for_epoch`).
-            // Hydrating from the lagging snapshot would file a
-            // possibly-stale value under this epoch, so two signers would
-            // hash different `NetworkReconfigurationOutput` digests and
-            // cross-reject as `AttestationMismatch`.
-        }
+        hydrate_network_dkg_digests(epoch_store, &snapshot);
     }
 
     async fn send(&self) -> DwalletMPCResult<()> {
@@ -299,15 +278,15 @@ impl HandoffSignatureSender {
         // makes the cert structurally unverifiable by the very joiner it
         // certifies whenever the freeze excludes a seated member.
         let next_committee_pubkeys = next_committee_pubkey_set(&next_committee);
-        // Hydrate the local digest cache from the chain-canonical
-        // output bytes BEFORE building the attestation. Reading
-        // from chain (via the `network_keys_receiver` published by
-        // `sui_syncer`) is the only consensus-deterministic source
-        // — the original local MPC-driven cache writes race with
-        // EndOfPublish (a slow validator can see EndOfPublish
-        // before its own MPC produces output, so the cache is
-        // empty at signing time and the items list diverges from
-        // peers => signatures cross-reject as `AttestationMismatch`).
+        // Fill ABSENT DKG digests from the overlay snapshot BEFORE
+        // building the attestation: a slow validator can see
+        // EndOfPublish before its own MPC produced/cached the output,
+        // and an empty cache at signing time makes the items list
+        // diverge from peers => signatures cross-reject as
+        // `AttestationMismatch`. Fill-absence only — the snapshot is
+        // NOT authoritative over an existing digest (post-restart it
+        // can carry the chain's pre-V3 anchor; see
+        // `hydrate_network_dkg_digests`).
         self.hydrate_protocol_output_digests_from_chain(&epoch_store);
         let attestation = epoch_store
             .build_local_handoff_attestation(next_committee_pubkeys, &self.builders)
@@ -379,5 +358,189 @@ impl HandoffSignatureSender {
             );
         }
         Ok(())
+    }
+}
+
+/// For each network encryption key in the overlay snapshot that has
+/// finished its initial DKG and has NO locally-recorded DKG digest yet,
+/// cache the snapshot's DKG output bytes into the local digest cache.
+/// Fill-absence ONLY: a validator that saw EndOfPublish before its own
+/// MPC produced/cached the output would otherwise build an attestation
+/// missing the `NetworkDkgOutput` item and cross-reject peers as
+/// `AttestationMismatch`.
+///
+/// NEVER overwrite an existing digest: the local mirror is written
+/// canonically by the instantiation path (the reconstructed V3 output
+/// once the V2→V3 canonical migration flips) and by the cert-anchored
+/// barrier install — both strictly more authoritative than this watch
+/// snapshot, which can carry the chain's original pre-V3 anchor whenever
+/// the syncer chain-read before the off-chain blob source was installed
+/// (a post-restart window). An unconditional write here clobbered the
+/// DURABLE perpetual canonical mirror with that anchor, permanently
+/// failing the handoff-cert DKG-digest adoption gate every later epoch —
+/// the never-instantiated variant of issue #1852.
+///
+/// The per-epoch reconfiguration output is deliberately NOT hydrated
+/// here. Unlike the one-time DKG output, it is epoch-specific, and the
+/// overlay snapshot is a non-consensus watch channel that can surface
+/// the *prior* epoch's output (via the perpetual mirror) a round behind.
+/// The reconfiguration digest is written solely by this validator's
+/// local reconfiguration MPC in `dwallet_mpc_service`, keyed by the
+/// reconfiguration session's own epoch, and both the handoff items
+/// builder and `snapshot_ready_for_signing` read it from that epoch-keyed
+/// slice (`get_network_reconfiguration_output_digests_for_epoch`).
+/// Hydrating from the lagging snapshot would file a possibly-stale value
+/// under this epoch, so two signers would hash different
+/// `NetworkReconfigurationOutput` digests and cross-reject as
+/// `AttestationMismatch`.
+fn hydrate_network_dkg_digests(
+    epoch_store: &Arc<AuthorityPerEpochStore>,
+    snapshot: &HashMap<ObjectID, DWalletNetworkEncryptionKeyData>,
+) {
+    // The merged per-epoch + perpetual view — the same view the
+    // attestation items builder reads, so "absent here" is exactly
+    // "the attestation would omit the item".
+    //
+    // The view is read once per pass, so a canonical write landing
+    // between this read and the cache write below can be overwritten by
+    // the snapshot value for a key that was absent at the read. The
+    // window is one pass, requires the key's first-ever cache to race
+    // it, and the barrier's cert-anchored DKG repair heals the affected
+    // epoch at the next boundary — accepted rather than locked.
+    let existing_dkg_digests = epoch_store
+        .get_network_dkg_output_digests()
+        .unwrap_or_default();
+    for (key_id, data) in snapshot.iter() {
+        // DKG output: present once the key crosses out of
+        // `AwaitingNetworkDKG`. Cache only when no digest is recorded
+        // for the key yet (fill-absence; see above).
+        if data.network_dkg_public_output.is_empty()
+            || matches!(
+                data.state,
+                DWalletNetworkEncryptionKeyState::AwaitingNetworkDKG
+            )
+        {
+            continue;
+        }
+        if let Some(existing) = existing_dkg_digests.get(key_id) {
+            // A skip may be correct; a SILENT skip on a contradiction
+            // never is: an overlay carrying bytes that hash differently
+            // from the recorded canonical digest is the #1852
+            // hydration-clobber signature (e.g. the chain's pre-V3
+            // anchor after a restart) — surface it. Routine
+            // identical-bytes skips stay quiet.
+            let snapshot_digest = mpc_data_blob_hash(&data.network_dkg_public_output);
+            if *existing != snapshot_digest {
+                warn!(
+                    key_id = ?key_id,
+                    existing_digest = ?existing,
+                    snapshot_digest = ?snapshot_digest,
+                    "overlay snapshot's DKG bytes contradict the locally-recorded canonical \
+                     digest — keeping the canonical value (fill-absence hydration never \
+                     overwrites); if this validator was recently restarted this is the \
+                     stale pre-V3-anchor overlay shape"
+                );
+            }
+            continue;
+        }
+        if let Err(e) =
+            epoch_store.cache_network_dkg_output(*key_id, &data.network_dkg_public_output)
+        {
+            warn!(
+                error = ?e,
+                key_id = ?key_id,
+                "failed to hydrate network DKG digest from chain bytes"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authority::authority_perpetual_tables::AuthorityPerpetualTables;
+    use crate::authority::epoch_start_configuration::EpochStartConfiguration;
+    use crate::epoch::epoch_metrics::EpochMetrics;
+    use ika_types::digests::ChainIdentifier;
+    use ika_types::messages_dwallet_mpc::IkaNetworkConfig;
+    use ika_types::sui::EpochStartSystem;
+    use prometheus::Registry;
+
+    fn snapshot_entry(
+        key_id: ObjectID,
+        dkg_bytes: &[u8],
+    ) -> (ObjectID, DWalletNetworkEncryptionKeyData) {
+        (
+            key_id,
+            DWalletNetworkEncryptionKeyData {
+                id: key_id,
+                current_epoch: 0,
+                dkg_at_epoch: 0,
+                network_dkg_public_output: dkg_bytes.to_vec(),
+                current_reconfiguration_public_output: vec![],
+                state: DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted,
+            },
+        )
+    }
+
+    /// The hydration pass is fill-absence only (#1852, never-instantiated
+    /// variant): a key with an existing locally-recorded DKG digest must NOT
+    /// be overwritten by the overlay snapshot's bytes — the snapshot can
+    /// carry the chain's pre-V3 anchor after a restart, and the durable
+    /// canonical mirror it would clobber is what the handoff-cert DKG-digest
+    /// adoption gate verifies. A key with no recorded digest is still filled.
+    #[tokio::test]
+    async fn hydration_fills_absent_digests_but_never_overwrites() {
+        let (committee, _keys) = Committee::new_simple_test_committee_of_size(4);
+        let committee = Arc::new(committee);
+        let names: Vec<_> = committee.names().copied().collect();
+        let dir = tempfile::tempdir().unwrap();
+        let epoch_start_configuration =
+            EpochStartConfiguration::new(EpochStartSystem::new_for_testing_with_epoch(0)).unwrap();
+        let epoch_store = AuthorityPerEpochStore::new(
+            names[0],
+            committee.clone(),
+            dir.path(),
+            None,
+            EpochMetrics::new(&Registry::new()),
+            epoch_start_configuration,
+            ChainIdentifier::default(),
+            IkaNetworkConfig::new_for_testing(),
+        )
+        .unwrap();
+        let perpetual_dir = tempfile::tempdir().unwrap();
+        let perpetual = Arc::new(AuthorityPerpetualTables::open(perpetual_dir.path(), None));
+        epoch_store.install_perpetual_tables_for_handoff(perpetual);
+
+        let mirrored_key = ObjectID::random();
+        let fresh_key = ObjectID::random();
+        let canonical_bytes = b"canonical v3 dkg output".to_vec();
+        let anchor_bytes = b"chain pre-v3 dkg anchor".to_vec();
+        let fresh_bytes = b"fresh key dkg output".to_vec();
+
+        // The instantiation path already mirrored the canonical bytes.
+        epoch_store
+            .cache_network_dkg_output(mirrored_key, &canonical_bytes)
+            .unwrap();
+
+        // Post-restart overlay snapshot: the mirrored key carries the
+        // chain's pre-V3 anchor; the fresh key has no local digest yet.
+        let snapshot = HashMap::from([
+            snapshot_entry(mirrored_key, &anchor_bytes),
+            snapshot_entry(fresh_key, &fresh_bytes),
+        ]);
+        hydrate_network_dkg_digests(&epoch_store, &snapshot);
+
+        let digests = epoch_store.get_network_dkg_output_digests().unwrap();
+        assert_eq!(
+            digests.get(&mirrored_key),
+            Some(&mpc_data_blob_hash(&canonical_bytes)),
+            "hydration must never overwrite an existing (canonical) DKG digest"
+        );
+        assert_eq!(
+            digests.get(&fresh_key),
+            Some(&mpc_data_blob_hash(&fresh_bytes)),
+            "hydration must still fill a key with no recorded digest"
+        );
     }
 }

--- a/crates/ika-core/src/sui_connector/mod.rs
+++ b/crates/ika-core/src/sui_connector/mod.rs
@@ -20,7 +20,7 @@ use ika_types::messages_dwallet_mpc::{
     DWalletNetworkEncryptionKeyData, SESSIONS_MANAGER_MODULE_NAME,
 };
 use shared_crypto::intent::{Intent, IntentMessage};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
@@ -103,6 +103,12 @@ impl SuiConnectorService {
         last_session_to_complete_in_current_epoch_sender: Sender<(EpochId, u64)>,
         uncompleted_requests_sender: Sender<(Vec<DWalletSessionRequest>, EpochId)>,
         noa_checkpoints_finalized: Arc<dyn Fn() -> bool + Send + Sync>,
+        // Shared set of network keys the MPC manager has instantiated. Created
+        // once at the node seam and shared with the MPC manager (the writer);
+        // the network-keys sync task reads it to decide, per key, whether to
+        // serve the off-chain reconfiguration output (instantiated) or source
+        // the current-epoch output from chain (un-instantiated fresh/restart).
+        instantiated_network_keys: Arc<arc_swap::ArcSwap<HashSet<ObjectID>>>,
         // OCS verified-read surface. `Some` when the OCS stack was built
         // (a trust anchor is configured); `None` otherwise. Its presence is
         // the node-level switch between the OCS `BagEventPump` and the legacy
@@ -190,6 +196,7 @@ impl SuiConnectorService {
             syncer_uncompleted,
             noa_checkpoints_finalized,
             network_key_blob_source.clone(),
+            instantiated_network_keys,
             off_chain_mpc_data_source.clone(),
         )
         .await

--- a/crates/ika-core/src/sui_connector/mod.rs
+++ b/crates/ika-core/src/sui_connector/mod.rs
@@ -103,12 +103,13 @@ impl SuiConnectorService {
         last_session_to_complete_in_current_epoch_sender: Sender<(EpochId, u64)>,
         uncompleted_requests_sender: Sender<(Vec<DWalletSessionRequest>, EpochId)>,
         noa_checkpoints_finalized: Arc<dyn Fn() -> bool + Send + Sync>,
-        // Shared set of network keys the MPC manager has instantiated. Created
-        // once at the node seam and shared with the MPC manager (the writer);
-        // the network-keys sync task reads it to decide, per key, whether to
-        // serve the off-chain reconfiguration output (instantiated) or source
-        // the current-epoch output from chain (un-instantiated fresh/restart).
-        instantiated_network_keys: Arc<arc_swap::ArcSwap<HashSet<ObjectID>>>,
+        // Shared set of network keys the MPC manager flagged as stranded by a
+        // mid-epoch restart. Created once at the node seam and shared with the
+        // MPC manager (the writer); the network-keys sync task reads it to
+        // decide, per key, whether to serve the off-chain reconfiguration
+        // output (healthy) or source the current-epoch output from chain
+        // (stranded recovery).
+        stranded_network_keys: Arc<arc_swap::ArcSwap<HashSet<ObjectID>>>,
         // OCS verified-read surface. `Some` when the OCS stack was built
         // (a trust anchor is configured); `None` otherwise. Its presence is
         // the node-level switch between the OCS `BagEventPump` and the legacy
@@ -196,7 +197,7 @@ impl SuiConnectorService {
             syncer_uncompleted,
             noa_checkpoints_finalized,
             network_key_blob_source.clone(),
-            instantiated_network_keys,
+            stranded_network_keys,
             off_chain_mpc_data_source.clone(),
         )
         .await

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -876,6 +876,19 @@ where
             ObjectID,
             (u64, DWalletNetworkEncryptionKeyState),
         > = HashMap::new();
+        // Pointer identity of the blob source the previous pass merged
+        // with. Installing (or per-epoch replacing) the source changes
+        // which bytes a merge produces for the SAME chain state, so the
+        // `(epoch, state)` fetch memo below is stale the moment the
+        // source flips: an overlay published from a source-less
+        // chain-read pass right after a restart carries the chain's
+        // original pre-V3 DKG anchor, and with no re-merge it would sit
+        // in the watch channel for the rest of the epoch — where the
+        // end-of-epoch hydration pass can cache it over the canonical
+        // mirror (the never-instantiated variant of issue #1852). Clear
+        // the memo whenever the source identity changes so the next
+        // pass re-merges every key through the new source.
+        let mut last_blob_source_ptr: Option<usize> = None;
         // Consecutive 5s ticks each key's overlay has been incomplete.
         // An incomplete overlay is the designed steady state on a
         // notifier/fullnode (whose overlay is legitimately empty for
@@ -887,6 +900,20 @@ where
         let mut consecutive_overlay_incomplete_ticks: HashMap<ObjectID, u64> = HashMap::new();
         loop {
             time::sleep(Duration::from_secs(5)).await;
+
+            let blob_source_ptr = network_key_blob_source
+                .load_full()
+                .map(|source| Arc::as_ptr(&source) as *const () as usize);
+            if blob_source_ptr != last_blob_source_ptr {
+                // Inequality implies at least one side is Some, so this
+                // always concerns a real install/replacement.
+                info!(
+                    source_installed = blob_source_ptr.is_some(),
+                    "network-key blob source changed; re-merging all network keys"
+                );
+                last_fetched_network_keys.clear();
+                last_blob_source_ptr = blob_source_ptr;
+            }
 
             let Some((_, system_inner)) = system_object_receiver.borrow().as_ref().cloned() else {
                 warn!("System object not available, retrying...");

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -23,7 +23,10 @@ use ika_types::sui::{
     DWalletCoordinator, DWalletCoordinatorInner, System, SystemInner, SystemInnerTrait,
 };
 use mysten_metrics::spawn_logged_monitored_task;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 use sui_types::base_types::ObjectID;
 use sui_types::{Identifier, event::EventID};
 use tokio::sync::watch::{Receiver, Sender};
@@ -105,6 +108,12 @@ where
         network_key_blob_source: Arc<
             arc_swap::ArcSwapOption<Box<dyn crate::validator_metadata::NetworkKeyBlobSource>>,
         >,
+        // Set of network keys the MPC manager has actually instantiated (it
+        // writes here post-instantiation). Read by `sync_dwallet_network_keys`
+        // to distinguish a running validator (key present → keep serving the
+        // off-chain reconfiguration output) from a fresh/restart validator (key
+        // absent → source the current-epoch output from chain instead).
+        instantiated_network_keys: Arc<arc_swap::ArcSwap<HashSet<ObjectID>>>,
         off_chain_mpc_data_source: Arc<
             arc_swap::ArcSwapOption<
                 Box<dyn crate::validator_metadata::OffChainCommitteeMpcDataSource>,
@@ -123,6 +132,7 @@ where
             dwallet_coordinator_object_receiver.clone(),
             network_keys_sender,
             network_key_blob_source,
+            instantiated_network_keys,
             mode,
             self.metrics.clone(),
         ));
@@ -850,6 +860,7 @@ where
         network_key_blob_source: Arc<
             arc_swap::ArcSwapOption<Box<dyn crate::validator_metadata::NetworkKeyBlobSource>>,
         >,
+        instantiated_network_keys: Arc<arc_swap::ArcSwap<HashSet<ObjectID>>>,
         mode: NodeMode,
         metrics: Arc<SuiConnectorMetrics>,
     ) {
@@ -874,7 +885,7 @@ where
         // validator stuck incomplete escalates to warn every 60th
         // consecutive tick (~5 min).
         let mut consecutive_overlay_incomplete_ticks: HashMap<ObjectID, u64> = HashMap::new();
-        'sync_network_keys: loop {
+        loop {
             time::sleep(Duration::from_secs(5)).await;
 
             let Some((_, system_inner)) = system_object_receiver.borrow().as_ref().cloned() else {
@@ -979,9 +990,14 @@ where
                 // TODO(v3->v4 migration): once all keys are off-chain, delete this
                 // whole `key_blobs_already_cached` branch and collapse
                 // `chain_fetched` back to the unconditional `off_chain_on`
-                // synthesize-empty fast path — a v4-native key carries empty
-                // on-chain blobs, so the import would read empty and the cache
-                // path already covers it.
+                // synthesize-empty fast path — in steady-state v4 the off-chain
+                // overlay always fills a v4-native key's blobs, so the fast path
+                // covers it. (The chain still HOLDS the real DKG/reconfiguration
+                // blobs — they are written on-chain at DKG/reconfiguration
+                // regardless of protocol version — but no steady-state chain read
+                // is needed once every key is off-chain. This is also why the
+                // un-instantiated fresh/restart chain read below reliably yields
+                // the real current-epoch output rather than empty bytes.)
                 // ===================================================================
                 let dkg_in_handoff = network_key_blob_source
                     .load_full()
@@ -998,8 +1014,27 @@ where
                 // DKG'd in a PRIOR epoch whose DKG output is absent from the
                 // handoff is a genuine not-yet-migrated pre-v4 key.
                 let freshly_dkgd_this_epoch = network_dec_key_shares.dkg_at_epoch == current_epoch;
-                let key_blobs_already_cached =
-                    off_chain_on && (dkg_in_handoff || freshly_dkgd_this_epoch);
+                // Whether the MPC manager has already instantiated this key.
+                // A fresh/restart validator holds nothing instantiated yet: for
+                // such a key the off-chain overlay serves this epoch's
+                // just-produced reconfiguration output R(M) (encrypted to the
+                // NEXT committee, undecryptable here), which the adoption
+                // pass's produced-this-epoch guard then skips forever — the key
+                // is never instantiated and every session parks on it. An
+                // un-instantiated key must therefore NOT take the cached fast
+                // path: it falls through to the full chain read and installs
+                // the canonical current-epoch output R(M-1). A running
+                // validator that already holds the key is byte-unchanged: it
+                // keeps the off-chain fast path. Non-validator modes never
+                // instantiate keys, so they keep the fast path unconditionally
+                // (their overlay is legitimately blob-empty by design).
+                let key_is_instantiated = !mode.is_validator()
+                    || instantiated_network_keys
+                        .load()
+                        .contains(&network_dec_key_shares.id);
+                let key_blobs_already_cached = off_chain_on
+                    && key_is_instantiated
+                    && (dkg_in_handoff || freshly_dkgd_this_epoch);
                 let chain_fetched = if off_chain_on && key_blobs_already_cached {
                     Ok(
                         ika_types::messages_dwallet_mpc::DWalletNetworkEncryptionKeyData {
@@ -1030,15 +1065,12 @@ where
                         // installed or the source has neither blob,
                         // the merged value equals the chain copy
                         // byte-for-byte.
-                        let merged = match network_key_blob_source.load_full() {
-                            Some(source) => {
-                                crate::validator_metadata::fetch_network_key_data_with_off_chain_blobs(
-                                    key_full_data,
-                                    source.as_ref().as_ref(),
-                                )
-                            }
-                            None => key_full_data,
-                        };
+                        let source_snapshot = network_key_blob_source.load_full();
+                        let merged = overlay_network_key_data(
+                            key_is_instantiated,
+                            key_full_data,
+                            source_snapshot.as_deref().map(|source| source.as_ref()),
+                        );
                         // Under off-chain mode the chain copy carries
                         // empty blob bytes; the overlay above fills them
                         // from the local producer cache. A usable entry
@@ -1129,7 +1161,18 @@ where
                             error=?err,
                             "failed to get network decryption key data, retrying...",
                         );
-                        continue 'sync_network_keys;
+                        // Skip only THIS key: it stays out of
+                        // `last_fetched_network_keys`, so the next tick
+                        // re-selects it. Aborting the whole outer pass would
+                        // also skip the channel send below — and a sibling key
+                        // that merged COMPLETE earlier in this same pass was
+                        // already recorded as fetched, so its data would never
+                        // be published: absent from the overlay, never
+                        // adopted, never instantiated until the next epoch's
+                        // refetch. The un-instantiated restart-recovery chain
+                        // read makes this arm hot on exactly that recovery
+                        // path.
+                        continue;
                     }
                 }
             }
@@ -1479,6 +1522,115 @@ where
                     "Observed {len} new events from Sui network"
                 );
             }
+        }
+    }
+}
+
+/// Chooses how to overlay locally-cached off-chain blobs onto chain-fetched
+/// network-key data, based on whether the MPC manager has already
+/// instantiated the key on this node.
+///
+/// - **Instantiated** (running validator): prefer the off-chain source for
+///   both blobs — the steady-state v4 read path (the chain copy may even be
+///   metadata-only with empty blobs, synthesized by the fast path).
+/// - **Un-instantiated** (fresh/restart validator): keep the chain's
+///   canonical current-epoch reconfiguration output. Overlaying the
+///   off-chain source's reconfiguration blob would re-override it with the
+///   output this epoch's reconfiguration just produced — encrypted to the
+///   NEXT committee, which the adoption pass's produced-this-epoch guard
+///   then skips forever, stranding the key un-instantiated for the rest of
+///   the epoch (every session parks on it). The DKG blob is the one field
+///   still preferred from the off-chain source: it is the stable per-key
+///   anchor, and the locally-mirrored copy is the CANONICAL representation
+///   whose digest the prior epoch's handoff cert pins — after the V2→V3
+///   canonical migration the chain's original anchor no longer matches the
+///   cert, and adoption would reject the key on the DKG-digest gate.
+///
+/// With no source installed the chain copy flows through unchanged.
+fn overlay_network_key_data(
+    key_is_instantiated: bool,
+    chain_data: DWalletNetworkEncryptionKeyData,
+    source: Option<&dyn crate::validator_metadata::NetworkKeyBlobSource>,
+) -> DWalletNetworkEncryptionKeyData {
+    let Some(source) = source else {
+        return chain_data;
+    };
+    if key_is_instantiated {
+        crate::validator_metadata::fetch_network_key_data_with_off_chain_blobs(chain_data, source)
+    } else {
+        let network_dkg_public_output = source
+            .network_dkg_output_blob(&chain_data.id)
+            .unwrap_or(chain_data.network_dkg_public_output);
+        DWalletNetworkEncryptionKeyData {
+            network_dkg_public_output,
+            ..chain_data
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::validator_metadata::StaticNetworkKeyBlobSource;
+
+    fn chain_data(key_id: ObjectID) -> DWalletNetworkEncryptionKeyData {
+        DWalletNetworkEncryptionKeyData {
+            id: key_id,
+            current_epoch: 7,
+            dkg_at_epoch: 0,
+            network_dkg_public_output: b"chain dkg anchor".to_vec(),
+            current_reconfiguration_public_output: b"chain current-epoch reconfiguration output"
+                .to_vec(),
+            state: DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted,
+        }
+    }
+
+    /// The restart-recovery contract (#1852): for a key the manager has NOT
+    /// instantiated, the off-chain source must never override the chain's
+    /// current-epoch reconfiguration output (the source serves the output
+    /// this epoch's reconfiguration just produced, encrypted to the next
+    /// committee), while the DKG blob still prefers the source's canonical
+    /// mirror (the digest the handoff cert pins).
+    #[test]
+    fn un_instantiated_key_keeps_chain_reconfiguration_output_and_canonical_dkg() {
+        let key_id = ObjectID::random();
+        let mut source = StaticNetworkKeyBlobSource::new();
+        source.insert_dkg(key_id, b"canonical mirrored dkg output".to_vec());
+        source.insert_reconfig(
+            key_id,
+            b"this epoch's output for the next committee".to_vec(),
+        );
+
+        let merged = overlay_network_key_data(false, chain_data(key_id), Some(&source));
+        assert_eq!(
+            merged.current_reconfiguration_public_output,
+            b"chain current-epoch reconfiguration output".to_vec(),
+            "an un-instantiated key must keep the chain's current-epoch output"
+        );
+        assert_eq!(
+            merged.network_dkg_public_output,
+            b"canonical mirrored dkg output".to_vec(),
+            "the DKG blob must still prefer the canonical off-chain mirror"
+        );
+
+        // An instantiated key keeps the steady-state behavior: both blobs
+        // prefer the off-chain source.
+        let merged = overlay_network_key_data(true, chain_data(key_id), Some(&source));
+        assert_eq!(
+            merged.current_reconfiguration_public_output,
+            b"this epoch's output for the next committee".to_vec(),
+            "an instantiated key keeps the off-chain overlay for the reconfiguration output"
+        );
+        assert_eq!(
+            merged.network_dkg_public_output,
+            b"canonical mirrored dkg output".to_vec(),
+        );
+
+        // No source installed: the chain copy flows through unchanged for
+        // both instantiation states.
+        for key_is_instantiated in [false, true] {
+            let merged = overlay_network_key_data(key_is_instantiated, chain_data(key_id), None);
+            assert_eq!(merged, chain_data(key_id));
         }
     }
 }

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -108,12 +108,12 @@ where
         network_key_blob_source: Arc<
             arc_swap::ArcSwapOption<Box<dyn crate::validator_metadata::NetworkKeyBlobSource>>,
         >,
-        // Set of network keys the MPC manager has actually instantiated (it
-        // writes here post-instantiation). Read by `sync_dwallet_network_keys`
-        // to distinguish a running validator (key present → keep serving the
-        // off-chain reconfiguration output) from a fresh/restart validator (key
-        // absent → source the current-epoch output from chain instead).
-        instantiated_network_keys: Arc<arc_swap::ArcSwap<HashSet<ObjectID>>>,
+        // Network keys the MPC manager flagged as stranded by a mid-epoch
+        // restart (adoption's produced-this-epoch guard skipping a key the
+        // validator holds nothing for). Read by `sync_dwallet_network_keys`:
+        // a flagged key gets a chain-sourced current-epoch reconfiguration
+        // output instead of the off-chain overlay; empty in healthy flows.
+        stranded_network_keys: Arc<arc_swap::ArcSwap<HashSet<ObjectID>>>,
         off_chain_mpc_data_source: Arc<
             arc_swap::ArcSwapOption<
                 Box<dyn crate::validator_metadata::OffChainCommitteeMpcDataSource>,
@@ -132,7 +132,7 @@ where
             dwallet_coordinator_object_receiver.clone(),
             network_keys_sender,
             network_key_blob_source,
-            instantiated_network_keys,
+            stranded_network_keys,
             mode,
             self.metrics.clone(),
         ));
@@ -860,7 +860,7 @@ where
         network_key_blob_source: Arc<
             arc_swap::ArcSwapOption<Box<dyn crate::validator_metadata::NetworkKeyBlobSource>>,
         >,
-        instantiated_network_keys: Arc<arc_swap::ArcSwap<HashSet<ObjectID>>>,
+        stranded_network_keys: Arc<arc_swap::ArcSwap<HashSet<ObjectID>>>,
         mode: NodeMode,
         metrics: Arc<SuiConnectorMetrics>,
     ) {
@@ -924,6 +924,15 @@ where
                 network_encryption_keys
                     .into_iter()
                     .filter(|(id, key)| {
+                        // A key the MPC manager flagged as stranded (mid-epoch
+                        // restart, #1852) is re-fetched regardless of the
+                        // cache: the flag is raised AFTER the overlay entry
+                        // that revealed the strand was already recorded here,
+                        // so without this the chain-sourced recovery read
+                        // below would never run.
+                        if stranded_network_keys.load().contains(id) {
+                            return true;
+                        }
                         if let Some((last_epoch, last_state)) = last_fetched_network_keys.get(id) {
                             // Refetch when either the epoch has
                             // advanced or the chain-side state has
@@ -996,7 +1005,7 @@ where
                 // blobs — they are written on-chain at DKG/reconfiguration
                 // regardless of protocol version — but no steady-state chain read
                 // is needed once every key is off-chain. This is also why the
-                // un-instantiated fresh/restart chain read below reliably yields
+                // stranded-key recovery chain read below reliably yields
                 // the real current-epoch output rather than empty bytes.)
                 // ===================================================================
                 let dkg_in_handoff = network_key_blob_source
@@ -1014,27 +1023,24 @@ where
                 // DKG'd in a PRIOR epoch whose DKG output is absent from the
                 // handoff is a genuine not-yet-migrated pre-v4 key.
                 let freshly_dkgd_this_epoch = network_dec_key_shares.dkg_at_epoch == current_epoch;
-                // Whether the MPC manager has already instantiated this key.
-                // A fresh/restart validator holds nothing instantiated yet: for
-                // such a key the off-chain overlay serves this epoch's
-                // just-produced reconfiguration output R(M) (encrypted to the
-                // NEXT committee, undecryptable here), which the adoption
-                // pass's produced-this-epoch guard then skips forever — the key
-                // is never instantiated and every session parks on it. An
-                // un-instantiated key must therefore NOT take the cached fast
-                // path: it falls through to the full chain read and installs
-                // the canonical current-epoch output R(M-1). A running
-                // validator that already holds the key is byte-unchanged: it
-                // keeps the off-chain fast path. Non-validator modes never
-                // instantiate keys, so they keep the fast path unconditionally
-                // (their overlay is legitimately blob-empty by design).
-                let key_is_instantiated = !mode.is_validator()
-                    || instantiated_network_keys
-                        .load()
-                        .contains(&network_dec_key_shares.id);
-                let key_blobs_already_cached = off_chain_on
-                    && key_is_instantiated
-                    && (dkg_in_handoff || freshly_dkgd_this_epoch);
+                // Whether the MPC manager flagged this key as STRANDED by a
+                // mid-epoch restart (#1852): the validator holds nothing for
+                // the key while the off-chain overlay serves only this epoch's
+                // just-produced reconfiguration output R(M) — encrypted to the
+                // NEXT committee, which the adoption pass's produced-this-epoch
+                // guard then skips forever, parking every session on the key.
+                // A flagged key must NOT take the cached fast path: it falls
+                // through to the full chain read and installs the canonical
+                // current-epoch output R(M-1); a confirmed instantiation
+                // un-flags it. The set is empty in every healthy flow —
+                // including a fresh key's DKG-bootstrap window and the
+                // first-instantiation-in-flight window — so the v4
+                // no-steady-state-chain-read invariant is preserved exactly.
+                let key_is_stranded = stranded_network_keys
+                    .load()
+                    .contains(&network_dec_key_shares.id);
+                let key_blobs_already_cached =
+                    off_chain_on && !key_is_stranded && (dkg_in_handoff || freshly_dkgd_this_epoch);
                 let chain_fetched = if off_chain_on && key_blobs_already_cached {
                     Ok(
                         ika_types::messages_dwallet_mpc::DWalletNetworkEncryptionKeyData {
@@ -1067,7 +1073,7 @@ where
                         // byte-for-byte.
                         let source_snapshot = network_key_blob_source.load_full();
                         let merged = overlay_network_key_data(
-                            key_is_instantiated,
+                            key_is_stranded,
                             key_full_data,
                             source_snapshot.as_deref().map(|source| source.as_ref()),
                         );
@@ -1169,9 +1175,8 @@ where
                         // already recorded as fetched, so its data would never
                         // be published: absent from the overlay, never
                         // adopted, never instantiated until the next epoch's
-                        // refetch. The un-instantiated restart-recovery chain
-                        // read makes this arm hot on exactly that recovery
-                        // path.
+                        // refetch. The stranded-key recovery chain read makes
+                        // this arm hot on exactly that recovery path.
                         continue;
                     }
                 }
@@ -1527,19 +1532,19 @@ where
 }
 
 /// Chooses how to overlay locally-cached off-chain blobs onto chain-fetched
-/// network-key data, based on whether the MPC manager has already
-/// instantiated the key on this node.
+/// network-key data, based on whether the MPC manager flagged the key as
+/// stranded by a mid-epoch restart (#1852).
 ///
-/// - **Instantiated** (running validator): prefer the off-chain source for
+/// - **Not stranded** (every healthy flow): prefer the off-chain source for
 ///   both blobs — the steady-state v4 read path (the chain copy may even be
 ///   metadata-only with empty blobs, synthesized by the fast path).
-/// - **Un-instantiated** (fresh/restart validator): keep the chain's
-///   canonical current-epoch reconfiguration output. Overlaying the
-///   off-chain source's reconfiguration blob would re-override it with the
-///   output this epoch's reconfiguration just produced — encrypted to the
-///   NEXT committee, which the adoption pass's produced-this-epoch guard
-///   then skips forever, stranding the key un-instantiated for the rest of
-///   the epoch (every session parks on it). The DKG blob is the one field
+/// - **Stranded** (restart-recovery chain read): keep the chain's canonical
+///   current-epoch reconfiguration output. Overlaying the off-chain
+///   source's reconfiguration blob would re-override it with the output
+///   this epoch's reconfiguration just produced — encrypted to the NEXT
+///   committee, which the adoption pass's produced-this-epoch guard then
+///   skips forever, keeping the key un-instantiated for the rest of the
+///   epoch (every session parks on it). The DKG blob is the one field
 ///   still preferred from the off-chain source: it is the stable per-key
 ///   anchor, and the locally-mirrored copy is the CANONICAL representation
 ///   whose digest the prior epoch's handoff cert pins — after the V2→V3
@@ -1548,16 +1553,14 @@ where
 ///
 /// With no source installed the chain copy flows through unchanged.
 fn overlay_network_key_data(
-    key_is_instantiated: bool,
+    key_is_stranded: bool,
     chain_data: DWalletNetworkEncryptionKeyData,
     source: Option<&dyn crate::validator_metadata::NetworkKeyBlobSource>,
 ) -> DWalletNetworkEncryptionKeyData {
     let Some(source) = source else {
         return chain_data;
     };
-    if key_is_instantiated {
-        crate::validator_metadata::fetch_network_key_data_with_off_chain_blobs(chain_data, source)
-    } else {
+    if key_is_stranded {
         let network_dkg_public_output = source
             .network_dkg_output_blob(&chain_data.id)
             .unwrap_or(chain_data.network_dkg_public_output);
@@ -1565,6 +1568,8 @@ fn overlay_network_key_data(
             network_dkg_public_output,
             ..chain_data
         }
+    } else {
+        crate::validator_metadata::fetch_network_key_data_with_off_chain_blobs(chain_data, source)
     }
 }
 
@@ -1585,14 +1590,14 @@ mod tests {
         }
     }
 
-    /// The restart-recovery contract (#1852): for a key the manager has NOT
-    /// instantiated, the off-chain source must never override the chain's
+    /// The restart-recovery contract (#1852): for a key the manager flagged
+    /// as stranded, the off-chain source must never override the chain's
     /// current-epoch reconfiguration output (the source serves the output
     /// this epoch's reconfiguration just produced, encrypted to the next
     /// committee), while the DKG blob still prefers the source's canonical
     /// mirror (the digest the handoff cert pins).
     #[test]
-    fn un_instantiated_key_keeps_chain_reconfiguration_output_and_canonical_dkg() {
+    fn stranded_key_keeps_chain_reconfiguration_output_and_canonical_dkg() {
         let key_id = ObjectID::random();
         let mut source = StaticNetworkKeyBlobSource::new();
         source.insert_dkg(key_id, b"canonical mirrored dkg output".to_vec());
@@ -1601,11 +1606,11 @@ mod tests {
             b"this epoch's output for the next committee".to_vec(),
         );
 
-        let merged = overlay_network_key_data(false, chain_data(key_id), Some(&source));
+        let merged = overlay_network_key_data(true, chain_data(key_id), Some(&source));
         assert_eq!(
             merged.current_reconfiguration_public_output,
             b"chain current-epoch reconfiguration output".to_vec(),
-            "an un-instantiated key must keep the chain's current-epoch output"
+            "a stranded key must keep the chain's current-epoch output"
         );
         assert_eq!(
             merged.network_dkg_public_output,
@@ -1613,23 +1618,23 @@ mod tests {
             "the DKG blob must still prefer the canonical off-chain mirror"
         );
 
-        // An instantiated key keeps the steady-state behavior: both blobs
+        // A non-stranded key keeps the steady-state behavior: both blobs
         // prefer the off-chain source.
-        let merged = overlay_network_key_data(true, chain_data(key_id), Some(&source));
+        let merged = overlay_network_key_data(false, chain_data(key_id), Some(&source));
         assert_eq!(
             merged.current_reconfiguration_public_output,
             b"this epoch's output for the next committee".to_vec(),
-            "an instantiated key keeps the off-chain overlay for the reconfiguration output"
+            "a non-stranded key keeps the off-chain overlay for the reconfiguration output"
         );
         assert_eq!(
             merged.network_dkg_public_output,
             b"canonical mirrored dkg output".to_vec(),
         );
 
-        // No source installed: the chain copy flows through unchanged for
-        // both instantiation states.
-        for key_is_instantiated in [false, true] {
-            let merged = overlay_network_key_data(key_is_instantiated, chain_data(key_id), None);
+        // No source installed: the chain copy flows through unchanged in
+        // both states.
+        for key_is_stranded in [false, true] {
+            let merged = overlay_network_key_data(key_is_stranded, chain_data(key_id), None);
             assert_eq!(merged, chain_data(key_id));
         }
     }

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -1449,6 +1449,10 @@ impl StaticNetworkKeyBlobSource {
     pub fn insert_dkg(&mut self, key_id: sui_types::base_types::ObjectID, bytes: Vec<u8>) {
         self.dkg.insert(key_id, bytes);
     }
+
+    pub fn insert_reconfig(&mut self, key_id: sui_types::base_types::ObjectID, bytes: Vec<u8>) {
+        self.reconfig.insert(key_id, bytes);
+    }
 }
 
 impl NetworkKeyBlobSource for StaticNetworkKeyBlobSource {

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -229,13 +229,13 @@ pub struct IkaNode {
     noa_dwallet_finalized: Arc<std::sync::atomic::AtomicBool>,
     noa_system_finalized: Arc<std::sync::atomic::AtomicBool>,
 
-    /// Set of network keys the MPC manager has instantiated, shared with the
-    /// sui-connector network-keys sync task (the reader) and every per-epoch
-    /// MPC manager (the writer). Created once at node start and threaded to
-    /// both services so the syncer and manager agree, across reconfigurations,
-    /// on which keys are instantiated (drives serve-off-chain-output vs
-    /// read-current-epoch-output-from-chain for a fresh/restart validator).
-    instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
+    /// Network keys the MPC manager flagged as stranded by a mid-epoch
+    /// restart, shared with the sui-connector network-keys sync task (the
+    /// reader) and every per-epoch MPC manager (the writer). Created once at
+    /// node start and threaded to both services so the syncer and manager
+    /// agree, across reconfigurations, on which keys need the chain-sourced
+    /// current-epoch reconfiguration output instead of the off-chain overlay.
+    stranded_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
 
     /// Prunes per-epoch authority store directories
     /// (`<db-path>/live/store/epoch_<N>/`); the `perpetual/` sibling never
@@ -1069,11 +1069,11 @@ impl IkaNode {
                 && noa_system_finalized_clone.load(std::sync::atomic::Ordering::Acquire)
         });
 
-        // Shared instantiated-network-keys set: created once here, handed to
+        // Shared stranded-network-keys set: created once here, handed to
         // both the sui-connector syncer (reader) and every per-epoch MPC
         // manager (writer). Must be the SAME `Arc` across reconfigurations, so
         // it is stored on the node and re-cloned each epoch.
-        let instantiated_network_keys = Arc::new(ArcSwap::from_pointee(HashSet::new()));
+        let stranded_network_keys = Arc::new(ArcSwap::from_pointee(HashSet::new()));
 
         let (sui_connector_service, network_keys_receiver) = SuiConnectorService::new(
             dwallet_checkpoint_store.clone(),
@@ -1091,7 +1091,7 @@ impl IkaNode {
             last_session_to_complete_in_current_epoch_sender,
             uncompleted_requests_sender,
             noa_checkpoints_finalized,
-            instantiated_network_keys.clone(),
+            stranded_network_keys.clone(),
             reader_opt.clone(),
             ocs_metrics.clone(),
         )
@@ -1161,7 +1161,7 @@ impl IkaNode {
                 sui_data_receivers.clone(),
                 noa_dwallet_finalized.clone(),
                 noa_system_finalized.clone(),
-                instantiated_network_keys.clone(),
+                stranded_network_keys.clone(),
             )
             .await?;
             // This is only needed during cold start.
@@ -1218,7 +1218,7 @@ impl IkaNode {
             shutdown_channel_tx: shutdown_channel,
             noa_dwallet_finalized,
             noa_system_finalized,
-            instantiated_network_keys,
+            stranded_network_keys,
             authority_store_pruner,
         };
 
@@ -1707,7 +1707,7 @@ impl IkaNode {
         sui_data_receivers: SuiDataReceivers,
         noa_dwallet_finalized: Arc<std::sync::atomic::AtomicBool>,
         noa_system_finalized: Arc<std::sync::atomic::AtomicBool>,
-        instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
+        stranded_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
     ) -> Result<ValidatorComponents> {
         let mut config_clone = config.clone();
         let consensus_config = config_clone
@@ -1768,7 +1768,7 @@ impl IkaNode {
             sui_data_receivers,
             noa_dwallet_finalized,
             noa_system_finalized,
-            instantiated_network_keys,
+            stranded_network_keys,
         )
         .await
     }
@@ -1793,7 +1793,7 @@ impl IkaNode {
         sui_data_receivers: SuiDataReceivers,
         noa_dwallet_finalized: Arc<std::sync::atomic::AtomicBool>,
         noa_system_finalized: Arc<std::sync::atomic::AtomicBool>,
-        instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
+        stranded_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
     ) -> Result<ValidatorComponents> {
         // Channel for network-owned-address sign requests (sender unused after
         // pipeline→handler migration; receiver still drained by service loop).
@@ -1925,7 +1925,7 @@ impl IkaNode {
             network_owned_address_sign_output_receiver,
             dwallet_checkpoint_handler,
             system_checkpoint_handler,
-            instantiated_network_keys,
+            stranded_network_keys,
         );
 
         // create a new map that gets injected into both the consensus handler and the consensus adapter
@@ -2877,7 +2877,7 @@ impl IkaNode {
                             sui_data_receivers.clone(),
                             self.noa_dwallet_finalized.clone(),
                             self.noa_system_finalized.clone(),
-                            self.instantiated_network_keys.clone(),
+                            self.stranded_network_keys.clone(),
                         )
                         .await?,
                     )
@@ -2915,7 +2915,7 @@ impl IkaNode {
                             sui_data_receivers.clone(),
                             self.noa_dwallet_finalized.clone(),
                             self.noa_system_finalized.clone(),
-                            self.instantiated_network_keys.clone(),
+                            self.stranded_network_keys.clone(),
                         )
                         .await?,
                     )

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -10,7 +10,7 @@ use anemo_tower::trace::TraceLayer;
 use anyhow::{Result, anyhow};
 use arc_swap::ArcSwap;
 use prometheus::Registry;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -3208,15 +3208,20 @@ impl IkaNode {
     ///   1. The cross-epoch trust anchor (the `cur_epoch` handoff cert) is
     ///      locally present + verified — `prepare_handoff_anchor` returns it,
     ///      fetching it inline if missing.
-    ///   2. Every `NetworkReconfigurationOutput` item the cert certifies is
-    ///      held locally with a digest matching the cert. The cert's single
+    ///   2. Every network-key output item the cert certifies —
+    ///      `NetworkReconfigurationOutput` AND `NetworkDkgOutput` — is held
+    ///      locally with a digest matching the cert. The cert's single
     ///      `epoch` field scopes the whole handoff, so there is no per-key
-    ///      epoch to check — only per-key presence in this validator's
-    ///      reconfiguration-output digest slice (keyed by `cur_epoch`, the
-    ///      reconfiguration session's epoch). A continuing validator caches
-    ///      its own MPC output there; a joiner has `prepare_handoff_anchor`
-    ///      fetch + cache the cert's outputs into the same slice. See
-    ///      `all_cert_reconfiguration_outputs_held_locally`.
+    ///      epoch to check — only per-key presence: reconfiguration outputs
+    ///      in this validator's epoch-keyed digest slice (keyed by
+    ///      `cur_epoch`, the reconfiguration session's epoch), DKG outputs in
+    ///      the NEW epoch store's merged view (empty per-epoch table → the
+    ///      perpetual canonical mirror — the value the installer repairs; the
+    ///      outgoing store's per-epoch table is exactly what the end-of-epoch
+    ///      hydration may have poisoned, issue #1852). A continuing validator
+    ///      caches its own MPC output; `prepare_handoff_anchor` and the
+    ///      per-retry installer fetch + cache missing/mismatching outputs
+    ///      from peers. See `all_cert_network_key_outputs_held_locally`.
     async fn wait_for_handoff_data_ready(
         &self,
         next_epoch: EpochId,
@@ -3263,20 +3268,37 @@ impl IkaNode {
             }
             let cert = anchor_cert.as_ref();
 
-            // Condition 2: every network-key reconfiguration output the cert
-            // certifies is held locally with a digest matching the cert.
-            // Grounded entirely in the verified cert (the off-chain anchor)
-            // and this validator's own reconfiguration-output digest slice,
-            // keyed by the reconfiguration session's epoch (`cur_epoch`) — no
+            // Condition 2: every network-key output the cert certifies —
+            // reconfiguration AND DKG — is held locally with a digest
+            // matching the cert. Grounded entirely in the verified cert (the
+            // off-chain anchor) and this validator's own digest slices — no
             // chain state, and no per-key epoch (the cert's single epoch
-            // scopes the whole handoff). A read error is treated as not-ready
-            // (empty slice); the periodic WARN below surfaces a persistent
-            // failure.
+            // scopes the whole handoff). A read error is treated as
+            // not-ready (empty slice); the periodic WARN below surfaces a
+            // persistent failure.
+            //
+            // The reconfiguration slice is keyed by the reconfiguration
+            // session's epoch (`cur_epoch`) on the outgoing store. The DKG
+            // digests are read from the NEW epoch store deliberately: its
+            // per-epoch table is empty at entry, so the merged view is the
+            // perpetual canonical mirror — the exact value the installer
+            // repairs. Reading them from the outgoing store would consult
+            // its per-epoch table first, which is precisely what the
+            // end-of-epoch hydration pass may have poisoned (the issue
+            // #1852 clobber variant), and the repaired perpetual value
+            // would never win — deadlocking this barrier.
             let local_reconfiguration_digests = cur_epoch_store
                 .get_network_reconfiguration_output_digests_for_epoch(cur_epoch)
                 .unwrap_or_default();
+            let local_dkg_digests = new_epoch_store
+                .get_network_dkg_output_digests()
+                .unwrap_or_default();
             let ready = cert.is_some_and(|cert| {
-                all_cert_reconfiguration_outputs_held_locally(cert, &local_reconfiguration_digests)
+                all_cert_network_key_outputs_held_locally(
+                    cert,
+                    &local_dkg_digests,
+                    &local_reconfiguration_digests,
+                )
             });
 
             if ready {
@@ -3319,31 +3341,39 @@ impl IkaNode {
             // Surface the breakdown roughly every 10s so a hang is never
             // silent on a dashboard or in the logs.
             if retries.is_multiple_of(10) {
-                let (cert_reconfiguration_items, missing_key_ids, unmapped_cert_keys) = match &cert
-                {
+                let (cert_network_key_items, missing_key_ids, unmapped_cert_keys) = match &cert {
                     Some(cert) => {
                         let total = cert
                             .attestation
                             .items
                             .iter()
                             .filter(|(item, _)| {
-                                matches!(item, HandoffItemKey::NetworkReconfigurationOutput { .. })
+                                matches!(
+                                    item,
+                                    HandoffItemKey::NetworkReconfigurationOutput { .. }
+                                        | HandoffItemKey::NetworkDkgOutput { .. }
+                                )
                             })
                             .count();
                         let missing: Vec<ObjectID> = cert
                             .attestation
                             .items
                             .iter()
-                            .filter_map(|(item, digest)| match item {
-                                HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
-                                    // Cert keys by NetworkKeyId; local digests by
-                                    // ObjectID — translate via the temporary map.
-                                    let object_id =
-                                        ika_core::network_key_id_mapping::object_id_for(key_id)?;
-                                    (local_reconfiguration_digests.get(&object_id) != Some(digest))
-                                        .then_some(object_id)
-                                }
-                                _ => None,
+                            .filter_map(|(item, digest)| {
+                                // Cert keys by NetworkKeyId; local digests by
+                                // ObjectID — translate via the temporary map.
+                                let (key_id, local_digests) = match item {
+                                    HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
+                                        (key_id, &local_reconfiguration_digests)
+                                    }
+                                    HandoffItemKey::NetworkDkgOutput { key_id } => {
+                                        (key_id, &local_dkg_digests)
+                                    }
+                                    HandoffItemKey::ValidatorMpcData { .. } => return None,
+                                };
+                                let object_id =
+                                    ika_core::network_key_id_mapping::object_id_for(key_id)?;
+                                (local_digests.get(&object_id) != Some(digest)).then_some(object_id)
                             })
                             .collect();
                         // Cert keys with NO ObjectID mapping (this validator
@@ -3355,12 +3385,15 @@ impl IkaNode {
                         // `missing_locally=0`. The MPC service's adoption
                         // pass derives and registers the mapping in the
                         // background; this state should clear on its own.
-                        let unmapped: Vec<NetworkKeyId> = cert
+                        // A key with both a DKG and a reconfiguration item
+                        // would list twice — dedup via the ordered set.
+                        let unmapped: BTreeSet<NetworkKeyId> = cert
                             .attestation
                             .items
                             .iter()
                             .filter_map(|(item, _)| match item {
                                 HandoffItemKey::NetworkReconfigurationOutput { key_id }
+                                | HandoffItemKey::NetworkDkgOutput { key_id }
                                     if ika_core::network_key_id_mapping::object_id_for(key_id)
                                         .is_none() =>
                                 {
@@ -3369,6 +3402,7 @@ impl IkaNode {
                                 _ => None,
                             })
                             .collect();
+                        let unmapped: Vec<NetworkKeyId> = unmapped.into_iter().collect();
                         (total, missing, unmapped)
                     }
                     None => (0, Vec::new(), Vec::new()),
@@ -3377,7 +3411,7 @@ impl IkaNode {
                     next_epoch,
                     cur_epoch,
                     have_cert = cert.is_some(),
-                    cert_reconfiguration_items,
+                    cert_network_key_items,
                     missing_locally = missing_key_ids.len(),
                     missing_key_ids = ?missing_key_ids,
                     unmapped_cert_keys = ?unmapped_cert_keys,
@@ -3583,27 +3617,35 @@ fn max_tx_per_checkpoint(_: &ProtocolConfig) -> usize {
 
 /// Readiness predicate for the prepare-then-start barrier's network-key
 /// condition, grounded entirely in the verified handoff cert (the off-chain
-/// cross-epoch trust anchor) and this validator's local reconfiguration-output
-/// digest slice — no chain state.
+/// cross-epoch trust anchor) and this validator's local digest slices — no
+/// chain state.
 ///
 /// The cert's single `epoch` field scopes the whole handoff (one cert per
 /// epoch, committee-signed), so there is no per-key epoch to check: every
 /// `NetworkReconfigurationOutput` item is an output of the same reconfiguration
-/// session (the one that ran during `cert.attestation.epoch`). The only per-key
-/// question is presence: for each reconfiguration output the cert certifies,
-/// has this validator locally computed/cached a digest-matching copy? (A
-/// continuing validator caches its own MPC output; a joiner has
-/// `install_joiner_network_key_outputs` fetch + cache the cert's outputs into
-/// the same slice.)
+/// session (the one that ran during `cert.attestation.epoch`), and the DKG
+/// items pin the key's canonical anchor. The only per-key question is
+/// presence: for each certified output, has this validator locally
+/// computed/cached a digest-matching copy? (A continuing validator caches its
+/// own MPC output; `install_joiner_network_key_outputs` fetches + caches
+/// missing/mismatching ones from peers into the same slices.)
 ///
-/// Returns true iff every `NetworkReconfigurationOutput { key_id }` item in the
-/// cert has a local digest equal to the cert's item digest. DKG and
-/// validator-mpc_data items are not gated here — the barrier exists to keep the
-/// new epoch from signing against a stale reconfiguration sharing, and the
-/// reconfiguration output is the epoch-varying material. A cert with no
-/// reconfiguration items is trivially ready on this condition.
-fn all_cert_reconfiguration_outputs_held_locally(
+/// Returns true iff every `NetworkReconfigurationOutput { key_id }` AND every
+/// `NetworkDkgOutput { key_id }` item in the cert has a local digest equal to
+/// the cert's item digest. The reconfiguration output is the epoch-varying
+/// sharing material; the DKG output is equally load-bearing — adoption's
+/// cert-digest gate rejects the key when the local DKG mirror doesn't hash to
+/// the cert's digest, and a mirror poisoned with the chain's pre-V3 anchor
+/// (the hydration-clobber variant of issue #1852) can ONLY be repaired here,
+/// because the installer runs solely while this predicate reads not-ready.
+/// Do not narrow this back to reconfiguration-only: that made the barrier
+/// instantly ready for a poisoned validator every epoch and the wedge
+/// permanent. `ValidatorMpcData` items are not gated (they feed the mpc_data
+/// freeze, a separate plane). A cert with no network-key items is trivially
+/// ready on this condition.
+fn all_cert_network_key_outputs_held_locally(
     cert: &CertifiedHandoffAttestation,
+    local_dkg_digests: &BTreeMap<ObjectID, [u8; 32]>,
     local_reconfiguration_digests: &BTreeMap<ObjectID, [u8; 32]>,
 ) -> bool {
     cert.attestation
@@ -3616,9 +3658,21 @@ fn all_cert_reconfiguration_outputs_held_locally(
                     local_reconfiguration_digests.get(&object_id) == Some(cert_digest)
                 })
             }
-            HandoffItemKey::NetworkDkgOutput { .. } | HandoffItemKey::ValidatorMpcData { .. } => {
-                true
+            // The DKG output is as load-bearing as the reconfiguration
+            // output: adoption's cert-digest gate rejects the key when the
+            // locally-mirrored DKG bytes don't hash to the cert's digest,
+            // and a mirror poisoned with the chain's pre-V3 anchor (the
+            // hydration-clobber variant of issue #1852) can only be
+            // repaired here — the barrier's installer fetches the
+            // cert-pinned bytes from peers and re-caches them. Skipping
+            // DKG items made that repair unreachable (the gate read ready
+            // instantly and the installer only runs while not-ready),
+            // leaving a poisoned validator wedged permanently.
+            HandoffItemKey::NetworkDkgOutput { key_id } => {
+                ika_core::network_key_id_mapping::object_id_for(key_id)
+                    .is_some_and(|object_id| local_dkg_digests.get(&object_id) == Some(cert_digest))
             }
+            HandoffItemKey::ValidatorMpcData { .. } => true,
         })
 }
 
@@ -3661,28 +3715,32 @@ mod tests {
     }
 
     #[test]
-    fn all_cert_reconfiguration_outputs_held_locally_cases() {
-        // The cert is keyed by NetworkKeyId; the local slice by ObjectID.
+    fn all_cert_network_key_outputs_held_locally_cases() {
+        // The cert is keyed by NetworkKeyId; the local slices by ObjectID.
         // Register the mappings so the predicate can translate.
         ika_core::network_key_id_mapping::register(key_id(0), network_key_id(0));
         ika_core::network_key_id_mapping::register(key_id(1), network_key_id(1));
+        let no_dkg = BTreeMap::new();
         // Cert certifies one reconfiguration output; the local slice holds a
         // matching digest → ready.
         let cert = cert_with_reconfiguration_items(vec![(network_key_id(0), [1u8; 32])]);
         let held = BTreeMap::from([(key_id(0), [1u8; 32])]);
-        assert!(all_cert_reconfiguration_outputs_held_locally(&cert, &held));
+        assert!(all_cert_network_key_outputs_held_locally(
+            &cert, &no_dkg, &held
+        ));
 
         // Output not yet computed/cached locally (empty slice) → not ready.
-        assert!(!all_cert_reconfiguration_outputs_held_locally(
+        assert!(!all_cert_network_key_outputs_held_locally(
             &cert,
+            &no_dkg,
             &BTreeMap::new()
         ));
 
         // Local digest differs from the cert's (a stale/wrong local output —
         // the exact condition the cert-digest match exists to catch) → not ready.
         let stale = BTreeMap::from([(key_id(0), [9u8; 32])]);
-        assert!(!all_cert_reconfiguration_outputs_held_locally(
-            &cert, &stale
+        assert!(!all_cert_network_key_outputs_held_locally(
+            &cert, &no_dkg, &stale
         ));
 
         // Two certified outputs, only one held locally → not ready (EVERY item
@@ -3692,19 +3750,20 @@ mod tests {
             (network_key_id(1), [2u8; 32]),
         ]);
         let one = BTreeMap::from([(key_id(0), [1u8; 32])]);
-        assert!(!all_cert_reconfiguration_outputs_held_locally(
-            &cert_two, &one
+        assert!(!all_cert_network_key_outputs_held_locally(
+            &cert_two, &no_dkg, &one
         ));
 
         // Both held with matching digests → ready.
         let both = BTreeMap::from([(key_id(0), [1u8; 32]), (key_id(1), [2u8; 32])]);
-        assert!(all_cert_reconfiguration_outputs_held_locally(
-            &cert_two, &both
+        assert!(all_cert_network_key_outputs_held_locally(
+            &cert_two, &no_dkg, &both
         ));
 
-        // A cert with no reconfiguration items is trivially ready (nothing to
-        // wait for), even against an empty slice — and a DKG-only item must NOT
-        // be gated by this reconfiguration-readiness predicate.
+        // A certified DKG output is load-bearing too: a local mirror whose
+        // digest contradicts the cert (the hydration-clobber shape of issue
+        // #1852 — e.g. the chain's pre-V3 anchor over the canonical V3) must
+        // read NOT ready, so the barrier's installer runs and repairs it.
         let dkg_only = CertifiedHandoffAttestation {
             attestation: HandoffAttestation {
                 epoch: 7,
@@ -3718,8 +3777,24 @@ mod tests {
             },
             signatures: vec![],
         };
-        assert!(all_cert_reconfiguration_outputs_held_locally(
+        // Absent locally → not ready.
+        assert!(!all_cert_network_key_outputs_held_locally(
             &dkg_only,
+            &BTreeMap::new(),
+            &BTreeMap::new()
+        ));
+        // Poisoned mirror (digest mismatch) → not ready.
+        let poisoned = BTreeMap::from([(key_id(0), [9u8; 32])]);
+        assert!(!all_cert_network_key_outputs_held_locally(
+            &dkg_only,
+            &poisoned,
+            &BTreeMap::new()
+        ));
+        // Canonical mirror matching the cert → ready.
+        let canonical = BTreeMap::from([(key_id(0), [5u8; 32])]);
+        assert!(all_cert_network_key_outputs_held_locally(
+            &dkg_only,
+            &canonical,
             &BTreeMap::new()
         ));
     }

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -10,7 +10,7 @@ use anemo_tower::trace::TraceLayer;
 use anyhow::{Result, anyhow};
 use arc_swap::ArcSwap;
 use prometheus::Registry;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -228,6 +228,14 @@ pub struct IkaNode {
     /// Per-kind flags for NOA checkpoint finalization epoch gate.
     noa_dwallet_finalized: Arc<std::sync::atomic::AtomicBool>,
     noa_system_finalized: Arc<std::sync::atomic::AtomicBool>,
+
+    /// Set of network keys the MPC manager has instantiated, shared with the
+    /// sui-connector network-keys sync task (the reader) and every per-epoch
+    /// MPC manager (the writer). Created once at node start and threaded to
+    /// both services so the syncer and manager agree, across reconfigurations,
+    /// on which keys are instantiated (drives serve-off-chain-output vs
+    /// read-current-epoch-output-from-chain for a fresh/restart validator).
+    instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
 
     /// Prunes per-epoch authority store directories
     /// (`<db-path>/live/store/epoch_<N>/`); the `perpetual/` sibling never
@@ -1061,6 +1069,12 @@ impl IkaNode {
                 && noa_system_finalized_clone.load(std::sync::atomic::Ordering::Acquire)
         });
 
+        // Shared instantiated-network-keys set: created once here, handed to
+        // both the sui-connector syncer (reader) and every per-epoch MPC
+        // manager (writer). Must be the SAME `Arc` across reconfigurations, so
+        // it is stored on the node and re-cloned each epoch.
+        let instantiated_network_keys = Arc::new(ArcSwap::from_pointee(HashSet::new()));
+
         let (sui_connector_service, network_keys_receiver) = SuiConnectorService::new(
             dwallet_checkpoint_store.clone(),
             system_checkpoint_store.clone(),
@@ -1077,6 +1091,7 @@ impl IkaNode {
             last_session_to_complete_in_current_epoch_sender,
             uncompleted_requests_sender,
             noa_checkpoints_finalized,
+            instantiated_network_keys.clone(),
             reader_opt.clone(),
             ocs_metrics.clone(),
         )
@@ -1146,6 +1161,7 @@ impl IkaNode {
                 sui_data_receivers.clone(),
                 noa_dwallet_finalized.clone(),
                 noa_system_finalized.clone(),
+                instantiated_network_keys.clone(),
             )
             .await?;
             // This is only needed during cold start.
@@ -1202,6 +1218,7 @@ impl IkaNode {
             shutdown_channel_tx: shutdown_channel,
             noa_dwallet_finalized,
             noa_system_finalized,
+            instantiated_network_keys,
             authority_store_pruner,
         };
 
@@ -1690,6 +1707,7 @@ impl IkaNode {
         sui_data_receivers: SuiDataReceivers,
         noa_dwallet_finalized: Arc<std::sync::atomic::AtomicBool>,
         noa_system_finalized: Arc<std::sync::atomic::AtomicBool>,
+        instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
     ) -> Result<ValidatorComponents> {
         let mut config_clone = config.clone();
         let consensus_config = config_clone
@@ -1750,6 +1768,7 @@ impl IkaNode {
             sui_data_receivers,
             noa_dwallet_finalized,
             noa_system_finalized,
+            instantiated_network_keys,
         )
         .await
     }
@@ -1774,6 +1793,7 @@ impl IkaNode {
         sui_data_receivers: SuiDataReceivers,
         noa_dwallet_finalized: Arc<std::sync::atomic::AtomicBool>,
         noa_system_finalized: Arc<std::sync::atomic::AtomicBool>,
+        instantiated_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
     ) -> Result<ValidatorComponents> {
         // Channel for network-owned-address sign requests (sender unused after
         // pipeline→handler migration; receiver still drained by service loop).
@@ -1905,6 +1925,7 @@ impl IkaNode {
             network_owned_address_sign_output_receiver,
             dwallet_checkpoint_handler,
             system_checkpoint_handler,
+            instantiated_network_keys,
         );
 
         // create a new map that gets injected into both the consensus handler and the consensus adapter
@@ -2856,6 +2877,7 @@ impl IkaNode {
                             sui_data_receivers.clone(),
                             self.noa_dwallet_finalized.clone(),
                             self.noa_system_finalized.clone(),
+                            self.instantiated_network_keys.clone(),
                         )
                         .await?,
                     )
@@ -2893,6 +2915,7 @@ impl IkaNode {
                             sui_data_receivers.clone(),
                             self.noa_dwallet_finalized.clone(),
                             self.noa_system_finalized.clone(),
+                            self.instantiated_network_keys.clone(),
                         )
                         .await?,
                     )

--- a/dev-docs/playbooks/mpc-stall-postmortem.md
+++ b/dev-docs/playbooks/mpc-stall-postmortem.md
@@ -110,10 +110,11 @@ four fixed; kept for the diagnostic shapes):
   just-produced next-committee output, which adoption skips
   (`adoption skipping network key` log with
   `already_instantiated=false` — that field value IS the strand).
-  Fixed by the instantiation-aware overlay (the syncer chain-reads the
-  current-epoch output for an un-instantiated key — see the third
+  Fixed by stranded-key recovery (adoption flags the key; the syncer
+  chain-reads the current-epoch output for flagged keys — see the third
   adoption guard in `../specs/handoff.md`); if the shape recurs, check
-  that read path first.
+  for the "network key stranded after a mid-epoch restart" log and that
+  read path first.
 - **`all_epoch_sessions_finished=false` — a locked user session that is
   never re-pulled (WAS the open core of #1736; root-caused and fixed in
   PR #1809).** All other gate conditions read true; the epoch locked its

--- a/dev-docs/playbooks/mpc-stall-postmortem.md
+++ b/dev-docs/playbooks/mpc-stall-postmortem.md
@@ -99,6 +99,21 @@ four fixed; kept for the diagnostic shapes):
   at 3-of-4 quorum). TWO at one boundary = quorum death for internal
   presigns = pool starvation = the wedge. Check whether sessions created
   during a validator's key gap ever compute afterwards.
+- **mid-epoch-restart strand (issue #1852): sessions parked, zero
+  instantiation attempts.** Signature (per wedged validator):
+  `ika_dwallet_mpc_requests_pending_for_network_key` climbing while
+  `network_key_instantiations_in_flight` stays 0,
+  `network_key_instantiation_failures_total` shows no increase (never
+  attempted, not failing), and `network_key_loaded_epoch` cut off
+  exactly at process restart. Mechanism: the validator restarted after
+  this epoch's reconfiguration completed; the overlay served only the
+  just-produced next-committee output, which adoption skips
+  (`adoption skipping network key` log with
+  `already_instantiated=false` — that field value IS the strand).
+  Fixed by the instantiation-aware overlay (the syncer chain-reads the
+  current-epoch output for an un-instantiated key — see the third
+  adoption guard in `../specs/handoff.md`); if the shape recurs, check
+  that read path first.
 - **`all_epoch_sessions_finished=false` — a locked user session that is
   never re-pulled (WAS the open core of #1736; root-caused and fixed in
   PR #1809).** All other gate conditions read true; the epoch locked its

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -187,12 +187,22 @@ next epoch inherits.
    entering epoch E+1, the validator blocks until the FULL verified
    handoff data for epoch E is local: the certificate (fetched and
    verified via the same verifier, anchored once per barrier entry) and
-   every certified network-key output blob. Holding the certificate
+   every certified network-key output blob — reconfiguration outputs
+   AND the canonical DKG outputs. Holding the certificate
    does NOT imply holding the outputs (a lagging validator can adopt
    the certificate from a buffered signature quorum without ever
    computing the outputs), so the barrier installs missing outputs by
    digest. This is what prevents stale-share `InvalidParameters`
-   signing failures after the boundary.
+   signing failures after the boundary. The DKG items are part of the
+   readiness predicate deliberately: a local mirror whose digest
+   contradicts the certificate (the hydration-clobber shape below) can
+   only be repaired here — the installer fetches the cert-pinned bytes
+   from peers and re-caches them, and it only runs while the gate reads
+   not-ready. When the gate skipped DKG items, a poisoned mirror passed
+   the barrier instantly every epoch and stayed wedged permanently. The
+   DKG digests are read from the NEW epoch store (empty per-epoch table
+   → perpetual mirror), never the outgoing store, whose per-epoch table
+   is exactly what the end-of-epoch hydration may have poisoned.
 3. **Network-key adoption (steady state)**: each epoch, locally-held
    network-key outputs are adopted into the instantiation set only if
    their digests match the prior epoch's certificate
@@ -264,6 +274,27 @@ next epoch inherits.
      next epoch's cert pins V3. Fail-closed, bounded to that one
      epoch, identical to pre-recovery behavior; epoch close is
      unaffected (the validator still votes EndOfPublish).
+   - The hydration-clobber variant (issue #1852, never-instantiated
+     shape) and its three defenses. Post-restart, until the per-epoch
+     blob source installs, the sync task's full chain read publishes an
+     overlay whose DKG blob is the chain's ORIGINAL pre-V3 anchor; with
+     no later refetch trigger that overlay used to sit in the watch
+     channel all epoch, and the end-of-epoch hydration pass cached it —
+     overwriting the DURABLE perpetual canonical mirror. Every later
+     epoch then failed the DKG-digest gate above before reaching the
+     produced-this-epoch guard (so the stranded-key recovery never
+     fired), permanently: the barrier read ready without checking DKG
+     items, so its installer never repaired the mirror. Defenses, each
+     independently sufficient for its layer: (1) hydration is
+     fill-absence only — it never overwrites an existing per-key DKG
+     digest (the instantiation mirror and the cert-anchored barrier
+     install are strictly more authoritative than the overlay
+     snapshot); (2) the sync task clears its per-key fetch memo
+     whenever the blob-source identity changes, so a source-less
+     chain-read overlay is re-merged within a tick of the install
+     instead of persisting; (3) the barrier verifies and repairs DKG
+     items (see the barrier section) — the only layer that heals an
+     already-poisoned mirror.
 
 ## Key invariants
 

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -209,10 +209,11 @@ next epoch inherits.
    not be conflated with the genuinely-absent-certificate case, which
    exists only at the v3→v4 boundary and falls back to the chain copy.
    Chain reads here are deprecated: v4 keeps chain writes for
-   compatibility, but the certificate-gated off-chain copy is the only
-   sanctioned read path.
+   compatibility, and the certificate-gated off-chain copy is the
+   sanctioned steady-state read path — the one exception is the
+   un-instantiated restart-recovery read (third guard below).
 
-   Two adoption guards keep the installed parameter set identical
+   Three adoption guards keep the installed parameter set identical
    across the committee (a validator that installs anything else
    honestly computes byte-divergent MPC outputs and is convicted
    malicious by the output-quorum byte-equality tally — silently
@@ -229,6 +230,36 @@ next epoch inherits.
      otherwise burns the instantiation and blocks the same key's
      correct data behind the in-flight entry, widening the
      epoch-entry key gap during which sessions park.
+   - The overlay the sync task publishes is instantiation-aware
+     (mid-epoch-restart recovery, issue #1852). Once this epoch's
+     reconfiguration completes, the off-chain copy of a key's
+     reconfiguration output is the just-produced NEXT-committee output;
+     adoption's produced-this-epoch guard correctly skips it (a running
+     validator already holds this epoch's parameters and is only
+     pre-staging the boundary flip), but for a validator holding
+     nothing — restarted or freshly booted after that completion — the
+     skip would strand the key un-instantiated all epoch, parking every
+     session on it. For a key the MPC manager has NOT instantiated, the
+     sync task therefore serves the CHAIN's canonical current-epoch
+     reconfiguration output (skipping both the synthesize-empty fast
+     path and the off-chain reconfiguration overlay) so adoption and
+     instantiation proceed; the DKG blob still prefers the canonical
+     off-chain mirror — the digest the certificate pins — because the
+     chain's pre-V3 anchor would fail the DKG-digest gate and, via the
+     handoff hydration path, file a divergent DKG digest for this
+     epoch's attestation. The instantiated-key set is node-lifetime
+     state written only on confirmed instantiation, so a running
+     validator's read path is byte-unchanged, and both paths install
+     the identical canonical output for the epoch (no fork surface).
+     Non-validator modes never instantiate keys and keep the
+     blob-empty overlay unconditionally. KNOWN RESIDUAL: a mid-epoch
+     restart during the single V2→V3 canonical-migration epoch is NOT
+     recovered — the prior cert pins the V2 DKG digest while the
+     restarted validator's mirror already flipped to V3 (the V2 bytes
+     no longer exist locally), so adoption warns and skips until the
+     next epoch's cert pins V3. Fail-closed, bounded to that one
+     epoch, identical to pre-recovery behavior; epoch close is
+     unaffected (the validator still votes EndOfPublish).
 
 ## Key invariants
 

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -230,29 +230,33 @@ next epoch inherits.
      otherwise burns the instantiation and blocks the same key's
      correct data behind the in-flight entry, widening the
      epoch-entry key gap during which sessions park.
-   - The overlay the sync task publishes is instantiation-aware
-     (mid-epoch-restart recovery, issue #1852). Once this epoch's
-     reconfiguration completes, the off-chain copy of a key's
+   - Stranded-key recovery (mid-epoch restart, issue #1852). Once this
+     epoch's reconfiguration completes, the off-chain copy of a key's
      reconfiguration output is the just-produced NEXT-committee output;
      adoption's produced-this-epoch guard correctly skips it (a running
      validator already holds this epoch's parameters and is only
      pre-staging the boundary flip), but for a validator holding
      nothing — restarted or freshly booted after that completion — the
      skip would strand the key un-instantiated all epoch, parking every
-     session on it. For a key the MPC manager has NOT instantiated, the
-     sync task therefore serves the CHAIN's canonical current-epoch
-     reconfiguration output (skipping both the synthesize-empty fast
-     path and the off-chain reconfiguration overlay) so adoption and
-     instantiation proceed; the DKG blob still prefers the canonical
-     off-chain mirror — the digest the certificate pins — because the
-     chain's pre-V3 anchor would fail the DKG-digest gate and, via the
-     handoff hydration path, file a divergent DKG digest for this
-     epoch's attestation. The instantiated-key set is node-lifetime
-     state written only on confirmed instantiation, so a running
-     validator's read path is byte-unchanged, and both paths install
-     the identical canonical output for the epoch (no fork surface).
-     Non-validator modes never instantiate keys and keep the
-     blob-empty overlay unconditionally. KNOWN RESIDUAL: a mid-epoch
+     session on it. When the guard skips a key the validator holds
+     NOTHING for (not instantiated, no instantiation in flight, nothing
+     adopted — the in-flight/adopted checks keep the healthy
+     first-instantiation window out of the set), adoption flags it in a
+     shared stranded-key set, and the sync task chain-reads exactly the
+     flagged keys: a full read instead of the synthesize-empty fast
+     path, serving the CHAIN's canonical current-epoch reconfiguration
+     output (never overlaid by the off-chain copy) so adoption and
+     instantiation proceed; a confirmed instantiation un-flags the key.
+     The DKG blob still prefers the canonical off-chain mirror — the
+     digest the certificate pins — because the chain's pre-V3 anchor
+     would fail the DKG-digest gate and, via the handoff hydration
+     path, file a divergent DKG digest for this epoch's attestation.
+     The set is empty in every healthy flow — non-validators never run
+     adoption at all — so the v4 no-steady-state-chain-read invariant
+     holds exactly (asserted by the
+     `off_chain_metadata_v4_does_not_read_blobs_from_chain` cluster
+     test), and both paths install the identical canonical output for
+     the epoch (no fork surface). KNOWN RESIDUAL: a mid-epoch
      restart during the single V2→V3 canonical-migration epoch is NOT
      recovered — the prior cert pins the V2 DKG digest while the
      restarted validator's mirror already flipped to V3 (the V2 bytes


### PR DESCRIPTION
Addresses the restart-strand variant of #1852 (deliberately NOT auto-closing: live post-handoff monitoring split the issue into three variants — see https://github.com/dwallet-labs/ika/issues/1852#issuecomment-5012364385 — and this PR covers variant 1, the produced-this-epoch strand; variant 2 = missing canonical DKG anchor after restart, variant 3 = missed MPC-data freeze, tracked in #1856) — **testnet liveness**: 4 validators (~11% of stake) that restarted mid-epoch completed zero MPC advances for 6–8.7h, with 263 sessions parked on the network key and re-instantiation never attempted.

## Mechanism

Once an epoch's network-key reconfiguration completes, the off-chain overlay serves the just-produced reconfiguration output R(M) — the shares for the **next** committee. The adoption pass's `produced_this_epoch` guard correctly skips R(M) for a running validator (it already holds this epoch's output R(M-1) from epoch entry and is only pre-staging the boundary flip). A validator that restarts after that completion holds **nothing**: the overlay serves only R(M), the guard skips it forever, and the key is never instantiated. #1835's level-triggered drain releases parked requests once a key's public data exists — but nothing ever made the data exist. This exactly matches the issue's metric signature: `requests_pending_for_network_key` climbing, `instantiations_in_flight` 0, `instantiation_failures_total` flat (never attempted — the skip is upstream of any attempt), `network_key_loaded_epoch` cut off at process restart.

## Fix: stranded-key recovery

The manager is the only component that can see the strand, so it drives the recovery:

- When the `produced_this_epoch` guard skips a key the validator holds **nothing** for — not instantiated, no instantiation in flight, nothing adopted (the in-flight/adopted checks keep the healthy first-instantiation window out) — adoption flags the key in a node-lifetime `Arc<ArcSwap<HashSet<ObjectID>>>` shared with the sui-connector network-keys sync task.
- The syncer chain-reads **exactly the flagged keys**: full read instead of the synthesize-empty fast path (the Move contract writes reconfiguration outputs on-chain under `current_epoch + 1` regardless of protocol version, so `get_current_reconfiguration_public_output(M)` = R(M-1) with real bytes), and the new `overlay_network_key_data` helper does **not** overlay the off-chain reconfiguration blob for a flagged key (which would re-override R(M-1) with R(M)). A flagged key also bypasses the syncer's `(epoch, state)` fetch memo — the flag is raised after the strand-revealing entry was already recorded there.
- A confirmed instantiation un-flags the key, returning it to the off-chain read path. Recovery completes within one syncer tick (~5s) plus one instantiation (~10s).
- The **DKG blob still prefers the off-chain mirror** on the recovery read: the mirror holds the canonical (post-V2→V3) representation whose digest the prior epoch's handoff cert pins. Serving the chain's original V2 anchor would (a) fail adoption's cert DKG-digest gate — trading the silent wedge for a loud one — and (b) let the handoff hydration path file the stale anchor's digest under this epoch, diverging this validator's DKG handoff item from peers (`AttestationMismatch`).
- The previously-silent `produced_this_epoch` skip now logs at info with an `already_instantiated` field, and the strand-flagging logs explicitly — the observability the issue's monitoring note asked for.

The set is **empty in every healthy flow** (non-validators never run adoption at all), so the v4 no-steady-state-chain-read invariant holds exactly — asserted by the `off_chain_metadata_v4_does_not_read_blobs_from_chain` cluster test. An earlier draft of this fix keyed the syncer on an instantiated-keys set instead (the shape validated on the multichain feature branch as `80e028821e`); the cluster test caught it chain-reading during healthy first-instantiation windows, and the strand-set inversion is the result: the chain read now happens exactly when the wedge exists, and only then. Relative to that feature-branch fix, the NetworkKeyId-derivation-guard re-arm is also **not** ported — #1825's input-digest memo supersedes it (the recovery read changes the derivation inputs, which re-arms that memo naturally).

## No fork / epoch-close safety

Cleared by a dedicated consensus-determinism review pass:

- Both a recovered and a running validator install the identical canonical R(M-1) for the epoch (chain bytes are the same checkpoint-chunk bytes the local cache holds); the cert-digest equality gate rejects anything else.
- The stranded set is a local read-path signal that reaches no consensus artifact.
- EndOfPublish readiness (`snapshot_ready_for_signing`) gates the reconfiguration output on the epoch-keyed digest slice, not overlay bytes, so the R(M-1)-carrying overlay can neither withhold the vote nor sign a stale digest.

The review also surfaced one MEDIUM adjacent defect this PR fixes: the sync pass's chain-read `Err` arm aborted the **whole pass including the channel send**, after a sibling key that merged complete earlier in the same pass was already recorded as fetched — permanently withholding that sibling from the overlay until the next epoch. Pre-existing (the arm was unreachable for v4 cached keys), but the recovery read makes it hot on exactly the restart path. The arm now skips only the failed key.

Known residual (documented in the spec): a mid-epoch restart during the single V2→V3 canonical-migration epoch is not recovered (the prior cert pins V2 while the local mirror already flipped to V3) — fail-closed, warns loudly, self-heals at the next epoch boundary, identical to pre-fix behavior in that epoch.

## Spec/playbook

- `dev-docs/specs/handoff.md`: stranded-key recovery is now the third adoption guard; the "chain reads deprecated" sentence gains its one exception.
- `dev-docs/playbooks/mpc-stall-postmortem.md`: the #1852 metric signature added to the stall catalogue.

## Validation

- New manager-level regression test `this_epoch_reconfiguration_output_is_skipped_and_current_epoch_output_recovers`: an overlay serving R(M) is skipped by the produced-this-epoch guard even when the cert deliberately matches (isolating the guard), the skipped key is flagged as stranded, and an overlay serving R(M-1) — what the recovery read delivers — is adopted and spawns instantiation. **Fault-validated** per the test-testing playbook: disabling the guard makes the test fail at exactly the phase-1 assertion; reverted.
- New unit test `stranded_key_keeps_chain_reconfiguration_output_and_canonical_dkg` pins the overlay-merge contract (chain reconfiguration output kept, canonical DKG mirror preferred, chain copy untouched with no source).
- `network_key_adoption` suite (6 tests) and `missing_network_key` suite (incl. #1835's park-then-materialize vehicle) green in release with real crypto; `off_chain_metadata_v4_does_not_read_blobs_from_chain` green locally after the strand-set redesign.
- `cargo check --workspace --all-targets --release` and clippy clean.
- Heavy CI suites (integration / cluster / TS) dispatched on the final commit.

Follow-up (not in this PR): an explicit `sessions_parked_without_key_instantiation` anomaly kind, per the issue's monitoring note — the fix makes the state self-healing and observable via logs, but a first-class anomaly would let infra alert on any future variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Scope expansion: variant 2 (merged from #1859)

This branch now also carries the **variant-2 fix** — the permanent never-instantiated wedge (`canonical_dkg_output_version=0`: Full Sail, n1stake, alphab.ai), root-caused in [#1852 (comment)](https://github.com/dwallet-labs/ika/issues/1852#issuecomment-5012466405):

- **Hydration guard:** the handoff sender's `hydrate_network_dkg_digests` pass is now fill-absence-only — it never overwrites an existing DKG digest, so a stale boot-race overlay can no longer clobber the durable perpetual canonical mirror.
- **Fetch-memo invalidation:** the network-keys sync task re-merges all keys when the off-chain blob source installs, closing the boot-race window minutes after startup instead of carrying a stale chain-anchor overlay all epoch.
- **Barrier DKG repair:** the prepare-then-start barrier's readiness predicate now digest-checks `NetworkDkgOutput` items against the handoff cert (previously unconditionally ready), and the existing peer-fetch installer repairs a missing/mismatching mirror — this is what recovers the three currently-poisoned validators at their first epoch boundary after deploy, with no operator action.

Rolling-upgrade safe: no protocol/Move/wire changes; the repair fetch uses the existing digest-verified blob protocol already served by v1.2.1 peers.
