### PR TITLE
fix(sui-connector): unwedge committee-ratchet boot on history-less Sui sources — terminal NotFound classification, pruned-boundary fallback for epoch records, loud anchor-less-boot failure (#1882)

### DIFF
--- a/crates/ika-core/src/sui_connector/committee_store.rs
+++ b/crates/ika-core/src/sui_connector/committee_store.rs
@@ -369,7 +369,7 @@ mod tests {
     use std::sync::Barrier;
 
     use sui_types::committee::{Committee, ProtocolVersion};
-    use sui_types::crypto::AuthorityKeyPair;
+    use sui_types::crypto::{AuthorityKeyPair, KeypairTraits, get_key_pair};
     use sui_types::gas::GasCostSummary;
     use sui_types::messages_checkpoint::{
         CheckpointContents, CheckpointSequenceNumber, CheckpointSummary, EndOfEpochData,
@@ -714,5 +714,64 @@ mod tests {
             Some(2),
             "persisted head must not regress on a staggered lower install"
         );
+    }
+
+    /// The persisted anchor is a *verification root*, so a corrupted or
+    /// hand-edited anchor must fail CLOSED. Tampering the stored transition
+    /// summary (replacing it with one signed by a foreign committee) makes the
+    /// store reopen — the head still resolves, from the forged summary — but
+    /// every genuine current-epoch summary then fails BLS verification
+    /// (`BadSignature`, terminal): the forged root can misdirect derivation,
+    /// yet nothing real ever verifies against it, and nothing is accepted
+    /// silently.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tampered_persisted_anchor_fails_closed() {
+        let (base, keys) = Committee::new_simple_test_committee();
+        let dir = tempfile::tempdir().unwrap();
+        let tables = Arc::new(AuthorityPerpetualTables::open(dir.path(), None));
+        {
+            let store = CommitteeStore::open(
+                tables.clone(),
+                Some(CommitteeBootstrap::UnsafeGenesis(base.clone())),
+            )
+            .unwrap();
+            for epoch in 0..=1u64 {
+                let committee_e = committee_at(&base, epoch);
+                store
+                    .install_next_from_summary(&signed_end_of_epoch(&committee_e, &keys, epoch))
+                    .unwrap();
+            }
+            assert_eq!(store.head_epoch(), 2);
+        }
+
+        // Hand-edit the anchor: overwrite the epoch-1 transition summary with
+        // one signed by a DIFFERENT (attacker) committee, so committee[2] now
+        // derives to the attacker's set. `new_simple_test_committee` is
+        // fixed-seed (it would reproduce the REAL keys), so the attacker's
+        // keys come from the OS RNG.
+        let attacker_keys: Vec<AuthorityKeyPair> = (0..4)
+            .map(|_| get_key_pair::<AuthorityKeyPair>().1)
+            .collect();
+        let attacker = Committee::new_for_testing_with_normalized_voting_power(
+            1,
+            attacker_keys
+                .iter()
+                .map(|key| (key.public().into(), 1))
+                .collect(),
+        );
+        let forged = signed_end_of_epoch(&attacker, &attacker_keys, 1);
+        tables.sui_committee_summaries.insert(&1, &forged).unwrap();
+
+        let reopened = CommitteeStore::open(tables, None).unwrap();
+        assert_eq!(reopened.head_epoch(), 2);
+
+        // A genuine summary signed by the REAL committee[2] must not verify
+        // against the tampered chain — fail closed, never silent acceptance.
+        let genuine = signed_end_of_epoch(&committee_at(&base, 2), &keys, 2);
+        match reopened.verify_summary(genuine) {
+            Err(SummaryVerifyError::BadSignature { epoch: 2, .. }) => {}
+            Ok(_) => panic!("a tampered anchor must not verify genuine summaries"),
+            Err(other) => panic!("expected a terminal BadSignature, got {other:?}"),
+        }
     }
 }

--- a/crates/ika-core/src/sui_connector/ocs_metrics.rs
+++ b/crates/ika-core/src/sui_connector/ocs_metrics.rs
@@ -29,6 +29,16 @@ pub struct OcsMetrics {
     /// `allow_unverified_committee_fallback` is on). Security-critical: each
     /// increment is a link of the proof chain trusted on the endpoint's word.
     pub unverified_committee_fallback_total: IntCounter,
+    /// 1 while the last completed committee-ratchet attempt failed, 0 once one
+    /// succeeds. The direct health signal for a node that cannot advance its
+    /// committee head — e.g. booted against a source that serves no historical
+    /// epochs — which otherwise presents only as absent downstream series
+    /// while every verified read fails `missing_committee`.
+    pub ratchet_stalled: IntGauge,
+    /// Committee-ratchet attempt failures by reason (`transport` is the only
+    /// retryable one; every other reason is determinate and needs the operator
+    /// to act — typically re-anchor against a full-retention source).
+    pub ratchet_failures_total: IntCounterVec, // labels: ["reason"]
 
     // Pusher (sui-state-direct)
     pub pusher_cursor_seq: IntGauge,
@@ -88,6 +98,19 @@ impl OcsMetrics {
             unverified_committee_fallback_total: register_int_counter_with_registry!(
                 "ika_ocs_unverified_committee_fallback_total",
                 "SECURITY-CRITICAL: committee[E+1] installed via the unverified direct-fetch prune fallback (trust degraded to the endpoint's word)",
+                registry,
+            )
+            .unwrap(),
+            ratchet_stalled: register_int_gauge_with_registry!(
+                "ika_ocs_ratchet_stalled",
+                "1 while the last completed Sui-committee-ratchet attempt failed, 0 once one succeeds; a persistent 1 means verified reads past the persisted anchor cannot work (re-anchor against a full-retention source)",
+                registry,
+            )
+            .unwrap(),
+            ratchet_failures_total: register_int_counter_vec_with_registry!(
+                "ika_ocs_ratchet_failures_total",
+                "Sui-committee-ratchet attempt failures by reason (only `transport` is retryable; every other reason is determinate and needs operator action)",
+                &["reason"],
                 registry,
             )
             .unwrap(),

--- a/crates/ika-core/src/sui_connector/ocs_verifier.rs
+++ b/crates/ika-core/src/sui_connector/ocs_verifier.rs
@@ -41,11 +41,12 @@ pub enum OcsError {
     #[error("checkpoint {0} is not end-of-epoch")]
     NotEndOfEpoch(CheckpointSequenceNumber),
     #[error(
-        "proof chain broken at epoch {epoch}: the end-of-epoch checkpoint is pruned upstream (and \
-         absent from any configured checkpoint archive) so the next committee cannot be \
-         BLS-verified; configure a `sui_checkpoint_archive` that retains this epoch's \
-         end-of-epoch checkpoint, or set allow_unverified_committee_fallback to accept degraded \
-         trust"
+        "proof chain broken at epoch {epoch}: the epoch record or its end-of-epoch checkpoint is \
+         pruned upstream (and absent from any configured checkpoint archive) so the next \
+         committee cannot be BLS-verified from the persisted anchor. Remediation: boot once \
+         against a full-retention Sui RPC so the persisted committee anchor catches up, \
+         configure a `sui_checkpoint_archive` that retains this epoch's end-of-epoch \
+         checkpoint, or set allow_unverified_committee_fallback to accept degraded trust"
     )]
     ProofChainBroken { epoch: u64 },
     #[error(
@@ -83,6 +84,50 @@ impl OcsError {
     /// rather than spin forever against an unhealable condition.
     pub fn is_retryable(&self) -> bool {
         matches!(self, OcsError::Transport(_))
+    }
+
+    /// Bounded label for `OcsMetrics::ratchet_failures_total`.
+    pub fn metric_reason(&self) -> &'static str {
+        match self {
+            OcsError::Transport(_) => "transport",
+            OcsError::MissingCommittee(_) => "missing_committee",
+            OcsError::BadCheckpointSig(..) => "bad_checkpoint_sig",
+            OcsError::NotEndOfEpoch(_) => "not_end_of_epoch",
+            OcsError::ProofChainBroken { .. } => "proof_chain_broken",
+            OcsError::FallbackEpochMismatch { .. } | OcsError::RatchetEpochMismatch { .. } => {
+                "epoch_mismatch"
+            }
+            OcsError::Ika(_) => "store",
+        }
+    }
+}
+
+/// Map one committee-transition install onto the ratchet's error surface.
+/// `Installed(E)` is the only success; a checkpoint served at an epoch
+/// boundary that is not the next transition means the chain the source
+/// presented is inconsistent with the verified head — a determinate
+/// `NotEndOfEpoch` at `seq`.
+fn installed_epoch(
+    result: Result<CommitteeTransition, CommitteeTransitionError>,
+    seq: CheckpointSequenceNumber,
+) -> Result<u64, OcsError> {
+    match result {
+        Ok(CommitteeTransition::Installed(epoch)) => Ok(epoch),
+        Ok(CommitteeTransition::NotNextTransition) => Err(OcsError::NotEndOfEpoch(seq)),
+        Err(CommitteeTransitionError::MissingCommittee(epoch)) => {
+            Err(OcsError::MissingCommittee(epoch))
+        }
+        Err(
+            CommitteeTransitionError::BadSignature { error, .. }
+            | CommitteeTransitionError::Extract { error, .. },
+        ) => Err(OcsError::BadCheckpointSig(seq, error)),
+        Err(CommitteeTransitionError::EpochMismatch { expected, got }) => {
+            Err(OcsError::RatchetEpochMismatch {
+                requested: expected,
+                returned: got,
+            })
+        }
+        Err(CommitteeTransitionError::Store(e)) => Err(e.into()),
     }
 }
 
