### PR TITLE
fix(dwallet-mpc): preserve buffered messages when a NOA sign instantiates late

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
@@ -13,7 +13,7 @@
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStoreTrait;
 use crate::dwallet_mpc::NetworkOwnedAddressSignRequest;
 use crate::dwallet_mpc::crytographic_computation::mpc_computations::network_owned_address_sign_dkg_emulation::network_owned_address_sign_dkg_session_identifier;
-use crate::dwallet_mpc::mpc_session::SessionStatus;
+use crate::dwallet_mpc::mpc_session::{SessionComputationType, SessionStatus};
 use crate::dwallet_mpc::integration_tests::network_dkg::{
     create_network_key_test, create_reconfigured_network_key_test,
 };
@@ -24,7 +24,10 @@ use crate::dwallet_mpc::integration_tests::utils::{
 use dwallet_mpc_types::dwallet_mpc::{
     DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm,
 };
-use ika_types::messages_dwallet_mpc::{SessionIdentifier, SessionType};
+use ika_types::message::{DWalletCheckpointMessageKind, MakeDWalletUserSecretKeySharesPublicOutput};
+use ika_types::messages_dwallet_mpc::{
+    DWalletMPCOutput, DWalletMPCOutputReport, SessionIdentifier, SessionType,
+};
 use std::collections::HashSet;
 use itertools::Itertools;
 use tracing::info;
@@ -700,6 +703,145 @@ async fn test_late_instantiating_validator_preserves_buffered_sign_messages() {
         "signature should not be empty"
     );
     info!("Late-instantiation NOA sign completed — buffered messages survived");
+}
+
+/// A byzantine peer must not be able to wedge a NOA sign with a single message.
+///
+/// The NOA sign session id is predictable from public inputs, and the
+/// output-receipt path derives a placeholder's computation type from the
+/// *sender-controlled* `is_native()` flag. A peer that sends a "native" output
+/// for the id before this validator instantiates creates a `Native`-typed
+/// `WaitingForSessionRequest` placeholder. If instantiation preserved that type
+/// (the in-place upgrade this fix introduced), `add_message` would drop every
+/// real round message and the sign would route to the native path and fail
+/// `InvalidDWalletProtocolType` on every honest validator — a permanent,
+/// unattributed epoch wedge from one message. Instantiation must normalize the
+/// poisoned placeholder back to an MPC buffer.
+///
+/// Fault-check for that normalization guard: without it, the final assertion
+/// (session typed MPC after instantiation) fails — the placeholder stays Native.
+#[tokio::test]
+#[cfg(test)]
+async fn test_instantiation_normalizes_byzantine_native_placeholder() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard();
+
+    let curve = DWalletCurve::Curve25519;
+    let signature_algorithm = DWalletSignatureAlgorithm::EdDSA;
+    let hash_scheme = DWalletHashScheme::SHA512;
+
+    let mut test_state = build_test_state(4);
+    let (consensus_round, _network_key_bytes, encryption_key) =
+        create_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+    let start_round = test_state.consensus_round as u64;
+    let consensus_round = utils::advance_rounds_while_presign_pool_empty(
+        &mut test_state,
+        signature_algorithm,
+        encryption_key,
+        start_round,
+    )
+    .await;
+    test_state.consensus_round = consensus_round as usize;
+
+    let test_message = b"byzantine-native-placeholder sign".to_vec();
+
+    // Learn the (validator-independent) NOA sign session id by instantiating on
+    // one validator and reading it back.
+    let id_source = 1usize;
+    test_state.network_owned_address_sign_request_senders[id_source]
+        .send(NetworkOwnedAddressSignRequest {
+            message: test_message.clone(),
+            curve,
+            signature_algorithm,
+            hash_scheme,
+        })
+        .await
+        .expect("failed to send id-source sign request");
+    test_state.dwallet_mpc_services[id_source]
+        .run_service_loop_iteration()
+        .await;
+    let noa_session_id = *test_state.dwallet_mpc_services[id_source]
+        .dwallet_mpc_manager()
+        .sessions
+        .keys()
+        .find(|id| id.session_type() == SessionType::NetworkOwnedAddressSign)
+        .expect("id-source validator should have instantiated a NOA sign session");
+
+    // A byzantine peer sends a "native" output for that id to the target
+    // validator, which has not yet instantiated — creating a Native-typed
+    // placeholder via the output-receipt path.
+    let target = 0usize;
+    let byzantine_authority = test_state
+        .committee
+        .names()
+        .nth(1)
+        .copied()
+        .expect("committee has a second member");
+    let poison = DWalletMPCOutputReport::External(DWalletMPCOutput {
+        authority: byzantine_authority,
+        session_identifier: noa_session_id,
+        output: vec![
+            DWalletCheckpointMessageKind::RespondMakeDWalletUserSecretKeySharesPublic(
+                MakeDWalletUserSecretKeySharesPublicOutput {
+                    dwallet_id: vec![1u8; 32],
+                    public_user_secret_key_shares: vec![],
+                    rejected: false,
+                    session_sequence_number: 0,
+                },
+            ),
+        ],
+        malicious_authorities: vec![],
+    });
+    let _ = test_state.dwallet_mpc_services[target]
+        .dwallet_mpc_manager_mut()
+        .handle_consensus_round_outputs(test_state.consensus_round as u64, vec![poison]);
+
+    // Attack precondition: the target now holds a Native-typed placeholder.
+    {
+        let session = test_state.dwallet_mpc_services[target]
+            .dwallet_mpc_manager()
+            .sessions
+            .get(&noa_session_id)
+            .expect("poison output should have created a placeholder on the target");
+        assert!(
+            matches!(session.status, SessionStatus::WaitingForSessionRequest),
+            "poisoned placeholder should be WaitingForSessionRequest"
+        );
+        assert!(
+            !matches!(session.computation_type, SessionComputationType::MPC { .. }),
+            "poisoned placeholder should be typed Native (the attack precondition)"
+        );
+    }
+
+    // The target instantiates the sign; normalization must reset the type.
+    test_state.network_owned_address_sign_request_senders[target]
+        .send(NetworkOwnedAddressSignRequest {
+            message: test_message.clone(),
+            curve,
+            signature_algorithm,
+            hash_scheme,
+        })
+        .await
+        .expect("failed to send target sign request");
+    test_state.dwallet_mpc_services[target]
+        .run_service_loop_iteration()
+        .await;
+
+    let session = test_state.dwallet_mpc_services[target]
+        .dwallet_mpc_manager()
+        .sessions
+        .get(&noa_session_id)
+        .expect("target should still have the NOA session after instantiation");
+    assert!(
+        matches!(session.status, SessionStatus::Active { .. }),
+        "instantiation should activate the NOA sign session"
+    );
+    assert!(
+        matches!(session.computation_type, SessionComputationType::MPC { .. }),
+        "instantiation must normalize the byzantine Native placeholder back to an MPC buffer"
+    );
+    info!("Byzantine Native placeholder normalized to MPC on instantiation");
 }
 
 // === Fast Schnorr (VSS) NOA sign E2E tests ===

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
@@ -13,6 +13,7 @@
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStoreTrait;
 use crate::dwallet_mpc::NetworkOwnedAddressSignRequest;
 use crate::dwallet_mpc::crytographic_computation::mpc_computations::network_owned_address_sign_dkg_emulation::network_owned_address_sign_dkg_session_identifier;
