### PR TITLE
refactor(reconfiguration): denominate the freeze-gate deadline in consensus time (#1868, Part A)

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -16,7 +16,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use sui_types::base_types::{EpochId, ObjectID};
 use tracing::{debug, error, info, instrument, trace, warn};
 use typed_store::rocks::{DBBatch, DBMap, DBOptions, MetricConf, default_db_options};
@@ -951,6 +951,19 @@ pub struct AuthorityPerEpochStore {
     /// tick, so without the latch the identical warn floods for hours.
     /// The `own_mpc_data_blob_unhealthy` gauge carries the ongoing state.
     self_blob_unhealthy_warned: AtomicBool,
+
+    /// Running max of `commit_timestamp_ms` over every consensus commit
+    /// this validator has processed this epoch — the epoch's consensus
+    /// clock. In-memory only: it starts at 0 on (re)open and restores
+    /// itself on the next processed commit (replayed or fresh), and its
+    /// only consumer — the mpc_data ready-signal emit gate — treats 0 as
+    /// "consensus time unknown", which merely defers a wall-clock-free
+    /// deadline that could not have any effect while no commits flow
+    /// anyway (nothing can be sequenced). Leader-proposed timestamps are
+    /// only manipulable at seconds scale against the hours-scale
+    /// deadlines built on this; the max makes it monotone locally
+    /// regardless.
+    max_processed_commit_timestamp_ms: AtomicU64,
 }
 
 /// The reconfiguration state of the authority.
@@ -1067,6 +1080,17 @@ pub struct AuthorityEpochTables {
     /// every validator (including one restarting mid-grace) freezes at the
     /// same round on the same signal set.
     mpc_data_ready_quorum_round: DBMap<u64, u64>,
+
+    /// Single-key (0) table holding the `commit_timestamp_ms` of the FIRST
+    /// consensus commit this validator processed this epoch — the
+    /// consensus-clock anchor of the mpc_data ready-signal 3/4-epoch
+    /// backstop deadline (`ready_signal_deadline_ms`). Persisted (written
+    /// atomically with the first commit's batch) because replay after a
+    /// restart resumes from the last processed commit, so the first
+    /// commit's timestamp is otherwise unrecoverable. Identical across
+    /// honest validators up to consensus determinism; consumed only for
+    /// emit timing, never for signal content.
+    epoch_first_commit_timestamp_ms: DBMap<u64, u64>,
 
     /// Contains a single key, which overrides the value of
     /// ProtocolConfig::buffer_stake_for_protocol_upgrade_bps
@@ -1794,6 +1818,7 @@ impl AuthorityPerEpochStore {
             handoff_aggregator: parking_lot::Mutex::new(None),
             perpetual_tables_for_handoff: ArcSwapOption::empty(),
             self_blob_unhealthy_warned: AtomicBool::new(false),
+            max_processed_commit_timestamp_ms: AtomicU64::new(0),
         });
 
         s.update_buffer_stake_metric();
@@ -3614,6 +3639,30 @@ impl AuthorityPerEpochStore {
             .collect())
     }
 
+    /// The epoch's consensus clock: the max `commit_timestamp_ms` over all
+    /// consensus commits processed so far, or `None` if no commit has been
+    /// processed since this store opened (fresh epoch, or a restart whose
+    /// replay hasn't reached the handler yet). Emit-timing consumer only.
+    pub(crate) fn max_processed_commit_timestamp_ms(&self) -> Option<u64> {
+        match self
+            .max_processed_commit_timestamp_ms
+            .load(Ordering::Acquire)
+        {
+            0 => None,
+            timestamp_ms => Some(timestamp_ms),
+        }
+    }
+
+    /// Commit timestamp of the epoch's first processed consensus commit
+    /// (the persisted ready-signal backstop anchor), or `None` before any
+    /// commit landed.
+    pub(crate) fn epoch_first_commit_timestamp_ms(&self) -> IkaResult<Option<u64>> {
+        self.tables()?
+            .epoch_first_commit_timestamp_ms
+            .get(&0)
+            .map_err(IkaError::from)
+    }
+
     /// The consensus leader round at which this validator observed the
     /// `EndOfPublish` stake quorum — the persisted anchor of the
     /// deferred-close grace countdown — or `None` if quorum hasn't been
