### PR TITLE
chore: bump version to v1.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-classgroups-types"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "bcs",
  "class_groups",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-rng"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "commitment",
  "fastcrypto",
@@ -6548,7 +6548,7 @@ dependencies = [
 
 [[package]]
 name = "ika"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6592,7 +6592,7 @@ dependencies = [
 
 [[package]]
 name = "ika-archival"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6763,7 +6763,7 @@ dependencies = [
 
 [[package]]
 name = "ika-node"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6834,7 +6834,7 @@ dependencies = [
 
 [[package]]
 name = "ika-proxy"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -6983,7 +6983,7 @@ dependencies = [
 
 [[package]]
 name = "ika-test-cluster"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "ika-upgrade-test"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 [workspace.package]
 # This version string will be inherited by ika-core, ika-node, ika-tools, ika-sdk, and ika crates.
-version = "1.2.3"
+version = "1.2.4"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/sdk/ika-wasm/Cargo.lock
+++ b/sdk/ika-wasm/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "bcs",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "bcs",


### PR DESCRIPTION
Prepares the **v1.2.4** cut, for the `release/testnet-v1.2.4` and
`release/mainnet-v1.2.4` tags.

This must land before those tags are pushed: the release workflow
resolves the tag's version and refuses to build when it disagrees with
the `ika-node` Cargo version —

```
::error::Tag version (1.2.4) does not match Cargo.toml workspace version (1.2.3). Update Cargo.toml first.
```

## Changes

Same shape as the v1.2.3 bump (#1877):

- `Cargo.toml` — workspace version `1.2.3` → `1.2.4`
- `Cargo.lock` — root workspace members re-pinned
- `sdk/ika-wasm/Cargo.lock` — the standalone lockfile the v1.2.2 bump
  missed, which is what motivated the guard in #1876

## Verification

- `scripts/check-workspace-version-consistency.sh` → `workspace version consistency OK (workspace 1.2.4)`
- `cargo metadata … select(.name == "ika-node") | .version` → `1.2.4`, so the
  release gate's comparison now passes for both tags.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)