### PR TITLE
feat(sui-connector): default to the public Sui checkpoint archive on mainnet/testnet

### DIFF
--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -350,6 +350,41 @@ pub struct SuiCheckpointArchiveConfig {
     pub options: Vec<(String, String)>,
 }
 
+/// The public Sui checkpoint stores for the well-known networks. They retain
+/// the complete **end-of-epoch** checkpoint history (a root `epochs.json` plus
+/// `{seq}.binpb.zst` blobs) needed for committee-chain proofs, even though they
+/// don't promise retention of every ordinary checkpoint.
+pub const SUI_MAINNET_CHECKPOINT_ARCHIVE_URL: &str = "https://checkpoints.mainnet.sui.io";
+pub const SUI_TESTNET_CHECKPOINT_ARCHIVE_URL: &str = "https://checkpoints.testnet.sui.io";
+
+/// Resolve the end-of-epoch checkpoint archive the verified OCS connector
+/// stack should use. An explicit `sui-checkpoint-archive` config always wins,
+/// verbatim (URL and options untouched). With none configured, the known
+/// public chains fall back to their public Sui checkpoint store; there is no
+/// default to guess for `Devnet`/`Custom` (localnet), so those resolve to
+/// `None`.
+///
+/// Trust is unaffected either way: the archive is an untrusted availability
+/// source, and every checkpoint fetched from it is BLS-verified against the
+/// genesis-rooted committee chain (see [`SuiCheckpointArchiveConfig`]).
+pub fn resolve_sui_checkpoint_archive(
+    chain_identifier: SuiChainIdentifier,
+    configured: Option<&SuiCheckpointArchiveConfig>,
+) -> Option<SuiCheckpointArchiveConfig> {
+    if let Some(explicit) = configured {
+        return Some(explicit.clone());
+    }
+    let url = match chain_identifier {
+        SuiChainIdentifier::Mainnet => SUI_MAINNET_CHECKPOINT_ARCHIVE_URL,
+        SuiChainIdentifier::Testnet => SUI_TESTNET_CHECKPOINT_ARCHIVE_URL,
+        SuiChainIdentifier::Devnet | SuiChainIdentifier::Custom => return None,
+    };
+    Some(SuiCheckpointArchiveConfig {
+        url: url.to_string(),
+        options: vec![],
+    })
+}
+
 /// The Sui read-transport a node boots, decided by [`select_sui_transport`]
 /// purely from config shape + role — never from chain state, so a protocol
 /// flag can't halt running validators en masse at an upgrade boundary.
@@ -519,7 +554,10 @@ pub struct SuiConnectorConfig {
     /// Optional Sui checkpoint archive used as a *verified fallback* source of
     /// end-of-epoch checkpoints when the upstream fullnode has pruned them (and
     /// for cold genesis bootstrap). Verified, never trusted — see
-    /// [`SuiCheckpointArchiveConfig`].
+    /// [`SuiCheckpointArchiveConfig`]. When unset, the verified OCS connector
+    /// defaults to the public Sui checkpoint store on `mainnet`/`testnet`
+    /// (see [`resolve_sui_checkpoint_archive`]); an explicit value here always
+    /// wins.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sui_checkpoint_archive: Option<SuiCheckpointArchiveConfig>,
     /// When the committee ratchet reaches an end-of-epoch checkpoint that the
@@ -1326,6 +1364,61 @@ mod tests {
             Some(custom_v2),
             "explicit v2 must win"
         );
+    }
+
+    // ---- default end-of-epoch checkpoint archive resolution ----
+
+    /// An explicit archive config wins verbatim on every chain — URL and
+    /// options untouched, never merged with or replaced by the network default.
+    #[test]
+    fn explicit_archive_wins_on_every_chain() {
+        let explicit = SuiCheckpointArchiveConfig {
+            url: "s3://my-own-archive".to_string(),
+            options: vec![("aws-region".to_string(), "us-west-2".to_string())],
+        };
+        for chain in [
+            SuiChainIdentifier::Mainnet,
+            SuiChainIdentifier::Testnet,
+            SuiChainIdentifier::Devnet,
+            SuiChainIdentifier::Custom,
+        ] {
+            let resolved = resolve_sui_checkpoint_archive(chain, Some(&explicit))
+                .expect("explicit config must resolve");
+            assert_eq!(resolved.url, explicit.url, "{chain}");
+            assert_eq!(resolved.options, explicit.options, "{chain}");
+        }
+    }
+
+    /// With no archive configured, the known public chains default to their
+    /// public Sui checkpoint store.
+    #[test]
+    fn public_chains_default_to_public_checkpoint_store() {
+        for (chain, url) in [
+            (
+                SuiChainIdentifier::Mainnet,
+                SUI_MAINNET_CHECKPOINT_ARCHIVE_URL,
+            ),
+            (
+                SuiChainIdentifier::Testnet,
+                SUI_TESTNET_CHECKPOINT_ARCHIVE_URL,
+            ),
+        ] {
+            let resolved =
+                resolve_sui_checkpoint_archive(chain, None).expect("public chain must default");
+            assert_eq!(resolved.url, url, "{chain}");
+            assert!(resolved.options.is_empty(), "{chain}");
+        }
+    }
+
+    /// No default is guessed for chains without a known public store.
+    #[test]
+    fn no_default_archive_for_devnet_or_custom() {
+        for chain in [SuiChainIdentifier::Devnet, SuiChainIdentifier::Custom] {
+            assert!(
+                resolve_sui_checkpoint_archive(chain, None).is_none(),
+                "{chain}: must not guess an archive"
+            );
+        }
     }
 
     // ---- old-style config (no `sui-data-source`) ----

