### PR TITLE
ci: guard standalone lockfiles against workspace-version drift

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,13 @@ jobs:
         # see dev-docs/conventions/sui-version-bump.md.
         run: ./scripts/check-sui-version-consistency.sh
 
+      - name: Workspace version consistency (standalone lockfiles)
+        # Standalone lockfiles (sdk/ika-wasm) pin root-workspace crates and
+        # don't update with the root lock: the v1.2.2 bump missed the wasm
+        # lock, breaking --locked SDK builds. Red PR instead of a
+        # post-release discovery.
+        run: ./scripts/check-workspace-version-consistency.sh
+
   # Runs on PRs AND pushes: clippy used to be push-to-main-only, which let a
   # workspace-wide lint backlog accumulate invisibly (PRs merged unlinted and
   # only the FIRST failing crate ever surfaced on main).

--- a/scripts/check-workspace-version-consistency.sh
+++ b/scripts/check-workspace-version-consistency.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Guard: every standalone lockfile that pins root-workspace crates must agree
+# with the workspace version. The v1.2.2 bump updated Cargo.toml + the root
+# Cargo.lock but missed sdk/ika-wasm/Cargo.lock, leaving its path deps at
+# 1.2.1 and breaking --locked SDK builds. This makes that class of miss a
+# red PR instead of a post-release discovery.
+#
+# A path dependency appears in a lockfile as a [[package]] with NO `source`
+# line. We assert every such package (except the wasm workspace's own crates)
+# matches the root workspace version.
+set -euo pipefail
+
+WS_VERSION=$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)
+[ -n "$WS_VERSION" ] || { echo "::error::could not read workspace version from Cargo.toml"; exit 1; }
+
+FAIL=0
+check_lock() {
+  local lock="$1"; shift
+  local skip_names=("$@")
+  # Emit "name version has_source" per [[package]] block.
+  awk '
+    /^\[\[package\]\]/ { if (name != "") print name, ver, src; name=""; ver=""; src="0" }
+    /^name = / { gsub(/"/,"",$3); name=$3 }
+    /^version = / { gsub(/"/,"",$3); ver=$3 }
+    /^source = / { src="1" }
+    END { if (name != "") print name, ver, src }
+  ' "$lock" | while read -r name ver has_source; do
+    [ "$has_source" = "1" ] && continue
+    for s in "${skip_names[@]}"; do [ "$name" = "$s" ] && continue 2; done
+    if [ "$ver" != "$WS_VERSION" ]; then
+      echo "::error file=$lock::$lock pins path dependency '$name' at $ver but the workspace version is $WS_VERSION - run 'cargo update --workspace' in $(dirname "$lock")"
+      echo "MISMATCH" >> /tmp/lock-guard-failures
+    fi
+  done
+}
+
+rm -f /tmp/lock-guard-failures
+# sdk/ika-wasm is its own workspace; its own package (dwallet-mpc-wasm,
+# independently versioned) is skipped. Add new standalone lockfiles here as
+# they appear.
+check_lock sdk/ika-wasm/Cargo.lock dwallet-mpc-wasm
+
+if [ -s /tmp/lock-guard-failures ]; then
+  exit 1
+fi
+echo "workspace version consistency OK (workspace $WS_VERSION)"


### PR DESCRIPTION
Answer to 'how do we make sure the wasm lock is never missed again': a Format Check step (next to the existing Sui-version-consistency check) asserting every path dependency in standalone lockfiles (`sdk/ika-wasm/Cargo.lock`) matches the root workspace version. A version-bump PR that misses a lockfile now goes red at PR time instead of surfacing as a broken `--locked` SDK build after the release.

- Generic over path deps (no hardcoded crate list); the wasm workspace's own independently-versioned package (`dwallet-mpc-wasm`) is skipped; new standalone lockfiles get one line in the script.
- Fault-validated both directions: exit 1 on a simulated 1.2.1-stale lock, exit 0 on current main (post bf6ccc5fcb).
- Context: the v1.2.2 bump (#1861) missed the wasm lock; fixed on main in bf6ccc5fcb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)