### PR TITLE
fix(consensus): append NOAPresignDemand at the enum tails - restore v1.2.1 wire tags

### DIFF
--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -774,9 +774,8 @@ mod wire_format_tests {
     /// NOAPresignDemand, crash-looping upgraded validators mid-rollout).
     #[test]
     fn consensus_transaction_kind_wire_tags_are_append_only() {
-        let tag = |kind: &ConsensusTransactionKind| -> u8 {
-            bcs::to_bytes(kind).expect("bcs encode")[0]
-        };
+        let tag =
+            |kind: &ConsensusTransactionKind| -> u8 { bcs::to_bytes(kind).expect("bcs encode")[0] };
         assert_eq!(
             tag(&ConsensusTransactionKind::EndOfPublish(
                 AuthorityName::default()

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -81,10 +81,6 @@ pub enum ConsensusTransactionKey {
     GlobalPresignRequest(AuthorityName, u64),
     /// An NOA checkpoint observation, keyed by authority + nonce.
     NOAObservation(AuthorityName, [u8; 32]),
-    /// A NOA sign presign demand, keyed by its `demand_id` digest ONLY (not
-    /// authority), so redundant announcements of the same demand from different
-    /// validators collapse to a single consensus transaction.
-    NOAPresignDemand([u8; 32]),
     /// A current-committee validator's self-submitted MPC data
     /// announcement, keyed by validator + epoch + timestamp_ms. The
     /// timestamp is the version within (validator, epoch); the
@@ -130,6 +126,14 @@ pub enum ConsensusTransactionKey {
     /// signature inside V2 is not separately keyed; the consumer
     /// routes it through the handoff aggregator after extraction.
     EndOfPublishV2(AuthorityName),
+    // WIRE/DB-FORMAT DISCIPLINE: BCS-serialized as the key of persisted
+    // DBMaps (pending_consensus_transactions, consensus_message_processed)
+    // and rebuilt across binary upgrades - variants are APPEND-ONLY, same
+    // as ConsensusTransactionKind above.
+    /// A NOA sign presign demand, keyed by its `demand_id` digest ONLY (not
+    /// authority), so redundant announcements of the same demand from different
+    /// validators collapse to a single consensus transaction.
+    NOAPresignDemand([u8; 32]),
 }
 
 impl Debug for ConsensusTransactionKey {
@@ -331,7 +335,6 @@ pub enum ConsensusTransactionKind {
     SuiChainObservationUpdate(SuiChainObservationUpdate),
     GlobalPresignRequest(ConsensusGlobalPresignRequest),
     NOAObservation(ConsensusNOAObservation),
-    NOAPresignDemand(ConsensusNOAPresignDemand),
     /// Self-submission by a current-committee validator: the
     /// announcement (digest + metadata) plus the full mpc_data blob
     /// carried in-band. No payload signature (the consensus block
@@ -351,6 +354,13 @@ pub enum ConsensusTransactionKind {
     /// whole committee via consensus replication.
     RelayedValidatorMpcDataAnnouncement(SignedValidatorMpcDataAnnouncement, Vec<u8>),
     EpochMpcDataReadySignal(EpochMpcDataReadySignal),
+    // WIRE-FORMAT DISCIPLINE: this enum is BCS-serialized into consensus
+    // blocks and decoded by every binary version in a mixed committee.
+    // Variants are APPEND-ONLY - inserting mid-enum shifts every later
+    // tag, so old binaries' transactions decode as the WRONG variant on
+    // new binaries (caught live in v121_rollout: v1.2.1 announcements,
+    // tag 10, decoded as NOAPresignDemand when it was inserted at index
+    // 10, crash-looping the upgraded validator mid-rollout).
     /// V2 of `EndOfPublish` that bundles the validator's signed
     /// handoff attestation into the same consensus message.
     ///
@@ -379,6 +389,7 @@ pub enum ConsensusTransactionKind {
         authority: AuthorityName,
         handoff_signature: Box<HandoffSignatureMessage>,
     },
+    NOAPresignDemand(ConsensusNOAPresignDemand),
 }
 
 impl ConsensusTransaction {
@@ -742,5 +753,51 @@ impl ConsensusTransaction {
                 ConsensusTransactionKey::EndOfPublishV2(*authority)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod wire_format_tests {
+    use super::*;
+    use dwallet_mpc_types::dwallet_mpc::DWalletSignatureAlgorithm;
+    use sui_types::base_types::ObjectID;
+
+    /// The BCS variant tag of `ConsensusTransactionKind` is a cross-version
+    /// wire contract: every binary in a mixed committee decodes every other
+    /// binary's transactions. Tags 0-12 are what deployed binaries
+    /// (release/testnet-v1.2.1) emit and expect; they may NEVER shift.
+    /// New variants append after the last pinned tag. This test pins the
+    /// contract with cheap-to-construct variants bracketing the enum, plus
+    /// the appended tail. If it fails, a variant was inserted mid-enum -
+    /// move it to the end (see the WIRE-FORMAT DISCIPLINE comment on the
+    /// enum; live incident: v1.2.1 announcements decoded as the mid-enum
+    /// NOAPresignDemand, crash-looping upgraded validators mid-rollout).
+    #[test]
+    fn consensus_transaction_kind_wire_tags_are_append_only() {
+        let tag = |kind: &ConsensusTransactionKind| -> u8 {
+            bcs::to_bytes(kind).expect("bcs encode")[0]
+        };
+        assert_eq!(
+            tag(&ConsensusTransactionKind::EndOfPublish(
+                AuthorityName::default()
+            )),
+            3,
+            "EndOfPublish must keep wire tag 3 (v1.2.1 contract)"
+        );
+        assert_eq!(
+            tag(&ConsensusTransactionKind::NOAPresignDemand(
+                ConsensusNOAPresignDemand {
+                    authority: AuthorityName::default(),
+                    demand_id: crate::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
+                        [0u8; 32],
+                    ),
+                    signature_algorithm: DWalletSignatureAlgorithm::ECDSASecp256k1,
+                    network_encryption_key_id: ObjectID::ZERO,
+                }
+            )),
+            15,
+            "NOAPresignDemand is post-v1.2.1 and must stay APPENDED at tag 15; \
+             renumbering it (or anything before it) breaks mixed-committee decoding"
+        );
     }
 }


### PR DESCRIPTION
## What broke

The full upgrade-test matrix (v121_rollout) caught a mixed-committee crash that blocks the v1.2.2 tag: #1865 inserted `NOAPresignDemand` **mid-enum** in `ConsensusTransactionKind` (index 11), shifting every later v1.2.1 wire tag by one (`ValidatorMpcDataAnnouncement` 11→12, `Relayed…` 12→13, `EpochMpcDataReadySignal` 13→14, `EndOfPublishV2` 14→15). The swapped-in new validator decoded an old peer's announcement (tag 11) as `NOAPresignDemand` and panicked in `consensus_output_api.rs:107` on the two-variant `NOAPresignDemandId` inside ('invalid value: integer 2, expected variant index 0 <= i < 2'), crash-looping on the committed round — run 29765849960, validator-0 logs + resource sampler tell the whole story (fleet memory ballooned to the cgroup ceiling from the replay storm).

## Why no earlier gate saw it

v1.1.8 predates every shifted variant (protocol 3 has no announcements/ready-signals/EndOfPublishV2), so the PR-level `v118_mixed_rollout` gate never exercises tags ≥11 — and `v121_rollout` only runs in the full matrix / releases. All-new-binary suites agree with themselves on any ordering.

## Fix

- Move `NOAPresignDemand` to the **true tail** (after `EndOfPublishV2`, tag 15) in `ConsensusTransactionKind` **and** in the persisted `ConsensusTransactionKey` (it keys `pending_consensus_transactions` / `consensus_message_processed` DBMaps, which must survive a mid-epoch binary upgrade).
- WIRE-FORMAT DISCIPLINE comments on both enums: append-only, with the incident inline.
- A bcs tag-pin test (`EndOfPublish`=3, `NOAPresignDemand`=15) that fails on any future mid-enum insertion — it caught this fix's own first attempt, which appended before the struct-form `EndOfPublishV2` that line-greps miss.

The reorder is itself wire-safe: nothing emits `NOAPresignDemand` yet (noa_checkpoints off everywhere), so no deployed bytes carry either index.

## Validation

`cargo test -p ika-types consensus_transaction_kind_wire_tags` green; `cargo check -p ika-core` green (matches are name-based, no arms change). Dispatching `v121_rollout` on this branch — the scenario that caught it — as the acceptance gate, then the full matrix re-runs on main before the v1.2.2 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)