### PR TITLE
fix(dwallet-mpc): peer-refetch missing prior-cert mpc_data blobs on ingest (permanent wedge #1881)

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -157,6 +157,15 @@ pub struct DWalletMPCMetrics {
     /// validators — tune alerts per reason.
     pub(crate) network_key_instantiation_failures_total: IntCounterVec,
 
+    /// Number of prior-handoff-cert `ValidatorMpcData` blobs (∩ current
+    /// committee) missing from the local perpetual store while the manager
+    /// sources the current epoch's validator MPC key bundle. Non-zero means
+    /// key ingestion is deferred and the peer-blob fetcher's prior-cert
+    /// repair is fetching the missing blobs; 0 once the bundle assembles.
+    /// Sustained non-zero = the wedge of issue #1881 (no advances, every
+    /// session deferred) — previously visible only in logs.
+    pub(crate) prior_cert_blobs_missing: IntGauge,
+
     /// Number of distinct authorities this validator has recorded as malicious
     /// in the current epoch (quorum-agreed; see
     /// `DWalletMPCManager::record_malicious_actors`). A scrapable signal that
@@ -517,6 +526,12 @@ impl DWalletMPCMetrics {
                 "ika_dwallet_mpc_network_key_instantiation_failures_total",
                 "Network-key instantiation failures by reason",
                 &["reason"],
+                registry
+            )
+            .unwrap(),
+            prior_cert_blobs_missing: register_int_gauge_with_registry!(
+                "ika_dwallet_mpc_prior_cert_blobs_missing",
+                "Prior-handoff-cert mpc_data blobs missing from the local perpetual store while sourcing the current epoch's validator MPC keys (non-zero = key ingestion deferred; sustained non-zero = wedged ingest)",
                 registry
             )
             .unwrap(),

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/mid_epoch_restart_keys.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/mid_epoch_restart_keys.rs
@@ -518,3 +518,179 @@ async fn missing_prior_cert_blob_is_refetched_from_peers_and_ingested() {
         "the gauge must return to 0 once assembly completes"
     );
 }
+
+/// The compound case observed live on testnet: the cert-pinned member is
+/// ALIVE and reachable — it keeps signing and participating in consensus —
+/// but MPC-dead: it never announced this epoch, so its own blob store lacks
+/// its blob and its Anemo endpoint answers `GetMpcDataBlob` with not-found.
+/// Distinct from the fully-dark case (unreachable peer) above: the repair
+/// must fall through from the owner's not-found answer to another live
+/// committee holder, persist, and let ingestion complete — recording both
+/// the owner's `not_found` and the eventual `ok` on the shared
+/// fetch-outcomes counter.
+#[tokio::test(flavor = "multi_thread")]
+async fn mpc_dead_owner_not_found_falls_through_to_live_holder() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard();
+
+    let (committee, seeds, bundles) = utils::build_committee_with_random_seeds(4);
+    let (mut services, sui_data_senders, _stores, epoch_stores, ..) =
+        utils::create_dwallet_mpc_services_with_committee_and_seeds(
+            committee.clone(),
+            seeds,
+            bundles.clone(),
+        );
+    let service = services.first_mut().unwrap();
+    let own_authority = service.name;
+    let epoch_id = service.dwallet_mpc_manager().epoch_id;
+    let prior_epoch = epoch_id - 1;
+
+    // Restart shape: a fresh process's watch channel starts empty.
+    let _ = sui_data_senders
+        .first()
+        .unwrap()
+        .current_epoch_mpc_keys_sender
+        .send(None);
+
+    let members: Vec<AuthorityName> = committee
+        .voting_rights
+        .iter()
+        .map(|(name, _)| *name)
+        .collect();
+    // The MPC-dead member whose blob this host never stored, and the live
+    // committee holder that will serve it — both distinct from this
+    // validator.
+    let dead_member = *members
+        .iter()
+        .rev()
+        .find(|member| **member != own_authority)
+        .expect("committee has peers");
+    let holder_member = *members
+        .iter()
+        .find(|member| **member != own_authority && **member != dead_member)
+        .expect("committee has a second peer");
+
+    // Cert pins all four members, but the MPC-dead member's blob is absent
+    // from the local perpetual store.
+    let perpetual_dir = tempfile::tempdir().expect("tempdir");
+    let perpetual = Arc::new(AuthorityPerpetualTables::open(perpetual_dir.path(), None));
+    let mut dead_member_blob: Option<([u8; 32], Vec<u8>)> = None;
+    let cert_entries: Vec<(AuthorityName, [u8; 32])> = members
+        .iter()
+        .map(|authority| {
+            let blob = mpc_data_blob_for(&bundles, authority);
+            let digest = mpc_data_blob_hash(&blob);
+            if *authority == dead_member {
+                dead_member_blob = Some((digest, blob));
+            } else {
+                perpetual
+                    .insert_mpc_artifact_blob(digest, &blob)
+                    .expect("blob insert");
+            }
+            (*authority, digest)
+        })
+        .collect();
+    let epoch_store = epoch_stores.first().unwrap();
+    epoch_store
+        .perpetual_tables
+        .lock()
+        .unwrap()
+        .replace(perpetual.clone());
+    epoch_store
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(prior_epoch, cert_with_mpc_data(prior_epoch, &cert_entries));
+
+    let manager = service.dwallet_mpc_manager_mut();
+    manager
+        .ingest_offchain_mpc_keys()
+        .expect("ingest_offchain_mpc_keys");
+    assert!(
+        !manager.current_epoch_keys_ingested,
+        "a missing cert-pinned blob must defer ingestion"
+    );
+
+    // The MPC-dead owner is reachable but has nothing to serve (empty blob
+    // store — it never announced this epoch); a live committee holder
+    // serves the blob.
+    let (dead_digest, dead_blob) = dead_member_blob.expect("dead member blob");
+    let owner_network = build_test_network(Router::new().add_rpc_service(build_server(
+        InMemoryBlobStore::new(),
+        AnnouncementRelayHandle::new(),
+        Arc::new(NoHandoffCerts),
+    )));
+    let holder_store = InMemoryBlobStore::new();
+    holder_store.insert(dead_digest, dead_blob);
+    let holder_network = build_test_network(Router::new().add_rpc_service(build_server(
+        holder_store,
+        AnnouncementRelayHandle::new(),
+        Arc::new(NoHandoffCerts),
+    )));
+    let local_network = build_test_network(Router::new());
+    let owner_peer_id = local_network
+        .connect(owner_network.local_addr())
+        .await
+        .expect("connect to MPC-dead owner");
+    let holder_peer_id = local_network
+        .connect(holder_network.local_addr())
+        .await
+        .expect("connect to live holder");
+    let authority_names_to_peer_ids: HashMap<AuthorityName, PeerId> = HashMap::from([
+        (dead_member, owner_peer_id),
+        (holder_member, holder_peer_id),
+    ]);
+
+    let blob_cache = BlobCache::new(InMemoryBlobStore::new(), perpetual.clone());
+    let fetch_outcomes = IntCounterVec::new(
+        Opts::new("test_mpc_data_blob_fetch_total", "test fetch outcomes"),
+        &["result"],
+    )
+    .expect("counter");
+    let fetched = fetch_missing_prior_cert_mpc_data_blobs(
+        &cert_with_mpc_data(prior_epoch, &cert_entries),
+        own_authority,
+        &blob_cache,
+        &local_network,
+        &authority_names_to_peer_ids,
+        &fetch_outcomes,
+    )
+    .await;
+    assert_eq!(
+        fetched, 1,
+        "the repair must fall through from the owner's not-found to the \
+         live holder"
+    );
+    assert_eq!(
+        fetch_outcomes.with_label_values(&["not_found"]).get(),
+        1,
+        "the reachable-but-empty owner must be recorded as not_found"
+    );
+    assert_eq!(
+        fetch_outcomes.with_label_values(&["ok"]).get(),
+        1,
+        "the holder's serve must be recorded as ok"
+    );
+    assert!(
+        perpetual
+            .get_mpc_artifact_blob(&dead_digest)
+            .expect("perpetual read")
+            .is_some(),
+        "the fetched blob must be persisted to the perpetual store"
+    );
+
+    let manager = services.first_mut().unwrap().dwallet_mpc_manager_mut();
+    manager
+        .ingest_offchain_mpc_keys()
+        .expect("ingest_offchain_mpc_keys");
+    assert!(
+        manager.current_epoch_keys_ingested,
+        "ingestion must complete after the fall-through refetch"
+    );
+    assert_eq!(
+        manager.validator_mpc_keys_by_party_id.secp256k1_pvss.len(),
+        members.len(),
+        "every cert-covered committee member must be dealt, including the \
+         MPC-dead member"
+    );
+}

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/mid_epoch_restart_keys.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/mid_epoch_restart_keys.rs
@@ -27,6 +27,7 @@ use ika_network::mpc_artifacts::{
 use ika_types::committee::{EpochId, ValidatorEncryptionKeysAndProofs};
 use ika_types::crypto::AuthorityName;
 use ika_types::handoff::{CertifiedHandoffAttestation, HandoffAttestation, HandoffItemKey};
+use prometheus::{IntCounterVec, Opts};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -463,17 +464,28 @@ async fn missing_prior_cert_blob_is_refetched_from_peers_and_ingested() {
         (serving_member, live_peer_id),
     ]);
     let blob_cache = BlobCache::new(InMemoryBlobStore::new(), perpetual.clone());
