### PR TITLE
ci(release): name mainnet releases mainnet-v<version>, not a bare v<version>

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -457,19 +457,25 @@ jobs:
       - name: Package release assets
         run: |
           VERSION="v${{ needs.version.outputs.version }}"
-          # Mainnet mints the bare v-tag: the Homebrew formula's download URL
-          # and asset glob interpolate it. Other networks attach the release
-          # to the TRIGGER tag itself (release/<network>-v<version>, already
-          # pointing at this run's commit) — publishing a release on an
-          # existing tag creates no tag and fires no push event, so it cannot
-          # re-trigger this workflow. Asset filenames use the network-qualified
-          # slash-free stem — GitHub asset names cannot contain '/'.
+          # Every network names its release and assets <network>-v<version>,
+          # so a release page is self-describing about which network it is for.
+          # Asset filenames use that same slash-free stem — GitHub asset names
+          # cannot contain '/'.
+          #
+          # They differ only in which tag the release hangs off. Non-mainnet
+          # attaches to the TRIGGER tag itself (release/<network>-v<version>,
+          # already pointing at this run's commit). Mainnet instead mints its
+          # own slash-free <network>-v<version> tag on publish, because the
+          # Homebrew formula's download URL interpolates the tag, and a tag
+          # containing '/' would make that URL's path ambiguous. Minting it is
+          # safe: the push trigger is `release/*-*`, which a bare
+          # mainnet-v<version> tag does not match, so publishing cannot
+          # re-trigger this workflow.
           NETWORK="${{ needs.version.outputs.network }}"
+          ASSET_STEM="${NETWORK}-${VERSION}"
           if [ "$NETWORK" = "mainnet" ]; then
-            ASSET_STEM="$VERSION"
-            RELEASE_TAG="$VERSION"
+            RELEASE_TAG="${NETWORK}-${VERSION}"
           else
-            ASSET_STEM="${NETWORK}-${VERSION}"
             RELEASE_TAG="${{ github.ref_name }}"
           fi
           echo "ASSET_STEM=${ASSET_STEM}" >> "$GITHUB_ENV"
@@ -601,13 +607,13 @@ jobs:
 
           # gh can download from draft releases with GITHUB_TOKEN
           mkdir -p /tmp/release-assets
-          gh release download "v${VERSION}" \
+          gh release download "mainnet-v${VERSION}" \
             --repo "${{ github.repository }}" \
             --dir /tmp/release-assets \
-            --pattern "ika-v${VERSION}-*.tar.gz"
+            --pattern "ika-mainnet-v${VERSION}-*.tar.gz"
 
           for platform in macos-arm64 macos-x64 linux-arm64 linux-x64; do
-            FILE="/tmp/release-assets/ika-v${VERSION}-${platform}.tar.gz"
+            FILE="/tmp/release-assets/ika-mainnet-v${VERSION}-${platform}.tar.gz"
             if [ ! -f "$FILE" ]; then
               echo "::error::Release asset not found: ${FILE}"
               exit 1


### PR DESCRIPTION
## The inconsistency

Mainnet releases and their assets were named after the **bare version**
(`v1.2.5`, `ika-v1.2.5-*.tar.gz`), while every other network was
**network-qualified** (`testnet-v1.2.5`, `ika-testnet-v1.2.5-*.tar.gz`).
A mainnet release page was the only one that did not say which network
it was for.

## Why it was that way — and why the constraint is weaker than it looks

The bare name existed for exactly one reason, recorded in the workflow
comment: the Homebrew formula interpolates the release tag into its
download URL, and the trigger tag `release/mainnet-v<version>` contains
a `/`, which would make that URL's path ambiguous:

```
.../releases/download/release/mainnet-v1.2.5/ika-...   # two extra segments
```

But that constraint only requires the tag to be **slash-free** — not to
drop the network. So mainnet now mints `mainnet-v<version>`, which is
slash-free *and* self-describing, and matches the `mainnet-v1.1.8` tag
the pre-1.2 releases actually used.

## Changes

- `Package release assets`: `ASSET_STEM` is now `<network>-v<version>` for
  every network. Only `RELEASE_TAG` still branches — non-mainnet attaches
  to the trigger tag, mainnet mints `mainnet-v<version>`.
- `Update Homebrew formula`: fetches by the new tag and glob
  (`gh release download "mainnet-v${VERSION}" --pattern "ika-mainnet-v${VERSION}-*.tar.gz"`).

Resulting names:

| network | release title | release tag | asset |
|---|---|---|---|
| mainnet | `mainnet-v1.2.5` | `mainnet-v1.2.5` (minted) | `ika-mainnet-v1.2.5-macos-arm64.tar.gz` |
| testnet | `testnet-v1.2.5` | `release/testnet-v1.2.5` (trigger) | `ika-testnet-v1.2.5-macos-arm64.tar.gz` |

## Safety

Minting `mainnet-v<version>` cannot re-trigger this workflow: the push
trigger is `release/*-*`, which a bare `mainnet-v<version>` tag does not
match. That is the same property the old bare `v<version>` tag had.

## Coordination required

The tap formula (`ika-xyz/homebrew-tap`, `Formula/ika.rb`) hardcodes
`releases/download/v#{version}/ika-v#{version}-<platform>.tar.gz`. Its URL
lines must change to `mainnet-v#{version}` in lockstep — the release job
only rewrites the formula's `version` and `sha256` fields, never the URLs.
**Merging this without the tap change would break `brew install ika` on
the next mainnet release.**

Verified: workflow YAML parses (all 9 jobs); naming logic simulated for
mainnet/testnet/devnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)