### PR TITLE
fix(handoff): stop the hydration pass clobbering the canonical DKG mirror; repair it at the barrier (#1852 variant 2)

### DIFF
--- a/crates/ika-core/src/epoch_tasks/handoff_signature_sender.rs
+++ b/crates/ika-core/src/epoch_tasks/handoff_signature_sender.rs
@@ -21,6 +21,7 @@ use crate::authority::authority_per_epoch_store::{
 use crate::consensus_adapter::SubmitToConsensus;
 use crate::validator_metadata::{HandoffItemsBuilder, next_committee_pubkey_set};
 use fastcrypto::ed25519::Ed25519KeyPair;
+use ika_network::mpc_artifacts::mpc_data_blob_hash;
 use ika_types::committee::Committee;
 use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
 use ika_types::messages_consensus::ConsensusTransaction;
@@ -181,54 +182,32 @@ impl HandoffSignatureSender {
     }
 
     /// For each network encryption key that has finished its initial
-    /// DKG, re-cache the canonical DKG output bytes into the per-epoch
-    /// digest table. Idempotent — re-caching the same bytes keeps the
-    /// same digest (the cache layer is content-addressed). The DKG
-    /// output is a one-time stable value, so caching it from the
-    /// (possibly-lagging) `network_keys_receiver` snapshot can't diverge
-    /// across the committee. The per-epoch reconfiguration output is
-    /// intentionally left to its consensus-ordered sources — see the
-    /// note in the loop body.
+    /// DKG and has NO locally-recorded DKG digest yet, cache the DKG
+    /// output bytes from the overlay snapshot into the per-epoch digest
+    /// table. Fill-absence ONLY: a validator that saw EndOfPublish
+    /// before its own MPC produced/cached the output would otherwise
+    /// build an attestation missing the `NetworkDkgOutput` item and
+    /// cross-reject peers as `AttestationMismatch`. The per-epoch
+    /// reconfiguration output is intentionally left to its
+    /// consensus-ordered sources — see the note in the loop body.
+    ///
+    /// NEVER overwrite an existing digest: the local mirror is written
+    /// canonically by the instantiation path (the reconstructed V3
+    /// output once the V2→V3 canonical migration flips) and by the
+    /// cert-anchored barrier install — both strictly more authoritative
+    /// than this watch snapshot, which can carry the chain's original
+    /// pre-V3 anchor whenever the syncer chain-read before the
+    /// off-chain blob source was installed (a post-restart window).
+    /// An unconditional write here clobbered the DURABLE perpetual
+    /// canonical mirror with that anchor, permanently failing the
+    /// handoff-cert DKG-digest adoption gate every later epoch — the
+    /// never-instantiated variant of issue #1852.
     fn hydrate_protocol_output_digests_from_chain(
         &self,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) {
         let snapshot = self.network_keys_receiver.borrow().clone();
-        for (key_id, data) in snapshot.iter() {
-            // DKG output: present once the key crosses out of
-            // `AwaitingNetworkDKG`. Always cache if we have non-empty
-            // bytes — re-caching with the same canonical bytes is a
-            // no-op for the digest.
-            if !data.network_dkg_public_output.is_empty()
-                && !matches!(
-                    data.state,
-                    DWalletNetworkEncryptionKeyState::AwaitingNetworkDKG
-                )
-                && let Err(e) =
-                    epoch_store.cache_network_dkg_output(*key_id, &data.network_dkg_public_output)
-            {
-                warn!(
-                    error = ?e,
-                    key_id = ?key_id,
-                    "failed to hydrate network DKG digest from chain bytes"
-                );
-            }
-            // NOTE: the *reconfiguration* output is deliberately NOT
-            // hydrated here. Unlike the one-time DKG output, it is
-            // epoch-specific, and this `network_keys_receiver` snapshot
-            // is a non-consensus watch channel that can surface the
-            // *prior* epoch's output (via the perpetual mirror) a round
-            // behind. The reconfiguration digest is written solely by
-            // this validator's local reconfiguration MPC in
-            // `dwallet_mpc_service`, keyed by the reconfiguration
-            // session's own epoch, and both the handoff items builder and
-            // `snapshot_ready_for_signing` read it from that epoch-keyed
-            // slice (`get_network_reconfiguration_output_digests_for_epoch`).
-            // Hydrating from the lagging snapshot would file a
-            // possibly-stale value under this epoch, so two signers would
-            // hash different `NetworkReconfigurationOutput` digests and
-            // cross-reject as `AttestationMismatch`.
-        }
+        hydrate_network_dkg_digests(epoch_store, &snapshot);
     }
 
     async fn send(&self) -> DwalletMPCResult<()> {
@@ -299,15 +278,15 @@ impl HandoffSignatureSender {
         // makes the cert structurally unverifiable by the very joiner it
         // certifies whenever the freeze excludes a seated member.
         let next_committee_pubkeys = next_committee_pubkey_set(&next_committee);
-        // Hydrate the local digest cache from the chain-canonical
-        // output bytes BEFORE building the attestation. Reading
-        // from chain (via the `network_keys_receiver` published by
-        // `sui_syncer`) is the only consensus-deterministic source
-        // — the original local MPC-driven cache writes race with
-        // EndOfPublish (a slow validator can see EndOfPublish
-        // before its own MPC produces output, so the cache is
-        // empty at signing time and the items list diverges from
-        // peers => signatures cross-reject as `AttestationMismatch`).
+        // Fill ABSENT DKG digests from the overlay snapshot BEFORE
+        // building the attestation: a slow validator can see
+        // EndOfPublish before its own MPC produced/cached the output,
+        // and an empty cache at signing time makes the items list
+        // diverge from peers => signatures cross-reject as
+        // `AttestationMismatch`. Fill-absence only — the snapshot is
+        // NOT authoritative over an existing digest (post-restart it
+        // can carry the chain's pre-V3 anchor; see
+        // `hydrate_network_dkg_digests`).
         self.hydrate_protocol_output_digests_from_chain(&epoch_store);
         let attestation = epoch_store
             .build_local_handoff_attestation(next_committee_pubkeys, &self.builders)
@@ -379,5 +358,189 @@ impl HandoffSignatureSender {
             );
         }
         Ok(())
+    }
+}
+
+/// For each network encryption key in the overlay snapshot that has
+/// finished its initial DKG and has NO locally-recorded DKG digest yet,
+/// cache the snapshot's DKG output bytes into the local digest cache.
+/// Fill-absence ONLY: a validator that saw EndOfPublish before its own
+/// MPC produced/cached the output would otherwise build an attestation
+/// missing the `NetworkDkgOutput` item and cross-reject peers as
+/// `AttestationMismatch`.
+///
+/// NEVER overwrite an existing digest: the local mirror is written
+/// canonically by the instantiation path (the reconstructed V3 output
+/// once the V2→V3 canonical migration flips) and by the cert-anchored
+/// barrier install — both strictly more authoritative than this watch
+/// snapshot, which can carry the chain's original pre-V3 anchor whenever
+/// the syncer chain-read before the off-chain blob source was installed
+/// (a post-restart window). An unconditional write here clobbered the
+/// DURABLE perpetual canonical mirror with that anchor, permanently
+/// failing the handoff-cert DKG-digest adoption gate every later epoch —
+/// the never-instantiated variant of issue #1852.
+///
+/// The per-epoch reconfiguration output is deliberately NOT hydrated
+/// here. Unlike the one-time DKG output, it is epoch-specific, and the
+/// overlay snapshot is a non-consensus watch channel that can surface
+/// the *prior* epoch's output (via the perpetual mirror) a round behind.
+/// The reconfiguration digest is written solely by this validator's
+/// local reconfiguration MPC in `dwallet_mpc_service`, keyed by the
+/// reconfiguration session's own epoch, and both the handoff items
+/// builder and `snapshot_ready_for_signing` read it from that epoch-keyed
+/// slice (`get_network_reconfiguration_output_digests_for_epoch`).
+/// Hydrating from the lagging snapshot would file a possibly-stale value
+/// under this epoch, so two signers would hash different
+/// `NetworkReconfigurationOutput` digests and cross-reject as
+/// `AttestationMismatch`.
+fn hydrate_network_dkg_digests(
+    epoch_store: &Arc<AuthorityPerEpochStore>,
+    snapshot: &HashMap<ObjectID, DWalletNetworkEncryptionKeyData>,
+) {
+    // The merged per-epoch + perpetual view — the same view the
+    // attestation items builder reads, so "absent here" is exactly
+    // "the attestation would omit the item".
+    //
+    // The view is read once per pass, so a canonical write landing
+    // between this read and the cache write below can be overwritten by
+    // the snapshot value for a key that was absent at the read. The
+    // window is one pass, requires the key's first-ever cache to race
+    // it, and the barrier's cert-anchored DKG repair heals the affected
+    // epoch at the next boundary — accepted rather than locked.
+    let existing_dkg_digests = epoch_store
+        .get_network_dkg_output_digests()
+        .unwrap_or_default();
+    for (key_id, data) in snapshot.iter() {
+        // DKG output: present once the key crosses out of
+        // `AwaitingNetworkDKG`. Cache only when no digest is recorded
+        // for the key yet (fill-absence; see above).
+        if data.network_dkg_public_output.is_empty()
+            || matches!(
+                data.state,
+                DWalletNetworkEncryptionKeyState::AwaitingNetworkDKG
+            )
+        {
+            continue;
+        }
+        if let Some(existing) = existing_dkg_digests.get(key_id) {
+            // A skip may be correct; a SILENT skip on a contradiction
+            // never is: an overlay carrying bytes that hash differently
+            // from the recorded canonical digest is the #1852
+            // hydration-clobber signature (e.g. the chain's pre-V3
+            // anchor after a restart) — surface it. Routine
+            // identical-bytes skips stay quiet.
+            let snapshot_digest = mpc_data_blob_hash(&data.network_dkg_public_output);
+            if *existing != snapshot_digest {
+                warn!(
+                    key_id = ?key_id,
+                    existing_digest = ?existing,
+                    snapshot_digest = ?snapshot_digest,
+                    "overlay snapshot's DKG bytes contradict the locally-recorded canonical \
+                     digest — keeping the canonical value (fill-absence hydration never \
+                     overwrites); if this validator was recently restarted this is the \
+                     stale pre-V3-anchor overlay shape"
+                );
+            }
+            continue;
+        }
+        if let Err(e) =
+            epoch_store.cache_network_dkg_output(*key_id, &data.network_dkg_public_output)
+        {
+            warn!(
+                error = ?e,
+                key_id = ?key_id,
+                "failed to hydrate network DKG digest from chain bytes"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authority::authority_perpetual_tables::AuthorityPerpetualTables;
+    use crate::authority::epoch_start_configuration::EpochStartConfiguration;
+    use crate::epoch::epoch_metrics::EpochMetrics;
+    use ika_types::digests::ChainIdentifier;
+    use ika_types::messages_dwallet_mpc::IkaNetworkConfig;
+    use ika_types::sui::EpochStartSystem;
+    use prometheus::Registry;
+
+    fn snapshot_entry(
+        key_id: ObjectID,
+        dkg_bytes: &[u8],
+    ) -> (ObjectID, DWalletNetworkEncryptionKeyData) {
+        (
+            key_id,
+            DWalletNetworkEncryptionKeyData {
+                id: key_id,
+                current_epoch: 0,
+                dkg_at_epoch: 0,
+                network_dkg_public_output: dkg_bytes.to_vec(),
+                current_reconfiguration_public_output: vec![],
+                state: DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted,
+            },
+        )
+    }
+
+    /// The hydration pass is fill-absence only (#1852, never-instantiated
+    /// variant): a key with an existing locally-recorded DKG digest must NOT
+    /// be overwritten by the overlay snapshot's bytes — the snapshot can
+    /// carry the chain's pre-V3 anchor after a restart, and the durable
+    /// canonical mirror it would clobber is what the handoff-cert DKG-digest
+    /// adoption gate verifies. A key with no recorded digest is still filled.
+    #[tokio::test]
+    async fn hydration_fills_absent_digests_but_never_overwrites() {
+        let (committee, _keys) = Committee::new_simple_test_committee_of_size(4);
+        let committee = Arc::new(committee);
+        let names: Vec<_> = committee.names().copied().collect();
+        let dir = tempfile::tempdir().unwrap();
+        let epoch_start_configuration =
+            EpochStartConfiguration::new(EpochStartSystem::new_for_testing_with_epoch(0)).unwrap();
+        let epoch_store = AuthorityPerEpochStore::new(
+            names[0],
+            committee.clone(),
+            dir.path(),
+            None,
+            EpochMetrics::new(&Registry::new()),
+            epoch_start_configuration,
+            ChainIdentifier::default(),
+            IkaNetworkConfig::new_for_testing(),
+        )
+        .unwrap();
+        let perpetual_dir = tempfile::tempdir().unwrap();
+        let perpetual = Arc::new(AuthorityPerpetualTables::open(perpetual_dir.path(), None));
+        epoch_store.install_perpetual_tables_for_handoff(perpetual);
+
+        let mirrored_key = ObjectID::random();
+        let fresh_key = ObjectID::random();
+        let canonical_bytes = b"canonical v3 dkg output".to_vec();
+        let anchor_bytes = b"chain pre-v3 dkg anchor".to_vec();
+        let fresh_bytes = b"fresh key dkg output".to_vec();
+
+        // The instantiation path already mirrored the canonical bytes.
+        epoch_store
+            .cache_network_dkg_output(mirrored_key, &canonical_bytes)
+            .unwrap();
+
+        // Post-restart overlay snapshot: the mirrored key carries the
+        // chain's pre-V3 anchor; the fresh key has no local digest yet.
+        let snapshot = HashMap::from([
+            snapshot_entry(mirrored_key, &anchor_bytes),
+            snapshot_entry(fresh_key, &fresh_bytes),
+        ]);
+        hydrate_network_dkg_digests(&epoch_store, &snapshot);
+
+        let digests = epoch_store.get_network_dkg_output_digests().unwrap();
+        assert_eq!(
+            digests.get(&mirrored_key),
+            Some(&mpc_data_blob_hash(&canonical_bytes)),
+            "hydration must never overwrite an existing (canonical) DKG digest"
+        );
+        assert_eq!(
+            digests.get(&fresh_key),
+            Some(&mpc_data_blob_hash(&fresh_bytes)),
+            "hydration must still fill a key with no recorded digest"
+        );
     }
 }

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -876,6 +876,19 @@ where
             ObjectID,
             (u64, DWalletNetworkEncryptionKeyState),
         > = HashMap::new();
+        // Pointer identity of the blob source the previous pass merged
+        // with. Installing (or per-epoch replacing) the source changes
+        // which bytes a merge produces for the SAME chain state, so the
+        // `(epoch, state)` fetch memo below is stale the moment the
+        // source flips: an overlay published from a source-less
+        // chain-read pass right after a restart carries the chain's
+        // original pre-V3 DKG anchor, and with no re-merge it would sit
+        // in the watch channel for the rest of the epoch — where the
+        // end-of-epoch hydration pass can cache it over the canonical
+        // mirror (the never-instantiated variant of issue #1852). Clear
+        // the memo whenever the source identity changes so the next
+        // pass re-merges every key through the new source.
+        let mut last_blob_source_ptr: Option<usize> = None;
         // Consecutive 5s ticks each key's overlay has been incomplete.
         // An incomplete overlay is the designed steady state on a
         // notifier/fullnode (whose overlay is legitimately empty for
@@ -887,6 +900,20 @@ where
         let mut consecutive_overlay_incomplete_ticks: HashMap<ObjectID, u64> = HashMap::new();
         loop {
             time::sleep(Duration::from_secs(5)).await;
+
+            let blob_source_ptr = network_key_blob_source
+                .load_full()
+                .map(|source| Arc::as_ptr(&source) as *const () as usize);
+            if blob_source_ptr != last_blob_source_ptr {
+                // Inequality implies at least one side is Some, so this
+                // always concerns a real install/replacement.
+                info!(
+                    source_installed = blob_source_ptr.is_some(),
+                    "network-key blob source changed; re-merging all network keys"
+                );
+                last_fetched_network_keys.clear();
+                last_blob_source_ptr = blob_source_ptr;
+            }
 
             let Some((_, system_inner)) = system_object_receiver.borrow().as_ref().cloned() else {
                 warn!("System object not available, retrying...");

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -10,7 +10,7 @@ use anemo_tower::trace::TraceLayer;
 use anyhow::{Result, anyhow};
 use arc_swap::ArcSwap;
 use prometheus::Registry;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -3208,15 +3208,20 @@ impl IkaNode {
     ///   1. The cross-epoch trust anchor (the `cur_epoch` handoff cert) is
     ///      locally present + verified — `prepare_handoff_anchor` returns it,
     ///      fetching it inline if missing.
-    ///   2. Every `NetworkReconfigurationOutput` item the cert certifies is
-    ///      held locally with a digest matching the cert. The cert's single
+    ///   2. Every network-key output item the cert certifies —
+    ///      `NetworkReconfigurationOutput` AND `NetworkDkgOutput` — is held
+    ///      locally with a digest matching the cert. The cert's single
     ///      `epoch` field scopes the whole handoff, so there is no per-key
-    ///      epoch to check — only per-key presence in this validator's
-    ///      reconfiguration-output digest slice (keyed by `cur_epoch`, the
-    ///      reconfiguration session's epoch). A continuing validator caches
-    ///      its own MPC output there; a joiner has `prepare_handoff_anchor`
-    ///      fetch + cache the cert's outputs into the same slice. See
-    ///      `all_cert_reconfiguration_outputs_held_locally`.
+    ///      epoch to check — only per-key presence: reconfiguration outputs
+    ///      in this validator's epoch-keyed digest slice (keyed by
+    ///      `cur_epoch`, the reconfiguration session's epoch), DKG outputs in
+    ///      the NEW epoch store's merged view (empty per-epoch table → the
+    ///      perpetual canonical mirror — the value the installer repairs; the
+    ///      outgoing store's per-epoch table is exactly what the end-of-epoch
+    ///      hydration may have poisoned, issue #1852). A continuing validator
+    ///      caches its own MPC output; `prepare_handoff_anchor` and the
+    ///      per-retry installer fetch + cache missing/mismatching outputs
+    ///      from peers. See `all_cert_network_key_outputs_held_locally`.
     async fn wait_for_handoff_data_ready(
         &self,
         next_epoch: EpochId,
@@ -3263,20 +3268,37 @@ impl IkaNode {
             }
             let cert = anchor_cert.as_ref();
 
-            // Condition 2: every network-key reconfiguration output the cert
-            // certifies is held locally with a digest matching the cert.
-            // Grounded entirely in the verified cert (the off-chain anchor)
-            // and this validator's own reconfiguration-output digest slice,
-            // keyed by the reconfiguration session's epoch (`cur_epoch`) — no
+            // Condition 2: every network-key output the cert certifies —
+            // reconfiguration AND DKG — is held locally with a digest
+            // matching the cert. Grounded entirely in the verified cert (the
+            // off-chain anchor) and this validator's own digest slices — no
             // chain state, and no per-key epoch (the cert's single epoch
-            // scopes the whole handoff). A read error is treated as not-ready
-            // (empty slice); the periodic WARN below surfaces a persistent
-            // failure.
+            // scopes the whole handoff). A read error is treated as
+            // not-ready (empty slice); the periodic WARN below surfaces a
+            // persistent failure.
+            //
+            // The reconfiguration slice is keyed by the reconfiguration
+            // session's epoch (`cur_epoch`) on the outgoing store. The DKG
+            // digests are read from the NEW epoch store deliberately: its
+            // per-epoch table is empty at entry, so the merged view is the
+            // perpetual canonical mirror — the exact value the installer
+            // repairs. Reading them from the outgoing store would consult
+            // its per-epoch table first, which is precisely what the
+            // end-of-epoch hydration pass may have poisoned (the issue
+            // #1852 clobber variant), and the repaired perpetual value
+            // would never win — deadlocking this barrier.
             let local_reconfiguration_digests = cur_epoch_store
                 .get_network_reconfiguration_output_digests_for_epoch(cur_epoch)
                 .unwrap_or_default();
+            let local_dkg_digests = new_epoch_store
+                .get_network_dkg_output_digests()
+                .unwrap_or_default();
             let ready = cert.is_some_and(|cert| {
-                all_cert_reconfiguration_outputs_held_locally(cert, &local_reconfiguration_digests)
+                all_cert_network_key_outputs_held_locally(
+                    cert,
+                    &local_dkg_digests,
+                    &local_reconfiguration_digests,
+                )
             });
 
             if ready {
@@ -3319,31 +3341,39 @@ impl IkaNode {
             // Surface the breakdown roughly every 10s so a hang is never
             // silent on a dashboard or in the logs.
             if retries.is_multiple_of(10) {
-                let (cert_reconfiguration_items, missing_key_ids, unmapped_cert_keys) = match &cert
-                {
+                let (cert_network_key_items, missing_key_ids, unmapped_cert_keys) = match &cert {
                     Some(cert) => {
                         let total = cert
                             .attestation
                             .items
                             .iter()
                             .filter(|(item, _)| {
-                                matches!(item, HandoffItemKey::NetworkReconfigurationOutput { .. })
+                                matches!(
+                                    item,
+                                    HandoffItemKey::NetworkReconfigurationOutput { .. }
+                                        | HandoffItemKey::NetworkDkgOutput { .. }
+                                )
                             })
                             .count();
                         let missing: Vec<ObjectID> = cert
                             .attestation
                             .items
                             .iter()
-                            .filter_map(|(item, digest)| match item {
-                                HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
-                                    // Cert keys by NetworkKeyId; local digests by
-                                    // ObjectID — translate via the temporary map.
-                                    let object_id =
-                                        ika_core::network_key_id_mapping::object_id_for(key_id)?;
-                                    (local_reconfiguration_digests.get(&object_id) != Some(digest))
-                                        .then_some(object_id)
-                                }
-                                _ => None,
+                            .filter_map(|(item, digest)| {
+                                // Cert keys by NetworkKeyId; local digests by
+                                // ObjectID — translate via the temporary map.
+                                let (key_id, local_digests) = match item {
+                                    HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
+                                        (key_id, &local_reconfiguration_digests)
+                                    }
+                                    HandoffItemKey::NetworkDkgOutput { key_id } => {
+                                        (key_id, &local_dkg_digests)
+                                    }
+                                    HandoffItemKey::ValidatorMpcData { .. } => return None,
+                                };
+                                let object_id =
+                                    ika_core::network_key_id_mapping::object_id_for(key_id)?;
+                                (local_digests.get(&object_id) != Some(digest)).then_some(object_id)
                             })
                             .collect();
                         // Cert keys with NO ObjectID mapping (this validator
@@ -3355,12 +3385,15 @@ impl IkaNode {
                         // `missing_locally=0`. The MPC service's adoption
                         // pass derives and registers the mapping in the
                         // background; this state should clear on its own.
-                        let unmapped: Vec<NetworkKeyId> = cert
+                        // A key with both a DKG and a reconfiguration item
+                        // would list twice — dedup via the ordered set.
+                        let unmapped: BTreeSet<NetworkKeyId> = cert
                             .attestation
                             .items
                             .iter()
                             .filter_map(|(item, _)| match item {
                                 HandoffItemKey::NetworkReconfigurationOutput { key_id }
+                                | HandoffItemKey::NetworkDkgOutput { key_id }
                                     if ika_core::network_key_id_mapping::object_id_for(key_id)
                                         .is_none() =>
                                 {
@@ -3369,6 +3402,7 @@ impl IkaNode {
                                 _ => None,
                             })
                             .collect();
+                        let unmapped: Vec<NetworkKeyId> = unmapped.into_iter().collect();
                         (total, missing, unmapped)
                     }
                     None => (0, Vec::new(), Vec::new()),
@@ -3377,7 +3411,7 @@ impl IkaNode {
                     next_epoch,
                     cur_epoch,
                     have_cert = cert.is_some(),
-                    cert_reconfiguration_items,
+                    cert_network_key_items,
                     missing_locally = missing_key_ids.len(),
                     missing_key_ids = ?missing_key_ids,
                     unmapped_cert_keys = ?unmapped_cert_keys,
@@ -3583,27 +3617,35 @@ fn max_tx_per_checkpoint(_: &ProtocolConfig) -> usize {
 
 /// Readiness predicate for the prepare-then-start barrier's network-key
 /// condition, grounded entirely in the verified handoff cert (the off-chain
-/// cross-epoch trust anchor) and this validator's local reconfiguration-output
-/// digest slice — no chain state.
+/// cross-epoch trust anchor) and this validator's local digest slices — no
+/// chain state.
 ///
 /// The cert's single `epoch` field scopes the whole handoff (one cert per
 /// epoch, committee-signed), so there is no per-key epoch to check: every
 /// `NetworkReconfigurationOutput` item is an output of the same reconfiguration
-/// session (the one that ran during `cert.attestation.epoch`). The only per-key
-/// question is presence: for each reconfiguration output the cert certifies,
-/// has this validator locally computed/cached a digest-matching copy? (A
-/// continuing validator caches its own MPC output; a joiner has
-/// `install_joiner_network_key_outputs` fetch + cache the cert's outputs into
-/// the same slice.)
+/// session (the one that ran during `cert.attestation.epoch`), and the DKG
+/// items pin the key's canonical anchor. The only per-key question is
+/// presence: for each certified output, has this validator locally
+/// computed/cached a digest-matching copy? (A continuing validator caches its
+/// own MPC output; `install_joiner_network_key_outputs` fetches + caches
+/// missing/mismatching ones from peers into the same slices.)
 ///
-/// Returns true iff every `NetworkReconfigurationOutput { key_id }` item in the
-/// cert has a local digest equal to the cert's item digest. DKG and
-/// validator-mpc_data items are not gated here — the barrier exists to keep the
-/// new epoch from signing against a stale reconfiguration sharing, and the
-/// reconfiguration output is the epoch-varying material. A cert with no
-/// reconfiguration items is trivially ready on this condition.
-fn all_cert_reconfiguration_outputs_held_locally(
+/// Returns true iff every `NetworkReconfigurationOutput { key_id }` AND every
+/// `NetworkDkgOutput { key_id }` item in the cert has a local digest equal to
+/// the cert's item digest. The reconfiguration output is the epoch-varying
+/// sharing material; the DKG output is equally load-bearing — adoption's
+/// cert-digest gate rejects the key when the local DKG mirror doesn't hash to
+/// the cert's digest, and a mirror poisoned with the chain's pre-V3 anchor
+/// (the hydration-clobber variant of issue #1852) can ONLY be repaired here,
+/// because the installer runs solely while this predicate reads not-ready.
+/// Do not narrow this back to reconfiguration-only: that made the barrier
+/// instantly ready for a poisoned validator every epoch and the wedge
+/// permanent. `ValidatorMpcData` items are not gated (they feed the mpc_data
+/// freeze, a separate plane). A cert with no network-key items is trivially
+/// ready on this condition.
+fn all_cert_network_key_outputs_held_locally(
     cert: &CertifiedHandoffAttestation,
+    local_dkg_digests: &BTreeMap<ObjectID, [u8; 32]>,
     local_reconfiguration_digests: &BTreeMap<ObjectID, [u8; 32]>,
 ) -> bool {
     cert.attestation
@@ -3616,9 +3658,21 @@ fn all_cert_reconfiguration_outputs_held_locally(
                     local_reconfiguration_digests.get(&object_id) == Some(cert_digest)
                 })
             }
-            HandoffItemKey::NetworkDkgOutput { .. } | HandoffItemKey::ValidatorMpcData { .. } => {
-                true
+            // The DKG output is as load-bearing as the reconfiguration
+            // output: adoption's cert-digest gate rejects the key when the
+            // locally-mirrored DKG bytes don't hash to the cert's digest,
+            // and a mirror poisoned with the chain's pre-V3 anchor (the
+            // hydration-clobber variant of issue #1852) can only be
+            // repaired here — the barrier's installer fetches the
+            // cert-pinned bytes from peers and re-caches them. Skipping
+            // DKG items made that repair unreachable (the gate read ready
+            // instantly and the installer only runs while not-ready),
+            // leaving a poisoned validator wedged permanently.
+            HandoffItemKey::NetworkDkgOutput { key_id } => {
+                ika_core::network_key_id_mapping::object_id_for(key_id)
+                    .is_some_and(|object_id| local_dkg_digests.get(&object_id) == Some(cert_digest))
             }
+            HandoffItemKey::ValidatorMpcData { .. } => true,
         })
 }
 
@@ -3661,28 +3715,32 @@ mod tests {
     }
 
     #[test]
-    fn all_cert_reconfiguration_outputs_held_locally_cases() {
-        // The cert is keyed by NetworkKeyId; the local slice by ObjectID.
+    fn all_cert_network_key_outputs_held_locally_cases() {
+        // The cert is keyed by NetworkKeyId; the local slices by ObjectID.
         // Register the mappings so the predicate can translate.
         ika_core::network_key_id_mapping::register(key_id(0), network_key_id(0));
         ika_core::network_key_id_mapping::register(key_id(1), network_key_id(1));
+        let no_dkg = BTreeMap::new();
         // Cert certifies one reconfiguration output; the local slice holds a
         // matching digest → ready.
         let cert = cert_with_reconfiguration_items(vec![(network_key_id(0), [1u8; 32])]);
         let held = BTreeMap::from([(key_id(0), [1u8; 32])]);
-        assert!(all_cert_reconfiguration_outputs_held_locally(&cert, &held));
+        assert!(all_cert_network_key_outputs_held_locally(
+            &cert, &no_dkg, &held
+        ));
 
         // Output not yet computed/cached locally (empty slice) → not ready.
-        assert!(!all_cert_reconfiguration_outputs_held_locally(
+        assert!(!all_cert_network_key_outputs_held_locally(
             &cert,
+            &no_dkg,
             &BTreeMap::new()
         ));
 
         // Local digest differs from the cert's (a stale/wrong local output —
         // the exact condition the cert-digest match exists to catch) → not ready.
         let stale = BTreeMap::from([(key_id(0), [9u8; 32])]);
-        assert!(!all_cert_reconfiguration_outputs_held_locally(
-            &cert, &stale
+        assert!(!all_cert_network_key_outputs_held_locally(
+            &cert, &no_dkg, &stale
         ));
 
         // Two certified outputs, only one held locally → not ready (EVERY item
@@ -3692,19 +3750,20 @@ mod tests {
             (network_key_id(1), [2u8; 32]),
         ]);
         let one = BTreeMap::from([(key_id(0), [1u8; 32])]);
-        assert!(!all_cert_reconfiguration_outputs_held_locally(
-            &cert_two, &one
+        assert!(!all_cert_network_key_outputs_held_locally(
+            &cert_two, &no_dkg, &one
         ));
 
         // Both held with matching digests → ready.
         let both = BTreeMap::from([(key_id(0), [1u8; 32]), (key_id(1), [2u8; 32])]);
-        assert!(all_cert_reconfiguration_outputs_held_locally(
-            &cert_two, &both
+        assert!(all_cert_network_key_outputs_held_locally(
+            &cert_two, &no_dkg, &both
         ));
 
-        // A cert with no reconfiguration items is trivially ready (nothing to
-        // wait for), even against an empty slice — and a DKG-only item must NOT
-        // be gated by this reconfiguration-readiness predicate.
+        // A certified DKG output is load-bearing too: a local mirror whose
+        // digest contradicts the cert (the hydration-clobber shape of issue
+        // #1852 — e.g. the chain's pre-V3 anchor over the canonical V3) must
+        // read NOT ready, so the barrier's installer runs and repairs it.
         let dkg_only = CertifiedHandoffAttestation {
             attestation: HandoffAttestation {
                 epoch: 7,
@@ -3718,8 +3777,24 @@ mod tests {
             },
             signatures: vec![],
         };
-        assert!(all_cert_reconfiguration_outputs_held_locally(
+        // Absent locally → not ready.
+        assert!(!all_cert_network_key_outputs_held_locally(
             &dkg_only,
+            &BTreeMap::new(),
+            &BTreeMap::new()
+        ));
+        // Poisoned mirror (digest mismatch) → not ready.
+        let poisoned = BTreeMap::from([(key_id(0), [9u8; 32])]);
+        assert!(!all_cert_network_key_outputs_held_locally(
+            &dkg_only,
+            &poisoned,
+            &BTreeMap::new()
+        ));
+        // Canonical mirror matching the cert → ready.
+        let canonical = BTreeMap::from([(key_id(0), [5u8; 32])]);
+        assert!(all_cert_network_key_outputs_held_locally(
+            &dkg_only,
+            &canonical,
             &BTreeMap::new()
         ));
     }

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -187,12 +187,22 @@ next epoch inherits.
    entering epoch E+1, the validator blocks until the FULL verified
    handoff data for epoch E is local: the certificate (fetched and
    verified via the same verifier, anchored once per barrier entry) and
-   every certified network-key output blob. Holding the certificate
+   every certified network-key output blob — reconfiguration outputs
+   AND the canonical DKG outputs. Holding the certificate
    does NOT imply holding the outputs (a lagging validator can adopt
    the certificate from a buffered signature quorum without ever
    computing the outputs), so the barrier installs missing outputs by
    digest. This is what prevents stale-share `InvalidParameters`
-   signing failures after the boundary.
+   signing failures after the boundary. The DKG items are part of the
+   readiness predicate deliberately: a local mirror whose digest
+   contradicts the certificate (the hydration-clobber shape below) can
+   only be repaired here — the installer fetches the cert-pinned bytes
+   from peers and re-caches them, and it only runs while the gate reads
+   not-ready. When the gate skipped DKG items, a poisoned mirror passed
+   the barrier instantly every epoch and stayed wedged permanently. The
+   DKG digests are read from the NEW epoch store (empty per-epoch table
+   → perpetual mirror), never the outgoing store, whose per-epoch table
+   is exactly what the end-of-epoch hydration may have poisoned.
 3. **Network-key adoption (steady state)**: each epoch, locally-held
    network-key outputs are adopted into the instantiation set only if
    their digests match the prior epoch's certificate
@@ -264,6 +274,27 @@ next epoch inherits.
      next epoch's cert pins V3. Fail-closed, bounded to that one
      epoch, identical to pre-recovery behavior; epoch close is
      unaffected (the validator still votes EndOfPublish).
+   - The hydration-clobber variant (issue #1852, never-instantiated
+     shape) and its three defenses. Post-restart, until the per-epoch
+     blob source installs, the sync task's full chain read publishes an
+     overlay whose DKG blob is the chain's ORIGINAL pre-V3 anchor; with
+     no later refetch trigger that overlay used to sit in the watch
+     channel all epoch, and the end-of-epoch hydration pass cached it —
+     overwriting the DURABLE perpetual canonical mirror. Every later
+     epoch then failed the DKG-digest gate above before reaching the
+     produced-this-epoch guard (so the stranded-key recovery never
+     fired), permanently: the barrier read ready without checking DKG
+     items, so its installer never repaired the mirror. Defenses, each
+     independently sufficient for its layer: (1) hydration is
+     fill-absence only — it never overwrites an existing per-key DKG
+     digest (the instantiation mirror and the cert-anchored barrier
+     install are strictly more authoritative than the overlay
+     snapshot); (2) the sync task clears its per-key fetch memo
+     whenever the blob-source identity changes, so a source-less
+     chain-read overlay is re-merged within a tick of the install
+     instead of persisting; (3) the barrier verifies and repairs DKG
+     items (see the barrier section) — the only layer that heals an
+     already-poisoned mirror.
 
 ## Key invariants
 


### PR DESCRIPTION
Fixes variant 2 of #1852 — the **never-instantiated** wedge: three testnet validators (Full Sail Validator, n1stake, alphab.ai) with `canonical_dkg_output_version=0`, no `network_key_loaded_epoch` series, and zero instantiation attempts across **multiple epoch handoffs** (Full Sail: 45h, two handoffs). Root-cause analysis with confirmable predictions: https://github.com/dwallet-labs/ika/issues/1852#issuecomment-5012466405; monitoring verification (metric check confirmed, code chain independently verified): https://github.com/dwallet-labs/ika/issues/1852#issuecomment-5012484218.

Stacked on #1855 (variant 1); base auto-retargets to main when it merges.

## Mechanism

1. **Boot race** — after a cold start, the syncer's off-chain blob source is `None` until `monitor_reconfiguration`'s first iteration reaches the install, which sits behind a consensus submission (can block while consensus reconnects) and the joiner-bootstrap block. The syncer's first fetch then takes the full chain read and publishes an overlay whose DKG blob is the chain's **original pre-V3 anchor** (the chain never carries the reconstructed V3 canonical output).
2. **Stale overlay persists** — the entry is complete, so it's recorded in the fetch memo; if the restart landed after the epoch's reconfiguration completed, no chain-state change ever retriggers a re-merge, and installing the source didn't invalidate the memo. The V2-anchor overlay sits in the watch channel for the rest of the epoch.
3. **The clobber** — at EndOfPublish, the handoff sender's hydration pass cached the snapshot's DKG bytes unconditionally, overwriting the per-epoch digest table **and the durable perpetual canonical mirror** (`cache_protocol_output` writes both). The intact V3 mirror on disk is destroyed.
4. **Permanent wedge** — every later epoch serves the poisoned mirror (empty per-epoch table → perpetual fallback), adoption rejects the key at the handoff-cert DKG-digest gate *before* the `produced_this_epoch` branch (so #1855's stranded-key recovery is inert by design), and the barrier never repairs it: its readiness predicate returned `true` unconditionally for `NetworkDkgOutput` items, so the peer-fetch installer — which handles DKG items correctly — only ran while "not ready", i.e. never.

## Fix: three independent layers

**A — hydration is fill-absence only** (`hydrate_network_dkg_digests`, extracted for testability): the pass now skips any key that already has a digest in the merged view. Its purpose (a validator seeing EndOfPublish before its own MPC cached the output would build an attestation missing the item → `AttestationMismatch`) is fully preserved — filling absence is all it ever needed to do. The canonical overwrite paths (the instantiation mirror, including the one-shot V2→V3 flip, and the barrier's cert-anchored install) are deliberately NOT routed through this guard and still overwrite.

**B — the syncer clears its fetch memo when the blob-source identity changes** (install or per-epoch replacement, detected by `Arc` pointer identity): a source-less chain-read overlay from the boot window is re-merged within one tick of the install instead of persisting all epoch. The re-merge goes through the v4 fast path (no chain reads), so the no-chain-read invariant is unaffected.

**C — the barrier verifies and repairs DKG items** (`all_cert_network_key_outputs_held_locally`): epoch entry now blocks until every cert-pinned `NetworkDkgOutput` digest matches the local mirror, which makes the existing installer (already DKG-capable) actually run and re-cache the cert-pinned bytes from peers on mismatch or absence. The DKG digests are read from the **new** epoch store deliberately — its empty per-epoch table falls back to the perpetual mirror, the exact value the installer repairs; reading the outgoing store would consult the possibly-poisoned per-epoch table and deadlock the barrier. The every-10th-retry diagnostic warn now itemizes missing/unmapped keys across both item kinds.

**C is the layer that heals the three currently-wedged validators** — their poisoned perpetual mirror survives restarts, so A+B alone would prevent new poisonings but leave them stranded forever. With C deployed they recover at their next epoch boundary.

Migration-safety note (verified): the V2→V3 canonical flip happens at instantiation, *after* the barrier — so at the single migration boundary the cert pins V2 and the not-yet-flipped local mirror is V2 (match), and post-flip both sides are V3. The barrier's new DKG condition is satisfied on both sides of the migration for honest validators.

## Validation

- `hydration_fills_absent_digests_but_never_overwrites` — real epoch store + perpetual tables; asserts the existing canonical digest survives a conflicting snapshot while an absent key is still filled. **Fault-validated**: removing the guard fails the test at exactly the clobber assertion; reverted.
- `all_cert_network_key_outputs_held_locally_cases` — extended for DKG items: absent → not ready, poisoned (mismatching) mirror → not ready, canonical → ready.
- `network_key_adoption` suite (6), stranded-key overlay unit test, and the `off_chain_metadata_v4_does_not_read_blobs_from_chain` cluster test (layer B's blast radius) green in release.
- `cargo check --workspace --all-targets --release` and clippy clean. (Pre-existing, unrelated: `ika-node`'s `metrics::tests::test_metrics_endpoint_with_multiple_registries_add_remove` fails on the clean tree too.)
- Dedicated consensus-determinism review pass on the diff: no High findings; every barrier-liveness suspicion (missing perpetual handle, V2→V3 migration boundary, fresh-key closing epoch, all-poisoned committee, unmapped keys, layer-B ABA/cost) refuted with evidence. Its findings are addressed in this PR: the stale predicate/barrier docs that described the pre-fix reconfiguration-only gate are rewritten (they would have instructed a future maintainer to delete the fix), the fill-absence skip now WARNS when the snapshot contradicts an existing canonical digest (the #1852 signature, previously silent), the one-pass TOCTOU window is documented as accepted (healed by layer C), and a dead guard in the memo-clear was removed.

Spec: the barrier section and a new hydration-clobber entry under the adoption guards in `dev-docs/specs/handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
