### PR TITLE
chore: bump version to v1.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-classgroups-types"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "bcs",
  "class_groups",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-rng"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "commitment",
  "fastcrypto",
@@ -6548,7 +6548,7 @@ dependencies = [
 
 [[package]]
 name = "ika"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6592,7 +6592,7 @@ dependencies = [
 
 [[package]]
 name = "ika-archival"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6763,7 +6763,7 @@ dependencies = [
 
 [[package]]
 name = "ika-node"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6834,7 +6834,7 @@ dependencies = [
 
 [[package]]
 name = "ika-proxy"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -6983,7 +6983,7 @@ dependencies = [
 
 [[package]]
 name = "ika-test-cluster"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "ika-upgrade-test"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 [workspace.package]
 # This version string will be inherited by ika-core, ika-node, ika-tools, ika-sdk, and ika crates.
-version = "1.2.2"
+version = "1.2.3"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/sdk/ika-wasm/Cargo.lock
+++ b/sdk/ika-wasm/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "bcs",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "bcs",


### PR DESCRIPTION
Release prep for **testnet-v1.2.3**. Workspace version + **both** lockfiles (root and `sdk/ika-wasm` — the discipline #1876 enforces; the v1.2.2 bump missed the wasm lock).

Intended release contents on top of v1.2.2:
- **#1875** — sui-data-source genesis verification compares against the pinned Sui upstream's genesis checkpoint digests instead of the ika system object IDs, unblocking the gRPC/OCS path on both public networks (operator-reported; urgency driven by Mysten's JSON-RPC sunset).
- **#1876** — CI guard: standalone lockfiles must track the workspace version.
- `bf6ccc5fcb` (already on main) — wasm lockfile synced to 1.2.2.

**Merge order:** #1875 and #1876 first, then this. Rolling-upgrade safe: #1875 only changes a boot-time verification constant source on a path no deployed validator uses yet; no protocol/wire changes anywhere in the set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)