--- a/crates/ika-core/src/sui_connector/setup.rs
+++ b/crates/ika-core/src/sui_connector/setup.rs
@@ -35,7 +35,7 @@
 use std::sync::Arc;
 
 use anemo::PeerId;
-use ika_config::node::{SuiConnectorConfig, SuiDataSource};
+use ika_config::node::{SuiConnectorConfig, SuiDataSource, resolve_sui_checkpoint_archive};
 use ika_network::proof_provider::{
     LocalProofProvider, ProofCacheConfig, ProofProvider, ProofProviderMetrics,
 };
@@ -333,10 +333,28 @@ pub async fn build_sui_connector_stack(
     };
     let committees = Arc::new(CommitteeStore::open(perpetual.clone(), bootstrap)?);
     // Verified-fallback end-of-epoch checkpoint archive (object store). Used by
-    // the ratchet when the upstream fullnode has pruned an end-of-epoch
-    // checkpoint; every byte is BLS-verified, so the archive is untrusted.
+    // the ratchet for cold bootstrap and when the upstream fullnode has pruned
+    // an end-of-epoch checkpoint; every byte is BLS-verified, so the archive is
+    // untrusted. An explicit config wins verbatim; with none, the known public
+    // chains default to their public Sui checkpoint store (localnet gets none).
+    let archive_config = resolve_sui_checkpoint_archive(
+        cfg.sui_chain_identifier,
+        cfg.sui_checkpoint_archive.as_ref(),
+    );
+    if cfg.sui_checkpoint_archive.is_none()
+        && let Some(default_archive) = &archive_config
+    {
+        info!(
+            url = %default_archive.url,
+            chain = %cfg.sui_chain_identifier,
+            "no sui-checkpoint-archive configured; using the network's public Sui \
+             end-of-epoch checkpoint store as the verified fallback archive \
+             (untrusted availability source — every checkpoint is BLS-verified \
+             against the genesis-rooted committee chain)"
+        );
+    }
     let archive: Option<Arc<dyn ika_sui_client::archive::CheckpointArchive>> =
