### PR TITLE
chore: bump version to v1.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-classgroups-types"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "bcs",
  "class_groups",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-rng"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "commitment",
  "fastcrypto",
@@ -6548,7 +6548,7 @@ dependencies = [
 
 [[package]]
 name = "ika"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6592,7 +6592,7 @@ dependencies = [
 
 [[package]]
 name = "ika-archival"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6763,7 +6763,7 @@ dependencies = [
 
 [[package]]
 name = "ika-node"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6831,7 +6831,7 @@ dependencies = [
 
 [[package]]
 name = "ika-proxy"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -6980,7 +6980,7 @@ dependencies = [
 
 [[package]]
 name = "ika-test-cluster"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7065,7 +7065,7 @@ dependencies = [
 
 [[package]]
 name = "ika-upgrade-test"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 [workspace.package]
 # This version string will be inherited by ika-core, ika-node, ika-tools, ika-sdk, and ika crates.
-version = "1.2.1"
+version = "1.2.2"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces


### PR DESCRIPTION
Release prep for **testnet-v1.2.2**. Workspace version + lockfile only.

Intended release contents on top of v1.2.1:
- #1855 — mid-epoch-restart network-key recovery: strand re-instantiation **plus** the variant-2 canonical-DKG-mirror fix (hydration guard / boot-race fetch-memo invalidation / barrier DKG repair) for #1852. Recovers the three currently-wedged validators (Full Sail, n1stake, alphab.ai) at their first epoch boundary after deploy.
- #1854 — MPC anomaly taxonomy reclassification (#1853), including session-origin provenance + `ika_dwallet_mpc_sessions_reconstructed_total` (#1857).
- #1860 — validator host telemetry over the existing ika-proxy push path (additive metric families; also hardens the proxy against node-supplied spoofed/duplicate `host` labels).

**Merge order:** land #1855 and #1854 first, then this.

**Rolling-upgrade safe** (verified): no protocol/Move/wire changes; the barrier repair fetch uses the existing digest-verified blob protocol already served by v1.2.1 peers; attestation digests only *converge* for previously-poisoned validators. Operator note: prefer rolling shortly **after an epoch boundary** — a restart between the mid-epoch freeze and epoch end sits out until the next freeze (#1856, not fixed in this release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