+use crate::dwallet_mpc::mpc_session::SessionStatus;
 use crate::dwallet_mpc::integration_tests::network_dkg::{
     create_network_key_test, create_reconfigured_network_key_test,
 };
@@ -565,6 +566,140 @@ async fn test_presign_pool_exhaustion_buffers_excess_sign_requests() {
     info!(
         "Test passed: presign pool exhaustion correctly buffers and later processes excess requests"
     );
+}
+
+/// A validator that instantiates a NOA sign *after* its peers have already
+/// broadcast their first-round messages must keep those buffered messages when
+/// it activates the session.
+///
+/// This reproduces the migration-rehearsal epoch wedge: during a staggered
+/// (rolling-restart) sign, some validators reach the sign later than others —
+/// their signing key / presign becomes available only after peers have started
+/// the round. The message-receipt path buffers peers' first-round messages in a
+/// `WaitingForSessionRequest` placeholder; if instantiation overwrites that
+/// placeholder with an empty message buffer, those messages are lost (the
+/// consensus rounds that carried them have already been processed and are never
+/// redelivered). The late validators are then stranded below the sign
+/// threshold, the sign never completes, and the epoch hard-wedges on
+/// NOA-checkpoint finalization.
+///
+/// Without the in-place placeholder upgrade in
+/// `instantiate_network_owned_address_sign_session`, the sign here never yields
+/// an output and `wait_for_network_owned_address_sign_output` times out.
+#[tokio::test]
+#[cfg(test)]
+async fn test_late_instantiating_validator_preserves_buffered_sign_messages() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard();
+
+    let curve = DWalletCurve::Curve25519;
+    let signature_algorithm = DWalletSignatureAlgorithm::EdDSA;
+    let hash_scheme = DWalletHashScheme::SHA512;
+
+    let mut test_state = build_test_state(4);
+
+    // Create a network key and fill the EdDSA presign pool so every validator
+    // is able to instantiate the sign.
+    let (consensus_round, _network_key_bytes, encryption_key) =
+        create_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+    let start_round = test_state.consensus_round as u64;
+    let consensus_round = utils::advance_rounds_while_presign_pool_empty(
+        &mut test_state,
+        signature_algorithm,
+        encryption_key,
+        start_round,
+    )
+    .await;
+    test_state.consensus_round = consensus_round as usize;
+
+    // The threshold for a 4-validator committee is 3, so two "early" and two
+    // "late" validators means the sign can only complete if the late ones keep
+    // the early ones' first-round messages across instantiation.
+    let early_parties = [2usize, 3usize];
+    let late_parties = [0usize, 1usize];
+    let test_message = b"staggered-restart committee-freeze sign".to_vec();
+
+    // Phase 1: only the early validators receive the request. They instantiate
+    // and compute their first-round messages.
+    for &i in &early_parties {
+        test_state.network_owned_address_sign_request_senders[i]
+            .send(NetworkOwnedAddressSignRequest {
+                message: test_message.clone(),
+                curve,
+                signature_algorithm,
+                hash_scheme,
+            })
+            .await
+            .expect("failed to send early network-owned-address sign request");
+    }
+    for service in test_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration().await;
+    }
+    utils::wait_for_computations(&mut test_state).await;
+
+    // Deliver the early validators' first-round messages to everyone. This is
+    // the only time these messages are on the wire — the collectors are cleared
+    // after distribution, exactly as a consensus round is processed once.
+    utils::send_advance_results_between_parties(
+        &test_state.committee,
+        &mut test_state.sent_consensus_messages_collectors,
+        &mut test_state.epoch_stores,
+        test_state.consensus_round as u64,
+    );
+    test_state.consensus_round += 1;
+    for service in test_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration().await;
+    }
+
+    // Each late validator now holds a placeholder NOA-sign session buffering the
+    // early validators' messages, without having instantiated the sign itself.
+    for &i in &late_parties {
+        let has_buffering_placeholder = test_state.dwallet_mpc_services[i]
+            .dwallet_mpc_manager()
+            .sessions
+            .iter()
+            .any(|(id, session)| {
+                id.session_type() == SessionType::NetworkOwnedAddressSign
+                    && matches!(session.status, SessionStatus::WaitingForSessionRequest)
+            });
+        assert!(
+            has_buffering_placeholder,
+            "late validator {} should hold a WaitingForSessionRequest NOA-sign \
+             placeholder buffering the early validators' first-round messages",
+            i
+        );
+    }
+
+    // Phase 2: the late validators finally receive the request and instantiate.
+    for &i in &late_parties {
+        test_state.network_owned_address_sign_request_senders[i]
+            .send(NetworkOwnedAddressSignRequest {
+                message: test_message.clone(),
+                curve,
+                signature_algorithm,
+                hash_scheme,
+            })
+            .await
+            .expect("failed to send late network-owned-address sign request");
+    }
+    for service in test_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration().await;
+    }
+    utils::wait_for_computations(&mut test_state).await;
+
+    // The sign completes only if the late validators preserved the buffered
+    // messages: all four then reach threshold and drive the sign to an output.
+    let sign_output = wait_for_network_owned_address_sign_output(&mut test_state).await;
+    assert_eq!(
+        sign_output.message, test_message,
+        "output message should match the request"
+    );
+    assert!(
+        !sign_output.signature.is_empty(),
+        "signature should not be empty"
+    );
+    info!("Late-instantiation NOA sign completed — buffered messages survived");
 }
 
 // === Fast Schnorr (VSS) NOA sign E2E tests ===

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -2469,12 +2469,13 @@ impl DWalletMPCManager {
         );
 
         let session_identifier = request.session_identifier;