-        cfg.sui_checkpoint_archive.as_ref().map(|a| {
+        archive_config.as_ref().map(|a| {
             Arc::new(ika_sui_client::archive::SuiCheckpointArchive::new(
                 a.url.clone(),
                 a.options.clone(),

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -284,13 +284,19 @@ a retryable `Network` error, which made a boot against a history-less source
 spin forever in a 30-second retry loop with no health signal (the 2026-07
 testnet incident: three validators restarted on `sui_state_direct` and their
 entire MPC stacks sat dead behind `MissingCommittee` retries). The chain:
-the ratchet first tries a configured **Sui checkpoint archive**
-(`sui_checkpoint_archive`): it fetches the end-of-epoch checkpoint from the
+the ratchet first tries the resolved **Sui checkpoint archive** — an explicit
+`sui_checkpoint_archive` config wins verbatim; with none configured, mainnet
+and testnet default to the network's public checkpoint store
+(`https://checkpoints.{mainnet,testnet}.sui.io`, which retains the complete
+end-of-epoch history; no default is guessed for devnet/custom — see
+`resolve_sui_checkpoint_archive` in `ika-config`, applied only where the
+verified connector stack is built, so legacy JSON-RPC configs are untouched).
+The ratchet fetches the end-of-epoch checkpoint from the
 object store (`epochs.json` + `{seq}.binpb.zst` — when the epoch record was
 pruned, the sequence comes from the archive's own enumeration) and
 BLS-verifies it the same way — a *verified* fallback (a forged archive
 summary fails closed; the `epochs.json` enumeration is an untrusted hint, so
-omission/reorder can stall but never forge). Only if no archive is configured
+omission/reorder can stall but never forge). Only if no archive resolved
 (or it also lacks the checkpoint) does the legacy
 `allow_unverified_committee_fallback` path apply (default **false** →
 terminal `ProofChainBroken`; true → a degraded direct `get_committee(head+1)`
@@ -305,8 +311,9 @@ exactly the source's retention window for those two artifacts — unbounded on
 a full-retention fullnode; the fullnode's pruning window on a pruned one; on
 the p2p relay, the serving direct node's retained end-of-epoch store (kept
 back to its own bootstrap anchor, pruned with the verified-cache retention);
-and unbounded when a `sui_checkpoint_archive` is configured (the verified
-archive bridges any gap). Beyond the window the outcome is **defined and
+and unbounded when a checkpoint archive resolved (the verified archive
+bridges any gap; on mainnet/testnet one resolves by default — the public
+checkpoint store). Beyond the window the outcome is **defined and
 loud**: terminal, non-retryable `ProofChainBroken` whose message names the
 remediation (boot once against a full-retention Sui RPC so the anchor
 catches up, configure an archive, or accept the degraded unverified


### PR DESCRIPTION
## What

When no `sui-checkpoint-archive` is configured, the verified OCS connector now defaults to the network's public Sui checkpoint store, resolved from the config's `sui-chain-identifier`:

- `mainnet` → `https://checkpoints.mainnet.sui.io`
- `testnet` → `https://checkpoints.testnet.sui.io`

These public stores retain the complete **end-of-epoch** checkpoint history (root `epochs.json` + `{seq}.binpb.zst` blobs) needed for committee-chain proofs, even though they don't promise retention of every ordinary checkpoint. With the default in place, the committee ratchet's archive-backed paths — cold bootstrap from genesis and the pruned-epoch-boundary fallback — work out of the box against pruning fullnodes, instead of requiring every operator to hand-configure the archive.

## How

A pure resolver in `ika-config` (`resolve_sui_checkpoint_archive(chain_identifier, configured)`), applied at the single point where the verified connector stack builds its archive (`build_sui_connector_stack`). The resolved config feeds the existing `OcsVerifyingClient::with_archive(...)` wiring, which already covers both cold bootstrap and the runtime pruned-boundary fallback.

Precedence and scope:

- An explicit `sui-checkpoint-archive` config wins **verbatim** (URL and options untouched) — the default is never merged into or substituted over it.
- No default is guessed for `Devnet`/`Custom` (localnet) chains; swarm/localnet configs use `Custom`, so tests see no behavior change.
- Legacy JSON-RPC configs are untouched: they never reach `build_sui_connector_stack` (it errors with `MissingDataSource` before archive resolution), and no unrelated config is mutated.
- Startup logs once which default archive URL was selected.

## Security model (unchanged)

- Genesis remains the trust root; the archive is an **untrusted availability source** only.
- `epochs.json` stays a location hint; every fetched end-of-epoch summary is BLS-verified against `committee[E]`, and the store's `next.epoch == head + 1` contiguity assertion still gates every install.
- `allow_unverified_committee_fallback` is untouched (default `false`).
- A malformed, forged, reordered, incomplete, or unreachable archive can stall bootstrap (the archive paths are best-effort and fall through with warnings) but can never install an unverified committee.

## Testing

- New unit tests in `ika-config`: explicit config wins on every chain, mainnet/testnet default to the public store, devnet/custom resolve to no archive.
- `cargo test --release -p ika-config` — 18 passed.
- `cargo test --release -p ika-core sui_connector::setup` / `sui_connector::ocs_verifier` — all passed (existing archive backfill / pruned-boundary coverage).
- `cargo test --release -p ika-sui-client archive` — passed.
- `cargo clippy --release -p ika-config -p ika-core --all-targets` — clean.

Spec updated in the same PR: `dev-docs/specs/ocs-verified-sui-reads.md` (archive resolution + staleness-bound sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnRjdvthoSVjPG5UtGtj57