@@ -183,33 +228,12 @@ impl OcsVerifyingClient {
                 .fetch_checkpoint(seq)
                 .await
                 .map_err(|e| OcsError::Ika(format!("archive fetch checkpoint {seq}: {e}")))?;
-            match self.committees.install_next_from_summary(&summary) {
-                Ok(CommitteeTransition::Installed(epoch)) => {
-                    info!(epoch, seq, "cold-bootstrapped Sui committee from archive");
-                }
-                // `epochs.json[head]` is not epoch `head`'s end-of-epoch
-                // checkpoint — the enumeration is inconsistent with the verified
-                // chain (gapped/reordered), so we cannot verify past this point.
-                Ok(CommitteeTransition::NotNextTransition) => {
-                    return Err(OcsError::NotEndOfEpoch(seq));
-                }
-                Err(CommitteeTransitionError::MissingCommittee(e)) => {
-                    return Err(OcsError::MissingCommittee(e));
-                }
-                Err(
-                    CommitteeTransitionError::BadSignature { error, .. }
-                    | CommitteeTransitionError::Extract { error, .. },
-                ) => {
-                    return Err(OcsError::BadCheckpointSig(seq, error));
-                }
-                Err(CommitteeTransitionError::EpochMismatch { expected, got }) => {
-                    return Err(OcsError::RatchetEpochMismatch {
-                        requested: expected,
-                        returned: got,
-                    });
-                }
-                Err(CommitteeTransitionError::Store(e)) => return Err(e.into()),
-            }
+            // `epochs.json[head]` not being epoch `head`'s end-of-epoch
+            // checkpoint means the enumeration is inconsistent with the
+            // verified chain (gapped/reordered) — `installed_epoch` surfaces
+            // that as `NotEndOfEpoch`, so we cannot verify past this point.
+            let epoch = installed_epoch(self.committees.install_next_from_summary(&summary), seq)?;
+            info!(epoch, seq, "cold-bootstrapped Sui committee from archive");
         }
     }
 
@@ -234,6 +258,28 @@ impl OcsVerifyingClient {
                 return Ok(());
             }
         };