+        let session_sequence_number = request.session_sequence_number;
+        let session_type = request.session_type;
+        let protocol_name = DWalletSessionRequestMetricData::from(&request.protocol_data)
+            .name()
+            .to_owned();
 
         let status = self.session_status_from_request(request, true);
-
-        let session_computation_type = SessionComputationType::MPC {
-            messages_by_consensus_round: HashMap::new(),
-        };
 
         info!(
             ?curve,
@@ -2484,7 +2485,37 @@ impl DWalletMPCManager {
             "instantiating network-owned-address sign session",
         );
 
-        self.new_session(&session_identifier, status, None, session_computation_type);
+        // Upgrade an existing `WaitingForSessionRequest` placeholder in place
+        // rather than overwriting it with a fresh session. When this validator
+        // instantiates the sign late — it restarted, or its signing key /
+        // presign became available only after peers had already started the
+        // round — the message-receipt path may have created a placeholder that
+        // holds peers' buffered round messages. A blind `new_session` replaces
+        // that placeholder with an empty message buffer, dropping those
+        // messages; the late validator then can never advance (peers' earlier
+        // rounds arrived in consensus rounds it has already processed and are
+        // never redelivered), leaving the threshold sign permanently below
+        // quorum and wedging the epoch on NOA-checkpoint finalization. The
+        // event and internal-presign activation paths already upgrade in place
+        // for this exact reason (`handle_mpc_request`,
+        // `try_activate_internal_presign_request`).
+        if let Some(session) = self.sessions.get_mut(&session_identifier) {
+            if let SessionStatus::Active { request, .. } = &status {
+                session.set_request_diagnostic_metadata(request);
+            }
+            session.set_status(status);
+            session.set_request_metadata(session_sequence_number, session_type);
+            session.set_protocol_name(protocol_name);
+        } else {
+            self.new_session(
+                &session_identifier,
+                status,
+                None,
+                SessionComputationType::MPC {
+                    messages_by_consensus_round: HashMap::new(),
+                },
+            );
+        }
         true
     }
 

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -2496,10 +2496,37 @@ impl DWalletMPCManager {
         // rounds arrived in consensus rounds it has already processed and are
         // never redelivered), leaving the threshold sign permanently below
         // quorum and wedging the epoch on NOA-checkpoint finalization. The
-        // event and internal-presign activation paths already upgrade in place
-        // for this exact reason (`handle_mpc_request`,
-        // `try_activate_internal_presign_request`).
+        // event and internal-presign activation paths handle the same race
+        // (`handle_mpc_request`, `try_activate_internal_presign_request`); the
+        // two guards below match their short-circuit and type-normalization.
         if let Some(session) = self.sessions.get_mut(&session_identifier) {
+            // A quorum of peers may have completed this sign 3-of-4 while our
+            // own request was still parked (key/presign not yet local). Don't
+            // flip an already-resolved session back to `Active` — that would
+            // strand it `Active` forever and pin this validator's idle status.
+            // The presign was popped above (and stays popped) so our pop order
+            // remains network-uniform with the peers that ran the session.
+            // Mirrors the non-`WaitingForSessionRequest` short-circuit in
+            // `try_activate_internal_presign_request`.
+            if !matches!(session.status, SessionStatus::WaitingForSessionRequest) {
+                return true;
+            }
+            // Normalize a non-MPC placeholder type before activating. A
+            // placeholder can be created with `SessionComputationType::Native`
+            // by an output report that arrives before the request: the
+            // output-receipt path derives the type from the sender-controlled
+            // `is_native()` flag and the NOA session id is predictable from
+            // public inputs. Left as-is, `add_message` would drop every real
+            // round message and the sign would route to the native path and
+            // fail `InvalidDWalletProtocolType` on every honest validator — one
+            // byzantine message wedging the epoch unattributably. Resetting to a
+            // fresh MPC buffer discards the poison; a legitimate MPC placeholder
+            // keeps its buffered messages. Mirrors `handle_mpc_request`.
+            if !matches!(session.computation_type, SessionComputationType::MPC { .. }) {
+                session.computation_type = SessionComputationType::MPC {
+                    messages_by_consensus_round: HashMap::new(),
+                };
+            }
             if let SessionStatus::Active { request, .. } = &status {
                 session.set_request_diagnostic_metadata(request);
             }


### PR DESCRIPTION
## What

Preserve buffered consensus messages when a network-owned-address (NOA) sign session instantiates late, and harden the late-instantiation path against a poisoned placeholder type and an already-resolved session.

`instantiate_network_owned_address_sign_session` ended in a bare `new_session(...)` that unconditionally overwrote any existing session entry. When a validator instantiates a NOA sign **late** — its network key or presign becomes available only after peers have already begun the signing round — the message-receipt path has already created a `WaitingForSessionRequest` placeholder and buffered peers' round-1 messages in it. The overwrite replaced that placeholder with an empty message buffer, dropping the buffered messages. Consensus rounds are delivered once and never redelivered, so the late validator was permanently stuck at round 1 with only its own message — below the signing threshold. The sign never assembled, and any NOA checkpoint gated on it (e.g. an epoch-close checkpoint) wedged the epoch.

The other two activation paths (`handle_mpc_request`, `try_activate_internal_presign_request`) already upgrade the placeholder in place with explicit "must survive" comments; the NOA sign path was written without that care.

## Fix

- **Upgrade the placeholder in place** (`set_status` / `set_request_metadata` / `set_protocol_name` / `set_request_diagnostic_metadata`), creating a new session only when no entry exists — composing the resolved-session short-circuit from `try_activate_internal_presign_request` with the computation-type normalization from `handle_mpc_request`.
- **Normalize a poisoned `Native` computation type** on upgrade. A pre-instantiation placeholder can be typed `Native` from a sender-controlled output report, and the NOA session identifier is predictable from public inputs — so without this guard a single byzantine consensus message would route instantiation to `try_new_native` (which errors for NOA sign) forever, on every honest validator, a permanent unattributed wedge. Reset a non-`MPC` placeholder type to a fresh `MPC` buffer before activating.
- **Short-circuit an already-resolved session** (not `WaitingForSessionRequest`), placed after the presign pop so pool consumption order stays network-uniform.

## Why this matters on `main`

The NOA settlement system is not live, so this code path is not exercised in production today — but the defect is in shared session machinery `main` already ships, and it is a correctness bug (the un-hardened upgrade would be a one-byzantine-message permanent epoch wedge). Fixing it now removes a latent landmine before NOA activation on any `main`-derived branch.

## Validation

- New regression test `test_late_instantiating_validator_preserves_buffered_sign_messages` — four validators, two instantiate only after the other two's round-1 messages are delivered; the sign completes only if the buffered messages survive. Fault-checked: reverting to the overwrite reproduces the exact production signature (`NetworkOwnedAddressSignOutput not received after 300 consensus rounds`).
- New regression test `test_instantiation_normalizes_byzantine_native_placeholder` — delivers a byzantine `Native` output report for the predictable session id before instantiation, asserts the placeholder is `Native` (attack precondition met), then asserts instantiation activates it as `MPC`. Fault-checked: removing the type-reset fails the assertion.
- Consensus-determinism reviewed: both branches yield a session built from consensus-uniform inputs; the local branch taken affects only whether this validator can participate, never a consensus-visible output.

Found and validated via the multichain-migration rehearsal, whose staggered rolling restarts are the natural trigger for the late-instantiation window.
