### PR TITLE
ci(release): hang the mainnet release off the trigger tag like every other network

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -464,20 +464,20 @@ jobs:
           #
           # They differ only in which tag the release hangs off. Non-mainnet
           # attaches to the TRIGGER tag itself (release/<network>-v<version>,
-          # already pointing at this run's commit). Mainnet instead mints its
-          # own slash-free <network>-v<version> tag on publish, because the
-          # Homebrew formula's download URL interpolates the tag, and a tag
-          # containing '/' would make that URL's path ambiguous. Minting it is
-          # safe: the push trigger is `release/*-*`, which a bare
-          # mainnet-v<version> tag does not match, so publishing cannot
-          # re-trigger this workflow.
+          # already pointing at this run's commit) — publishing a release on
+          # an existing tag creates no tag and fires no push event, so it
+          # cannot re-trigger this workflow.
+          #
+          # Mainnet used to mint its own slash-free tag instead, on the belief
+          # that the '/' in the trigger tag would break the Homebrew formula's
+          # download URL. It does not: GitHub serves
+          # /releases/download/release/<network>-v<version>/<asset> with the
+          # slash either literal or percent-encoded. Minting bought nothing and
+          # left mainnet commits carrying two tags, so every network now hangs
+          # its release off the trigger tag.
           NETWORK="${{ needs.version.outputs.network }}"
           ASSET_STEM="${NETWORK}-${VERSION}"
-          if [ "$NETWORK" = "mainnet" ]; then
-            RELEASE_TAG="${NETWORK}-${VERSION}"
-          else
-            RELEASE_TAG="${{ github.ref_name }}"
-          fi
+          RELEASE_TAG="${{ github.ref_name }}"
           echo "ASSET_STEM=${ASSET_STEM}" >> "$GITHUB_ENV"
           echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
           for dir in artifacts/*/; do
@@ -607,7 +607,7 @@ jobs:
 
           # gh can download from draft releases with GITHUB_TOKEN
           mkdir -p /tmp/release-assets
-          gh release download "mainnet-v${VERSION}" \
+          gh release download "release/mainnet-v${VERSION}" \
             --repo "${{ github.repository }}" \
             --dir /tmp/release-assets \
             --pattern "ika-mainnet-v${VERSION}-*.tar.gz"


### PR DESCRIPTION
Follow-up to #1889, which kept mainnet minting its own slash-free
`mainnet-v<version>` tag rather than attaching the release to the
`release/mainnet-v<version>` tag that triggered the run.

## The premise was wrong

The stated reason — carried over from the original comment — was that a
`/` in the tag would break the Homebrew formula's download URL. Tested
against the **published** `release/testnet-v1.2.3` release, which sits on
a slashed tag:

```
.../releases/download/release/testnet-v1.2.3/ika-testnet-v1.2.3-macos-arm64.tar.gz   -> 200
.../releases/download/release%2Ftestnet-v1.2.3/ika-testnet-v1.2.3-macos-arm64.tar.gz -> 200
```

GitHub serves it either way. Minting bought nothing, and cost something:
every mainnet commit ended up carrying **two tags** for one release (the
pushed `release/mainnet-v<version>` plus the minted `mainnet-v<version>`),
while every other network had exactly one.

## Change

- `RELEASE_TAG` stops branching — it is `github.ref_name` for every
  network. `ASSET_STEM` is unchanged (`<network>-v<version>`).
- The Homebrew job downloads by `release/mainnet-v${VERSION}`.

| network | release tag | asset |
|---|---|---|
| mainnet | `release/mainnet-v1.2.5` | `ika-mainnet-v1.2.5-macos-arm64.tar.gz` |
| testnet | `release/testnet-v1.2.5` | `ika-testnet-v1.2.5-macos-arm64.tar.gz` |

Attaching to an existing tag is also the safer half of the old comment:
publishing on a tag that already exists creates no tag and fires no push
event, so it cannot re-trigger this workflow.

## Coordination

The tap formula (`ika-xyz/homebrew-tap`) must change its URL to
`download/release/mainnet-v#{version}/…` in the same window — companion PR
linked below. The in-flight `mainnet-v1.2.5` draft is being retagged to
`release/mainnet-v1.2.5` to match; it is still unpublished, so no
published release ever disagrees with the formula.

Verified: workflow YAML parses (9 jobs); naming simulated for mainnet and
testnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)