+        // Health signal around the actual attempt (the coalesced early return
+        // above must not clear a stall another caller is observing): stalled
+        // is 1 while the last completed ratchet attempt failed, 0 once one
+        // succeeds. This is what makes a wedged ratchet — e.g. a boot against
+        // a source that serves no historical epochs — visible to alerting
+        // instead of presenting only as absent downstream series.
+        let result = self.ratchet_locked().await;
+        match &result {
+            Ok(()) => self.metrics.ratchet_stalled.set(0),
+            Err(e) => {
+                self.metrics.ratchet_stalled.set(1);
+                self.metrics
+                    .ratchet_failures_total
+                    .with_label_values(&[e.metric_reason()])
+                    .inc();
+            }
+        }
+        result
+    }
+
+    /// The walk itself; the caller holds `ratchet_lock`.
+    async fn ratchet_locked(&self) -> Result<(), OcsError> {
         // Cold-bootstrap once from the archive (if configured): walk the
         // committee chain genesis -> latest purely from the object store before
         // the transport walk below, BLS-verifying every summary from genesis
@@ -266,105 +312,28 @@ impl OcsVerifyingClient {
             if head >= target {
                 break;
             }
-            let last_seq = self.transport.last_checkpoint_of_epoch(head).await?;
+            // Both boundary reads can come back `NotFound` on a source that no
+            // longer serves epoch `head`: the epoch *record* itself (a pruned
+            // fullnode or sui-state-direct, which serves current state only —
+            // "Epoch N not found"), or the end-of-epoch *checkpoint*. Either
+            // way the transition can't be verified from this source, which is
+            // determinate for it — so both route to the same fallback chain
+            // instead of surfacing as a retryable transport error the callers
+            // would spin on forever.
+            let last_seq = match self.transport.last_checkpoint_of_epoch(head).await {
+                Ok(seq) => seq,
+                Err(TransportError::NotFound(reason)) => {
+                    self.pruned_boundary_fallback(head, target, None, &reason)
+                        .await?;
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            };
             let data = match self.transport.get_full_checkpoint(last_seq).await {
                 Ok(d) => d,
                 Err(TransportError::NotFound(reason)) => {
-                    // Verified fallback first: the end-of-epoch checkpoint was
-                    // pruned upstream, but a checkpoint archive may still retain
-                    // it. Fetch + BLS-verify against committee[head] + install —
-                    // identical trust to the primary path. The archive is
-                    // untrusted: a forged/corrupt summary fails verification here
-                    // (hard error, fail-closed), while a mere fetch miss falls
-                    // through to the next fallback.
-                    if let Some(archive) = &self.archive {
-                        match archive.fetch_checkpoint(last_seq).await {
-                            Ok((summary, _contents)) => {
-                                match self.committees.install_next_from_summary(&summary) {
-                                    Ok(CommitteeTransition::Installed(epoch)) => {
-                                        info!(
-                                            epoch,
-                                            last_seq,
-                                            "ratcheted Sui committee (verified archive fallback)"
-                                        );
-                                        continue;
-                                    }
-                                    Ok(CommitteeTransition::NotNextTransition) => {
-                                        return Err(OcsError::NotEndOfEpoch(last_seq));
-                                    }
-                                    Err(CommitteeTransitionError::MissingCommittee(e)) => {
-                                        return Err(OcsError::MissingCommittee(e));
-                                    }
-                                    Err(
-                                        CommitteeTransitionError::BadSignature { error, .. }
-                                        | CommitteeTransitionError::Extract { error, .. },
-                                    ) => {
-                                        return Err(OcsError::BadCheckpointSig(last_seq, error));
-                                    }
-                                    Err(CommitteeTransitionError::EpochMismatch {
-                                        expected,
-                                        got,
-                                    }) => {
-                                        return Err(OcsError::RatchetEpochMismatch {
-                                            requested: expected,
-                                            returned: got,
-                                        });
-                                    }
-                                    Err(CommitteeTransitionError::Store(e)) => {
-                                        return Err(e.into());
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                warn!(
-                                    head,
-                                    last_seq,
-                                    target,
-                                    error = %e,
-                                    "ratchet: end-of-epoch checkpoint pruned upstream and the \
-                                     verified archive fallback also failed; trying next fallback"
-                                );
-                            }
-                        }
-                    }
-                    if !self.allow_unverified_committee_fallback {
-                        error!(
-                            head,
-                            last_seq,
-                            target,
-                            ?reason,
-                            "ratchet: end-of-epoch checkpoint pruned upstream and the unverified \
-                             fallback is disabled — proof chain broken; re-anchor required"
-                        );
-                        return Err(OcsError::ProofChainBroken { epoch: head });
-                    }
-                    error!(
-                        security_critical = true,
-                        head,
-                        last_seq,
-                        target,
-                        ?reason,
-                        "ratchet: end-of-epoch checkpoint pruned upstream; installing committee[E+1] \
-                         via UNVERIFIED direct fetch — trust degraded to the endpoint's word"
-                    );
-                    self.metrics.unverified_committee_fallback_total.inc();
-                    let next = self.transport.get_committee(Some(head + 1)).await?;
-                    // Even in unverified mode the endpoint doesn't get to pick
-                    // the epoch: `install_next` keys the store by the
-                    // committee's own epoch field, so an endpoint returning a
-                    // mislabeled committee could jump the ratchet head past
-                    // epochs that were never installed.
-                    if next.epoch != head + 1 {
-                        return Err(OcsError::FallbackEpochMismatch {
-                            requested: head + 1,
-                            returned: next.epoch,
-                        });
-                    }
-                    self.committees.install_next(next, None)?;
-                    info!(
-                        epoch = head + 1,
-                        "ratcheted Sui committee (UNVERIFIED direct-fetch fallback)"
-                    );
+                    self.pruned_boundary_fallback(head, target, Some(last_seq), &reason)
+                        .await?;
                     continue;
                 }
                 Err(e) => return Err(e.into()),
@@ -374,34 +343,128 @@ impl OcsVerifyingClient {
             // (`CommitteeStore::install_next_from_checkpoint`). `data` is the
             // end-of-epoch checkpoint of `head`, so this installs
             // `committee[head + 1]`.
-            match self.committees.install_next_from_checkpoint(&data) {
-                Ok(CommitteeTransition::Installed(epoch)) => {
-                    info!(epoch, last_seq, "ratcheted Sui committee");
+            let epoch = installed_epoch(
+                self.committees.install_next_from_checkpoint(&data),
+                last_seq,
+            )?;
+            info!(epoch, last_seq, "ratcheted Sui committee");
+        }
+        Ok(())
+    }
+
+    /// Fallback chain for a pruned epoch boundary at `head` — the source
+    /// returned `NotFound` for the epoch record (`last_seq` is `None`) or for
+    /// its end-of-epoch checkpoint. On success `committee[head + 1]` is
+    /// installed and the caller continues the walk.
+    ///
+    /// Verified archive first: fetch + BLS-verify against `committee[head]` +
+    /// install — identical trust to the primary path. The archive is untrusted:
+    /// a forged/corrupt summary fails verification (hard error, fail-closed),
+    /// while a mere fetch miss falls through. When the epoch record itself was
+    /// pruned, the end-of-epoch sequence is resolved from the archive's own
+    /// `epochs.json` enumeration — an untrusted hint that can stall the walk
+    /// but never forge an install (the per-summary verification decides).
+    ///
+    /// Then the degraded unverified direct fetch, only when
+    /// `allow_unverified_committee_fallback` is set; otherwise the terminal,
+    /// non-retryable `ProofChainBroken` whose message names the remediation.
+    async fn pruned_boundary_fallback(
+        &self,
+        head: u64,
+        target: u64,
+        last_seq: Option<CheckpointSequenceNumber>,
+        reason: &str,
+    ) -> Result<(), OcsError> {
+        if let Some(archive) = &self.archive {
+            let seq = match last_seq {
+                Some(seq) => Some(seq),
+                None => match archive.enumerate_end_of_epoch_seqs().await {
+                    Ok(seqs) => seqs.get(head as usize).copied(),
+                    Err(e) => {
+                        warn!(
+                            head,
+                            target,
+                            error = %e,
+                            "ratchet: archive epochs.json enumeration failed while resolving a \
+                             pruned epoch record; trying next fallback"
+                        );
+                        None
+                    }
+                },
+            };
+            match seq {
+                Some(seq) => match archive.fetch_checkpoint(seq).await {
+                    Ok((summary, _contents)) => {
+                        let epoch = installed_epoch(
+                            self.committees.install_next_from_summary(&summary),
+                            seq,
+                        )?;
+                        info!(
+                            epoch,
+                            seq, "ratcheted Sui committee (verified archive fallback)"
+                        );
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        warn!(
+                            head,
+                            seq,
+                            target,
+                            error = %e,
+                            "ratchet: epoch boundary pruned upstream and the verified archive \
+                             fallback also failed; trying next fallback"
+                        );
+                    }
+                },
+                None => {
+                    warn!(
+                        head,
+                        target,
+                        "ratchet: epoch boundary pruned upstream and the archive does not \
+                         enumerate this epoch; trying next fallback"
+                    );
                 }
-                // The relay returned a checkpoint at `last_checkpoint_of_epoch(head)`
-                // that isn't the end-of-epoch checkpoint of `head` (wrong epoch
-                // or not end-of-epoch) — a broken proof chain, non-retryable.
-                Ok(CommitteeTransition::NotNextTransition) => {
-                    return Err(OcsError::NotEndOfEpoch(last_seq));
-                }
-                Err(CommitteeTransitionError::MissingCommittee(e)) => {
-                    return Err(OcsError::MissingCommittee(e));
-                }
-                Err(
-                    CommitteeTransitionError::BadSignature { error, .. }
-                    | CommitteeTransitionError::Extract { error, .. },
-                ) => {
-                    return Err(OcsError::BadCheckpointSig(last_seq, error));
-                }
-                Err(CommitteeTransitionError::EpochMismatch { expected, got }) => {
-                    return Err(OcsError::RatchetEpochMismatch {
-                        requested: expected,
-                        returned: got,
-                    });
-                }
-                Err(CommitteeTransitionError::Store(e)) => return Err(e.into()),
             }
         }
+        if !self.allow_unverified_committee_fallback {
+            error!(
+                head,
+                ?last_seq,
+                target,
+                reason,
+                "ratchet: epoch boundary pruned upstream and the unverified fallback is \
+                 disabled — proof chain broken; boot once against a full-retention Sui RPC (or \
+                 configure a `sui_checkpoint_archive`) so the persisted committee anchor \
+                 catches up"
+            );
+            return Err(OcsError::ProofChainBroken { epoch: head });
+        }
+        error!(
+            security_critical = true,
+            head,
+            ?last_seq,
+            target,
+            reason,
+            "ratchet: epoch boundary pruned upstream; installing committee[E+1] via UNVERIFIED \
+             direct fetch — trust degraded to the endpoint's word"
+        );
+        self.metrics.unverified_committee_fallback_total.inc();
+        let next = self.transport.get_committee(Some(head + 1)).await?;
+        // Even in unverified mode the endpoint doesn't get to pick the epoch:
+        // `install_next` keys the store by the committee's own epoch field, so
+        // an endpoint returning a mislabeled committee could jump the ratchet
+        // head past epochs that were never installed.
+        if next.epoch != head + 1 {
+            return Err(OcsError::FallbackEpochMismatch {
+                requested: head + 1,
+                returned: next.epoch,
+            });
+        }
+        self.committees.install_next(next, None)?;
+        info!(
+            epoch = head + 1,
+            "ratcheted Sui committee (UNVERIFIED direct-fetch fallback)"
+        );
         Ok(())
     }
 }
@@ -497,6 +560,11 @@ mod tests {
     /// `get_committee` call so a test can assert the fallback was (not) taken.
     struct RatchetMock {
         target_epoch: u64,
+        /// Epochs below this floor have no record on this source:
+        /// `last_checkpoint_of_epoch` answers NotFound ("Epoch N not found")
+        /// for them — the sui-state-direct / pruned-fullnode shape. `None`
+        /// serves every epoch record.
+        epoch_floor: Option<u64>,
         /// `last_checkpoint_of_epoch(E)` -> seq. Defaults to `E` when absent.
         full_checkpoints: HashMap<CheckpointSequenceNumber, FullCheckpointOutcome>,
         /// Committee handed back by the unverified `get_committee(Some(_))`
@@ -509,6 +577,7 @@ mod tests {
         fn new(target_epoch: u64) -> Self {
             Self {
                 target_epoch,
+                epoch_floor: None,
                 full_checkpoints: HashMap::new(),
                 committees: HashMap::new(),
                 get_committee_calls: StdMutex::new(Vec::new()),
@@ -528,6 +597,9 @@ mod tests {
             &self,
             epoch: u64,
         ) -> Result<CheckpointSequenceNumber, TransportError> {
+            if self.epoch_floor.is_some_and(|floor| epoch < floor) {
+                return Err(TransportError::NotFound(format!("Epoch {epoch} not found")));
+            }
             // Identity mapping epoch->seq keeps the test's checkpoint map simple.
             Ok(epoch)
         }
@@ -622,6 +694,11 @@ mod tests {
         seqs: Vec<CheckpointSequenceNumber>,
         checkpoints:
             HashMap<CheckpointSequenceNumber, (CertifiedCheckpointSummary, CheckpointContents)>,
+        /// Fail this many `enumerate_end_of_epoch_seqs` calls before serving.
+        /// Lets a test defeat the one-shot cold-bootstrap backfill (which
+        /// enumerates first) so the ratchet's per-boundary archive fallback is
+        /// what gets exercised.
+        fail_enumerations: StdMutex<u32>,
     }
 
     #[async_trait]
@@ -629,6 +706,14 @@ mod tests {
         async fn enumerate_end_of_epoch_seqs(
             &self,
         ) -> Result<Vec<CheckpointSequenceNumber>, ika_sui_client::archive::ArchiveError> {
+            let mut remaining = self.fail_enumerations.lock().unwrap();
+            if *remaining > 0 {
+                *remaining -= 1;
+                return Err(ika_sui_client::archive::ArchiveError::Enumerate {
+                    url: "mock".into(),
+                    source: anyhow::anyhow!("enumeration unavailable"),
+                });
+            }
             Ok(self.seqs.clone())
         }
         async fn fetch_checkpoint(
@@ -661,7 +746,11 @@ mod tests {
             seqs.push(seq);
             checkpoints.insert(seq, (cp.checkpoint_summary, cp.checkpoint_contents));
         }
-        MockArchive { seqs, checkpoints }
+        MockArchive {
+            seqs,
+            checkpoints,
+            fail_enumerations: StdMutex::new(0),
+        }
     }
 
     fn client_with_store(store: Arc<CommitteeStore>) -> OcsVerifyingClient {
@@ -940,5 +1029,282 @@ mod tests {
         assert!(!OcsError::BadCheckpointSig(42, "bad bls".into()).is_retryable());
         assert!(!OcsError::MissingCommittee(3).is_retryable());
         assert!(!OcsError::Ika("store write failed".into()).is_retryable());
+    }
+
+    /// A transport whose current epoch is `target` and which serves epoch
+    /// records + end-of-epoch checkpoints only for epochs in `floor..target`:
+    /// `floor = 0` is a full-retention source, `floor = target` a history-less
+    /// (sui-state-direct-shaped) one that answers "Epoch N not found" for every
+    /// completed epoch.
+    fn mock_with_history(
+        base: &Committee,
+        keys: &[AuthorityKeyPair],
+        target: u64,
+        floor: u64,
+    ) -> RatchetMock {
+        let mut mock = RatchetMock::new(target);
+        mock.epoch_floor = (floor > 0).then_some(floor);
+        for epoch in floor..target {
+            let committee_e = committee_at_epoch(base, keys, epoch);
+            mock.full_checkpoints.insert(
+                epoch,
+                FullCheckpointOutcome::Data(Box::new(end_of_epoch_checkpoint(
+                    &committee_e,
+                    keys,
+                    epoch,
+                ))),
+            );
+        }
+        mock
+    }
+
+    /// First boot: bootstrap from genesis and ratchet to `head` over a
+    /// full-retention source, persisting the anchor into the perpetual tables
+    /// at `path`. Everything is dropped before returning — the "process" exits.
+    async fn anchor_db_at(
+        path: &std::path::Path,
+        base: &Committee,
+        keys: &[AuthorityKeyPair],
+        head: u64,
+    ) {
+        let tables = Arc::new(AuthorityPerpetualTables::open(path, None));
+        let store = Arc::new(
+            CommitteeStore::open(
+                tables,
+                Some(CommitteeBootstrap::UnsafeGenesis(base.clone())),
+            )
+            .unwrap(),
+        );
+        let mock = Arc::new(mock_with_history(base, keys, head, 0));
+        let client =
+            OcsVerifyingClient::new(mock, store.clone(), OcsMetrics::new_for_testing(), false);
+        client.ratchet_to_current_epoch().await.unwrap();
+        assert_eq!(store.head_epoch(), head, "first boot must reach the anchor");
+    }
+
+    fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) {
+        std::fs::create_dir_all(dst).unwrap();
+        for entry in std::fs::read_dir(src).unwrap() {
+            let entry = entry.unwrap();
+            let target = dst.join(entry.file_name());
+            if entry.file_type().unwrap().is_dir() {
+                copy_dir_recursive(&entry.path(), &target);
+            } else {
+                std::fs::copy(entry.path(), &target).unwrap();
+            }
+        }
+    }
+
+    /// The regression for the state-direct boot wedge: verify → persist the
+    /// anchor → restart against a source with NO history (every completed epoch
+    /// answers "Epoch N not found") → verification resumes from the persisted
+    /// anchor, ratchets forward using only the source's live window, and
+    /// current-epoch summaries verify. No genesis re-bootstrap, no unverified
+    /// fallback, no stall.
+    #[tokio::test]
+    async fn persisted_anchor_round_trip_resumes_on_history_less_source() {
+        let (base, keys) = Committee::new_simple_test_committee();
+        let dir = tempfile::tempdir().unwrap();
+        anchor_db_at(dir.path(), &base, &keys, 3).await;
+
+        // Restart: no bootstrap material — resumption must come purely from the
+        // persisted anchor in the perpetual tables.
+        let tables = Arc::new(AuthorityPerpetualTables::open(dir.path(), None));
+        let store =
+            Arc::new(CommitteeStore::open(tables, None).expect("resume from the persisted anchor"));
+        assert_eq!(
+            store.head_epoch(),
+            3,
+            "boot resumes at the anchor, not genesis"
+        );
+
+        // History-less source at epoch 4: only epoch 3's record/checkpoint (the
+        // live window) is served; epochs 0..3 are "Epoch N not found".
+        let mock = Arc::new(mock_with_history(&base, &keys, 4, 3));
+        let metrics = OcsMetrics::new_for_testing();
+        let client = OcsVerifyingClient::new(mock.clone(), store.clone(), metrics.clone(), false);
+        client.ratchet_to_current_epoch().await.unwrap();
+        assert_eq!(
+            store.head_epoch(),
+            4,
+            "ratchet resumed forward from the anchor"
+        );
+        assert_eq!(
+            mock.get_committee_call_count(),
+            0,
+            "no unverified fallback on the resumed path"
+        );
+        assert_eq!(metrics.ratchet_stalled.get(), 0);
+
+        // The resumed chain verifies current-epoch summaries — the capability
+        // every verified read (`verify_summary`) hangs off.
+        let current = end_of_epoch_checkpoint(&committee_at_epoch(&base, &keys, 4), &keys, 99);
+        store
+            .verify_summary(current.checkpoint_summary)
+            .expect("current-epoch summary verifies against the resumed committee chain");
+    }
+
+    /// The anchor is machine/identity-independent: copying the perpetual DB to
+    /// fresh directories (a mirrored / snapshot-restored "different node") and
+    /// booting there against the history-less source verifies exactly like the
+    /// original.
+    #[tokio::test]
+    async fn mirrored_db_copy_boots_from_the_same_anchor() {
+        let (base, keys) = Committee::new_simple_test_committee();
+        let dir = tempfile::tempdir().unwrap();
+        anchor_db_at(dir.path(), &base, &keys, 3).await;
+
+        let mirror_dir = tempfile::tempdir().unwrap();
+        copy_dir_recursive(dir.path(), mirror_dir.path());
+
+        let tables = Arc::new(AuthorityPerpetualTables::open(mirror_dir.path(), None));
+        let store = Arc::new(
+            CommitteeStore::open(tables, None).expect("a copied DB must be exactly as bootable"),
+        );
+        assert_eq!(store.head_epoch(), 3);
+
+        let mock = Arc::new(mock_with_history(&base, &keys, 4, 3));
+        let client =
+            OcsVerifyingClient::new(mock, store.clone(), OcsMetrics::new_for_testing(), false);
+        client.ratchet_to_current_epoch().await.unwrap();
+        assert_eq!(store.head_epoch(), 4);
+        let current = end_of_epoch_checkpoint(&committee_at_epoch(&base, &keys, 4), &keys, 99);
+        store
+            .verify_summary(current.checkpoint_summary)
+            .expect("the mirrored DB verifies current-epoch summaries");
+    }
+
+    /// A stale anchor (mirror promoted after the primary ran on) ratchets
+    /// forward as long as the source still serves the walk's needs — the epoch
+    /// record and end-of-epoch checkpoint of every epoch from the anchor to
+    /// current. Here: anchor 3, current 6, source window `3..`.
+    #[tokio::test]
+    async fn stale_anchor_within_source_window_catches_up() {
+        let (base, keys) = Committee::new_simple_test_committee();
+        let dir = tempfile::tempdir().unwrap();
+        anchor_db_at(dir.path(), &base, &keys, 3).await;
+
+        let tables = Arc::new(AuthorityPerpetualTables::open(dir.path(), None));
+        let store = Arc::new(CommitteeStore::open(tables, None).unwrap());
+        let mock = Arc::new(mock_with_history(&base, &keys, 6, 3));
+        let metrics = OcsMetrics::new_for_testing();
+        let client = OcsVerifyingClient::new(mock.clone(), store.clone(), metrics.clone(), false);
+        client.ratchet_to_current_epoch().await.unwrap();
+        assert_eq!(
+            store.head_epoch(),
+            6,
+            "stale anchor bridged across the window"
+        );
+        assert_eq!(mock.get_committee_call_count(), 0);
+        assert_eq!(metrics.ratchet_stalled.get(), 0);
+    }
+
+    /// Beyond the source's window the walk cannot be verified: the outcome is
+    /// the terminal, non-retryable `ProofChainBroken` naming the remediation —
+    /// never a silent retryable loop — and the stall is visible in metrics.
+    /// Here: anchor 3, current 6, but the source only serves epochs `5..`.
+    #[tokio::test]
+    async fn stale_anchor_beyond_source_window_fails_terminally_not_silently() {
+        let (base, keys) = Committee::new_simple_test_committee();
+        let dir = tempfile::tempdir().unwrap();
+        anchor_db_at(dir.path(), &base, &keys, 3).await;
+
+        let tables = Arc::new(AuthorityPerpetualTables::open(dir.path(), None));
+        let store = Arc::new(CommitteeStore::open(tables, None).unwrap());
+        let mock = Arc::new(mock_with_history(&base, &keys, 6, 5));
+        let metrics = OcsMetrics::new_for_testing();
+        let client = OcsVerifyingClient::new(mock.clone(), store.clone(), metrics.clone(), false);
+
+        let err = client.ratchet_to_current_epoch().await.unwrap_err();
+        assert!(
+            matches!(err, OcsError::ProofChainBroken { epoch: 3 }),
+            "expected ProofChainBroken at the anchor epoch, got {err:?}"
+        );
+        assert!(
+            !err.is_retryable(),
+            "beyond the window is determinate, not a retry loop"
+        );
+        assert!(
+            err.to_string().contains("full-retention Sui RPC"),
+            "the error must name the remediation: {err}"
+        );
+        assert_eq!(store.head_epoch(), 3, "head holds at the anchor");
+        assert_eq!(mock.get_committee_call_count(), 0, "no unverified fallback");
+        assert_eq!(metrics.ratchet_stalled.get(), 1, "the stall is visible");
+        assert_eq!(
+            metrics
+                .ratchet_failures_total
+                .with_label_values(&["proof_chain_broken"])
+                .get(),
+            1
+        );
+    }
+
+    /// When the epoch *record* itself is pruned (`last_checkpoint_of_epoch` →
+    /// NotFound), a configured checkpoint archive bridges the boundary: the
+    /// end-of-epoch sequence is resolved from the archive's own enumeration and
+    /// the fetched summary is BLS-verified before install — same trust as the
+    /// primary path, no unverified fallback. The one-shot cold-bootstrap
+    /// backfill is defeated (its enumeration fails once) so the per-boundary
+    /// fallback is what bridges.
+    #[tokio::test]
+    async fn pruned_epoch_record_bridged_by_verified_archive_fallback() {
+        let (committee, keys) = Committee::new_simple_test_committee();
+        let (_dir, store) = store_with_genesis(committee.clone());
+        let mut archive = archive_for_chain(&committee, &keys, 2);
+        archive.fail_enumerations = StdMutex::new(1);
+        let archive: Arc<dyn CheckpointArchive> = Arc::new(archive);
+
+        // The transport serves NO epoch records below the current epoch (2).
+        let mock = Arc::new(mock_with_history(&committee, &keys, 2, 2));
+        let metrics = OcsMetrics::new_for_testing();
+        let client = OcsVerifyingClient::new(mock.clone(), store.clone(), metrics.clone(), false)
+            .with_archive(Some(archive));
+
+        client.ratchet_to_current_epoch().await.unwrap();
+        assert_eq!(store.head_epoch(), 2, "archive bridged the pruned records");
+        assert_eq!(mock.get_committee_call_count(), 0);
+        assert_eq!(metrics.unverified_committee_fallback_total.get(), 0);
+        assert_eq!(metrics.ratchet_stalled.get(), 0);
+    }
+
+    /// Anchor-less cold start on a history-less source (fresh DB, genesis-only
+    /// anchor, sui-state-direct-shaped source): the DEFINED behavior is an
+    /// immediate terminal error naming the remediation, plus the stall metric —
+    /// not the historical invisible 30s retry-forever loop. (At node boot the
+    /// non-retryable classification asserted here is what fails startup loudly.)
+    #[tokio::test]
+    async fn anchorless_cold_start_on_history_less_source_fails_loud_with_metric() {
+        let (committee, keys) = Committee::new_simple_test_committee();
+        let (_dir, store) = store_with_genesis(committee.clone());
+        assert_eq!(store.head_epoch(), 0, "genesis-only anchor");
+
+        let mock = Arc::new(mock_with_history(&committee, &keys, 100, 100));
+        let metrics = OcsMetrics::new_for_testing();
+        let client = OcsVerifyingClient::new(mock.clone(), store.clone(), metrics.clone(), false);
+
+        let err = client.ratchet_to_current_epoch().await.unwrap_err();
+        assert!(
+            matches!(err, OcsError::ProofChainBroken { epoch: 0 }),
+            "expected ProofChainBroken at genesis, got {err:?}"
+        );
+        assert!(
+            !err.is_retryable(),
+            "cold-start-on-pruned-source must be terminal"
+        );
+        assert!(
+            err.to_string().contains("full-retention Sui RPC"),
+            "the error must name the remediation: {err}"
+        );
+        assert_eq!(metrics.ratchet_stalled.get(), 1);
+        assert_eq!(
+            metrics
+                .ratchet_failures_total
+                .with_label_values(&["proof_chain_broken"])
+                .get(),
+            1
+        );
+        assert_eq!(store.head_epoch(), 0);
+        assert_eq!(mock.get_committee_call_count(), 0);
     }
 }

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -815,9 +815,29 @@ impl IkaNode {
                         head_epoch = stack.ratchet.committees().head_epoch(),
                         "Sui committee ratchet caught up before binding p2p"
                     ),
+                    // A determinate failure — typically the configured source
+                    // serves no history back to the persisted anchor (a pruned
+                    // fullnode, or an anchor-less first boot against
+                    // sui-state-direct) — cannot be healed by the periodic
+                    // retry: without a current committee every verified read
+                    // fails `missing_committee` and the whole MPC stack sits
+                    // dead behind an invisible retry loop. Fail boot loudly
+                    // instead (same posture as the peer-only boot ratchet);
+                    // at this point the node holds no in-flight duties, and a
+                    // crash loop is visible to supervisors where the zombie
+                    // was not.
+                    Err(e) if !e.is_retryable() => {
+                        return Err(anyhow!(
+                            "initial Sui committee ratchet hit a permanent error that retrying \
+                             cannot heal; boot once against a full-retention Sui RPC (or \
+                             configure a `sui_checkpoint_archive`) so the persisted committee \
+                             anchor catches up, then switch back to the pruned source: {e}"
+                        ));
+                    }
                     Err(e) => warn!(
                         error = ?e,
-                        "initial ratchet to current epoch failed; periodic ratchet will retry"
+                        "initial ratchet to current epoch failed (transient); periodic ratchet \
+                         will retry"
                     ),
                 }
                 unpack(stack)
@@ -893,11 +913,25 @@ impl IkaNode {
             if let Some(receiver) = stack.changeset_receiver.take() {
                 tokio::spawn(async move { receiver.run().await });
             }
-            if let Err(e) = stack.ratchet.ratchet_to_current_epoch().await {
-                warn!(
+            match stack.ratchet.ratchet_to_current_epoch().await {
+                Ok(()) => {}
+                // Same posture as the sui-state-direct and peer-only boot
+                // ratchets: a determinate failure means verified reads can
+                // never work past the persisted anchor, so fail boot loudly
+                // rather than leaving the MPC stack dead behind a retry loop.
+                Err(e) if !e.is_retryable() => {
+                    return Err(anyhow!(
+                        "initial Sui committee ratchet (sui-state-mirrored) hit a permanent \
+                         error that retrying cannot heal; boot once against a full-retention \
+                         Sui RPC (or configure a `sui_checkpoint_archive`) so the persisted \
+                         committee anchor catches up: {e}"
+                    ));
+                }
+                Err(e) => warn!(
                     error = ?e,
-                    "initial ratchet to current epoch (sui-state-mirrored) failed; periodic ratchet will retry"
-                );
+                    "initial ratchet to current epoch (sui-state-mirrored) failed (transient); \
+                     periodic ratchet will retry"
+                ),
             }
             reader_opt = Some(stack.reader);
             ratchet_opt = Some(stack.ratchet);
@@ -922,8 +956,23 @@ impl IkaNode {
                 let mut tick = tokio::time::interval(std::time::Duration::from_secs(30));
                 loop {
                     tick.tick().await;
-                    if let Err(e) = ratchet.ratchet_to_current_epoch().await {
-                        warn!(error = ?e, "Sui committee ratchet failed; will retry");
+                    match ratchet.ratchet_to_current_epoch().await {
+                        Ok(()) => {}
+                        // Mid-run we never tear the node down (it may hold live
+                        // consensus/MPC duties its in-memory state can still
+                        // serve), but a determinate failure is an operator
+                        // problem, not a transient: escalate the log and rely
+                        // on `ika_ocs_ratchet_stalled` (set inside the ratchet)
+                        // for alerting.
+                        Err(e) if !e.is_retryable() => error!(
+                            error = ?e,
+                            "Sui committee ratchet hit a permanent error retrying cannot heal \
+                             (ika_ocs_ratchet_stalled=1); verified Sui reads past the persisted \
+                             anchor will keep failing until the operator re-anchors — boot once \
+                             against a full-retention Sui RPC or configure a \
+                             `sui_checkpoint_archive`"
+                        ),
+                        Err(e) => warn!(error = ?e, "Sui committee ratchet failed; will retry"),
                     }
                 }
             });

--- a/crates/ika-sui-client/src/grpc.rs
+++ b/crates/ika-sui-client/src/grpc.rs
@@ -256,13 +256,19 @@ impl SuiTransport for SuiGrpcClient {
         let mut rpc = self.rpc.clone();
         let mut request = proto::GetEpochRequest::default();
         request.epoch = Some(epoch);
+        // NotFound must stay distinguishable (`rpc_status_err`, not `rpc_err`):
+        // a source that no longer serves this epoch's record ("Epoch N not
+        // found" — a pruned fullnode, or sui-state-direct serving current state
+        // only) is a determinate condition the committee ratchet routes to its
+        // pruned-boundary fallback chain. Collapsing it into `Network` made the
+        // ratchet retry it forever, invisibly.
         let response = rpc
             .inner_mut()
             .clone()
             .ledger_client()
             .get_epoch(request)
             .await
-            .map_err(Self::rpc_err)?
+            .map_err(Self::rpc_status_err)?
             .into_inner();
         let info = response
             .epoch

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -251,6 +251,20 @@ committee.)
 configured genesis seed is ignored on every later boot. Re-bootstrapping
 requires manually clearing the OCS committee tables.
 
+**The persisted anchor is the cross-restart verification root.** Every
+successful ratchet/follower/pusher install persists the verified transition
+summary and advances `sui_committee_head` in the perpetual tables
+(`sui_committee_summaries`, `sui_committees`, `sui_committee_head`), and boot
+resumes verification from that head — a validator that has ever been synced
+never needs historical Sui epochs again. The anchor is
+machine/identity-independent (plain rows keyed by Sui epoch, nothing derived
+from the host or the validator identity), so a snapshot-restored or mirrored
+DB is exactly as bootable as the original. It fails **closed**: an
+unresolvable head fails `CommitteeStore::open` fast, and a tampered/hand-
+edited summary or committee makes every genuine summary fail terminal BLS
+verification (`BadSignature`) — a forged root can stall the node, never make
+it accept forged state.
+
 The ratchet advances the trusted head strictly **+1 per step** up to the
 relay-claimed current epoch. For each step it fetches the end-of-epoch
 checkpoint of epoch `head`, BLS-verifies it against `committee[head]`,
@@ -260,17 +274,58 @@ side fetch. The store is keyed by each committee's own `.epoch`, so the
 relay never chooses the install key. Only one ratchet runs at a time
 (concurrent callers coalesce).
 
-If the end-of-epoch checkpoint has been pruned upstream (`NotFound`), the
-ratchet first tries a configured **Sui checkpoint archive**
+A pruned epoch boundary — the source answers `NotFound` for either the
+**epoch record** (`last_checkpoint_of_epoch(head)`, "Epoch N not found": a
+pruned fullnode, or `sui-state-direct` which serves current state + a change
+stream only) or the end-of-epoch **checkpoint** itself — routes to one shared
+fallback chain. The gRPC client maps the epoch-record "not found" status to
+`TransportError::NotFound` for exactly this reason: it used to collapse into
+a retryable `Network` error, which made a boot against a history-less source
+spin forever in a 30-second retry loop with no health signal (the 2026-07
+testnet incident: three validators restarted on `sui_state_direct` and their
+entire MPC stacks sat dead behind `MissingCommittee` retries). The chain:
+the ratchet first tries a configured **Sui checkpoint archive**
 (`sui_checkpoint_archive`): it fetches the end-of-epoch checkpoint from the
-object store (`epochs.json` + `{seq}.binpb.zst`) and BLS-verifies it the same
-way — a *verified* fallback (a forged archive summary fails closed; the
-`epochs.json` enumeration is an untrusted hint, so omission/reorder can stall
-but never forge). Only if no archive is configured (or it also lacks the
-checkpoint) does the legacy `allow_unverified_committee_fallback` path apply
-(default **false** → terminal `ProofChainBroken`; true → a degraded direct
-`get_committee(head+1)` fetch, gated by `epoch == head + 1`, logged
-security-critical).
+object store (`epochs.json` + `{seq}.binpb.zst` — when the epoch record was
+pruned, the sequence comes from the archive's own enumeration) and
+BLS-verifies it the same way — a *verified* fallback (a forged archive
+summary fails closed; the `epochs.json` enumeration is an untrusted hint, so
+omission/reorder can stall but never forge). Only if no archive is configured
+(or it also lacks the checkpoint) does the legacy
+`allow_unverified_committee_fallback` path apply (default **false** →
+terminal `ProofChainBroken`; true → a degraded direct `get_committee(head+1)`
+fetch, gated by `epoch == head + 1`, logged security-critical).
+
+### Anchor staleness bound and boot posture
+
+**Maximum anchor staleness the source must bridge**: the forward walk needs,
+for every epoch from the persisted anchor to the current one, the epoch
+record *and* the full end-of-epoch checkpoint. So the bridgeable staleness is
+exactly the source's retention window for those two artifacts — unbounded on
+a full-retention fullnode; the fullnode's pruning window on a pruned one; on
+the p2p relay, the serving direct node's retained end-of-epoch store (kept
+back to its own bootstrap anchor, pruned with the verified-cache retention);
+and unbounded when a `sui_checkpoint_archive` is configured (the verified
+archive bridges any gap). Beyond the window the outcome is **defined and
+loud**: terminal, non-retryable `ProofChainBroken` whose message names the
+remediation (boot once against a full-retention Sui RPC so the anchor
+catches up, configure an archive, or accept the degraded unverified
+fallback) — never a silent retry loop.
+
+**Boot posture (all roles: direct, mirrored-with-fallback, peer-only)**: the
+initial ratchet failing with a **non-retryable** error fails node startup
+with that remediation in the error — at boot the node holds no in-flight
+duties, and a supervisor-visible crash loop beats a zombie whose MPC stack is
+invisibly dead. Retryable (transport) failures only warn; the periodic
+ratchet retries. An anchor-less cold start on a history-less source (fresh
+DB, genesis-only anchor) is therefore a defined loud startup failure, not an
+emergent hang. **Mid-run** the node is never torn down: a determinate
+periodic-ratchet failure escalates to an `error!` log and sets
+`ika_ocs_ratchet_stalled` to 1 (with `ika_ocs_ratchet_failures_total{reason}`
+counting attempts; only `reason="transport"` is retryable) — set at the
+ratchet chokepoint itself, cleared on the next success — so a wedged ratchet
+is directly alertable instead of presenting only as absent downstream
+series.
 
 ## Freshness and rollback protection
 
@@ -585,8 +640,11 @@ mirror reads remains future work — see
    verified path `committee[head+1]` is only ever derived from a
    BLS-verified end-of-epoch summary signed by `committee[head]`. The
    store is keyed by each committee's own epoch.
-3. Trust is rooted in a single operator-pinned end-of-epoch digest;
-   persisted committee state always overrides a reconfigured anchor.
+3. Trust is rooted in the compiled-in chain identifier (the verified genesis
+   blob) on first boot, and thereafter in the persisted, machine-independent
+   committee anchor in the perpetual tables; persisted committee state always
+   overrides a configured genesis seed, and a corrupted/tampered anchor fails
+   closed (verification failure and a stall — never silent acceptance).
 4. Freshness is measured against a process-monotonic observed head,
    never the relay's per-response claim; per-object version high-water is
    monotone and recorded only after proof success.


### PR DESCRIPTION
## Problem

Any validator booting against `sui_state_direct` (or a pruned public Sui RPC) could never bring up its Sui connector. The committee ratchet walks committees forward from its anchor, and on a source that serves no historical epochs the walk's first read — `last_checkpoint_of_epoch(head)` → gRPC `GetEpoch` — comes back "Epoch N not found". Two compounding bugs turned that into the live testnet incident (three validators dead after a restart, `MissingCommittee(1168)` every 30s for hours, MPC stack fully down while the node looked alive):

1. `SuiGrpcClient::last_checkpoint_of_epoch` mapped the gRPC NotFound with the generic `rpc_err` → `TransportError::Network` (retryable), instead of `rpc_status_err` → `NotFound`. The exact log signature from the issue — `Transport(Network("... 'Some requested entity was not found' ... Epoch 0 not found"))` — is this mapping.
2. Even correctly mapped, the ratchet propagated `last_checkpoint_of_epoch` errors with `?`: its pruned-boundary handling (archive fallback → gated unverified fallback → terminal `ProofChainBroken`) existed only around `get_full_checkpoint`. A source that pruned the epoch *record* (state_direct's shape) never reached the loud terminal path.

Net effect: an invisible retry-forever loop with **no metric and no terminal error** — as the issue says, the invisibility is the bug even more than the missing capability.

## What was already there (and is now the proven contract)

The persisted verification anchor (option 1 of the issue) **already exists in main**: every successful ratchet/follower/pusher install persists the verified end-of-epoch summary and advances `sui_committee_head` in the replicated perpetual tables, and `CommitteeStore::open` resumes from that head ("perpetual state always wins"). What was missing was (a) the ratchet being *able to use* a current anchor on a history-less source without tripping over the pruned-history reads, (b) any defined/loud behavior when the anchor genuinely can't bridge, and (c) tests proving the anchor round-trip at all. This PR closes those three gaps; it does not add a second persistence mechanism.

## Mechanism

- **`ika-sui-client/grpc.rs`** — `last_checkpoint_of_epoch` now maps errors via `rpc_status_err`, so an upstream "Epoch N not found" surfaces as `TransportError::NotFound` (determinate) instead of a retryable `Network` error.
- **`ika-core/sui_connector/ocs_verifier.rs`** — the ratchet walk routes NotFound from *either* boundary read (epoch record or end-of-epoch checkpoint) through one shared `pruned_boundary_fallback`: verified checkpoint archive first (when the epoch record is gone, the end-of-epoch sequence is resolved from the archive's own `epochs.json` enumeration — an untrusted hint that can stall but never forge, since every summary is BLS-verified before install), then the existing `allow_unverified_committee_fallback` gate, else terminal non-retryable `ProofChainBroken` whose message names the remediation ("boot once against a full-retention Sui RPC …, configure a `sui_checkpoint_archive`, or …"). The three duplicated `CommitteeTransitionError` → `OcsError` match blocks are consolidated into one `installed_epoch` helper (the new fallback would have been a fourth copy).
- **Metrics (`ocs_metrics.rs`)** — `ika_ocs_ratchet_stalled` (1 while the last completed ratchet attempt failed, 0 on success) and `ika_ocs_ratchet_failures_total{reason}` (only `reason="transport"` is retryable), set at the single ratchet chokepoint so every caller (boot, periodic, reactive) is covered. The wedge previously presented **only** as absent downstream series; now it is directly alertable.
- **`ika-node/lib.rs`** — boot/mid-run posture (below).
- **Spec** — `dev-docs/specs/ocs-verified-sui-reads.md` updated in the same PR: the persisted anchor as the cross-restart verification root, the pruned-epoch-record handling, the staleness bound, the boot posture, and the corrected Key Invariant 3 (it still described the pre-genesis operator-pinned digest).

## Trust model

The anchor is a ratchet, not a new trust root: only committees derived from BLS-verified end-of-epoch summaries (or the first-boot genesis blob verified against the compiled-in chain identifier) are ever persisted, and this PR does not add any new install path. The anchor is machine/identity-independent — plain rows keyed by Sui epoch, nothing derived from host or validator identity — so a snapshot-restored or mirrored DB boots identically (proven by the mirrored-DB test). A corrupted/hand-edited anchor **fails closed**: an unresolvable head fails `CommitteeStore::open` fast (pre-existing, tested), and a tampered transition summary makes every genuine current-epoch summary fail terminal BLS verification — new `tampered_persisted_anchor_fails_closed` test (the attacker committee is built from OS-random keys because Sui's `new_simple_test_committee` is fixed-seed and would reproduce the real keys — the first version of the test passed vacuously and was caught by its own failure). The existing verification chain (`verify_summary` chokepoint, +1-per-step ratchet, epoch-keyed store) is unchanged.

## Anchor staleness bound

The forward walk needs, for **every** epoch from the anchor to current, the epoch record *and* the full end-of-epoch checkpoint from the source. So the bridgeable staleness is exactly the source's retention window for those two artifacts:

- full-retention fullnode → unbounded;
- pruned fullnode → its pruning window;
- p2p relay → the serving direct node's retained end-of-epoch store (`RetainedFullnodeTransport`, kept back to its bootstrap anchor);
- configured `sui_checkpoint_archive` → unbounded (verified bridging).

Beyond the window: terminal, non-retryable `ProofChainBroken` naming the remediation — never a silent loop. Documented in the spec; asserted by the stale-anchor tests.

## Cold-start decision: hard-fail at boot, loud-error + metric mid-run

- **Boot (initial ratchet), non-retryable error → fail startup** with the remediation in the error, on sui-state-direct and mirrored-with-fallback (the peer-only path already did exactly this, with an explicit comment that spinning "is exactly the silent boot hang we are guarding against" — this PR makes the posture uniform). Justification: at boot the node holds no in-flight consensus/MPC duties; a supervisor-visible crash loop is strictly more actionable than a zombie whose MPC stack is invisibly dead; and only *determinate* errors fail boot — a flaky fullnode (transport error) still warns and retries, so no crash-loop from transient conditions. NotFound on an epoch boundary is determinate for that source: the walk only runs for `head < target`, so the boundary data is at least one epoch old and "not found" means pruned, not not-yet-indexed.
- **Mid-run, never tear the node down**: a long-running node keeps working from its already-verified chain (exactly the observed incident behavior), so the periodic ratchet escalates determinate failures to `error!` and sets `ika_ocs_ratchet_stalled=1` instead of killing live duties.
- **Anchor-less cold start on a history-less source** (fresh DB, genesis-only anchor — the Full Sail shape) is therefore *defined*: immediate terminal `ProofChainBroken { epoch: 0 }` → loud boot failure naming the two bootstrap paths (boot once against a full-retention RPC to earn an anchor, or configure a checkpoint archive). A validator with no anchor material at all is already rejected by the existing `has_anchor` config gate.

## Tests (issue comment's list 1–5)

All in `cargo test --release -p ika-core sui_connector` (109 pass) + `-p ika-sui-client` (19 pass):

1. **Anchor round-trip** — `persisted_anchor_round_trip_resumes_on_history_less_source`: genesis-boot → ratchet to epoch 3 over full history → drop everything → reopen the same perpetual tables with **no bootstrap material** against a state_direct-shaped mock (every completed epoch answers "Epoch N not found") → resumes at 3, ratchets to 4 using only the live window, `verify_summary` of a current-epoch summary succeeds, no unverified fallback, `ratchet_stalled=0`.
2. **Mirrored-DB boot** — `mirrored_db_copy_boots_from_the_same_anchor`: byte-copy of the perpetual DB into fresh directories, booted on the history-less source → identical resume + verify. Proves the anchor is not machine-bound.
3. **Stale anchor** — `stale_anchor_within_source_window_catches_up` (anchor 3, current 6, source serves `3..` → head 6) and `stale_anchor_beyond_source_window_fails_terminally_not_silently` (source serves only `5..` → `ProofChainBroken{epoch:3}`, non-retryable, remediation text asserted, head holds, `ratchet_stalled=1`, `ratchet_failures_total{proof_chain_broken}=1`). Plus `pruned_epoch_record_bridged_by_verified_archive_fallback` for the archive bridging the pruned-record case specifically.
4. **Anchor-less cold start on a pruned source** — `anchorless_cold_start_on_history_less_source_fails_loud_with_metric`: genesis-only anchor, source serves nothing historical → terminal `ProofChainBroken{epoch:0}` + both metrics + remediation text. (The boot-time hard-fail wiring in `ika-node` is a thin match on `is_retryable()` mirroring the peer-only branch; it is not unit-testable without booting a node — covered by the deferred e2e below.)
5. **E2E `sui_state_direct` boot in the upgrade-test environment** — **deferred to CI dispatch** (see below).

Trust-model extra: `tampered_persisted_anchor_fails_closed` (committee_store).

### Test-testing evidence (anchor round-trip regression)

Per `dev-docs/playbooks/test-testing.md` — fault: `CommitteeStore::open` skips loading the persisted anchor (`highest_sui_committee_epoch()?.and(None)`, marked `TEST-TESTING FAULT`); predicted shape: hard-fail with the bootstrap-material error. Observed (then reverted; suite re-run green):

```
persisted_anchor_round_trip_resumes_on_history_less_source ... FAILED
  panicked: resume from the persisted anchor: SuiClientInternalError("OCS verifier
  needs bootstrap material: perpetual Sui committee state is empty and no
  `sui_genesis` / `sui_unsafe_genesis_committee` was provided")
mirrored_db_copy_boots_from_the_same_anchor ... FAILED
  panicked: a copied DB must be exactly as bootable: SuiClientInternalError(...)
```

Both anchor tests trip on exactly the guarded property (boot-time anchor resumption), with the predicted evidence.

## Deferred to CI (not silently skipped)

The e2e scenario — booting a validator against real `sui_state_direct` (mid-epoch restart and fresh join) and asserting full MPC recovery — needs the heavy cluster environment (`ika-test-cluster` `ocs_verifier` suite, which already exercises direct-validator restart-resume and stale-anchor-late-joiner ratcheting across real epoch boundaries). Dispatch per `dev-docs/playbooks/ci-suites.md` on this branch; the in-process mocks above cover the ratchet-level contract, the cluster suite is the acceptance layer. The one-line gRPC mapping change is exercised end-to-end only there (no fake tonic server exists in-repo; the mapper itself has a unit test asserting NotFound/Network distinctness).

## Verification

- `cargo test --release -p ika-core sui_connector` → 109 passed, 0 failed (all pre-existing sui_connector tests still green)
- `cargo test --release -p ika-sui-client` → 19 passed
- `cargo clippy --release --all-targets -p ika-sui-client -p ika-core -p ika-node` → clean
- `cargo fmt --all` → applied

Closes #1882

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnRjdvthoSVjPG5UtGtj57
