### PR TITLE
ci(release): run linux jobs on ika-k8s-large

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
       network: ${{ steps.resolve.outputs.network }}
       is_release: ${{ steps.resolve.outputs.is_release }}
       # Runner labels — change here to update all jobs
-      runner_linux: linux-32-runner
+      runner_linux: ika-k8s-large
       runner_macos_x64: macos-latest
       runner_macos_arm64: macos-latest
       runner_windows: windows-latest


### PR DESCRIPTION
One line: `runner_linux: linux-32-runner` → `ika-k8s-large`. The v1.2.2 release run's four Docker jobs failed runner acquisition in 31s (zero steps) on `linux-32-runner` while the repo's heavy CI pool (`ika-k8s-large`) was healthy. Aligns release linux builds + docker publishing to the same ARC pool. After merge the `release/testnet-v1.2.2` tag moves to the new tip (workflow-only delta over the matrix-validated `e97973baab`) to re-run publishing with the fixed runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)