### PR TITLE
fix(dwallet-mpc): cert-sourced current-epoch validator MPC keys + crash-atomic freeze writes (mid-epoch restart wedge)

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -1314,7 +1314,11 @@ pub struct AuthorityEpochTables {
     /// recorded in `epoch_excluded_validators` instead.
     /// Empty until quorum; populated once and never modified within
     /// the epoch (`freeze_mpc_data_if_first` is idempotent on a
-    /// non-empty table).
+    /// non-empty table). Written through the freeze commit's
+    /// `ConsensusCommitOutput` batch — never per-row — so the whole
+    /// partition lands atomically with the commit's processed-markers
+    /// (issue #1829: a partial write latched a shrunken, divergent
+    /// frozen set forever).
     pub(crate) frozen_validator_mpc_data_input_set: DBMap<AuthorityName, [u8; 32]>,
 
     /// Announcers that crossed the freeze gate's "announcement
@@ -3714,7 +3718,11 @@ impl AuthorityPerEpochStore {
             .collect())
     }
 
-    fn freeze_mpc_data_if_first(&self, tables: &AuthorityEpochTables) -> IkaResult {
+    fn freeze_mpc_data_if_first(
+        &self,
+        tables: &AuthorityEpochTables,
+        output: &mut ConsensusCommitOutput,
+    ) -> IkaResult {
         if !tables.frozen_validator_mpc_data_input_set.is_empty() {
             return Ok(());
         }
@@ -3771,20 +3779,22 @@ impl AuthorityPerEpochStore {
             excluded_set = ?partition.excluded,
             "ready quorum reached — freezing attestation-validated mpc_data input set (stable carry-forward applied)"
         );
-        for (authority, blob_hash) in &partition.frozen {
-            tables
-                .frozen_validator_mpc_data_input_set
-                .insert(authority, blob_hash)?;
-        }
-        for authority in &partition.excluded {
-            tables.epoch_excluded_validators.insert(authority, &())?;
-        }
         self.metrics
             .dwallet_mpc_data_freeze_epoch
             .set(self.epoch() as i64);
         self.metrics
             .dwallet_mpc_data_excluded_validators
             .set(partition.excluded.len() as i64);
+        // Persist through the commit's batch, NOT per-row inserts: the frozen
+        // + excluded rows must land atomically with this commit's
+        // processed-markers (`last_consensus_stats`). A crash between per-row
+        // inserts left a strict subset latched as frozen forever — the
+        // non-empty-table idempotence guard above stopped the replayed commit
+        // from re-firing, and the shrunken set byte-diverged this validator's
+        // reconfiguration output from the committee's (issue #1829). With the
+        // batch, a crash before the write replays the whole commit and the
+        // freeze re-fires cleanly; after it, the full partition is on disk.
+        output.set_mpc_data_freeze_partition(partition);
         Ok(())
     }
 
@@ -3840,6 +3850,17 @@ impl AuthorityPerEpochStore {
     pub(crate) fn epoch_first_commit_timestamp_ms(&self) -> IkaResult<Option<u64>> {
         self.tables()?
             .epoch_first_commit_timestamp_ms
+            .get(&0)
+            .map_err(IkaError::from)
+    }
+
+    /// The consensus round at which this epoch's mpc_data ready-signal
+    /// stake quorum was first observed (the freeze-grace anchor, written
+    /// with that commit's batch), or `None` if quorum hasn't been reached.
+    /// Consensus-anchored: identical across honest validators.
+    pub(crate) fn mpc_data_ready_quorum_round(&self) -> IkaResult<Option<u64>> {
+        self.tables()?
+            .mpc_data_ready_quorum_round
             .get(&0)
             .map_err(IkaError::from)
     }
@@ -4634,7 +4655,7 @@ impl AuthorityPerEpochStore {
                 let grace_elapsed = consensus_commit_info.round.saturating_sub(quorum_round)
                     >= self.protocol_config().mpc_data_freeze_grace_rounds();
                 if full_coverage || grace_elapsed {
-                    self.freeze_mpc_data_if_first(&tables)?;
+                    self.freeze_mpc_data_if_first(&tables, output)?;
                     info!(
                         validator = ?self.name,
                         quorum_round,
@@ -5431,6 +5452,14 @@ pub(crate) struct ConsensusCommitOutput {
     /// (the ready-signal backstop anchor). Set only on the commit observed
     /// first; same atomicity rationale as `mpc_data_ready_quorum_round`.
     epoch_first_commit_timestamp_ms: Option<u64>,
+
+    /// The mpc_data freeze partition decided at this commit's boundary
+    /// (`freeze_mpc_data_if_first`), or `None` when the freeze didn't fire
+    /// at this commit. Written to `frozen_validator_mpc_data_input_set` +
+    /// `epoch_excluded_validators` in the SAME batch as the commit's
+    /// processed-markers: a partially-persisted freeze is a divergent
+    /// (shrunken) frozen set on this validator only (issue #1829).
+    mpc_data_freeze_partition: Option<crate::validator_metadata::FreezePartition>,
 }
 
 impl ConsensusCommitOutput {
@@ -5455,6 +5484,13 @@ impl ConsensusCommitOutput {
 
     pub(crate) fn set_mpc_data_ready_quorum_round(&mut self, round: u64) {
         self.mpc_data_ready_quorum_round = Some(round);
+    }
+
+    pub(crate) fn set_mpc_data_freeze_partition(
+        &mut self,
+        partition: crate::validator_metadata::FreezePartition,
+    ) {
+        self.mpc_data_freeze_partition = Some(partition);
     }
 
     pub(crate) fn set_epoch_first_commit_timestamp_ms(&mut self, timestamp_ms: u64) {
@@ -5620,6 +5656,19 @@ impl ConsensusCommitOutput {
         }
         if let Some(round) = self.mpc_data_ready_quorum_round {
             batch.insert_batch(&tables.mpc_data_ready_quorum_round, [(0u64, round)])?;
+        }
+        if let Some(partition) = self.mpc_data_freeze_partition {
+            batch.insert_batch(
+                &tables.frozen_validator_mpc_data_input_set,
+                partition.frozen,
+            )?;
+            batch.insert_batch(
+                &tables.epoch_excluded_validators,
+                partition
+                    .excluded
+                    .into_iter()
+                    .map(|authority| (authority, ())),
+            )?;
         }
         if let Some(timestamp_ms) = self.epoch_first_commit_timestamp_ms {
             batch.insert_batch(

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/mid_epoch_restart_keys.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/mid_epoch_restart_keys.rs
@@ -1,0 +1,316 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Regression tests for issue #1879: the manager must acquire the CURRENT
+//! epoch's validator MPC key bundle from durable, consensus-agreed state —
+//! the prior epoch's handoff certificate plus the perpetual blob store —
+//! because the production watch-channel delivery happens once, in a boundary
+//! window a mid-epoch restart cannot replay (the channel is process-local).
+//! The tests also pin the divergence guard: with a prior cert present, the
+//! manager must NEVER fall back to the channel, whose post-freeze content
+//! (the current epoch's frozen set) can be a strict superset of the boundary
+//! set the rest of the committee latched.
+
+use crate::authority::authority_perpetual_tables::AuthorityPerpetualTables;
+use crate::dwallet_mpc::authority_name_to_party_id_from_committee;
+use crate::dwallet_mpc::integration_tests::utils;
+use crate::dwallet_mpc::integration_tests::utils::create_test_protocol_config_guard;
+use crate::validator_metadata::OffChainCommitteeBundles;
+use dwallet_mpc_types::dwallet_mpc::{MPCDataV1, VersionedMPCData};
+use ika_network::mpc_artifacts::mpc_data_blob_hash;
+use ika_types::committee::ValidatorEncryptionKeysAndProofs;
+use ika_types::crypto::AuthorityName;
+use ika_types::handoff::{CertifiedHandoffAttestation, HandoffAttestation, HandoffItemKey};
+use std::sync::Arc;
+
+/// Rebuilds a validator's canonical mpc_data blob (`VersionedMPCData::V1`
+/// over `ValidatorEncryptionKeysAndProofs`) from the test bundles — the same
+/// bytes `derive_mpc_data_blob` produces from the validator's root seed,
+/// without re-running the class-groups derivation.
+fn mpc_data_blob_for(bundles: &OffChainCommitteeBundles, authority: &AuthorityName) -> Vec<u8> {
+    let keys = ValidatorEncryptionKeysAndProofs {
+        class_groups: bundles.class_groups[authority].clone(),
+        secp256k1_pvss: bundles.secp256k1_pvss[authority].clone(),
+        secp256r1_pvss: bundles.secp256r1_pvss[authority].clone(),
+        ristretto_pvss: bundles.ristretto_pvss[authority].clone(),
+        vss_hpke_public_key_and_proof: bundles.vss_hpke[authority].clone(),
+    };
+    let mpc_data_bytes = bcs::to_bytes(&keys).expect("encode ValidatorEncryptionKeysAndProofs");
+    bcs::to_bytes(&VersionedMPCData::V1(MPCDataV1 { mpc_data_bytes })).expect("encode blob")
+}
+
+fn cert_with_mpc_data(
+    prior_epoch: u64,
+    entries: &[(AuthorityName, [u8; 32])],
+) -> CertifiedHandoffAttestation {
+    CertifiedHandoffAttestation {
+        attestation: HandoffAttestation {
+            epoch: prior_epoch,
+            next_committee_pubkey_set_hash: [0u8; 32],
+            items: entries
+                .iter()
+                .map(|(validator, digest)| {
+                    (
+                        HandoffItemKey::ValidatorMpcData {
+                            validator: *validator,
+                        },
+                        *digest,
+                    )
+                })
+                .collect(),
+        },
+        signatures: vec![],
+    }
+}
+
+/// The mid-epoch-restart shape: a fresh process has NOTHING on the
+/// current-epoch key channel (it is process-local, and the boundary-window
+/// delivery already happened in the previous process's lifetime). With the
+/// prior epoch's cert and the blobs in the perpetual store — both of which
+/// survive a restart — ingestion must complete anyway.
+#[tokio::test]
+async fn mid_epoch_restart_ingests_keys_without_channel_delivery() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard();
+
+    let (committee, seeds, bundles) = utils::build_committee_with_random_seeds(4);
+    let (mut services, sui_data_senders, _stores, epoch_stores, ..) =
+        utils::create_dwallet_mpc_services_with_committee_and_seeds(
+            committee.clone(),
+            seeds,
+            bundles.clone(),
+        );
+    let service = services.first_mut().unwrap();
+    let epoch_id = service.dwallet_mpc_manager().epoch_id;
+    let prior_epoch = epoch_id - 1;
+
+    // Simulate the restart: clear the helper's pre-seeded channel delivery —
+    // a fresh process's watch channel starts empty.
+    let _ = sui_data_senders
+        .first()
+        .unwrap()
+        .current_epoch_mpc_keys_sender
+        .send(None);
+
+    let perpetual_dir = tempfile::tempdir().expect("tempdir");
+    let perpetual = Arc::new(AuthorityPerpetualTables::open(perpetual_dir.path(), None));
+    let members: Vec<AuthorityName> = committee
+        .voting_rights
+        .iter()
+        .map(|(name, _)| *name)
+        .collect();
+    let cert_entries: Vec<(AuthorityName, [u8; 32])> = members
+        .iter()
+        .map(|authority| {
+            let blob = mpc_data_blob_for(&bundles, authority);
+            let digest = mpc_data_blob_hash(&blob);
+            perpetual
+                .insert_mpc_artifact_blob(digest, &blob)
+                .expect("blob insert");
+            (*authority, digest)
+        })
+        .collect();
+    let epoch_store = epoch_stores.first().unwrap();
+    epoch_store
+        .perpetual_tables
+        .lock()
+        .unwrap()
+        .replace(perpetual);
+    epoch_store
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(prior_epoch, cert_with_mpc_data(prior_epoch, &cert_entries));
+
+    let manager = service.dwallet_mpc_manager_mut();
+    manager
+        .ingest_offchain_mpc_keys()
+        .expect("ingest_offchain_mpc_keys");
+    assert!(
+        manager.current_epoch_keys_ingested,
+        "cert + perpetual blobs must suffice to ingest the current-epoch keys \
+         with an empty channel (the mid-epoch-restart shape)"
+    );
+    assert_eq!(
+        manager.validator_mpc_keys_by_party_id.secp256k1_pvss.len(),
+        members.len(),
+        "every cert-covered committee member must be dealt"
+    );
+    assert_eq!(
+        manager
+            .validator_mpc_keys_by_party_id
+            .vss_hpke_verified_party_encryption_key_values
+            .len(),
+        members.len(),
+        "the VSS HPKE keys (consumed by VSS presign public inputs) must be \
+         rebuilt from the cert-sourced bundle"
+    );
+}
+
+/// With a prior cert present, the cert set is authoritative even when the
+/// channel holds a WIDER bundle. Production shape: the channel's post-freeze
+/// content is the current epoch's frozen set, which in a joiner-churn epoch
+/// is a strict superset of the boundary set the rest of the committee
+/// latched — ingesting it would byte-diverge this validator's VSS presign
+/// public inputs from every peer's.
+#[tokio::test]
+async fn prior_cert_set_wins_over_wider_channel_bundle() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard();
+
+    let (committee, seeds, bundles) = utils::build_committee_with_random_seeds(4);
+    let (mut services, _senders, _stores, epoch_stores, ..) =
+        utils::create_dwallet_mpc_services_with_committee_and_seeds(
+            committee.clone(),
+            seeds,
+            bundles.clone(),
+        );
+    let service = services.first_mut().unwrap();
+    let epoch_id = service.dwallet_mpc_manager().epoch_id;
+    let prior_epoch = epoch_id - 1;
+
+    // The service helper pre-seeded the channel with the FULL 4-member
+    // bundle; the cert covers only 3 (the fourth is the excluded-joiner
+    // shape — no prior-cert digest).
+    let members: Vec<AuthorityName> = committee
+        .voting_rights
+        .iter()
+        .map(|(name, _)| *name)
+        .collect();
+    let covered = &members[..3];
+    let uncovered_member = members[3];
+
+    let perpetual_dir = tempfile::tempdir().expect("tempdir");
+    let perpetual = Arc::new(AuthorityPerpetualTables::open(perpetual_dir.path(), None));
+    let cert_entries: Vec<(AuthorityName, [u8; 32])> = covered
+        .iter()
+        .map(|authority| {
+            let blob = mpc_data_blob_for(&bundles, authority);
+            let digest = mpc_data_blob_hash(&blob);
+            perpetual
+                .insert_mpc_artifact_blob(digest, &blob)
+                .expect("blob insert");
+            (*authority, digest)
+        })
+        .collect();
+    let epoch_store = epoch_stores.first().unwrap();
+    epoch_store
+        .perpetual_tables
+        .lock()
+        .unwrap()
+        .replace(perpetual);
+    epoch_store
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(prior_epoch, cert_with_mpc_data(prior_epoch, &cert_entries));
+
+    let manager = service.dwallet_mpc_manager_mut();
+    manager
+        .ingest_offchain_mpc_keys()
+        .expect("ingest_offchain_mpc_keys");
+    assert!(manager.current_epoch_keys_ingested);
+    assert_eq!(
+        manager.validator_mpc_keys_by_party_id.secp256k1_pvss.len(),
+        covered.len(),
+        "the ingested set must be the cert set (3 members), not the wider \
+         channel bundle (4 members)"
+    );
+    let uncovered_party =
+        authority_name_to_party_id_from_committee(&committee, &uncovered_member).expect("party id");
+    assert!(
+        !manager
+            .validator_mpc_keys_by_party_id
+            .secp256k1_pvss
+            .contains_key(&uncovered_party),
+        "a member without a prior-cert digest must not be dealt, even though \
+         the channel bundle carries its keys"
+    );
+}
+
+/// A missing blob for a cert-pinned digest must DEFER ingestion (retry when
+/// the blob propagates), never fall back to the channel — the channel bundle
+/// is not the committee-agreed set whenever a cert exists.
+#[tokio::test]
+async fn missing_prior_cert_blob_defers_without_channel_fallback() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard();
+
+    let (committee, seeds, bundles) = utils::build_committee_with_random_seeds(4);
+    let (mut services, _senders, _stores, epoch_stores, ..) =
+        utils::create_dwallet_mpc_services_with_committee_and_seeds(
+            committee.clone(),
+            seeds,
+            bundles.clone(),
+        );
+    let service = services.first_mut().unwrap();
+    let epoch_id = service.dwallet_mpc_manager().epoch_id;
+    let prior_epoch = epoch_id - 1;
+
+    let perpetual_dir = tempfile::tempdir().expect("tempdir");
+    let perpetual = Arc::new(AuthorityPerpetualTables::open(perpetual_dir.path(), None));
+    let members: Vec<AuthorityName> = committee
+        .voting_rights
+        .iter()
+        .map(|(name, _)| *name)
+        .collect();
+    // Cert pins all four members, but only three blobs are locally present.
+    let mut withheld_blob: Option<([u8; 32], Vec<u8>)> = None;
+    let cert_entries: Vec<(AuthorityName, [u8; 32])> = members
+        .iter()
+        .enumerate()
+        .map(|(index, authority)| {
+            let blob = mpc_data_blob_for(&bundles, authority);
+            let digest = mpc_data_blob_hash(&blob);
+            if index == 3 {
+                withheld_blob = Some((digest, blob));
+            } else {
+                perpetual
+                    .insert_mpc_artifact_blob(digest, &blob)
+                    .expect("blob insert");
+            }
+            (*authority, digest)
+        })
+        .collect();
+    let epoch_store = epoch_stores.first().unwrap();
+    epoch_store
+        .perpetual_tables
+        .lock()
+        .unwrap()
+        .replace(perpetual.clone());
+    epoch_store
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(prior_epoch, cert_with_mpc_data(prior_epoch, &cert_entries));
+
+    let manager = service.dwallet_mpc_manager_mut();
+    manager
+        .ingest_offchain_mpc_keys()
+        .expect("ingest_offchain_mpc_keys");
+    assert!(
+        !manager.current_epoch_keys_ingested,
+        "a missing cert-pinned blob must defer ingestion — falling back to \
+         the channel's complete bundle here would ingest a set the committee \
+         did not agree on"
+    );
+
+    // The blob propagates (production: P2P fetch / consensus replication) —
+    // the next service iteration completes the ingest.
+    let (digest, blob) = withheld_blob.expect("withheld blob");
+    perpetual
+        .insert_mpc_artifact_blob(digest, &blob)
+        .expect("late blob insert");
+    let manager = services.first_mut().unwrap().dwallet_mpc_manager_mut();
+    manager
+        .ingest_offchain_mpc_keys()
+        .expect("ingest_offchain_mpc_keys");
+    assert!(
+        manager.current_epoch_keys_ingested,
+        "ingestion must complete once the missing blob lands"
+    );
+    assert_eq!(
+        manager.validator_mpc_keys_by_party_id.secp256k1_pvss.len(),
+        members.len(),
+    );
+}

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
@@ -8,6 +8,7 @@ mod internal_presign;
 mod late_reconfiguration_output;
 mod malicious_behavior;
 mod message_before_event;
+mod mid_epoch_restart_keys;
 mod missing_network_key;
 mod network_dkg;
 mod network_dkg_bwd_compat;

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -32,6 +32,7 @@ use crate::dwallet_mpc::{
 };
 use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionRequestMetricData};
 use crate::network_key_id_mapping::network_key_id_for;
+use crate::validator_metadata::{OffChainMpcDataAssembly, assemble_committee_mpc_data_off_chain};
 use arc_swap::ArcSwap;
 use dwallet_classgroups_types::ValidatorMPCSecrets;
 use dwallet_mpc_types::dwallet_mpc::{
@@ -137,6 +138,25 @@ pub(crate) struct ParkedInternalPresignRequest(pub(crate) Box<DWalletSessionRequ
 /// — Executing all active sessions, and
 /// — (De)activating sessions.
 ///
+/// Outcome of one attempt to source the CURRENT epoch's validator MPC keys
+/// from the prior epoch's handoff certificate
+/// (`DWalletMPCManager::try_ingest_current_epoch_keys_from_prior_handoff_cert`).
+enum PriorCertKeysOutcome {
+    /// Keys assembled and ingested; `current_epoch_keys_ingested` is set.
+    Ingested,
+    /// The prior epoch has no handoff certificate (or none observable yet):
+    /// genesis, a pre-v4 prior epoch, a cert without mpc_data items, or a
+    /// cold start whose bootstrap fetch hasn't landed the cert. The caller
+    /// may consult the freeze-gated `current_epoch_mpc_keys` channel this
+    /// iteration; the cert path re-runs next iteration regardless.
+    NoPriorCert,
+    /// Transient miss with the cert PRESENT (store read error, perpetual
+    /// handle not installed, blobs still propagating). Retry next service
+    /// iteration WITHOUT falling back to the channel — see the divergence
+    /// note at the call site.
+    RetryLater,
+}
+
 /// The correct way to use the manager is to create it along with all other Ika components
 /// at the start of each epoch.
 /// Ensuring it is destroyed when the epoch ends and providing a clean slate for each new epoch.
@@ -164,11 +184,14 @@ pub(crate) struct DWalletMPCManager {
     /// `class_groups` straight off the on-chain committee (the bare key Sui
     /// already carries), with empty PVSS/VSS — all the backward-compatible DKG
     /// needs. At version 3 it starts empty and the whole set (class_groups
-    /// included) is read from the `current_epoch_mpc_keys` channel by
-    /// `ingest_offchain_mpc_keys` once the consensus freeze decides the agreed
-    /// set. That agreed set may legitimately omit offline/withholding validators
-    /// — the DKG deals only to the parties that have keys. Passed to
-    /// `session_input_from_request` per session-input construction.
+    /// included) is filled by `ingest_offchain_mpc_keys`: primarily assembled
+    /// from the prior epoch's handoff certificate (restart-safe — issue
+    /// #1879), falling back to the `current_epoch_mpc_keys` channel (fed once
+    /// the consensus freeze decides the agreed set) only in the chain-true
+    /// no-cert epochs. That agreed set may legitimately omit
+    /// offline/withholding validators — the DKG deals only to the parties
+    /// that have keys. Passed to `session_input_from_request` per
+    /// session-input construction.
     pub(crate) validator_mpc_keys_by_party_id: ValidatorMpcKeysByPartyId,
     /// Set once the current epoch's off-chain key set has been ingested (the
     /// consensus-frozen agreed set). Gates session initiation so the DKG never
@@ -304,6 +327,13 @@ pub(crate) struct DWalletMPCManager {
     /// otherwise warn ~50x/second; warn at most every 10s (debug in
     /// between). The retry behavior itself is unthrottled.
     last_cert_read_warn: Option<Instant>,
+
+    /// Last time the prior-cert current-epoch key ingestion warned about
+    /// a retryable miss (cert read error, missing perpetual handle, or
+    /// missing/undecodable mpc_data blobs). Same 20ms-loop rationale as
+    /// `last_cert_read_warn`: warn at most every 10s, debug in between;
+    /// the retry itself is unthrottled.
+    last_prior_cert_keys_warn: Option<Instant>,
 
     /// `(key_id, local output digest)` pairs whose contradiction with the
     /// prior epoch's handoff cert was already warned about. The adoption
@@ -616,6 +646,7 @@ impl DWalletMPCManager {
             last_instantiated_network_key_data: HashMap::new(),
             pending_network_key_instantiations: HashMap::new(),
             last_cert_read_warn: None,
+            last_prior_cert_keys_warn: None,
             warned_cert_digest_mismatches: HashSet::new(),
             network_key_id_derivations_spawned: HashMap::new(),
             stranded_network_keys,
@@ -1089,37 +1120,68 @@ impl DWalletMPCManager {
     }
 
     /// Ingest the per-epoch off-chain validator MPC keys (3 PVSS HPKE + VSS
-    /// HPKE) delivered on the `current_epoch_mpc_keys` / `next_epoch_mpc_keys`
-    /// channels into `validator_mpc_keys_by_party_id` (current) and
+    /// HPKE) into `validator_mpc_keys_by_party_id` (current) and
     /// `next_epoch_validator_mpc_keys` (next).
     ///
-    /// The producer only delivers a bundle once the per-epoch set is frozen by
-    /// consensus (a stake-quorum of `EpochMpcDataReadySignal`s), so the delivered
-    /// bundle IS the agreed set. We ingest it **once** and do NOT re-impose an
-    /// all-committee completeness check: the agreed set may legitimately omit
+    /// CURRENT epoch: the primary source is the prior epoch's handoff
+    /// certificate (`try_ingest_current_epoch_keys_from_prior_handoff_cert`)
+    /// — the perpetual, quorum-signed pin of the prior epoch's frozen set,
+    /// which is the committee-agreed value of this epoch's key set and is
+    /// reachable after a mid-epoch restart (issue #1879). Only in the
+    /// chain-true no-cert epochs (genesis, first epoch after the off-chain
+    /// pipeline activated) does it fall back to the `current_epoch_mpc_keys`
+    /// channel, whose producer delivers once THIS epoch's set is frozen by
+    /// consensus (a stake-quorum of `EpochMpcDataReadySignal`s).
+    ///
+    /// NEXT epoch: delivered on the `next_epoch_mpc_keys` channel from this
+    /// epoch's post-freeze assembly.
+    ///
+    /// Either way we ingest **once** and do NOT re-impose an all-committee
+    /// completeness check: the agreed set may legitimately omit
     /// offline/withholding validators, and the DKG/reconfig deal only to the
     /// parties that have keys (the rest stay active in consensus, just undealt).
-    /// `class_groups` still comes from the committee.
     pub(crate) fn ingest_offchain_mpc_keys(&mut self) -> DwalletMPCResult<()> {
         // Current epoch: fill the within-epoch network DKG key set, once.
         if !self.current_epoch_keys_ingested {
-            let delivered = self
-                .sui_data_receivers
-                .current_epoch_mpc_keys_receiver
-                .borrow()
-                .clone();
-            if let Some((epoch, bundles)) = delivered
-                && epoch == self.epoch_id
-            {
-                self.validator_mpc_keys_by_party_id =
-                    get_validator_mpc_keys_by_party_id(&self.committee, &bundles)?;
-                self.current_epoch_keys_ingested = true;
-                info!(
-                    epoch = self.epoch_id,
-                    dealt = self.validator_mpc_keys_by_party_id.secp256k1_pvss.len(),
-                    committee = self.committee.voting_rights.len(),
-                    "ingested current-epoch off-chain validator MPC keys (agreed frozen set)"
-                );
+            // The cert path only applies at network-key version 3 (the
+            // off-chain pipeline); at version 2 the construction already
+            // seeded `class_groups` from the on-chain committee and a cert
+            // ingest would overwrite it with the wrong source/shape.
+            let cert_outcome = if self.protocol_config.is_network_encryption_key_version_v3() {
+                self.try_ingest_current_epoch_keys_from_prior_handoff_cert()?
+            } else {
+                PriorCertKeysOutcome::NoPriorCert
+            };
+            match cert_outcome {
+                PriorCertKeysOutcome::Ingested => {}
+                // Transient cert-path miss: retry next iteration WITHOUT
+                // falling back to the channel. Post-freeze the channel
+                // carries THIS epoch's frozen set, which in a joiner-churn
+                // epoch is a strict superset of the boundary set the rest
+                // of the committee latched at the flip — ingesting it here
+                // would byte-diverge this validator's VSS presign public
+                // inputs from every peer's.
+                PriorCertKeysOutcome::RetryLater => {}
+                PriorCertKeysOutcome::NoPriorCert => {
+                    let delivered = self
+                        .sui_data_receivers
+                        .current_epoch_mpc_keys_receiver
+                        .borrow()
+                        .clone();
+                    if let Some((epoch, bundles)) = delivered
+                        && epoch == self.epoch_id
+                    {
+                        self.validator_mpc_keys_by_party_id =
+                            get_validator_mpc_keys_by_party_id(&self.committee, &bundles)?;
+                        self.current_epoch_keys_ingested = true;
+                        info!(
+                            epoch = self.epoch_id,
+                            dealt = self.validator_mpc_keys_by_party_id.secp256k1_pvss.len(),
+                            committee = self.committee.voting_rights.len(),
+                            "ingested current-epoch off-chain validator MPC keys (agreed frozen set)"
+                        );
+                    }
+                }
             }
         }
 
@@ -1150,6 +1212,164 @@ impl DWalletMPCManager {
         }
 
         Ok(())
+    }
+
+    /// Assembles the CURRENT epoch's validator MPC key bundle from the prior
+    /// epoch's handoff certificate (`ValidatorMpcData` items ∩ current
+    /// committee) against the perpetual content-addressed blob store, and
+    /// ingests it into `validator_mpc_keys_by_party_id`.
+    ///
+    /// WHY the cert: the committee-agreed value of the current epoch's key
+    /// set is the PRIOR epoch's frozen set restricted to the current
+    /// committee — that is what every continuing validator ingests at the
+    /// epoch flip (the syncer assembles the prior epoch's post-freeze set
+    /// during the boundary window, the manager latches it for the whole
+    /// epoch, and the current epoch's own freeze never re-feeds it). The
+    /// cert pins exactly that set (`compute_handoff_items` builds the
+    /// `ValidatorMpcData` items 1:1 from the frozen map), is quorum-signed
+    /// and perpetual, and — unlike the boundary window's process-local watch
+    /// channel — is reachable after a mid-epoch restart (issue #1879). Blobs
+    /// are content-addressed and digest-verified at the store's write
+    /// boundary, so the assembled bundle is byte-identical to the boundary
+    /// delivery.
+    ///
+    /// Committee members without a prior-cert digest were excluded from the
+    /// prior epoch's frozen set (first-time joiners that missed its freeze
+    /// window); the boundary delivery skips them identically — DKG and the
+    /// VSS protocols deal only to the parties that have keys.
+    fn try_ingest_current_epoch_keys_from_prior_handoff_cert(
+        &mut self,
+    ) -> DwalletMPCResult<PriorCertKeysOutcome> {
+        let Some(prior_epoch) = self.epoch_id.checked_sub(1) else {
+            return Ok(PriorCertKeysOutcome::NoPriorCert);
+        };
+        let cert = match self
+            .epoch_store
+            .get_certified_handoff_attestation(prior_epoch)
+        {
+            Ok(Some(cert)) => cert,
+            // Ambiguous between "chain-true no cert" (a pre-v4 prior epoch,
+            // where the freeze-gated channel is the fleet-uniform source)
+            // and "bootstrap anchor still fetching" on a cold start. Fall
+            // through to the channel: this method re-runs every service
+            // iteration, and pre-freeze the channel delivers nothing, so the
+            // cert wins the race in any epoch whose cert arrives before the
+            // current epoch's freeze fires.
+            Ok(None) => return Ok(PriorCertKeysOutcome::NoPriorCert),
+            Err(e) => {
+                // A read ERROR must not degrade to the channel path — the
+                // cert may exist, and the channel post-freeze can carry a
+                // divergent (superset) key set. Retry.
+                if self.should_warn_prior_cert_keys() {
+                    warn!(
+                        error = ?e,
+                        prior_epoch,
+                        "failed to read the prior epoch's handoff cert while sourcing \
+                         current-epoch validator MPC keys; retrying"
+                    );
+                }
+                return Ok(PriorCertKeysOutcome::RetryLater);
+            }
+        };
+        let prior_cert_digests: HashMap<AuthorityName, [u8; 32]> = cert
+            .attestation
+            .items
+            .iter()
+            .filter_map(|(key, digest)| match key {
+                HandoffItemKey::ValidatorMpcData { validator } => Some((*validator, *digest)),
+                _ => None,
+            })
+            .collect();
+        if prior_cert_digests.is_empty() {
+            // A cert that predates mpc_data handoff items (the first epoch
+            // after the off-chain pipeline activated) — fleet-uniform, the
+            // channel is the source.
+            return Ok(PriorCertKeysOutcome::NoPriorCert);
+        }
+        let pairs: Vec<(AuthorityName, [u8; 32])> = self
+            .committee
+            .voting_rights
+            .iter()
+            .filter_map(|(name, _)| prior_cert_digests.get(name).map(|digest| (*name, *digest)))
+            .collect();
+        if pairs.is_empty() {
+            // Cert has mpc_data items but none for any current committee
+            // member — cannot happen on a continuing network (quorum
+            // continuity), so surface it rather than silently ingesting
+            // nothing.
+            if self.should_warn_prior_cert_keys() {
+                warn!(
+                    prior_epoch,
+                    "prior handoff cert carries mpc_data items but none for any current \
+                     committee member — falling back to the freeze-gated delivery"
+                );
+            }
+            return Ok(PriorCertKeysOutcome::NoPriorCert);
+        }
+        let Some(perpetual) = self.epoch_store.perpetual_tables_handle() else {
+            // Near-unreachable: a missing perpetual handle already made the
+            // cert read above return `Ok(None)` (its impl reads the cert
+            // THROUGH this handle), so reaching here means the handle
+            // vanished between the two loads. Defense-in-depth: retry rather
+            // than fall to the channel while a cert was just observed.
+            return Ok(PriorCertKeysOutcome::RetryLater);
+        };
+        let assembly = assemble_committee_mpc_data_off_chain(pairs, move |digest| {
+            perpetual.get_mpc_artifact_blob(digest).ok().flatten()
+        });
+        match assembly {
+            OffChainMpcDataAssembly::Complete(bundles) => {
+                self.validator_mpc_keys_by_party_id =
+                    get_validator_mpc_keys_by_party_id(&self.committee, &bundles)?;
+                self.current_epoch_keys_ingested = true;
+                info!(
+                    epoch = self.epoch_id,
+                    prior_epoch,
+                    dealt = self.validator_mpc_keys_by_party_id.secp256k1_pvss.len(),
+                    committee = self.committee.voting_rights.len(),
+                    "ingested current-epoch off-chain validator MPC keys from the prior \
+                     epoch's handoff certificate"
+                );
+                Ok(PriorCertKeysOutcome::Ingested)
+            }
+            OffChainMpcDataAssembly::Incomplete { missing } => {
+                if self.should_warn_prior_cert_keys() {
+                    warn!(
+                        prior_epoch,
+                        ?missing,
+                        "prior-cert mpc_data blobs missing or undecodable in the perpetual \
+                         store; current-epoch validator MPC keys not ingested yet — retrying"
+                    );
+                }
+                Ok(PriorCertKeysOutcome::RetryLater)
+            }
+            OffChainMpcDataAssembly::EverythingExcluded => {
+                // `assemble_committee_mpc_data_off_chain` never returns this
+                // variant (it belongs to the pre-assembly decision); guard
+                // defensively rather than panic.
+                error!(
+                    should_never_happen = true,
+                    prior_epoch,
+                    "off-chain assembly returned EverythingExcluded for a non-empty \
+                     prior-cert pair set"
+                );
+                Ok(PriorCertKeysOutcome::RetryLater)
+            }
+        }
+    }
+
+    /// 10s throttle for the prior-cert key-ingestion warns (the ingest runs
+    /// every 20ms service iteration). Returns whether to warn now and, if
+    /// so, stamps the throttle.
+    fn should_warn_prior_cert_keys(&mut self) -> bool {
+        let now = Instant::now();
+        match self.last_prior_cert_keys_warn {
+            Some(last) if now.duration_since(last) < Duration::from_secs(10) => false,
+            _ => {
+                self.last_prior_cert_keys_warn = Some(now);
+                true
+            }
+        }
     }
 
     /// Adopt this validator's locally-observed network-key outputs into

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -422,6 +422,16 @@ where
             // — assemble directly for the current committee, not by borrowing
             // the next committee's keys. Runs before the next-committee check so
             // it still fires when Sui hasn't selected a next committee yet.
+            //
+            // NOTE: this channel is the manager's FALLBACK source only — for
+            // the chain-true no-cert epochs (genesis, the first
+            // off-chain-enabled epoch). Whenever the prior epoch produced a
+            // handoff certificate, the manager sources the bundle from that
+            // cert instead (`try_ingest_current_epoch_keys_from_prior_handoff_cert`,
+            // issue #1879) and ignores this delivery: the cert set is the
+            // boundary set the committee latched, while this post-freeze
+            // assembly is the CURRENT epoch's frozen set, a possible strict
+            // superset in a joiner-churn epoch.
             let current_epoch = system_inner.epoch();
             // Only deliver once the set is FROZEN — the frozen set is the
             // consensus-agreed validator-key set (a stake-quorum of ready

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -900,6 +900,31 @@ impl HandoffItemsBuilder for MpcDataHandoffItemsBuilder {
             // succeed against peers' versions either.
             return Ok(Vec::new());
         };
+        // Divergence guard (issue #1879): an EMPTY frozen table while this
+        // epoch's ready-signal quorum is anchored means the freeze either
+        // hasn't fired yet (attestation built early) or its rows were lost
+        // to a crash window — either way every healthy peer's attestation
+        // WILL carry `ValidatorMpcData` items, so emitting an items list
+        // without them would byte-diverge and pollute the signature
+        // aggregation bucket. Defer signing instead (Err → the sender
+        // warns and retries next tick, the same deferral shape as the
+        // `to_network_key_id_keyed` guard below): the freeze re-fires at a
+        // commit boundary once quorum + grace hold, and a missing
+        // signature aggregates as nothing while a divergent one is poison.
+        // A quorum-less epoch (the pipeline never ran to quorum — also the
+        // off_chain-disabled case, where signals are never recorded)
+        // legitimately emits no `ValidatorMpcData` items, uniformly with
+        // peers.
+        if store.mpc_data_ready_quorum_round()?.is_some()
+            && store.get_frozen_validator_mpc_data_input_set()?.is_empty()
+        {
+            return Err(IkaError::Unknown(format!(
+                "mpc_data ready-signal quorum is anchored for epoch {epoch} but the \
+                 frozen set is empty — deferring handoff attestation build until the \
+                 freeze fires, rather than signing an attestation missing every \
+                 ValidatorMpcData item"
+            )));
+        }
         let effective =
             store.get_effective_reconfig_input_set(next_committee_pubkeys.iter().copied())?;
         // Translate the locally-stored ObjectID-keyed digests into the

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -41,7 +41,14 @@ next epoch inherits.
     excluded from it by design (the computing validators are a quorum).
   - `ValidatorMpcData { validator }` — pins the exact mpc_data version
     consumed by this epoch's MPC sessions (the frozen set; see the
-    announcements spec).
+    announcements spec). Divergence guard: if the ready-signal quorum
+    round is anchored for the epoch but the local frozen table is empty
+    (freeze not yet fired, or a crash window lost it), the items builder
+    DEFERS (errors → the sender retries) instead of emitting an
+    attestation missing every `ValidatorMpcData` item — a missing
+    signature aggregates as nothing, while a divergent one pollutes the
+    aggregation bucket. A quorum-less epoch legitimately emits none,
+    uniformly with peers.
 - The attestation is built once per epoch when the validator's local
   view is complete (snapshot-ready), and it must be DETERMINISTIC
   across validators: every digest source above is consensus-anchored.
@@ -274,6 +281,29 @@ next epoch inherits.
      next epoch's cert pins V3. Fail-closed, bounded to that one
      epoch, identical to pre-recovery behavior; epoch close is
      unaffected (the validator still votes EndOfPublish).
+   - Current-epoch validator MPC keys (mid-epoch restart, issue #1879).
+     The manager's current-epoch key bundle
+     (`validator_mpc_keys_by_party_id` — consumed by the within-epoch
+     network DKG and by every VSS presign/sign public input) is sourced
+     from the prior cert's `ValidatorMpcData` items ∩ current committee,
+     assembled against the perpetual blob store
+     (`try_ingest_current_epoch_keys_from_prior_handoff_cert`). The
+     cert set IS the committee-agreed value of this epoch's bundle: it
+     pins the prior epoch's frozen set, which is what the boundary-window
+     delivery hands every continuing validator, and blobs are
+     content-addressed, so the rebuild is byte-identical — and unlike
+     the boundary window's process-local watch channel it survives a
+     mid-epoch restart. With a cert present the freeze-gated channel
+     delivery is NEVER consulted: post-freeze it carries the CURRENT
+     epoch's frozen set, a possible strict superset of the boundary set
+     (a late-attested joiner), and ingesting that superset would
+     byte-diverge this validator's VSS presign inputs from the
+     committee's. The channel remains the source only for the
+     chain-true no-cert epochs (genesis, the first off-chain-enabled
+     epoch), where the epoch's own freeze is the only agreed set. A
+     cert READ ERROR retries without falling back to the channel; a
+     missing cert-pinned blob defers ingestion (retry as propagation
+     converges), never downgrades to the channel bundle.
    - The hydration-clobber variant (issue #1852, never-instantiated
      shape) and its three defenses. Post-restart, until the per-epoch
      blob source installs, the sync task's full chain read publishes an

--- a/dev-docs/specs/validator-mpc-data-announcements.md
+++ b/dev-docs/specs/validator-mpc-data-announcements.md
@@ -157,7 +157,15 @@ which bytes* deterministic in consensus order.
 - **Frozen set semantics**: `frozen: validator -> blob_hash` is written
   once per epoch (`freeze_mpc_data_if_first`) and is immutable for the
   epoch. Validators not in the frozen set are the epoch's **excluded**
-  set: the reconfiguration proceeds without them.
+  set: the reconfiguration proceeds without them. The frozen + excluded
+  rows are persisted through the freeze commit's `ConsensusCommitOutput`
+  batch — atomically with that commit's processed-markers — never as
+  per-row inserts: a crash mid-write would otherwise latch a strict
+  subset as frozen forever (the idempotence guard is table
+  non-emptiness, and the commit replays dedup-skipped), leaving this
+  validator on a divergent shrunken set (issue #1829). A crash before
+  the batch lands replays the whole commit and the freeze re-fires
+  identically.
 - **Carry-forward (stable mpc_data)**: a validator's blob is a pure
   function of its root seed (`derive_mpc_data_blob`), so a continuing
   validator's blob is byte-identical every epoch. At the freeze, a
@@ -200,6 +208,37 @@ which bytes* deterministic in consensus order.
   mechanism is announcement propagation reaching a stake quorum BEFORE
   the freeze fires: a joiner whose blob has not propagated in time is
   excluded for the epoch, with no after-the-fact recovery.
+
+## Current-epoch key bundle (manager ingestion)
+
+The MPC manager's current-epoch key set
+(`validator_mpc_keys_by_party_id` — consumed by the within-epoch network
+DKG and by every VSS presign/sign public input) is NOT fed by the
+current epoch's freeze. Its committee-agreed value is the **prior
+epoch's frozen set ∩ current committee** — the set the prior epoch's
+post-freeze assembly delivered at the boundary and every continuing
+validator latched for the whole epoch. Sourcing rules
+(`ingest_offchain_mpc_keys`, ingested once per manager):
+
+1. **Primary — the prior epoch's handoff certificate**: assemble the
+   cert's `ValidatorMpcData` digests ∩ current committee against the
+   perpetual blob store. Byte-identical to the boundary delivery (the
+   cert items are built 1:1 from the frozen map; blobs are
+   content-addressed) and, unlike the boundary window's process-local
+   watch channel, reachable after a mid-epoch restart — the restart
+   wedge of issue #1879. Members without a cert digest (prior-epoch
+   excluded joiners) are skipped, exactly as the boundary assembly
+   skips them.
+2. **Fallback — the freeze-gated syncer delivery** (the
+   `current_epoch_mpc_keys` channel): only for the chain-true no-cert
+   epochs (genesis, the first off-chain-enabled epoch), where the
+   epoch's own freeze is the only agreed set.
+3. **Never mix**: with a cert present, the channel is not consulted —
+   post-freeze it carries the CURRENT epoch's frozen set, a possible
+   strict superset of the boundary set (a late-attested joiner), and
+   ingesting it would byte-diverge this validator's VSS presign public
+   inputs from the committee's. Cert read errors retry; missing
+   cert-pinned blobs defer ingestion until propagation converges.
 
 ## Next-committee assembly
 


### PR DESCRIPTION
## Summary

Fixes the mid-epoch-restart MPC wedge (#1856, fix spec #1879) and the non-crash-atomic freeze writes (#1829). The mechanism differs from #1879's original layer-A design — the code-verified correction is on the issue (https://github.com/dwallet-labs/ika/issues/1879#issuecomment-5038450135) and was re-verified and endorsed there by @omersadika (boot-time freeze re-invocation withdrawn from the spec; the cert-based sourcing below adopted; one extra guard requested and included).

## The traced wedge

The manager's current-epoch validator MPC key bundle (`validator_mpc_keys_by_party_id` — consumed by the within-epoch network DKG and every VSS presign/sign public input) has exactly one producer: the freeze-gated syncer block. On a healthy validator the epoch-E+1 delivery actually happens in a **stale-source window at the epoch flip** — the node-lifetime syncer tick sees Sui at E+1 while `off_chain_mpc_data_source` still points at the (frozen) epoch-E store, so it assembles E's post-freeze set for the E+1 members and the manager latches it for the whole epoch. Both halves of that (the watch-channel content and the window itself) are process-local: a mid-epoch restart loses them, and the fallback — the current epoch's own freeze — fires hours later (publication + grace) or not at all. Hence zero VSS-family advances and stuck internal presigns until the next boundary (the 2026-07-21 five-validator incident). No lost RocksDB state is involved; the "frozen table empty on reopen" reading in #1879 was the pre-freeze gauge artifact documented in #1856.

There is also a latent divergence hazard in the old recovery path: post-freeze re-delivery assembles the **current** epoch's frozen set, which in a joiner-churn epoch is a strict superset of the boundary set the rest of the committee latched — a restarted validator ingesting it would byte-diverge its VSS presign public inputs from every peer's (the false-malicious class).

## The fix

**Layer A — cert-sourced current-epoch keys** (`mpc_manager.rs`): `ingest_offchain_mpc_keys` now assembles the bundle from the prior epoch's handoff certificate (`ValidatorMpcData` items ∩ current committee) against the perpetual blob store. The cert pins exactly the boundary set (`compute_handoff_items` builds the items 1:1 from the frozen map; blobs are content-addressed), is quorum-signed and perpetual — reachable at any process start, pre- or post-freeze. With a cert present the channel is **never** consulted (closes the superset-divergence hazard); the freeze-gated channel remains the source only for the chain-true no-cert epochs (genesis / first off-chain-enabled epoch). Missing blobs defer with a throttled warn and converge via this epoch's re-announcements (deterministic blobs, consensus-replicated into perpetual `mpc_artifact_blobs`). This also removes the healthy-path dependence on the wall-clock flip window.

**Layer B — crash-atomic freeze writes** (#1829, `authority_per_epoch_store.rs`): `freeze_mpc_data_if_first` no longer writes `frozen_validator_mpc_data_input_set` / `epoch_excluded_validators` as per-row inserts; the partition rides the freeze commit's `ConsensusCommitOutput` batch, atomic with `last_consensus_stats`. A crash before the batch replays the whole commit and the freeze re-fires identically; a partial freeze can no longer be latched by the non-empty-table idempotence guard. This makes the announcements spec's invariant 1 (already claiming batch atomicity) true.

**Attestation divergence guard** (requested in the issue thread, `validator_metadata.rs`): if the epoch's ready-signal quorum round is anchored but the local frozen table is empty (freeze not yet fired at build time, or a crash window lost it), `MpcDataHandoffItemsBuilder::build` defers (errors → the signature sender warns and retries each tick, the `to_network_key_id_keyed` deferral shape) instead of signing an attestation missing every `ValidatorMpcData` item — a missing signature aggregates as nothing; a divergent one pollutes the aggregation bucket.

**Layer C — regression tests** (`integration_tests/mid_epoch_restart_keys.rs`, real crypto):
- `mid_epoch_restart_ingests_keys_without_channel_delivery` — the restart shape: empty channel, cert + perpetual blobs suffice.
- `prior_cert_set_wins_over_wider_channel_bundle` — cert set (3 members) is ingested over the channel's wider bundle (4) — the divergence guard.
- `missing_prior_cert_blob_defers_without_channel_fallback` — a missing cert-pinned blob defers (no channel fallback), then completes when the blob lands.

Test-tested per `dev-docs/playbooks/test-testing.md`: with the cert path fault-injected out (simulating the pre-fix binary), all three tests fail; reverted.

**Not** included: boot-time re-invocation of `freeze_mpc_data_if_first` (layer A of the original spec). The commit-boundary check already re-evaluates quorum+grace on every commit while unfrozen and re-fires from durable ready-signals; a boot-time call cannot evaluate the grace condition (no current consensus round) and risks freezing early on a divergent signal subset.

Specs updated in the same PR: `dev-docs/specs/validator-mpc-data-announcements.md` (current-epoch bundle sourcing section; freeze-write atomicity), `dev-docs/specs/handoff.md` (new cert consumer).

## Acceptance criteria mapping (#1879)

- Restart mid-epoch (pre- or post-freeze) → keys ingest on the first MPC service iteration from cert + perpetual blobs; advances resume immediately.
- Rolling mid-epoch fleet upgrade → no stuck-session accumulation (each restarted validator re-ingests the identical boundary set).
- `ika_dwallet_mpc_data_freeze_epoch` reseed was already correct (survives restart; #1856's Mysten Labs observation) and the freeze rows are now batch-atomic.
- Closes #1856, closes #1829; closes #1879 (with the layer-A mechanism correction recorded on the issue).

## Verification

- `cargo test --release -p ika-core mid_epoch_restart_keys` — 3/3 pass (353s, real class-groups crypto), and 3/3 fail under the pre-fix fault injection.
- `cargo clippy -p ika-core --all-targets` clean; `cargo check -p ika-node` clean; `cargo fmt --all`.
- consensus-reviewer pass over the diff (determinism / epoch-close invariants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnRjdvthoSVjPG5UtGtj57