@@ -4004,6 +4053,22 @@ impl AuthorityPerEpochStore {
             .collect();
 
         let mut output = ConsensusCommitOutput::new(consensus_commit_info.round);
+
+        // Epoch consensus clock: advance the in-memory running max of
+        // processed commit timestamps, and persist the FIRST commit's
+        // timestamp once (the ready-signal backstop anchor — replay
+        // resumes from the last processed commit, so "first" is
+        // unrecoverable unless written with its own commit's batch).
+        self.max_processed_commit_timestamp_ms
+            .fetch_max(consensus_commit_info.timestamp, Ordering::AcqRel);
+        if self
+            .tables()?
+            .epoch_first_commit_timestamp_ms
+            .get(&0)?
+            .is_none()
+        {
+            output.set_epoch_first_commit_timestamp_ms(consensus_commit_info.timestamp);
+        }
 
         let (
             verified_dwallet_checkpoint_messages,
@@ -5141,6 +5206,11 @@ pub(crate) struct ConsensusCommitOutput {
     /// was observed (the freeze-grace anchor). Same atomicity rationale as
     /// `end_of_publish_quorum_round`.
     mpc_data_ready_quorum_round: Option<u64>,
+
+    /// Commit timestamp of the epoch's first processed consensus commit
+    /// (the ready-signal backstop anchor). Set only on the commit observed
+    /// first; same atomicity rationale as `mpc_data_ready_quorum_round`.
+    epoch_first_commit_timestamp_ms: Option<u64>,
 }
 
 impl ConsensusCommitOutput {
@@ -5165,6 +5235,10 @@ impl ConsensusCommitOutput {
 
     pub(crate) fn set_mpc_data_ready_quorum_round(&mut self, round: u64) {
         self.mpc_data_ready_quorum_round = Some(round);
+    }
+
+    pub(crate) fn set_epoch_first_commit_timestamp_ms(&mut self, timestamp_ms: u64) {
+        self.epoch_first_commit_timestamp_ms = Some(timestamp_ms);
     }
 
     pub(crate) fn set_dwallet_mpc_round_outputs(&mut self, new_value: Vec<DWalletMPCOutput>) {
@@ -5318,6 +5392,12 @@ impl ConsensusCommitOutput {
         }
         if let Some(round) = self.mpc_data_ready_quorum_round {
             batch.insert_batch(&tables.mpc_data_ready_quorum_round, [(0u64, round)])?;
+        }
+        if let Some(timestamp_ms) = self.epoch_first_commit_timestamp_ms {
+            batch.insert_batch(
+                &tables.epoch_first_commit_timestamp_ms,
+                [(0u64, timestamp_ms)],
+            )?;
         }
 
         batch.insert_batch(

--- a/crates/ika-core/src/epoch_tasks/mpc_data_announcement_sender.rs
+++ b/crates/ika-core/src/epoch_tasks/mpc_data_announcement_sender.rs
@@ -129,40 +129,47 @@ fn decide_ready_to_finalize(
 const POST_PUBLICATION_GRACE_MIN_MS: u64 = 30_000;
 const POST_PUBLICATION_GRACE_MAX_MS: u64 = 3_600_000;
 
-/// The wall-clock deadline after which the emit gate stops waiting for
-/// uncovered next-epoch members. Pure function so the timing rule is
-/// unit-testable.
+/// The deadline after which the emit gate stops waiting for uncovered
+/// next-epoch members, denominated in the epoch's CONSENSUS clock (max
+/// processed `commit_timestamp_ms`) — never machine wall-clock. Pure
+/// function so the timing rule is unit-testable.
 ///
-/// Before V_{e+1} is locally observed as published there is no member
-/// set to wait on, so the only bound is the 3/4-epoch liveness
-/// backstop. Once publication is observed, the wait shrinks to a
-/// propagation grace after that observation — a member that is neither
-/// validated nor prior-cert-covered by then is either a first-time
-/// joiner that failed to propagate or a never-alive member, and
-/// holding every validator's ready signal for it until the 3/4 mark
-/// would compress the reconfiguration into the last quarter of every
-/// epoch (observed live on testnet with two permanently-silent
-/// members; issue #1866). The `min` keeps the backstop as a hard upper
-/// bound, so this can only ever make the gate fire earlier — under
-/// short test epochs (where the clamped grace exceeds epoch/4) the
-/// deadline stays exactly the 3/4 backstop.
+/// `first_commit_ts_ms` anchors the 3/4-epoch liveness backstop at the
+/// epoch's first processed consensus commit; `None` (no commit
+/// processed yet) means no deadline at all — nothing can be sequenced
+/// while no commits flow, so a deadline could not have produced a
+/// freeze anyway (fate-sharing: the deadline pauses exactly when the
+/// machinery it times is paused). Once V_{e+1} publication has been
+/// observed (`next_committee_first_seen_ms`, also recorded off the
+/// consensus clock), the wait shrinks to a propagation grace after
+/// that observation — a member that is neither validated nor
+/// prior-cert-covered by then is either a first-time joiner that
+/// failed to propagate or a never-alive member, and holding every
+/// validator's ready signal for it until the 3/4 mark would compress
+/// the reconfiguration into the last quarter of every epoch (observed
+/// live on testnet with two permanently-silent members; issue #1866).
+/// The `min` keeps the backstop as a hard upper bound — under short
+/// test epochs (where the clamped grace exceeds epoch/4) the deadline
+/// stays exactly the 3/4 backstop.
 ///
-/// Wall-clock only affects WHEN each validator emits its signal; the
-/// freeze snapshot stays a pure function of the consensus-ordered
-/// signals, so per-validator skew in observing the publication is
-/// harmless.
+/// The clock choice only affects WHEN each validator emits its signal;
+/// the freeze snapshot stays a pure function of the consensus-ordered
+/// signals. Commit timestamps are leader-proposed and manipulable at
+/// seconds scale — immaterial against these hours-scale terms (issue
+/// #1868); the epoch store's running max makes the observed clock
+/// monotone locally regardless.
 fn ready_signal_deadline_ms(
-    epoch_start_ms: u64,
+    first_commit_ts_ms: Option<u64>,
     epoch_duration_ms: u64,
     next_committee_first_seen_ms: Option<u64>,
-) -> u64 {
-    let backstop = epoch_start_ms.saturating_add(epoch_duration_ms / 4 * 3);
+) -> Option<u64> {
+    let backstop = first_commit_ts_ms?.saturating_add(epoch_duration_ms / 4 * 3);
     let Some(first_seen_ms) = next_committee_first_seen_ms else {
-        return backstop;
+        return Some(backstop);
     };
     let grace = (epoch_duration_ms / 24)
         .clamp(POST_PUBLICATION_GRACE_MIN_MS, POST_PUBLICATION_GRACE_MAX_MS);
-    backstop.min(first_seen_ms.saturating_add(grace))
+    Some(backstop.min(first_seen_ms.saturating_add(grace)))
 }
 
 /// Per-epoch producer task that broadcasts this validator's
@@ -223,12 +230,16 @@ pub struct MpcDataAnnouncementSender {
     /// thereafter, so a sequencing stall still surfaces) logs at
     /// info, re-submissions in between at debug.
     announcement_submit_attempts: AtomicU64,
-    /// Wall-clock ms at which this validator FIRST observed the
+    /// Consensus-clock ms (the epoch store's max processed commit
+    /// timestamp) at which this validator FIRST observed the
     /// next-epoch committee published on the watch channel, or `0`
-    /// (sentinel: not yet observed). Anchors the post-publication
-    /// grace in [`ready_signal_deadline_ms`] — local-only emit
-    /// timing, so per-validator skew (including a reset to the
-    /// restart time after a mid-epoch restart) is harmless.
+    /// (sentinel: not yet observed, or observed while no commit had
+    /// been processed yet — re-recorded on a later tick). Anchors the
+    /// post-publication grace in [`ready_signal_deadline_ms`] —
+    /// local-only emit timing, so per-validator skew (including a
+    /// reset to the restart-time consensus view after a mid-epoch
+    /// restart) is harmless. Making this anchor fleet-identical
+    /// (consensus-sequenced publication attestations) is issue #1869.
     next_committee_first_seen_ms: AtomicU64,
 }
 
@@ -456,13 +467,20 @@ impl MpcDataAnnouncementSender {
     ///   present in the prior epoch's handoff cert (the freeze
     ///   carries such members forward, so waiting for them buys
     ///   nothing) — or
-    /// - the epoch-clock deadline has passed: the 3/4-epoch liveness
-    ///   backstop, tightened to a propagation grace after this
+    /// - the consensus-clock deadline has passed: the 3/4-epoch
+    ///   liveness backstop anchored at the epoch's first consensus
+    ///   commit, tightened to a propagation grace after this
     ///   validator first observes V_{e+1} published (see
     ///   `ready_signal_deadline_ms`) — so an uncovered member that
     ///   never announces can't hold every epoch's freeze to the 3/4
     ///   mark (the still-uncovered members are surfaced so the
     ///   caller can warn).
+    ///
+    /// Every time term is read off the epoch's consensus clock (max
+    /// processed commit timestamp) — machine wall-clock is never
+    /// consulted, so an NTP-skewed or partitioned validator's gate
+    /// pauses with its consensus view instead of deadline-emitting a
+    /// stale attestation set mid-catch-up (issue #1868, Part A).
     fn ready_to_finalize(
         &self,
         epoch_store: &AuthorityPerEpochStore,
@@ -470,11 +488,12 @@ impl MpcDataAnnouncementSender {
     ) -> ReadyToFinalize {
         use ika_types::sui::epoch_start_system::EpochStartSystemTrait;
         let epoch_start = epoch_store.epoch_start_state();
-        // On clock failure, treat as past the deadline (emit) rather
-        // than stalling the freeze.
-        let now = now_ms().unwrap_or(u64::MAX);
-        // Copy out of the watch borrow before the cert read below, so
-        // the channel's read guard isn't held across a DB access.
+        // The epoch's consensus clock. `None` (no commit processed yet)
+        // disables the deadline terms below; the coverage-based `Ready`
+        // path needs no clock at all.
+        let consensus_now = epoch_store.max_processed_commit_timestamp_ms();
+        // Copy out of the watch borrow before the DB reads below, so
+        // the channel's read guard isn't held across them.
         let (next_committee_epoch, next_members) = {
             let next = self.next_epoch_committee_receiver.borrow();
             let members: Vec<AuthorityName> =
@@ -482,10 +501,12 @@ impl MpcDataAnnouncementSender {
             (next.epoch(), members)
         };
         let next_published = next_committee_epoch == epoch_store.epoch() + 1;
-        if next_published {
+        if next_published && let Some(now) = consensus_now {
             // Record the FIRST observation only (compare-and-swap from
-            // the 0 sentinel), so re-borrows on later ticks don't slide
-            // the grace anchor forward.
+            // the 0 sentinel), so later ticks don't slide the grace
+            // anchor forward. Skipped while the consensus clock is
+            // unknown (`now` would be the 0 sentinel) — a later tick
+            // records it once commits flow.
             let _ = self.next_committee_first_seen_ms.compare_exchange(
                 0,
                 now,
@@ -497,11 +518,23 @@ impl MpcDataAnnouncementSender {
             0 => None,
             first_seen_ms => Some(first_seen_ms),
         };
-        let deadline = ready_signal_deadline_ms(
-            epoch_start.epoch_start_timestamp_ms(),
-            epoch_start.epoch_duration_ms(),
-            first_seen,
-        );
+        // Backstop anchor: the epoch's first processed consensus
+        // commit. A read error degrades to "no anchor" (deadline
+        // disabled this tick) — emit-timing only, so unlike freeze-
+        // commit reads it must not fail the caller.
+        let first_commit_ts = match epoch_store.epoch_first_commit_timestamp_ms() {
+            Ok(first_commit_ts) => first_commit_ts,
+            Err(err) => {
+                debug!(
+                    error = ?err,
+                    "failed to read the epoch's first-commit timestamp for the \
+                     ready-signal emit gate; deadline disabled this tick"
+                );
+                None
+            }
+        };
+        let deadline =
+            ready_signal_deadline_ms(first_commit_ts, epoch_start.epoch_duration_ms(), first_seen);
         // Members covered by the prior epoch's handoff cert cannot be
         // dropped by the freeze (carry-forward re-freezes them at the
         // prior-cert digest), so they must not hold the gate. A read
@@ -521,9 +554,14 @@ impl MpcDataAnnouncementSender {
                     HashSet::new()
                 }
             };
+        // Translate the Options at the pure-function boundary: an
+        // unknown consensus clock (0) can never reach a real deadline,
+        // and an absent deadline (u64::MAX) is never reached — both
+        // collapse to "the deadline terms are inert; only coverage can
+        // make us Ready".
         decide_ready_to_finalize(
-            now,
-            deadline,
+            consensus_now.unwrap_or(0),
+            deadline.unwrap_or(u64::MAX),
             next_committee_epoch,
             epoch_store.epoch() + 1,
             &next_members,
@@ -586,8 +624,8 @@ impl MpcDataAnnouncementSender {
         // lets joiners — who announce only after `V_{e+1}` is
         // published, mid-epoch — make it into the frozen set, the
         // next committee's class-groups map, and the handoff cert.
-        // The deadline (wall-clock) only affects WHEN each validator
-        // emits; the freeze snapshot itself is still computed
+        // The deadline (consensus-clock) only affects WHEN each
+        // validator emits; the freeze snapshot itself is still computed
         // deterministically at the consensus-ordered quorum point.
         let deadline_missing = match self.ready_to_finalize(&epoch_store, &validated_names) {
             ReadyToFinalize::NotYet => {
@@ -826,47 +864,62 @@ mod tests {
         );
     }
 
-    /// The deadline formula: 3/4-epoch backstop until V_{e+1} is
-    /// observed published, then min(backstop, first-observed + grace)
-    /// with grace = epoch/24 clamped to [30s, 1h]. The min means the
-    /// change can only fire the gate EARLIER than the old fixed 3/4
-    /// deadline, and short test epochs keep the 3/4 behavior exactly.
+    /// The deadline formula, all terms on the consensus clock: no
+    /// deadline before the epoch's first commit; then the 3/4-epoch
+    /// backstop anchored at that commit until V_{e+1} is observed
+    /// published; then min(backstop, first-observed + grace) with
+    /// grace = epoch/24 clamped to [30s, 1h]. The min means the
+    /// publication term can only fire the gate EARLIER than the
+    /// backstop, and short test epochs keep the 3/4 behavior exactly.
     #[test]
     fn ready_signal_deadline_tracks_publication_with_clamped_grace() {
         const HOUR_MS: u64 = 3_600_000;
+        // No consensus commit processed yet: no deadline at all —
+        // nothing can be sequenced, so a deadline could do nothing.
+        assert_eq!(ready_signal_deadline_ms(None, 24 * HOUR_MS, None), None);
+        assert_eq!(
+            ready_signal_deadline_ms(None, 24 * HOUR_MS, Some(12 * HOUR_MS)),
+            None
+        );
         // Publication not yet observed: the 3/4 backstop.
         assert_eq!(
-            ready_signal_deadline_ms(0, 24 * HOUR_MS, None),
-            18 * HOUR_MS
+            ready_signal_deadline_ms(Some(0), 24 * HOUR_MS, None),
+            Some(18 * HOUR_MS)
         );
         // 24h epoch, published at mid-epoch: grace = 24h/24 = 1h, so
         // the deadline is 13h — well before the 18h backstop.
         assert_eq!(
-            ready_signal_deadline_ms(0, 24 * HOUR_MS, Some(12 * HOUR_MS)),
-            13 * HOUR_MS
+            ready_signal_deadline_ms(Some(0), 24 * HOUR_MS, Some(12 * HOUR_MS)),
+            Some(13 * HOUR_MS)
         );
         // Publication observed very late: the backstop still caps it.
         assert_eq!(
-            ready_signal_deadline_ms(0, 24 * HOUR_MS, Some(HOUR_MS + 18 * HOUR_MS)),
-            18 * HOUR_MS
+            ready_signal_deadline_ms(Some(0), 24 * HOUR_MS, Some(HOUR_MS + 18 * HOUR_MS)),
+            Some(18 * HOUR_MS)
         );
         // 10s test epoch, published at mid-epoch: grace clamps up to
         // 30s which overshoots the epoch, so the 7.5s backstop wins —
         // identical to the pre-change behavior for short epochs.
-        assert_eq!(ready_signal_deadline_ms(0, 10_000, Some(5_000)), 7_500);
+        assert_eq!(
+            ready_signal_deadline_ms(Some(0), 10_000, Some(5_000)),
+            Some(7_500)
+        );
         // 5min epoch, published at mid-epoch: grace clamps up to 30s;
         // 150s + 30s = 180s beats the 225s backstop.
-        assert_eq!(ready_signal_deadline_ms(0, 300_000, Some(150_000)), 180_000);
+        assert_eq!(
+            ready_signal_deadline_ms(Some(0), 300_000, Some(150_000)),
+            Some(180_000)
+        );
         // 7-day epoch: grace caps at 1h rather than 7h.
         let week = 7 * 24 * HOUR_MS;
         assert_eq!(
-            ready_signal_deadline_ms(0, week, Some(84 * HOUR_MS)),
-            85 * HOUR_MS
+            ready_signal_deadline_ms(Some(0), week, Some(84 * HOUR_MS)),
+            Some(85 * HOUR_MS)
         );
-        // Non-zero epoch start shifts the backstop.
+        // A non-zero first-commit anchor shifts the backstop.
         assert_eq!(
-            ready_signal_deadline_ms(1_000_000, 24 * HOUR_MS, None),
-            1_000_000 + 18 * HOUR_MS
+            ready_signal_deadline_ms(Some(1_000_000), 24 * HOUR_MS, None),
+            Some(1_000_000 + 18 * HOUR_MS)
         );
     }
 

--- a/dev-docs/specs/validator-mpc-data-announcements.md
+++ b/dev-docs/specs/validator-mpc-data-announcements.md
@@ -85,12 +85,32 @@ which bytes* deterministic in consensus order.
   validator onto the backstop every epoch, compressing the
   reconfiguration + pricing + lock pipeline into the last quarter of
   every epoch (observed live on testnet — issue #1866). The deadline
-  and the publication-observation time are wall-clock and per-validator
-  (skew, restarts resetting the anchor): they only affect WHEN a
-  validator emits, never the signal's content, so determinism of the
-  freeze is untouched. The deadline warning names only uncovered
-  members — carry-forward-covered members stay in the frozen set, so
-  naming them would be a false exclusion alarm.
+  warning names only uncovered members — carry-forward-covered members
+  stay in the frozen set, so naming them would be a false exclusion
+  alarm.
+- **Emit-gate clock**: every time term of the gate is denominated in
+  the epoch's CONSENSUS clock — "now" is the running max of processed
+  `commit_timestamp_ms`, the backstop is anchored at the epoch's FIRST
+  processed commit's timestamp (persisted with that commit's batch —
+  replay resumes from the last processed commit, so "first" is
+  otherwise unrecoverable), and the publication observation is stamped
+  with the consensus "now" at the tick that first sees it. Machine
+  wall-clock is never consulted. This fate-shares the deadline with
+  the machinery it times: before the first commit (or during a
+  consensus stall) there is no deadline — nothing can be sequenced, so
+  a deadline could not have produced a freeze — and a partitioned or
+  catching-up validator's deadline pauses with its consensus view
+  instead of deadline-emitting a stale attestation set mid-catch-up.
+  Commit timestamps are leader-proposed and manipulable at seconds
+  scale — immaterial against these hours-scale terms. The first-commit
+  anchor sits a consensus spin-up after the Sui epoch-start timestamp
+  the backstop was historically measured from; the 3/4 slack absorbs
+  normal spin-up, but a pathologically late consensus start delays the
+  backstop by the same amount. All of these terms remain emit-timing
+  only (the freeze snapshot stays a pure function of consensus-ordered
+  signals); the publication anchor is still each validator's LOCAL
+  first observation — making it a fleet-identical consensus fact
+  (quorum of sequenced publication attestations) is issue #1869.
 - **Receive-time canonicalization** (`canonicalize_ready_signal_peers`)
   MUST be a pure function of the sequenced signal bytes: dedup by
   authority, a current-committee quorum-coverage floor, and a


### PR DESCRIPTION
Part A of #1868. **STACKED on #1867** (edits the same emit gate) — retarget to `main` after #1867 merges. Part B (fleet-identical publication anchor, protocol-gated) is deferred to #1869 and is deliberately absent here.

## What changes

Every time term of the ready-signal emit gate moves from machine wall-clock to the epoch's consensus clock:

| Term | Before (#1867) | Now |
|---|---|---|
| "now" | `SystemTime::now()` | running max of processed `commit_timestamp_ms` (in-memory on the epoch store, updated by the consensus handler) |
| 3/4 backstop anchor | Sui epoch-start timestamp | epoch's **first** processed commit's timestamp, persisted atomically with that commit's batch |
| publication grace anchor | local wall-clock at first observation | consensus "now" at the tick that first observes V(e+1) published |
| clock-failure sentinel | emit on `now_ms()` error | gone — wall-clock is no longer consulted by the gate |

The deadline function returns `None` before the epoch's first commit: nothing can be sequenced while no commits flow, so a deadline could not have produced a freeze — the deadline is fate-shared with the machinery it times. A partitioned or catching-up validator's deadline pauses with its consensus view instead of deadline-emitting a stale attestation set mid-catch-up. The coverage-based `Ready` path needs no clock at all.

## Safety

- **Emit-timing only.** Signal wire content, canonicalization, and the freeze decision are untouched; the frozen set remains a pure function of consensus-ordered signals. Rolling-safe next to wall-clock (#1867 or older) binaries — mixed fleets just emit at somewhat different moments, exactly as they already do.
- **Restart/replay**: the in-memory max self-restores on the next processed (or replayed) commit; the first-commit anchor is persisted because replay resumes from the *last* processed commit and could never re-observe the first. While the clock reads 0, the deadline terms are inert (conservative — wait, never early-emit).
- **Manipulation bound**: commit timestamps are leader-proposed, manipulable at seconds scale — immaterial against hours-scale terms; the running max keeps the local clock monotone regardless (stated in the code where the assumption lives).
- **Anchor drift caveat** (named in the spec): the first-commit anchor sits one consensus spin-up after the Sui epoch-start time; a pathologically late consensus start delays the backstop by the same amount. The backstop is rarely the binding term post-#1867.

## Verification

- Deadline unit test extended: `None` anchor → no deadline; anchored backstop; publication grace with clamp bounds across 10s / 5min / 24h / 7-day epochs; non-zero anchor shift.
- `cargo test --release -p ika-core mpc_data_announcement_sender` 6/6, `validator_metadata` 79/79, clippy clean.
- Spec updated in the same PR (`dev-docs/specs/validator-mpc-data-announcements.md`, new "Emit-gate clock" bullet, with a pointer to #1869 for the remaining local term).
- Heavy suites should run on CI once this retargets to main (the cluster suite exercises the gate end-to-end through the joiner tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)