### PR TITLE
feat(mpc): session-origin provenance and a sessions_reconstructed_total counter

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -74,7 +74,10 @@ pub struct DWalletMPCMetrics {
     computation_duration_variance: GaugeVec,
 
     /// Tracks the number of MPC protocol sessions that have been started.
-    session_start_count: IntGaugeVec,
+    /// A genuine counter (monotonic, inc-only); the legacy `_count` name
+    /// predates the counter/`_total` suffix convention and is kept so
+    /// existing dashboards keep working.
+    session_start_count: IntCounterVec,
 
     /// Tracks the total number of completed MPC protocol sessions.
     ///
@@ -200,6 +203,16 @@ pub struct DWalletMPCMetrics {
     /// `anomaly_snapshots_total` meaningful. Labels: `race` (fixed condition
     /// strings), `session_type`.
     pub(crate) completion_races_total: IntCounterVec,
+
+    /// Sessions created from peer artifacts arriving through consensus (a
+    /// stray message/output before the request, or a completion replayed at
+    /// restart) rather than from a locally processed session request. A
+    /// bounded burst at restart is healthy recovery; a stream still climbing
+    /// long after restart while `advance_completions` stays flat is a
+    /// validator that is not participating at all (the mid-epoch-restart
+    /// wedge class). Incremented at creation; a later upgrade to
+    /// local-request origin does not retract it. Labels: `session_type`.
+    pub(crate) sessions_reconstructed_total: IntCounterVec,
 
     /// Individual reasons present in emitted anomaly snapshots. One snapshot can
     /// increment several triggers. Trigger values are compile-time static strings.
@@ -356,7 +369,7 @@ impl DWalletMPCMetrics {
         ];
 
         Arc::new(Self {
-            session_start_count: register_int_gauge_vec_with_registry!(
+            session_start_count: register_int_counter_vec_with_registry!(
                 "ika_dwallet_mpc_session_start_count",
                 "Number of MPC protocol sessions started",
                 &protocol_metric_labels,
@@ -566,6 +579,13 @@ impl DWalletMPCMetrics {
                 "ika_dwallet_mpc_completion_races_total",
                 "Expected races where a session completed via the peers' output quorum before the local validator caught up",
                 &["race", "session_type"],
+                registry,
+            )
+            .unwrap(),
+            sessions_reconstructed_total: register_int_counter_vec_with_registry!(
+                "ika_dwallet_mpc_sessions_reconstructed_total",
+                "Sessions created from peer artifacts arriving through consensus instead of a locally processed session request",
+                &["session_type"],
                 registry,
             )
             .unwrap(),

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/anomaly_diagnostics.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/anomaly_diagnostics.rs
@@ -3,7 +3,7 @@ use crate::dwallet_mpc::dwallet_mpc_service::DWalletMPCService;
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::mpc_diagnostics::{
     LocalAuthorityMaliciousReason, LocalComputationState, MpcAnomalyContext, MpcAnomalyKind,
-    output_digest, report_digest,
+    SessionOrigin, output_digest, report_digest,
 };
 use crate::dwallet_mpc::mpc_manager::MAX_UNTRACKED_ANOMALIES;
 use crate::dwallet_mpc::mpc_session::DWalletMPCSessionOutput;
@@ -382,7 +382,8 @@ fn self_malicious_service_exit_records_termination_reason() {
 /// up is normal threshold-MPC behavior, not a defect: no anomaly snapshot may
 /// be emitted, and the races land on the plain completion-race counter
 /// instead (per-session dedup times high session churn flooded the anomaly
-/// taxonomy otherwise).
+/// taxonomy otherwise). The race is only a race for a locally requested
+/// session, so the session's origin is upgraded before quorum here.
 #[test]
 fn benign_quorum_race_counts_without_anomaly_snapshot() {
     let (authorities, mut services) = authorities(0);
@@ -397,10 +398,20 @@ fn benign_quorum_race_counts_without_anomaly_snapshot() {
             mpc_round: Some(3),
             attempt_number: 0,
         });
+    services[0].dwallet_mpc_manager_mut().handle_output(
+        40,
+        internal_report(authorities[1], session_identifier, vec![3], vec![]),
+    );
+    services[0]
+        .dwallet_mpc_manager_mut()
+        .sessions
+        .get_mut(&session_identifier)
+        .unwrap()
+        .origin = SessionOrigin::LocalRequest;
     let reports = authorities
         .iter()
-        .skip(1)
-        .take(3)
+        .skip(2)
+        .take(2)
         .map(|authority| internal_report(*authority, session_identifier, vec![3], vec![]))
         .collect();
 
@@ -438,9 +449,52 @@ fn benign_quorum_race_counts_without_anomaly_snapshot() {
     );
 }
 
-/// When a defect trigger fires for the same quorum, the snapshot is emitted
-/// and carries the benign race conditions as context, the running-computation
-/// state, and no protocol payload.
+/// A session known only from peer outputs (its request never activated
+/// locally — the dominant shape after a restart) can never have local
+/// output; quorum on it is a reconstruction, not a completion race. It
+/// lands on `sessions_reconstructed_total` at creation and must not touch
+/// the race counter or the anomaly taxonomy at quorum.
+#[test]
+fn reconstructed_session_quorum_counts_reconstruction_not_race() {
+    let (authorities, mut services) = authorities(0);
+    let session_identifier = SessionIdentifier::new(SessionType::System, [14; 32]);
+    let reports = authorities
+        .iter()
+        .skip(1)
+        .take(3)
+        .map(|authority| internal_report(*authority, session_identifier, vec![3], vec![]))
+        .collect();
+
+    services[0]
+        .dwallet_mpc_manager_mut()
+        .handle_consensus_round_outputs(41, reports);
+
+    let manager = services[0].dwallet_mpc_manager();
+    let session = manager.sessions.get(&session_identifier).unwrap();
+    assert_eq!(session.origin, SessionOrigin::ReconstructedFromConsensus);
+    assert_eq!(session.emitted_anomaly_count(), 0);
+    assert!(session.last_anomaly_snapshot().is_none());
+    assert_eq!(
+        manager
+            .dwallet_mpc_metrics
+            .sessions_reconstructed_total
+            .with_label_values(&["system"])
+            .get(),
+        1
+    );
+    assert_eq!(
+        manager
+            .dwallet_mpc_metrics
+            .completion_races_total
+            .with_label_values(&["quorum_reached_before_local_output_observed", "system"])
+            .get(),
+        0
+    );
+}
+
+/// When a defect trigger fires for the same quorum on a locally requested
+/// session, the snapshot is emitted and carries the benign race conditions
+/// as context, the running-computation state, and no protocol payload.
 #[test]
 fn defect_quorum_snapshot_keeps_race_context_and_redacts_payload() {
     let (authorities, mut services) = authorities(0);
@@ -457,10 +511,25 @@ fn defect_quorum_snapshot_keeps_race_context_and_redacts_payload() {
             mpc_round: Some(3),
             attempt_number: 0,
         });
+    services[0].dwallet_mpc_manager_mut().handle_output(
+        40,
+        internal_report(
+            authorities[1],
+            session_identifier,
+            secret_marker.clone(),
+            vec![malicious_authority],
+        ),
+    );
+    services[0]
+        .dwallet_mpc_manager_mut()
+        .sessions
+        .get_mut(&session_identifier)
+        .unwrap()
+        .origin = SessionOrigin::LocalRequest;
     let reports = authorities
         .iter()
-        .skip(1)
-        .take(3)
+        .skip(2)
+        .take(2)
         .map(|authority| {
             internal_report(
                 *authority,
@@ -482,6 +551,7 @@ fn defect_quorum_snapshot_keeps_race_context_and_redacts_payload() {
         .unwrap()
         .last_anomaly_snapshot()
         .unwrap();
+    assert_eq!(snapshot.session_origin, SessionOrigin::LocalRequest);
     assert!(
         snapshot
             .trigger_conditions
@@ -506,6 +576,62 @@ fn defect_quorum_snapshot_keeps_race_context_and_redacts_payload() {
     let rendered = snapshot.to_json().unwrap();
     assert!(!rendered.contains(&format!("{:?}", secret_marker)));
     assert!(!rendered.contains("PRIVATE_OUTPUT_MUST_NOT_APPEAR"));
+}
+
+/// The same defect on a session this validator only reconstructed from peer
+/// outputs still snapshots — but its missing local output is definitional,
+/// so the race-context condition is omitted and `session_origin` lets triage
+/// split the populations. The factual state fields are unaffected.
+#[test]
+fn defect_snapshot_on_reconstructed_session_omits_race_context() {
+    let (authorities, mut services) = authorities(0);
+    let session_identifier = SessionIdentifier::new(SessionType::System, [14; 32]);
+    let malicious_authority = authorities[3];
+    let reports = authorities
+        .iter()
+        .skip(1)
+        .take(3)
+        .map(|authority| {
+            internal_report(
+                *authority,
+                session_identifier,
+                vec![6],
+                vec![malicious_authority],
+            )
+        })
+        .collect();
+
+    services[0]
+        .dwallet_mpc_manager_mut()
+        .handle_consensus_round_outputs(41, reports);
+
+    let snapshot = services[0]
+        .dwallet_mpc_manager()
+        .sessions
+        .get(&session_identifier)
+        .unwrap()
+        .last_anomaly_snapshot()
+        .unwrap();
+    assert_eq!(
+        snapshot.session_origin,
+        SessionOrigin::ReconstructedFromConsensus
+    );
+    assert!(
+        snapshot
+            .trigger_conditions
+            .contains(&"malicious_authority_identified")
+    );
+    assert!(
+        !snapshot
+            .trigger_conditions
+            .contains(&"quorum_reached_before_local_output_observed")
+    );
+    assert!(!snapshot.local_output_observed);
+    assert!(snapshot.quorum_reached_without_local_output);
+    assert!(
+        serde_json::from_str::<serde_json::Value>(&snapshot.to_json().unwrap()).unwrap()["session_origin"]
+            == "reconstructed_from_consensus"
+    );
 }
 
 #[test]

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/message_before_event.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/message_before_event.rs
@@ -1,5 +1,6 @@
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::send_start_network_dkg_event_to_some_parties;
+use crate::dwallet_mpc::mpc_diagnostics::SessionOrigin;
 use crate::dwallet_mpc::mpc_session::SessionStatus;
 use ika_types::committee::Committee;
 use sui_types::base_types::ObjectID;
@@ -66,6 +67,34 @@ async fn some_parties_receive_mpc_message_before_session_start_event() {
             pending_event_session.status,
             SessionStatus::WaitingForSessionRequest
         ));
+        // A session known only from a peer's message is a reconstruction —
+        // it counts on the reconstruction counter at creation.
+        assert_eq!(
+            pending_event_session.origin,
+            SessionOrigin::ReconstructedFromConsensus
+        );
+        assert_eq!(
+            dwallet_mpc_service
+                .dwallet_mpc_manager()
+                .dwallet_mpc_metrics
+                .sessions_reconstructed_total
+                .with_label_values(&["system"])
+                .get(),
+            1
+        );
+    }
+    for i in &parties_that_receive_session_message_after_start_event {
+        // Parties that processed the request first created their session
+        // from it — nothing was reconstructed.
+        assert_eq!(
+            dwallet_mpc_services[*i]
+                .dwallet_mpc_manager()
+                .dwallet_mpc_metrics
+                .sessions_reconstructed_total
+                .with_label_values(&["system"])
+                .get(),
+            0
+        );
     }
     send_start_network_dkg_event_to_some_parties(
         epoch_id,
@@ -82,6 +111,28 @@ async fn some_parties_receive_mpc_message_before_session_start_event() {
         &parties_that_receive_session_message_before_start_event,
     )
     .await;
+    for i in &parties_that_receive_session_message_before_start_event {
+        // Receiving the request and activating upgrades the entry to a
+        // locally requested session; the creation-time reconstruction count
+        // is deliberately not retracted.
+        let dwallet_mpc_service = &dwallet_mpc_services[*i];
+        let activated_session = dwallet_mpc_service
+            .dwallet_mpc_manager()
+            .sessions
+            .values()
+            .next()
+            .unwrap();
+        assert_eq!(activated_session.origin, SessionOrigin::LocalRequest);
+        assert_eq!(
+            dwallet_mpc_service
+                .dwallet_mpc_manager()
+                .dwallet_mpc_metrics
+                .sessions_reconstructed_total
+                .with_label_values(&["system"])
+                .get(),
+            1
+        );
+    }
     utils::send_advance_results_between_parties(
         &committee,
         &mut sent_consensus_messages_collectors,

--- a/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
@@ -153,6 +153,31 @@ impl MpcAnomalyKind {
     }
 }
 
+/// How this validator first learned of a session. `LocalRequest` means the
+/// session request itself was processed locally (at creation, or by
+/// activating a `WaitingForSessionRequest` entry later);
+/// `ReconstructedFromConsensus` means the session exists only because peer
+/// artifacts (messages, outputs, a replayed completion) arrived through
+/// consensus — dominant after a restart, when pre-restart sessions are
+/// rebuilt from consensus outputs this validator can never have local
+/// output for. Missing local output is definitional for a reconstructed
+/// session, never a completion race.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SessionOrigin {
+    LocalRequest,
+    ReconstructedFromConsensus,
+}
+
+impl SessionOrigin {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::LocalRequest => "local_request",
+            Self::ReconstructedFromConsensus => "reconstructed_from_consensus",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum LocalComputationState {
@@ -335,6 +360,7 @@ pub(crate) struct MpcAnomalySnapshot {
     #[serde(serialize_with = "serialize_digest")]
     pub(crate) session_id: [u8; 32],
     pub(crate) session_type: SessionType,
+    pub(crate) session_origin: SessionOrigin,
     pub(crate) computation_type: &'static str,
     pub(crate) protocol: Option<String>,
     pub(crate) session_sequence_number: Option<u64>,

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -14,8 +14,8 @@ use crate::dwallet_mpc::dwallet_mpc_metrics::{
 };
 use crate::dwallet_mpc::mpc_diagnostics::{
     LocalAuthorityMaliciousReason, MPC_ANOMALY_SCHEMA_VERSION, MpcAnomalyContext, MpcAnomalyKind,
-    OutputReportDiagnostic, OutputVoteDiagnostics, OutputVoteGroupDiagnostic, mpc_error_diagnostic,
-    network_key_reconfiguration_raw_output_digest,
+    OutputReportDiagnostic, OutputVoteDiagnostics, OutputVoteGroupDiagnostic, SessionOrigin,
+    mpc_error_diagnostic, network_key_reconfiguration_raw_output_digest,
 };
 use crate::dwallet_mpc::mpc_session::{
     AddOutputResult, DWalletMPCSessionOutput, DWalletSession, PublicInput, SessionComputationType,
@@ -677,6 +677,16 @@ impl DWalletMPCManager {
                         .sessions
                         .get(&session_identifier)
                         .is_some_and(|session| session.self_output_consensus_round.is_some());
+                    // A session this validator only reconstructed from peer
+                    // artifacts (its request never activated locally —
+                    // dominant after a restart) can never have local output;
+                    // that absence is definitional, not a completion race.
+                    let session_reconstructed =
+                        self.sessions
+                            .get(&session_identifier)
+                            .is_some_and(|session| {
+                                session.origin == SessionOrigin::ReconstructedFromConsensus
+                            });
                     let running_computation_count = self
                         .cryptographic_computations_orchestrator
                         .running_computation_count_for_session(&session_identifier);
@@ -756,7 +766,7 @@ impl DWalletMPCManager {
                     // it to the snapshot only as context when one of the
                     // defect triggers above fired for the same session.
                     let session_type = session_type_label(session_identifier.session_type());
-                    if !local_output_observed {
+                    if !local_output_observed && !session_reconstructed {
                         self.dwallet_mpc_metrics
                             .completion_races_total
                             .with_label_values(&[
@@ -775,7 +785,7 @@ impl DWalletMPCManager {
                             .inc();
                     }
                     if !trigger_conditions.is_empty() {
-                        if !local_output_observed {
+                        if !local_output_observed && !session_reconstructed {
                             trigger_conditions.push("quorum_reached_before_local_output_observed");
                         }
                         if running_computation_count > 0 {
@@ -2544,11 +2554,19 @@ impl DWalletMPCManager {
             counterparty_chain,
             session_computation_type,
         );
+        let session_origin = new_session.origin;
+        if session_origin == SessionOrigin::ReconstructedFromConsensus {
+            self.dwallet_mpc_metrics
+                .sessions_reconstructed_total
+                .with_label_values(&[session_type_label(session_identifier.session_type())])
+                .inc();
+        }
 
         info!(
             party_id=self.party_id,
             authority=?self.validator_name,
             active,
+            session_origin = session_origin.label(),
             ?session_identifier,
             last_session_to_complete_in_current_epoch=?self.last_session_to_complete_in_current_epoch,
             "Adding a new MPC session to the active sessions map",
@@ -3694,6 +3712,7 @@ impl DWalletMPCManager {
                 severity = anomaly_kind.severity(),
                 session_id = %hex::encode(snapshot.session_id),
                 session_type = session_type_label(snapshot.session_type),
+                session_origin = snapshot.session_origin.label(),
                 epoch = snapshot.epoch,
                 local_party_id = snapshot.local_party_id,
                 tracked_session = true,
@@ -3719,6 +3738,7 @@ impl DWalletMPCManager {
                 severity = anomaly_kind.severity(),
                 session_id = %hex::encode(snapshot.session_id),
                 session_type = session_type_label(snapshot.session_type),
+                session_origin = snapshot.session_origin.label(),
                 epoch = snapshot.epoch,
                 local_party_id = snapshot.local_party_id,
                 tracked_session = true,

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -23,8 +23,8 @@ use tracing::{debug, error, info, warn};
 use crate::dwallet_mpc::dwallet_mpc_service::DWalletMPCService;
 use crate::dwallet_mpc::mpc_diagnostics::{
     BoundedSessionDiagnostics, LocalComputationState, MPC_ANOMALY_SCHEMA_VERSION,
-    MpcAnomalyContext, MpcAnomalyKind, MpcAnomalySnapshot, SessionDiagnosticEvent, output_digest,
-    report_digest,
+    MpcAnomalyContext, MpcAnomalyKind, MpcAnomalySnapshot, SessionDiagnosticEvent, SessionOrigin,
+    output_digest, report_digest,
 };
 use crate::dwallet_mpc::mpc_manager::DWalletMPCManager;
 use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionRequestMetricData};
@@ -82,6 +82,15 @@ pub(crate) struct DWalletSession {
 
     /// The status of the MPC session.
     pub(super) status: SessionStatus,
+
+    /// Provenance of this session entry: created from a locally processed
+    /// request, or reconstructed from peer artifacts arriving through
+    /// consensus (stray message/output, replayed completion). Derived from
+    /// the creation status; upgraded to `LocalRequest` if the session later
+    /// activates from its request. Reconstructed sessions are counted on
+    /// `ika_dwallet_mpc_sessions_reconstructed_total` and their missing
+    /// local output is never treated as a completion race.
+    pub(super) origin: SessionOrigin,
 
     pub(super) computation_type: SessionComputationType,
 
@@ -279,8 +288,21 @@ impl DWalletSession {
             _ => (None, None, None),
         };
         let diagnostics = BoundedSessionDiagnostics::new(status.to_string());
+        // The creation status encodes provenance: `WaitingForSessionRequest`
+        // (stray message/output before the request) and `ComputationCompleted`
+        // (completion replayed from consensus) entries exist only because of
+        // peer artifacts; every other creation site processes a local request.
+        let origin = match &status {
+            SessionStatus::WaitingForSessionRequest | SessionStatus::ComputationCompleted => {
+                SessionOrigin::ReconstructedFromConsensus
+            }
+            SessionStatus::Active { .. } | SessionStatus::Completed | SessionStatus::Failed => {
+                SessionOrigin::LocalRequest
+            }
+        };
         let mut session = Self {
             status,
+            origin,
             outputs_by_consensus_round: BTreeMap::new(),
             session_identifier,
             party_id,
@@ -631,6 +653,12 @@ impl DWalletSession {
     }
 
     pub(crate) fn set_status(&mut self, status: SessionStatus) {
+        // Activating means the session's own request was processed locally —
+        // a `WaitingForSessionRequest`-born entry stops being a
+        // reconstruction the moment it activates.
+        if matches!(status, SessionStatus::Active { .. }) {
+            self.origin = SessionOrigin::LocalRequest;
+        }
         self.record_status_transition(&status.to_string());
         self.status = status;
     }
@@ -841,6 +869,7 @@ impl DWalletSession {
             session_type: self
                 .session_type
                 .unwrap_or_else(|| self.session_identifier.session_type()),
+            session_origin: self.origin,
             computation_type: match &self.computation_type {
                 SessionComputationType::MPC { .. } => "MPC",
                 SessionComputationType::Native => "Native",

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -44,9 +44,12 @@ family (`last_pruned_{consensus,authority}_db_epoch`,
   `register_int_counter*` — e.g. `dwallet_mpc_global_presigns_served_total`,
   `dwallet_mpc_network_key_instantiation_failures_total`.
 - **Gauges** (a current value) are a plain noun, often `_count` / `_size`
-  / `_in_flight` — e.g. `dwallet_mpc_session_start_count`,
-  `dwallet_mpc_internal_presign_pool_size`,
+  / `_in_flight` — e.g. `dwallet_mpc_internal_presign_pool_size`,
   `ika_dwallet_mpc_malicious_actors_count`. Never give a gauge `_total`.
+  One legacy exception: `ika_dwallet_mpc_session_start_count` is a genuine
+  counter (converted from a gauge that was only ever incremented) whose
+  `_count` name predates the suffix convention and is kept so existing
+  dashboards keep working.
 - **Per-protocol metrics are LABELLED, not duplicated per protocol.** The
   MPC computation gauges are `*_vec` keyed by
   `["curve", "signature_algorithm", "key_role"]`; the label values come
@@ -178,6 +181,7 @@ ika_dwallet_mpc_session_output_rejected
 ika_dwallet_mpc_session_reported_malicious_actors
 ika_dwallet_mpc_session_start_count
 ika_dwallet_mpc_session_state_count
+ika_dwallet_mpc_sessions_reconstructed_total
 ika_dwallet_mpc_sessions_rejected_total
 ika_dwallet_mpc_sessions_with_self_output_no_quorum
 ika_dwallet_mpc_user_session_distinct_output_authorities

--- a/dev-docs/playbooks/mpc-anomaly-diagnostics.md
+++ b/dev-docs/playbooks/mpc-anomaly-diagnostics.md
@@ -66,6 +66,28 @@ to that snapshot's `trigger_conditions` as context, and the snapshot fields
 (`local_output_observed`, `quorum_reached_without_local_output`,
 `running_computation_count`) carry the race state either way.
 
+### Session origin: reconstructed sessions are not racing
+
+Every session carries a provenance tag, `session_origin`:
+`local_request` when the session request itself was processed locally
+(at creation, or by activating a waiting entry later), or
+`reconstructed_from_consensus` when the entry exists only because peer
+artifacts (a stray message or output, a completion replayed at restart)
+arrived through consensus. After a restart, reconstruction is the dominant
+path — the node rebuilds pre-restart sessions it can never have local
+output for.
+
+Missing local output on a still-reconstructed session is definitional, not
+a completion race: it does not increment the
+`quorum_reached_before_local_output_observed` race counter and is not
+attached as trigger context on defect snapshots. Instead, each
+reconstructed session increments
+`ika_dwallet_mpc_sessions_reconstructed_total{session_type}` once at
+creation (a later upgrade to `local_request` does not retract it), and
+`session_origin` appears both as a top-level field on snapshot log lines
+and inside `diagnostic_json`, so forensic triage can split the two
+populations directly.
+
 ### Late network-key reconfiguration outputs
 
 One update-after-completion case carries extra evidence and is the only one
@@ -177,7 +199,8 @@ have the same fields.
 
 The emitted line otherwise has stable top-level fields for filtering:
 `event`, `schema_version`, `anomaly_kind`, `severity`, `session_id`,
-`session_type`, `epoch`, `local_party_id`, `tracked_session`,
+`session_type`, `session_origin` (tracked sessions only), `epoch`,
+`local_party_id`, `tracked_session`,
 `local_output_observed`, `quorum_reached_without_local_output`, `error_code`,
 `error_backtrace_present`, `error_backtrace_truncated`,
 `local_authority_malicious`, and `recent_trace_dropped_events`.
@@ -375,7 +398,7 @@ filter the stored JSON line instead:
 
 ## Alerting metrics
 
-Three low-cardinality counters accompany the local log:
+Four low-cardinality counters accompany the local log:
 
 - `ika_dwallet_mpc_anomaly_snapshots_total{anomaly_kind,session_type,severity}`
   increments once per deduplicated snapshot (`session_type="unknown"` is used
@@ -385,7 +408,14 @@ Three low-cardinality counters accompany the local log:
 - `ika_dwallet_mpc_completion_races_total{race,session_type}` counts the benign
   completion races described above, once per occurrence (no per-session
   dedup). A healthy validator under load grows this steadily; it is a trend
-  panel, not an alert.
+  panel, not an alert;
+- `ika_dwallet_mpc_sessions_reconstructed_total{session_type}` counts sessions
+  created from peer artifacts instead of a locally processed request. A
+  bounded spike at restart that then flattens is healthy recovery. Still
+  climbing at the network's session rate long after a restart while
+  `ika_dwallet_mpc_advance_completions` stays flat is a validator that is
+  not participating at all (the mid-epoch-restart wedge class) — this pair
+  is directly alertable.
 
 Because the benign races no longer emit snapshots, any increase of
 `anomaly_snapshots_total` on a healthy network is worth investigating.


### PR DESCRIPTION
Fixes #1857. **Stacked on #1854** (base branch is `claude/issue-1853-0bb5fe`; retarget to `main` when #1854 merges — the diff shown here is the #1857 delta only).

## What

Sessions reconstructed from consensus artifacts after a restart were indistinguishable from sessions the validator participated in locally. After #1854 correctly silenced the benign quorum races, the unbounded no-local-output session stream — the #1852/#1856 mid-epoch-restart wedge signature ([NODERS]/bitszn: ~10k/8k such sessions in 2h with zero local advances) — went metric-dark except for advance counters.

- **`SessionOrigin` provenance tag** (`local_request` | `reconstructed_from_consensus`), derived from the creation status: `WaitingForSessionRequest` (stray message/output before the request) and `ComputationCompleted` (completion replayed from consensus) entries are reconstructions; every other creation site processes a local request. Activating a waiting entry upgrades it to `local_request` (the flip lives in `set_status`, so both the external-request and internal-presign activation paths get it for free).
- **`ika_dwallet_mpc_sessions_reconstructed_total{session_type}`** — a genuine `IntCounterVec`, incremented once at creation of a reconstructed session (a later upgrade doesn't retract it). Operational reading, now documented in the anomaly playbook: bounded spike at restart then flat = healthy recovery; still climbing at the network's session rate while `advance_completions` stays flat = the non-participation wedge, directly alertable.
- **Diagnostics rule**: missing local output on a *still-reconstructed* session is definitional, not a completion race — it no longer increments `completion_races_total{race="quorum_reached_before_local_output_observed"}` and is not attached as trigger context on defect snapshots. `session_origin` is carried inside the snapshot JSON and as a stable top-level field on tracked-session log lines, so triage can split the populations. The factual snapshot fields (`local_output_observed`, `quorum_reached_without_local_output`) are unchanged, and all correctness paths (voting, rejection, malicious attribution, output caching) are identical for both origins.
- **Opportunistic conversion** flagged in the issue: `session_start_count` was an inc-only `IntGaugeVec`; now a genuine `IntCounterVec`. Name kept (`_count`) for dashboard compatibility — noted as the one legacy exception in `dev-docs/conventions/metrics.md`; no in-repo consumer reads the exposition type.

## Interaction with #1854's tests

The #1854 benign-race and defect-context tests created their sessions *from outputs* — which under this PR makes them reconstructed. They now upgrade origin explicitly and keep pinning the local-request race semantics; two new tests pin the reconstructed side (quorum on a reconstructed session counts reconstruction, not a race, and emits nothing; a defect on one still snapshots, without race context and with `session_origin` split).

## Testing

- `cargo test --release -p ika-core anomaly_diagnostics` — 13 passed (2 new origin tests).
- `cargo test --release -p ika-core late_reconfiguration_output` — 3 passed (unchanged behavior; the #1844 evidence contract untouched).
- `cargo test --release -p ika-core message_before_event` — 1 passed, extended with real-path assertions: reconstruction counted at message-before-request creation, zero on prompt parties, origin upgraded to `local_request` on real activation with the creation count not retracted.
- `cargo clippy --release -p ika-core --all-targets` clean; `./scripts/check-metric-names.sh` OK (224 literal).
- Docs in the same PR: playbook section on session origin + the new counter's alerting reading; regenerated metrics inventory; convention note for the legacy counter name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known labeling edge (deliberate)

The origin upgrade fires only on activation (`set_status(Active)`), per the issue's wording. Consequence: a `WaitingForSessionRequest` entry whose request arrives but **fails input construction** stays `reconstructed_from_consensus`, while the identical failure with no pre-existing entry is labeled `local_request` — so the label for "locally processed request that failed" depends on peer-message arrival order. Node-local labels only (metric/log JSON), never a gate; a Failed session definitionally lacks local output either way, and failures emit their own anomalies with full context. Flagged here so triage splitting populations by `session_origin` knows the edge exists.