+    let fetch_outcomes = IntCounterVec::new(
+        Opts::new("test_mpc_data_blob_fetch_total", "test fetch outcomes"),
+        &["result"],
+    )
+    .expect("counter");
     let fetched = fetch_missing_prior_cert_mpc_data_blobs(
         &cert_with_mpc_data(prior_epoch, &cert_entries),
         own_authority,
         &blob_cache,
         &local_network,
         &authority_names_to_peer_ids,
+        &fetch_outcomes,
     )
     .await;
     assert_eq!(
         fetched, 1,
         "the dark member's cert-pinned blob must be fetched from the live peer"
+    );
+    assert_eq!(
+        fetch_outcomes.with_label_values(&["ok"]).get(),
+        1,
+        "the repair must record its fetch outcome on the shared counter"
     );
     assert!(
         perpetual

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/mid_epoch_restart_keys.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/mid_epoch_restart_keys.rs
@@ -12,15 +12,22 @@
 //! set the rest of the committee latched.
 
 use crate::authority::authority_perpetual_tables::AuthorityPerpetualTables;
+use crate::blob_cache::BlobCache;
 use crate::dwallet_mpc::authority_name_to_party_id_from_committee;
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::create_test_protocol_config_guard;
+use crate::epoch_tasks::peer_blob_fetcher::fetch_missing_prior_cert_mpc_data_blobs;
 use crate::validator_metadata::OffChainCommitteeBundles;
+use anemo::{Network, PeerId, Router};
 use dwallet_mpc_types::dwallet_mpc::{MPCDataV1, VersionedMPCData};
-use ika_network::mpc_artifacts::mpc_data_blob_hash;
-use ika_types::committee::ValidatorEncryptionKeysAndProofs;
+use ika_network::mpc_artifacts::{
+    AnnouncementRelayHandle, HandoffCertStorage, InMemoryBlobStore, build_server,
+    mpc_data_blob_hash,
+};
+use ika_types::committee::{EpochId, ValidatorEncryptionKeysAndProofs};
 use ika_types::crypto::AuthorityName;
 use ika_types::handoff::{CertifiedHandoffAttestation, HandoffAttestation, HandoffItemKey};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Rebuilds a validator's canonical mpc_data blob (`VersionedMPCData::V1`
@@ -312,5 +319,190 @@ async fn missing_prior_cert_blob_defers_without_channel_fallback() {
     assert_eq!(
         manager.validator_mpc_keys_by_party_id.secp256k1_pvss.len(),
         members.len(),
+    );
+}
+
+/// Test-local cert store for the serving peer's Anemo endpoint — the test
+/// fetches blobs, not certs.
+struct NoHandoffCerts;
+
+impl HandoffCertStorage for NoHandoffCerts {
+    fn get(&self, _epoch: EpochId) -> Option<CertifiedHandoffAttestation> {
+        None
+    }
+}
+
+fn build_test_network(router: Router) -> Network {
+    Network::bind("localhost:0")
+        .private_key(rand::random::<[u8; 32]>())
+        .server_name("mid-epoch-restart-keys-test")
+        .start(router)
+        .expect("bind test anemo network")
+}
+
+/// The permanent-wedge shape of issue #1881: the perpetual store never held
+/// one carried-forward member's cert-pinned blob — the member has been dark
+/// for epochs, so it never re-announces, and this host's store post-dates
+/// its last announcement. The cert-path deferral must not retry the same
+/// local store forever: the peer-blob fetcher's prior-cert repair fetches
+/// the missing blob from any committee peer over the real Anemo blob
+/// endpoint (content-addressed, cert-digest-verified), persists it to the
+/// perpetual store, and the next ingest attempt completes.
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_prior_cert_blob_is_refetched_from_peers_and_ingested() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard();
+
+    let (committee, seeds, bundles) = utils::build_committee_with_random_seeds(4);
+    let (mut services, sui_data_senders, _stores, epoch_stores, ..) =
+        utils::create_dwallet_mpc_services_with_committee_and_seeds(
+            committee.clone(),
+            seeds,
+            bundles.clone(),
+        );
+    let service = services.first_mut().unwrap();
+    let own_authority = service.name;
+    let epoch_id = service.dwallet_mpc_manager().epoch_id;
+    let prior_epoch = epoch_id - 1;
+
+    // Restart shape: a fresh process's watch channel starts empty.
+    let _ = sui_data_senders
+        .first()
+        .unwrap()
+        .current_epoch_mpc_keys_sender
+        .send(None);
+
+    let members: Vec<AuthorityName> = committee
+        .voting_rights
+        .iter()
+        .map(|(name, _)| *name)
+        .collect();
+    // The dark member whose blob this host never stored, and the live
+    // committee peer that will serve it — both distinct from this
+    // validator.
+    let dark_member = *members
+        .iter()
+        .rev()
+        .find(|member| **member != own_authority)
+        .expect("committee has peers");
+    let serving_member = *members
+        .iter()
+        .find(|member| **member != own_authority && **member != dark_member)
+        .expect("committee has a second peer");
+
+    // Cert pins all four members, but the dark member's blob is absent
+    // from the local perpetual store.
+    let perpetual_dir = tempfile::tempdir().expect("tempdir");
+    let perpetual = Arc::new(AuthorityPerpetualTables::open(perpetual_dir.path(), None));
+    let mut dark_member_blob: Option<([u8; 32], Vec<u8>)> = None;
+    let cert_entries: Vec<(AuthorityName, [u8; 32])> = members
+        .iter()
+        .map(|authority| {
+            let blob = mpc_data_blob_for(&bundles, authority);
+            let digest = mpc_data_blob_hash(&blob);
+            if *authority == dark_member {
+                dark_member_blob = Some((digest, blob));
+            } else {
+                perpetual
+                    .insert_mpc_artifact_blob(digest, &blob)
+                    .expect("blob insert");
+            }
+            (*authority, digest)
+        })
+        .collect();
+    let epoch_store = epoch_stores.first().unwrap();
+    epoch_store
+        .perpetual_tables
+        .lock()
+        .unwrap()
+        .replace(perpetual.clone());
+    epoch_store
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(prior_epoch, cert_with_mpc_data(prior_epoch, &cert_entries));
+
+    // Before the repair: ingestion defers, and the deferral is visible as
+    // a metric (issue #1881's wedge presented only as absent advances).
+    let manager = service.dwallet_mpc_manager_mut();
+    manager
+        .ingest_offchain_mpc_keys()
+        .expect("ingest_offchain_mpc_keys");
+    assert!(
+        !manager.current_epoch_keys_ingested,
+        "a missing cert-pinned blob must defer ingestion"
+    );
+    assert_eq!(
+        manager.dwallet_mpc_metrics.prior_cert_blobs_missing.get(),
+        1,
+        "the deferral must be scrapable via ika_dwallet_mpc_prior_cert_blobs_missing"
+    );
+
+    // A live committee peer serving the dark member's blob over the real
+    // Anemo blob endpoint — any holder is authoritative (the blob is
+    // content-addressed and pinned by the quorum-signed cert).
+    let (dark_digest, dark_blob) = dark_member_blob.expect("dark member blob");
+    let serving_store = InMemoryBlobStore::new();
+    serving_store.insert(dark_digest, dark_blob);
+    let server = build_server(
+        serving_store,
+        AnnouncementRelayHandle::new(),
+        Arc::new(NoHandoffCerts),
+    );
+    let peer_network = build_test_network(Router::new().add_rpc_service(server));
+    let local_network = build_test_network(Router::new());
+    let live_peer_id = local_network
+        .connect(peer_network.local_addr())
+        .await
+        .expect("connect to serving peer");
+
+    // The dark owner maps to an unreachable peer id (it is down — that is
+    // the scenario), forcing the repair through the any-holder fallback.
+    let authority_names_to_peer_ids: HashMap<AuthorityName, PeerId> = HashMap::from([
+        (dark_member, PeerId([0u8; 32])),
+        (serving_member, live_peer_id),
+    ]);
+    let blob_cache = BlobCache::new(InMemoryBlobStore::new(), perpetual.clone());
+    let fetched = fetch_missing_prior_cert_mpc_data_blobs(
+        &cert_with_mpc_data(prior_epoch, &cert_entries),
+        own_authority,
+        &blob_cache,
+        &local_network,
+        &authority_names_to_peer_ids,
+    )
+    .await;
+    assert_eq!(
+        fetched, 1,
+        "the dark member's cert-pinned blob must be fetched from the live peer"
+    );
+    assert!(
+        perpetual
+            .get_mpc_artifact_blob(&dark_digest)
+            .expect("perpetual read")
+            .is_some(),
+        "the fetched blob must be persisted to the perpetual store the \
+         manager assembles against"
+    );
+
+    // Next service iteration: the retry finds the repaired store and
+    // ingests — not RetryLater forever.
+    let manager = services.first_mut().unwrap().dwallet_mpc_manager_mut();
+    manager
+        .ingest_offchain_mpc_keys()
+        .expect("ingest_offchain_mpc_keys");
+    assert!(
+        manager.current_epoch_keys_ingested,
+        "ingestion must complete after the peer refetch"
+    );
+    assert_eq!(
+        manager.validator_mpc_keys_by_party_id.secp256k1_pvss.len(),
+        members.len(),
+        "every cert-covered committee member must be dealt, including the \
+         refetched dark member"
+    );
+    assert_eq!(
+        manager.dwallet_mpc_metrics.prior_cert_blobs_missing.get(),
+        0,
+        "the gauge must return to 0 once assembly completes"
     );
 }

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -1179,6 +1179,11 @@ impl DWalletMPCManager {
                         self.validator_mpc_keys_by_party_id =
                             get_validator_mpc_keys_by_party_id(&self.committee, &bundles)?;
                         self.current_epoch_keys_ingested = true;
+                        // Ingestion is complete, so no prior-cert blob can
+                        // still be "missing" — clear the gauge in case an
+                        // earlier iteration's cert attempt set it before
+                        // this epoch resolved as a chain-true no-cert one.
+                        self.dwallet_mpc_metrics.prior_cert_blobs_missing.set(0);
                         info!(
                             epoch = self.epoch_id,
                             dealt = self.validator_mpc_keys_by_party_id.secp256k1_pvss.len(),

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -153,7 +153,12 @@ enum PriorCertKeysOutcome {
     /// Transient miss with the cert PRESENT (store read error, perpetual
     /// handle not installed, blobs still propagating). Retry next service
     /// iteration WITHOUT falling back to the channel — see the divergence
-    /// note at the call site.
+    /// note at the call site. The repair action behind the retry is the
+    /// peer-blob fetcher's prior-cert pass
+    /// (`fetch_missing_prior_cert_mpc_data_blobs`), which fetches missing
+    /// cert-pinned blobs from committee peers into the perpetual store —
+    /// without it a store that never held a long-dark member's blob would
+    /// retry forever (issue #1881).
     RetryLater,
 }
 
@@ -1319,6 +1324,7 @@ impl DWalletMPCManager {
         });
         match assembly {
             OffChainMpcDataAssembly::Complete(bundles) => {
+                self.dwallet_mpc_metrics.prior_cert_blobs_missing.set(0);
                 self.validator_mpc_keys_by_party_id =
                     get_validator_mpc_keys_by_party_id(&self.committee, &bundles)?;
                 self.current_epoch_keys_ingested = true;
@@ -1333,6 +1339,13 @@ impl DWalletMPCManager {
                 Ok(PriorCertKeysOutcome::Ingested)
             }
             OffChainMpcDataAssembly::Incomplete { missing } => {
+                // Surface the deferral without log access (issue #1881): the
+                // gauge holds the missing-blob count until the peer-blob
+                // fetcher's prior-cert repair lands the blobs and assembly
+                // completes (which resets it to 0 above).
+                self.dwallet_mpc_metrics
+                    .prior_cert_blobs_missing
+                    .set(missing.len() as i64);
                 if self.should_warn_prior_cert_keys() {
                     warn!(
                         prior_epoch,

--- a/crates/ika-core/src/epoch_tasks/peer_blob_fetcher.rs
+++ b/crates/ika-core/src/epoch_tasks/peer_blob_fetcher.rs
@@ -173,6 +173,7 @@ impl PeerBlobFetcher {
             &self.blob_cache,
             &self.p2p_network,
             &self.authority_names_to_peer_ids,
+            &self.fetch_outcomes,
         )
         .await;
     }
@@ -406,15 +407,18 @@ impl PeerBlobFetcher {
 /// blob's owner is asked first, but it is typically exactly the dark member,
 /// so every other committee peer follows in shuffled order. Fetched bytes
 /// are verified (digest + structural decode) before the write-through
-/// insert into the perpetual + in-memory stores. Returns the number of
-/// blobs fetched and persisted this pass; still-missing blobs are retried
-/// on the next pass.
+/// insert into the perpetual + in-memory stores; every fetch outcome
+/// increments the same `fetch_outcomes` counter as the announcement pass,
+/// so a peer serving garbage on this path is equally visible. Returns the
+/// number of blobs fetched and persisted this pass; still-missing blobs
+/// are retried on the next pass.
 pub async fn fetch_missing_prior_cert_mpc_data_blobs(
     cert: &CertifiedHandoffAttestation,
     own_authority: AuthorityName,
     blob_cache: &BlobCache,
     p2p_network: &Network,
     authority_names_to_peer_ids: &HashMap<AuthorityName, PeerId>,
+    fetch_outcomes: &IntCounterVec,
 ) -> usize {
     let missing: Vec<(AuthorityName, [u8; 32])> = cert
         .attestation
@@ -457,21 +461,41 @@ pub async fn fetch_missing_prior_cert_mpc_data_blobs(
         for (candidate_authority, peer_id) in candidates {
             match fetch_blob(p2p_network, peer_id, digest).await {
                 Ok(Some(bytes)) => {
-                    if !matches!(
-                        verify_peer_blob_for_relay(&bytes, &digest),
-                        PeerBlobVerdict::Accept
-                    ) {
-                        debug!(
-                            ?owner,
-                            ?candidate_authority,
-                            ?peer_id,
-                            expected = ?digest,
-                            "prior-cert blob repair: candidate served bytes that fail \
-                             digest/decode verification; trying next peer"
-                        );
-                        continue;
+                    match verify_peer_blob_for_relay(&bytes, &digest) {
+                        PeerBlobVerdict::Accept => {}
+                        PeerBlobVerdict::HashMismatch => {
+                            fetch_outcomes.with_label_values(&["hash_mismatch"]).inc();
+                            debug!(
+                                ?owner,
+                                ?candidate_authority,
+                                ?peer_id,
+                                expected = ?digest,
+                                "prior-cert blob repair: candidate served bytes that don't \
+                                 match the cert digest; trying next peer"
+                            );
+                            continue;
+                        }
+                        PeerBlobVerdict::DecodeFailed => {
+                            // Hash matched but the bytes fail structural
+                            // decode — only the blob's producer could
+                            // craft hash-matching bad bytes, so this is a
+                            // byzantine signal, distinguished from a
+                            // plain mismatch in metrics and logs.
+                            fetch_outcomes.with_label_values(&["decode_failed"]).inc();
+                            debug!(
+                                ?owner,
+                                ?candidate_authority,
+                                ?peer_id,
+                                "prior-cert blob repair: candidate served hash-matching bytes \
+                                 that fail structural decode; refusing to persist"
+                            );
+                            continue;
+                        }
                     }
                     if let Err(e) = blob_cache.insert(digest, bytes) {
+                        fetch_outcomes
+                            .with_label_values(&["cache_insert_failed"])
+                            .inc();
                         warn!(
                             error = ?e,
                             ?owner,
@@ -480,6 +504,7 @@ pub async fn fetch_missing_prior_cert_mpc_data_blobs(
                         );
                         continue;
                     }
+                    fetch_outcomes.with_label_values(&["ok"]).inc();
                     info!(
                         ?owner,
                         served_by = ?candidate_authority,
@@ -491,6 +516,7 @@ pub async fn fetch_missing_prior_cert_mpc_data_blobs(
                     break;
                 }
                 Ok(None) => {
+                    fetch_outcomes.with_label_values(&["not_found"]).inc();
                     debug!(
                         ?owner,
                         ?candidate_authority,
@@ -499,6 +525,7 @@ pub async fn fetch_missing_prior_cert_mpc_data_blobs(
                     );
                 }
                 Err(e) => {
+                    fetch_outcomes.with_label_values(&["transport_error"]).inc();
                     debug!(
                         ?owner,
                         ?candidate_authority,

--- a/crates/ika-core/src/epoch_tasks/peer_blob_fetcher.rs
+++ b/crates/ika-core/src/epoch_tasks/peer_blob_fetcher.rs
@@ -34,13 +34,25 @@
 //! Anemo server — the in-memory write is what lets *other* peers
 //! fetch the blob from this validator without a restart, turning
 //! every honest receiver into a relay.
+//!
+//! Each pass also repairs the prior epoch's handoff-cert
+//! `ValidatorMpcData` blobs
+//! ([`fetch_missing_prior_cert_mpc_data_blobs`]): carried-forward
+//! members that have been dark for epochs never announce in the
+//! current epoch, so the announcement-driven pass cannot cover
+//! them, yet the MPC manager's current-epoch key ingestion needs
+//! exactly their cert-pinned blobs (issue #1881).
 
-use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use crate::authority::authority_per_epoch_store::{
+    AuthorityPerEpochStore, AuthorityPerEpochStoreTrait,
+};
 use crate::blob_cache::BlobCache;
+use crate::validator_metadata::{PeerBlobVerdict, verify_peer_blob_for_relay};
 use anemo::{Network, PeerId};
 use ika_network::mpc_artifacts::fetch_blob;
 use ika_types::committee::EpochId;
 use ika_types::crypto::AuthorityName;
+use ika_types::handoff::{CertifiedHandoffAttestation, HandoffItemKey};
 use prometheus::IntCounterVec;
 use rand::seq::SliceRandom;
 use std::collections::{HashMap, HashSet};
@@ -123,8 +135,46 @@ impl PeerBlobFetcher {
         }
         loop {
             self.fetch_missing_blobs_once().await;
+            self.fetch_missing_prior_cert_blobs_once().await;
             tokio::time::sleep(poll_interval).await;
         }
+    }
+
+    /// Single prior-cert repair pass: read the prior epoch's handoff cert
+    /// (if any) and fetch every cert-pinned `ValidatorMpcData` blob missing
+    /// locally from committee peers — see
+    /// [`fetch_missing_prior_cert_mpc_data_blobs`] for why the
+    /// announcement-driven pass alone cannot cover these blobs.
+    async fn fetch_missing_prior_cert_blobs_once(&self) {
+        let Some(prior_epoch) = self.epoch_id.checked_sub(1) else {
+            return;
+        };
+        let Some(epoch_store) = self.epoch_store.upgrade() else {
+            return;
+        };
+        let cert = match epoch_store.get_certified_handoff_attestation(prior_epoch) {
+            Ok(Some(cert)) => cert,
+            // No cert (genesis, a pre-v4 prior epoch, or the bootstrap
+            // anchor still fetching) — nothing to repair from; the next
+            // pass re-checks.
+            Ok(None) => return,
+            Err(e) => {
+                debug!(
+                    prior_epoch,
+                    error = ?e,
+                    "peer blob fetcher: prior handoff cert read failed; retrying next pass"
+                );
+                return;
+            }
+        };
+        fetch_missing_prior_cert_mpc_data_blobs(
+            &cert,
+            self.own_authority,
+            &self.blob_cache,
+            &self.p2p_network,
+            &self.authority_names_to_peer_ids,
+        )
+        .await;
     }
 
     /// Single pass over the per-epoch announcement table. Fetches any
@@ -333,4 +383,138 @@ impl PeerBlobFetcher {
             }
         }
     }
+}
+
+/// Fetch the prior handoff cert's `ValidatorMpcData` blobs (∩ current
+/// committee) that are missing from the local stores, from committee peers.
+///
+/// The announcement-driven pass only covers blobs someone announced THIS
+/// epoch. A carried-forward committee member that has been dark for epochs
+/// never re-announces — its digest re-enters each epoch's cert via
+/// carry-forward — so a validator whose perpetual store post-dates that
+/// member's last announcement (binary upgraded to the blob-writing version
+/// later, DB restored, writes lost in a crash window) holds no local copy
+/// and has no announcement to fetch by. The MPC manager sources the CURRENT
+/// epoch's validator key bundle from exactly these cert digests against the
+/// perpetual store and correctly defers ingestion while any pinned blob is
+/// missing (never falling back to the freeze channel); without this repair
+/// the deferral retries the same local store forever and the validator is
+/// MPC-dead for this and every following epoch (issue #1881).
+///
+/// Byte-safe by construction: the digests come from the quorum-signed cert
+/// and blobs are content-addressed, so ANY holder is authoritative. The
+/// blob's owner is asked first, but it is typically exactly the dark member,
+/// so every other committee peer follows in shuffled order. Fetched bytes
+/// are verified (digest + structural decode) before the write-through
+/// insert into the perpetual + in-memory stores. Returns the number of
+/// blobs fetched and persisted this pass; still-missing blobs are retried
+/// on the next pass.
+pub async fn fetch_missing_prior_cert_mpc_data_blobs(
+    cert: &CertifiedHandoffAttestation,
+    own_authority: AuthorityName,
+    blob_cache: &BlobCache,
+    p2p_network: &Network,
+    authority_names_to_peer_ids: &HashMap<AuthorityName, PeerId>,
+) -> usize {
+    let missing: Vec<(AuthorityName, [u8; 32])> = cert
+        .attestation
+        .items
+        .iter()
+        .filter_map(|(key, digest)| match key {
+            HandoffItemKey::ValidatorMpcData { validator } => Some((*validator, *digest)),
+            _ => None,
+        })
+        // Only current committee members feed the manager's key bundle; a
+        // departed validator's carried digest is dead weight here.
+        .filter(|(validator, _)| {
+            *validator == own_authority || authority_names_to_peer_ids.contains_key(validator)
+        })
+        .filter(|(_, digest)| !blob_cache.contains(digest))
+        .collect();
+    if missing.is_empty() {
+        return 0;
+    }
+    let mut other_peers: Vec<(AuthorityName, PeerId)> = authority_names_to_peer_ids
+        .iter()
+        .filter(|(authority, _)| **authority != own_authority)
+        .map(|(authority, peer_id)| (*authority, *peer_id))
+        .collect();
+    other_peers.shuffle(&mut rand::rng());
+
+    let mut fetched_count = 0;
+    for (owner, digest) in missing {
+        let owner_peer = authority_names_to_peer_ids.get(&owner).copied();
+        let candidates = owner_peer
+            .map(|peer_id| (owner, peer_id))
+            .into_iter()
+            .chain(
+                other_peers
+                    .iter()
+                    .filter(|(_, peer_id)| Some(*peer_id) != owner_peer)
+                    .copied(),
+            );
+        let mut fetched = false;
+        for (candidate_authority, peer_id) in candidates {
+            match fetch_blob(p2p_network, peer_id, digest).await {
+                Ok(Some(bytes)) => {
+                    if !matches!(
+                        verify_peer_blob_for_relay(&bytes, &digest),
+                        PeerBlobVerdict::Accept
+                    ) {
+                        debug!(
+                            ?owner,
+                            ?candidate_authority,
+                            ?peer_id,
+                            expected = ?digest,
+                            "prior-cert blob repair: candidate served bytes that fail \
+                             digest/decode verification; trying next peer"
+                        );
+                        continue;
+                    }
+                    if let Err(e) = blob_cache.insert(digest, bytes) {
+                        warn!(
+                            error = ?e,
+                            ?owner,
+                            ?candidate_authority,
+                            "prior-cert blob repair: cache insert failed; trying next peer"
+                        );
+                        continue;
+                    }
+                    info!(
+                        ?owner,
+                        served_by = ?candidate_authority,
+                        ?peer_id,
+                        "prior-cert blob repair: fetched + persisted missing mpc_data blob"
+                    );
+                    fetched = true;
+                    fetched_count += 1;
+                    break;
+                }
+                Ok(None) => {
+                    debug!(
+                        ?owner,
+                        ?candidate_authority,
+                        ?peer_id,
+                        "prior-cert blob repair: candidate doesn't have the blob; trying next"
+                    );
+                }
+                Err(e) => {
+                    debug!(
+                        ?owner,
+                        ?candidate_authority,
+                        ?peer_id,
+                        error = ?e,
+                        "prior-cert blob repair: transport error; trying next peer"
+                    );
+                }
+            }
+        }
+        if !fetched {
+            debug!(
+                ?owner,
+                "prior-cert blob repair: no candidate served the blob this pass; will retry"
+            );
+        }
+    }
+    fetched_count
 }

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -303,7 +303,15 @@ next epoch inherits.
      epoch), where the epoch's own freeze is the only agreed set. A
      cert READ ERROR retries without falling back to the channel; a
      missing cert-pinned blob defers ingestion (retry as propagation
-     converges), never downgrades to the channel bundle.
+     converges), never downgrades to the channel bundle. The deferral
+     has an active repair (issue #1881): each per-epoch peer-blob
+     fetcher pass also fetches the prior cert's `ValidatorMpcData`
+     blobs missing locally from committee peers (any holder is
+     authoritative — content-addressed, verified against the
+     quorum-signed cert digest) into the perpetual store, so a store
+     that never held a long-dark carried-forward member's blob heals
+     instead of deferring forever; the missing count is exported as
+     `ika_dwallet_mpc_prior_cert_blobs_missing`.
    - The hydration-clobber variant (issue #1852, never-instantiated
      shape) and its three defenses. Post-restart, until the per-epoch
      blob source installs, the sync task's full chain read publishes an

--- a/dev-docs/specs/validator-mpc-data-announcements.md
+++ b/dev-docs/specs/validator-mpc-data-announcements.md
@@ -239,6 +239,24 @@ validator latched for the whole epoch. Sourcing rules
    ingesting it would byte-diverge this validator's VSS presign public
    inputs from the committee's. Cert read errors retry; missing
    cert-pinned blobs defer ingestion until propagation converges.
+4. **Deferral repair — prior-cert blob refetch**: announcement-driven
+   fetching cannot converge a cert-pinned blob whose owner has been
+   dark for epochs — the owner never re-announces (carry-forward
+   re-pins its old digest into every cert instead), so a host whose
+   perpetual store post-dates the owner's last announcement holds no
+   copy and has no announcement to fetch by; the deferral in rule 3
+   would retry the same local store forever, MPC-wedging the validator
+   for this and every following epoch (issue #1881). Each peer-blob
+   fetcher pass therefore also fetches the prior cert's
+   `ValidatorMpcData` digests (∩ current committee) missing locally
+   from committee peers (`fetch_missing_prior_cert_mpc_data_blobs`):
+   any holder is authoritative — blobs are content-addressed and
+   verified (digest + structural decode) against the quorum-signed
+   cert digest before the write-through persist — and the manager's
+   next retry assembles from the repaired store. The missing-blob
+   count is exported as the `ika_dwallet_mpc_prior_cert_blobs_missing`
+   gauge (0 once assembly completes), so a stuck ingest is visible
+   without log access.
 
 ## Next-committee assembly
 


### PR DESCRIPTION
## Mechanism (issue #1881, 10 live testnet validators MPC-dead)

Since #1880, `ingest_offchain_mpc_keys` sources the current epoch's validator MPC key bundle from the prior epoch's handoff certificate (`ValidatorMpcData` items ∩ current committee) assembled against the perpetual `mpc_artifact_blobs` store. On `OffChainMpcDataAssembly::Incomplete` it returns `RetryLater` — correctly never falling back to the freeze channel (superset-divergence hazard) — but the retry had **no repair action behind it**:

- A carried-forward committee member that has been dark for epochs never re-announces; carry-forward re-pins its **old** digest into every next cert.
- The per-epoch `PeerBlobFetcher` only fetches digests from the current epoch's announcement table, so it never covers those blobs.
- A host whose perpetual store post-dates that member's last announcement (binary upgraded to the blob-writing version later, DB restored, crash-window write loss) holds no copy and retries the same local store forever. The next epoch boundary re-pins the same digests — the wedge is permanent.

## Fix

1. **Peer refetch on Incomplete** (`fetch_missing_prior_cert_mpc_data_blobs`, `crates/ika-core/src/epoch_tasks/peer_blob_fetcher.rs`): each fetcher pass (every ~2s, the existing async per-epoch task that owns the network handle — no new networking mechanism) now also reads the prior epoch's handoff cert and fetches every cert-pinned `ValidatorMpcData` blob (∩ current committee) missing locally, via the existing content-addressed `fetch_blob` path — the same pattern #1859 applied to `NetworkDkgOutput` (`install_joiner_network_key_outputs`). Owner asked first, then every other committee peer in shuffled order (any holder is authoritative); bytes verified with `verify_peer_blob_for_relay` (cert-digest + structural decode) before the write-through `BlobCache` insert (perpetual + in-memory, so the healed validator also relays). The manager's next 20ms retry assembles from the repaired store. Bounded: only missing digests, retried per pass.
2. **`RetryLater`-never-degrades-to-channel untouched** — the divergence guard and all assembly ordering/set semantics are exactly as before; the refetched blobs are digest-pinned by the quorum-signed cert, so persisting them cannot alter MPC public-input bytes.
3. **Metric**: new gauge `ika_dwallet_mpc_prior_cert_blobs_missing` — set to the missing-digest count on each `Incomplete`, reset to 0 when assembly completes. A stuck ingest is now scrapable instead of presenting only as absent advances.
4. The prepare-then-start barrier (`ika-node/src/lib.rs`) is deliberately unchanged: it never gated on `ValidatorMpcData` items (separate plane), and gating it would block epoch start on an unfetchable blob. The continuously-running fetcher heals mid-epoch regardless of boot path — which is what the wedged fleet needs.

Specs updated in the same PR: `dev-docs/specs/validator-mpc-data-announcements.md` (new sourcing rule 4: deferral repair) and `dev-docs/specs/handoff.md` (cert-consumer paragraph).

## Tests

`cargo test --release -p ika-core mid_epoch_restart_keys` (real class-groups crypto):

```
test ...::prior_cert_set_wins_over_wider_channel_bundle ... ok
test ...::missing_prior_cert_blob_is_refetched_from_peers_and_ingested ... ok
test ...::mid_epoch_restart_ingests_keys_without_channel_delivery ... ok
test ...::missing_prior_cert_blob_defers_without_channel_fallback ... ok
test result: ok. 4 passed; 0 failed; ... finished in 365.63s
```

New regression test `missing_prior_cert_blob_is_refetched_from_peers_and_ingested`: withholds one carried member's blob from the perpetual store (cert pins all four members), asserts ingestion defers with the gauge at 1, serves the blob from a live committee peer over a real Anemo `GetMpcDataBlob` endpoint with the dark owner mapped to an unreachable peer (exercising the any-holder fallback), then asserts the repair fetches + digest-verifies + persists the blob to the perpetual store and the next ingest attempt completes with all members dealt and the gauge back at 0.

### Test-testing (fault injection, per dev-docs/playbooks/test-testing.md)

Injected a minimal fault — an early `return 0;` in `fetch_missing_prior_cert_mpc_data_blobs` before the fetch loop, i.e. exactly the pre-fix "no repair behind RetryLater" behavior. The test failed with the expected evidence:

```
WARN ika_core::dwallet_mpc::mpc_manager: prior-cert mpc_data blobs missing or undecodable in the perpetual store; current-epoch validator MPC keys not ingested yet — retrying prior_epoch=0 missing=[k#91833a83...]
assertion `left == right` failed: the dark member's cert-pinned blob must be fetched from the live peer
  left: 0
 right: 1
test ...::missing_prior_cert_blob_is_refetched_from_peers_and_ingested ... FAILED
```

(the WARN is the exact wedge signature operators grepped on live testnet). Fault reverted; test re-run green (`1 passed; 0 failed; finished in 215.85s`).

## Verification

- `cargo check -p ika-core --all-targets` clean
- `cargo clippy -p ika-core --all-targets` clean (no new warnings)
- `cargo fmt --all` before commit
- `ika-node` untouched

## Live-evidence update (2026-07-23)

Per the [issue author's follow-up on #1881](https://github.com/dwallet-labs/ika/issues/1881#issuecomment-5056468913): the ten originally-wedged validators self-healed on 07-22 via epoch-360 **re-announcement backfill** — continuing members re-announced their (unchanged, content-addressed) blobs, the perpetual store backfilled, and the 20ms cert-path retry assembled — empirically confirming the missing-blob mechanism and the #1880 convergence path. Four other validators (Brightlystake, alphab.ai, pvl, remrerli) stayed wedged 16h+ through that same backfill window: their missing digests belong to members that **never announced in epoch 360** (alive in consensus but MPC-dead — the #1882 casualties), which re-announcement can never cover. Peer refetch is the complete fix for exactly that case, and the compound case is now in the regression matrix (`mpc_dead_owner_not_found_falls_through_to_live_holder`: a reachable owner answering `GetMpcDataBlob` not-found, repair falling through to a live committee holder, with `not_found` + `ok` recorded on the fetch-outcomes counter).

Closes #1881

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnRjdvthoSVjPG5UtGtj57
