### PR TITLE
feat(metrics): export committee quorum/validity thresholds and total stake

### DIFF
--- a/crates/ika-core/src/authority.rs
+++ b/crates/ika-core/src/authority.rs
@@ -326,6 +326,17 @@ impl AuthorityState {
         prometheus_registry: &Registry,
         config: NodeConfig,
     ) -> Arc<Self> {
+        // The advertised capability range is constant for the process; export
+        // it so fleet dashboards can measure upgrade support directly against
+        // the committee thresholds (see ika_committee_quorum_threshold).
+        epoch_store
+            .metrics
+            .supported_protocol_version_min
+            .set(supported_protocol_versions.min.as_u64() as i64);
+        epoch_store
+            .metrics
+            .supported_protocol_version_max
+            .set(supported_protocol_versions.max.as_u64() as i64);
         Self::check_protocol_version(supported_protocol_versions, epoch_store.protocol_version());
 
         let metrics = Arc::new(AuthorityMetrics::new(prometheus_registry));

--- a/crates/ika-core/src/authority.rs
+++ b/crates/ika-core/src/authority.rs
@@ -205,6 +205,10 @@ pub(crate) struct AuthorityCapabilitiesVotingResults {
     pub(crate) move_contracts_to_upgrade: Vec<(ObjectID, MovePackageDigest)>,
 }
 
+/// One tallied capability-vote group: the protocol-config digest, the set of
+/// Move packages that group votes to upgrade, and the group's aggregated stake.
+pub type ProtocolUpgradeVoteGroup = (Digest, Vec<(ObjectID, MovePackageDigest)>, u64);
+
 /// Trait for AuthorityState, which gets created once per validator (NOT recreated on epoch switch).
 pub trait AuthorityStateTrait: Sync + Send + 'static {
     fn insert_dwallet_mpc_computation_completed_sessions(
@@ -528,7 +532,7 @@ impl AuthorityState {
         proposed_protocol_version: ProtocolVersion,
         committee: &Committee,
         capabilities: Vec<AuthorityCapabilitiesV1>,
-    ) -> Option<Vec<(Digest, Vec<(ObjectID, MovePackageDigest)>, u64)>> {
+    ) -> Option<Vec<ProtocolUpgradeVoteGroup>> {
         // For each validator, gather the protocol version and system packages that it would like
         // to upgrade to in the next epoch.
         let mut desired_upgrades: Vec<_> = capabilities

--- a/crates/ika-core/src/authority.rs
+++ b/crates/ika-core/src/authority.rs
@@ -29,6 +29,7 @@ use ika_types::sui::epoch_start_system::EpochStartSystemTrait;
 use ika_types::supported_protocol_versions::SupportedProtocolVersions;
 use sui_macros::fail_point;
 use sui_types::crypto::Signer;
+use sui_types::digests::Digest;
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::metrics::{BytecodeVerifierMetrics, LimitsMetrics};
 
@@ -496,17 +497,38 @@ impl AuthorityState {
         epoch_store.clear_override_protocol_upgrade_buffer_stake()
     }
 
-    fn is_protocol_version_supported_v1(
-        proposed_protocol_version: ProtocolVersion,
+    /// The stake required for a protocol upgrade to arm: quorum plus
+    /// `buffer_stake_bps` of f, rounded up (0bps => plain 2f+1 suffices,
+    /// 10000bps => unanimity). SINGLE SOURCE OF TRUTH: consumed by the
+    /// activation decision (`is_protocol_version_supported_v1`) and by the
+    /// `ika_protocol_upgrade_effective_threshold` metric, so the exported
+    /// activation line can never drift from what the tally enforces.
+    pub fn protocol_upgrade_effective_threshold(
         committee: &Committee,
-        capabilities: Vec<AuthorityCapabilitiesV1>,
         mut buffer_stake_bps: u64,
-    ) -> (Option<AuthorityCapabilitiesVotingResults>, bool) {
+    ) -> u64 {
         if buffer_stake_bps > 10000 {
             warn!("clamping buffer_stake_bps to 10000");
             buffer_stake_bps = 10000;
         }
+        let quorum_threshold = committee.quorum_threshold();
+        let f = committee.total_votes() - committee.quorum_threshold();
+        // multiply by buffer_stake_bps / 10000, rounded up.
+        let buffer_stake = (f * buffer_stake_bps).div_ceil(10000);
+        quorum_threshold + buffer_stake
+    }
 
+    /// Group capability votes for `proposed_protocol_version` by
+    /// (protocol-config digest, move contracts) and tally each group's stake,
+    /// in the tally's deterministic sorted order. SINGLE SOURCE OF TRUTH for
+    /// what counts as "supporting stake": the activation decision walks these
+    /// groups in order, the `ika_protocol_upgrade_supporting_stake` metric
+    /// reports the strongest group. `None` when nobody votes for the version.
+    pub fn tally_protocol_upgrade_votes(
+        proposed_protocol_version: ProtocolVersion,
+        committee: &Committee,
+        capabilities: Vec<AuthorityCapabilitiesV1>,
+    ) -> Option<Vec<(Digest, Vec<(ObjectID, MovePackageDigest)>, u64)>> {
         // For each validator, gather the protocol version and system packages that it would like
         // to upgrade to in the next epoch.
         let mut desired_upgrades: Vec<_> = capabilities
@@ -529,51 +551,73 @@ impl AuthorityState {
             .collect();
 
         if desired_upgrades.is_empty() {
-            return (None, true);
+            return None;
         }
 
         // There can only be one set of votes that have a majority, find one if it exists.
         desired_upgrades.sort();
-        let res = desired_upgrades
-            .into_iter()
-            .chunk_by(|(digest, move_contracts_to_upgrade, _authority)| {
-                (*digest, move_contracts_to_upgrade.clone())
-            })
-            .into_iter()
-            .find_map(|((digest, move_contracts_to_upgrade), group)| {
-                let mut stake_aggregator: StakeAggregator<(), true> =
-                    StakeAggregator::new(Arc::new(committee.clone()));
-
-                for (_, _, authority) in group {
-                    stake_aggregator.insert_generic(authority, ());
-                }
-
-                let total_votes = stake_aggregator.total_votes();
-                let quorum_threshold = committee.quorum_threshold();
-                let f = committee.total_votes() - committee.quorum_threshold();
-
-                // multiply by buffer_stake_bps / 10000, rounded up.
-                let buffer_stake = (f * buffer_stake_bps).div_ceil(10000);
-                let effective_threshold = quorum_threshold + buffer_stake;
-                let has_support = total_votes >= effective_threshold;
-
-                info!(
-                    protocol_config_digest = ?digest,
-                    ?total_votes,
-                    ?quorum_threshold,
-                    ?buffer_stake_bps,
-                    ?effective_threshold,
-                    ?proposed_protocol_version,
-                    ?move_contracts_to_upgrade,
-                    has_support,
-                    "checking support for upgrade"
-                );
-
-                has_support.then_some(AuthorityCapabilitiesVotingResults {
-                    protocol_version: proposed_protocol_version,
-                    move_contracts_to_upgrade,
+        Some(
+            desired_upgrades
+                .into_iter()
+                .chunk_by(|(digest, move_contracts_to_upgrade, _authority)| {
+                    (*digest, move_contracts_to_upgrade.clone())
                 })
-            });
+                .into_iter()
+                .map(|((digest, move_contracts_to_upgrade), group)| {
+                    let mut stake_aggregator: StakeAggregator<(), true> =
+                        StakeAggregator::new(Arc::new(committee.clone()));
+
+                    for (_, _, authority) in group {
+                        stake_aggregator.insert_generic(authority, ());
+                    }
+
+                    (
+                        digest,
+                        move_contracts_to_upgrade,
+                        stake_aggregator.total_votes(),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    fn is_protocol_version_supported_v1(
+        proposed_protocol_version: ProtocolVersion,
+        committee: &Committee,
+        capabilities: Vec<AuthorityCapabilitiesV1>,
+        buffer_stake_bps: u64,
+    ) -> (Option<AuthorityCapabilitiesVotingResults>, bool) {
+        let effective_threshold =
+            Self::protocol_upgrade_effective_threshold(committee, buffer_stake_bps);
+
+        let Some(vote_groups) =
+            Self::tally_protocol_upgrade_votes(proposed_protocol_version, committee, capabilities)
+        else {
+            return (None, true);
+        };
+
+        let res =
+            vote_groups
+                .into_iter()
+                .find_map(|(digest, move_contracts_to_upgrade, total_votes)| {
+                    let has_support = total_votes >= effective_threshold;
+
+                    info!(
+                        protocol_config_digest = ?digest,
+                        ?total_votes,
+                        ?buffer_stake_bps,
+                        ?effective_threshold,
+                        ?proposed_protocol_version,
+                        ?move_contracts_to_upgrade,
+                        has_support,
+                        "checking support for upgrade"
+                    );
+
+                    has_support.then_some(AuthorityCapabilitiesVotingResults {
+                        protocol_version: proposed_protocol_version,
+                        move_contracts_to_upgrade,
+                    })
+                });
         (res, false)
     }
 

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -2186,6 +2186,47 @@ impl AuthorityPerEpochStore {
         self.metrics
             .effective_buffer_stake
             .set(self.get_effective_buffer_stake_bps() as i64);
+        self.update_protocol_upgrade_metrics();
+    }
+
+    /// Export the protocol-upgrade activation line and the current support
+    /// tally: effective_threshold = quorum + ceil(f * buffer_bps / 10000)
+    /// (the same formula `is_protocol_version_supported_v1` enforces), and
+    /// supporting_stake = stake whose consensus-recorded capabilities
+    /// advertise ANY version above the current protocol version. Called at
+    /// epoch-store open, on buffer-override changes, and on every capability
+    /// receipt - cheap (committee-sized scan of a per-epoch table).
+    fn update_protocol_upgrade_metrics(&self) {
+        let committee = self.committee();
+        let quorum = committee.quorum_threshold();
+        let f = committee.total_votes() - quorum;
+        let buffer = (f * self.get_effective_buffer_stake_bps()).div_ceil(10000);
+        self.metrics
+            .protocol_upgrade_effective_threshold
+            .set((quorum + buffer) as i64);
+        let current = self.protocol_version();
+        let Ok(capabilities) = self.get_capabilities_v1() else {
+            return;
+        };
+        let supporting: u64 = capabilities
+            .iter()
+            .filter(|cap| {
+                cap.supported_protocol_versions
+                    .versions
+                    .iter()
+                    .any(|(v, _)| *v > current)
+            })
+            .filter_map(|cap| {
+                committee
+                    .voting_rights
+                    .iter()
+                    .find(|(name, _)| *name == cap.authority)
+                    .map(|(_, stake)| *stake)
+            })
+            .sum();
+        self.metrics
+            .protocol_upgrade_supporting_stake
+            .set(supporting as i64);
     }
 
     pub fn get_effective_buffer_stake_bps(&self) -> u64 {
@@ -2220,6 +2261,7 @@ impl AuthorityPerEpochStore {
         tables
             .authority_capabilities_v1
             .insert(authority, capabilities)?;
+        self.update_protocol_upgrade_metrics();
         Ok(())
     }
 

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -1846,6 +1846,15 @@ impl AuthorityPerEpochStore {
         let epoch_start_configuration = Arc::new(epoch_start_configuration);
         metrics.current_epoch.set(epoch_id as i64);
         metrics
+            .committee_quorum_threshold
+            .set(committee.quorum_threshold() as i64);
+        metrics
+            .committee_validity_threshold
+            .set(committee.validity_threshold() as i64);
+        metrics
+            .committee_total_stake
+            .set(committee.total_votes() as i64);
+        metrics
             .current_voting_right
             .set(committee.weight(&name) as i64);
         // EpochMetrics is node-lifetime (shared across epoch stores), so the

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -2190,40 +2190,40 @@ impl AuthorityPerEpochStore {
     }
 
     /// Export the protocol-upgrade activation line and the current support
-    /// tally: effective_threshold = quorum + ceil(f * buffer_bps / 10000)
-    /// (the same formula `is_protocol_version_supported_v1` enforces), and
-    /// supporting_stake = stake whose consensus-recorded capabilities
-    /// advertise ANY version above the current protocol version. Called at
-    /// epoch-store open, on buffer-override changes, and on every capability
-    /// receipt - cheap (committee-sized scan of a per-epoch table).
+    /// tally, computed by the SAME shared functions the activation decision
+    /// uses (`AuthorityState::protocol_upgrade_effective_threshold` /
+    /// `tally_protocol_upgrade_votes`) - no duplicated formula to drift.
+    /// Supporting stake is the strongest same-(digest, contracts) vote group
+    /// for the next protocol version, exactly the quantity the decision
+    /// compares against the threshold. Called at epoch-store open, on
+    /// buffer-override changes, and on every capability receipt - cheap
+    /// (committee-sized scan of a per-epoch table).
     fn update_protocol_upgrade_metrics(&self) {
         let committee = self.committee();
-        let quorum = committee.quorum_threshold();
-        let f = committee.total_votes() - quorum;
-        let buffer = (f * self.get_effective_buffer_stake_bps()).div_ceil(10000);
+        let effective_threshold =
+            crate::authority::AuthorityState::protocol_upgrade_effective_threshold(
+                committee,
+                self.get_effective_buffer_stake_bps(),
+            );
         self.metrics
             .protocol_upgrade_effective_threshold
-            .set((quorum + buffer) as i64);
-        let current = self.protocol_version();
+            .set(effective_threshold as i64);
         let Ok(capabilities) = self.get_capabilities_v1() else {
             return;
         };
-        let supporting: u64 = capabilities
-            .iter()
-            .filter(|cap| {
-                cap.supported_protocol_versions
-                    .versions
-                    .iter()
-                    .any(|(v, _)| *v > current)
-            })
-            .filter_map(|cap| {
-                committee
-                    .voting_rights
-                    .iter()
-                    .find(|(name, _)| *name == cap.authority)
-                    .map(|(_, stake)| *stake)
-            })
-            .sum();
+        let supporting = crate::authority::AuthorityState::tally_protocol_upgrade_votes(
+            self.protocol_version() + 1,
+            committee,
+            capabilities,
+        )
+        .map(|groups| {
+            groups
+                .into_iter()
+                .map(|(_, _, stake)| stake)
+                .max()
+                .unwrap_or(0)
+        })
+        .unwrap_or(0);
         self.metrics
             .protocol_upgrade_supporting_stake
             .set(supporting as i64);

--- a/crates/ika-core/src/epoch/epoch_metrics.rs
+++ b/crates/ika-core/src/epoch/epoch_metrics.rs
@@ -69,6 +69,12 @@ pub struct EpochMetrics {
     /// The active committee's total voting stake (3f+1-ish; unit stake =>
     /// committee size).
     pub committee_total_stake: IntGauge,
+    /// The protocol-version range THIS binary advertises in its capability
+    /// votes (constant per process). Fleet aggregation of `..._max` against
+    /// committee_quorum_threshold + ika_effective_buffer_stake shows exactly
+    /// how much stake still has to upgrade before the next version arms.
+    pub supported_protocol_version_min: IntGauge,
+    pub supported_protocol_version_max: IntGauge,
 
     /// Epoch of the most recent mpc_data freeze observed locally. Alert when
     /// it lags `current_epoch` well past the freeze grace window — a freeze
@@ -209,6 +215,18 @@ impl EpochMetrics {
             committee_total_stake: register_int_gauge_with_registry!(
                 "ika_committee_total_stake",
                 "Active committee total voting stake",
+                registry,
+            )
+            .unwrap(),
+            supported_protocol_version_min: register_int_gauge_with_registry!(
+                "ika_supported_protocol_version_min",
+                "Lowest protocol version this binary advertises support for",
+                registry,
+            )
+            .unwrap(),
+            supported_protocol_version_max: register_int_gauge_with_registry!(
+                "ika_supported_protocol_version_max",
+                "Highest protocol version this binary advertises support for",
                 registry,
             )
             .unwrap(),

--- a/crates/ika-core/src/epoch/epoch_metrics.rs
+++ b/crates/ika-core/src/epoch/epoch_metrics.rs
@@ -75,6 +75,15 @@ pub struct EpochMetrics {
     /// how much stake still has to upgrade before the next version arms.
     pub supported_protocol_version_min: IntGauge,
     pub supported_protocol_version_max: IntGauge,
+    /// The stake required to arm the next protocol version:
+    /// quorum_threshold + ceil(f * buffer_stake_bps / 10000). THE activation
+    /// line - compare protocol_upgrade_supporting_stake against it.
+    pub protocol_upgrade_effective_threshold: IntGauge,
+    /// Stake whose consensus-recorded capability votes advertise support for
+    /// a version ABOVE the current protocol version. When this crosses
+    /// protocol_upgrade_effective_threshold, the upgrade arms and activates
+    /// at the next epoch boundary.
+    pub protocol_upgrade_supporting_stake: IntGauge,
 
     /// Epoch of the most recent mpc_data freeze observed locally. Alert when
     /// it lags `current_epoch` well past the freeze grace window — a freeze
@@ -227,6 +236,18 @@ impl EpochMetrics {
             supported_protocol_version_max: register_int_gauge_with_registry!(
                 "ika_supported_protocol_version_max",
                 "Highest protocol version this binary advertises support for",
+                registry,
+            )
+            .unwrap(),
+            protocol_upgrade_effective_threshold: register_int_gauge_with_registry!(
+                "ika_protocol_upgrade_effective_threshold",
+                "Stake required to arm the next protocol version (quorum + buffer)",
+                registry,
+            )
+            .unwrap(),
+            protocol_upgrade_supporting_stake: register_int_gauge_with_registry!(
+                "ika_protocol_upgrade_supporting_stake",
+                "Stake whose capability votes support a version above the current one",
                 registry,
             )
             .unwrap(),

--- a/crates/ika-core/src/epoch/epoch_metrics.rs
+++ b/crates/ika-core/src/epoch/epoch_metrics.rs
@@ -59,6 +59,16 @@ pub struct EpochMetrics {
 
     /// Buffer stake current in effect for this epoch
     pub effective_buffer_stake: IntGauge,
+    /// The active committee's quorum threshold (2f+1 in stake units). With
+    /// unit stake this pairs with total_stake to draw activation lines
+    /// (e.g. protocol upgrades need quorum + buffer, see
+    /// ika_effective_buffer_stake) without dashboards re-deriving BFT math.
+    pub committee_quorum_threshold: IntGauge,
+    /// The active committee's validity threshold (f+1 in stake units).
+    pub committee_validity_threshold: IntGauge,
+    /// The active committee's total voting stake (3f+1-ish; unit stake =>
+    /// committee size).
+    pub committee_total_stake: IntGauge,
 
     /// Epoch of the most recent mpc_data freeze observed locally. Alert when
     /// it lags `current_epoch` well past the freeze grace window — a freeze
@@ -182,6 +192,24 @@ impl EpochMetrics {
                 "ika_dwallet_mpc_data_freeze_epoch",
                 "Epoch of the most recent mpc_data freeze observed locally",
                 registry
+            )
+            .unwrap(),
+            committee_quorum_threshold: register_int_gauge_with_registry!(
+                "ika_committee_quorum_threshold",
+                "Active committee quorum threshold (2f+1) in stake units",
+                registry,
+            )
+            .unwrap(),
+            committee_validity_threshold: register_int_gauge_with_registry!(
+                "ika_committee_validity_threshold",
+                "Active committee validity threshold (f+1) in stake units",
+                registry,
+            )
+            .unwrap(),
+            committee_total_stake: register_int_gauge_with_registry!(
+                "ika_committee_total_stake",
+                "Active committee total voting stake",
+                registry,
             )
             .unwrap(),
             dwallet_mpc_data_excluded_validators: register_int_gauge_with_registry!(


### PR DESCRIPTION
Adds three gauges, set at every epoch-store open beside `ika_effective_buffer_stake`:

- `ika_committee_quorum_threshold` — 2f+1 in stake units
- `ika_committee_validity_threshold` — f+1
- `ika_committee_total_stake` — total voting stake

Motivation: today these are only *derivable* from committee row counts under the unit-stake assumption — which silently breaks if stake-weighting ever changes — and questions like 'how much stake arms the protocol-5 flip' (quorum + ⌈f×buffer_bps/10000⌉ = 39 of 46 on the current testnet committee) have to be computed by hand. With these exported, the version-rollout dashboard can draw the activation line directly.

Metrics-only: no behavior change, values come from the `Committee` fields the epoch store already holds. `cargo check -p ika-core` green; metric-name convention check green. Intended for the **v1.2.3** cut (tag not yet pushed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Extended with the Q2 half — advertised capability range**: `ika_supported_protocol_version_{min,max}`, set once at `AuthorityState` construction. Fleet aggregation of `..._max` against the committee threshold gauges turns upgrade-activation progress into a direct query — e.g. `count(ika_supported_protocol_version_max >= 5)` vs `ika_committee_quorum_threshold + ceil(f × ika_effective_buffer_stake/10000)` — instead of inferring capability votes from binary-version strings.


**And the direct "X of Y" pair**: `ika_protocol_upgrade_effective_threshold` (quorum + ⌈f×buffer_bps/10000⌉ — computed by the same code that enforces it in `is_protocol_version_supported_v1`, so the dashboard can never drift from the tally) and `ika_protocol_upgrade_supporting_stake` (stake whose **consensus-recorded capability votes** advertise a version above the current one — the true tally source rather than any proxy). Updated at epoch open, on buffer-override changes, and on every capability receipt. The upgrade-progress panel becomes literally `supporting_stake / effective_threshold`.
