### PR TITLE
ci(release): drop the v1.1.8 mixed-rollout gate from the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,19 +125,6 @@ jobs:
 
           echo "Version: $RAW  Docker tag: $DOCKER_TAG  Network: $NETWORK  Release: $IS_RELEASE"
 
-  # Release tags are blocked until the exact tagged commit survives a literal
-  # mainnet-v1.1.8/current mixed committee. This reusable call runs only the
-  # focused rollout scenario, not the expensive full upgrade matrix.
-  upgrade-compatibility-gate:
-    name: v1.1.8 mixed-rollout compatibility gate
-    if: github.event_name == 'push'
-    uses: ./.github/workflows/upgrade-test.yaml
-    with:
-      test: v118_mixed_rollout
-      candidate_sha: ${{ github.sha }}
-      use_mocks: false
-    secrets: inherit
-
   # ---------------------------------------------------------------------------
   # Build Linux binaries in Docker (reproducible, glibc-compatible)
   # Both x64 and arm64 use the same Dockerfile with different TARGET args
@@ -407,9 +394,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: artifacts/
-          # Platform binaries only: the upgrade-compatibility-gate is a called
-          # workflow, so its always()-uploaded log artifacts land in THIS run's
-          # artifact namespace and would otherwise show up as fake platforms.
+          # Platform binaries only — any non-platform artifact in this run's
+          # namespace would otherwise show up as a fake platform.
           pattern: "{linux,macos,windows}-*"
 
       - name: Create build summary
@@ -436,7 +422,7 @@ jobs:
   release:
     name: Draft GitHub Release
     runs-on: ubuntu-latest
-    needs: [version, docker, upload-binaries, upgrade-compatibility-gate]
+    needs: [version, docker, upload-binaries]
     if: needs.version.outputs.is_release == 'true'
     permissions:
       contents: write
@@ -448,10 +434,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: artifacts/
-          # Platform binaries only: the upgrade-compatibility-gate is a called
-          # workflow, so its always()-uploaded log artifacts (upgrade-test-log-*,
-          # resource-sampler-*, ...) land in THIS run's artifact namespace and
-          # would otherwise be packaged as fake platform tarballs.
+          # Platform binaries only — any non-platform artifact in this run's
+          # namespace would otherwise be packaged as a fake platform tarball.
           pattern: "{linux,macos,windows}-*"
 
       - name: Package release assets
@@ -542,11 +526,11 @@ jobs:
           ## Validation
 
           Built at [`__SHA_SHORT__`](https://github.com/__REPO__/commit/__SHA__).
-          This tag passed the release-blocking v1.1.8 mixed-rollout
-          compatibility gate before this draft was created.
 
-          <!-- Add further validation evidence for this exact commit (full
-          suite runs, upgrade matrix) — only what actually ran against it. -->
+          <!-- No suite is run by the release workflow itself — record here
+          what actually ran against THIS commit (cluster, integration, TS,
+          upgrade matrix), with run links. Dispatch anything missing before
+          publishing. -->
 
           <details>
           <summary>Full changelog (auto-generated)</summary>


### PR DESCRIPTION
Removes the `upgrade-compatibility-gate` job, which called
`upgrade-test.yaml` with `test=v118_mixed_rollout` on every release tag and
blocked the draft on the result.

## Knock-on edits

So that nothing refers to a job that no longer exists:

- the `release` job's `needs` drops it;
- the two `download-artifact` steps keep their `{linux,macos,windows}-*`
  pattern — still correct hygiene — but their comments no longer explain
  themselves via the called workflow's artifact namespace;
- **the release-notes scaffold no longer asserts the tag passed the gate.**
  That sentence is emitted into every generated draft; leaving it would
  print a false validation claim on every future release.

## Scope

Nothing else called `upgrade-test.yaml` as a reusable workflow, so the
`workflow_call` entrypoint is now unused but harmless — left in place. Its
`workflow_dispatch` and `pull_request` triggers are untouched:
`v118_mixed_rollout` is still runnable on demand, and still runs
automatically on PRs touching MPC/crypto/serialization paths.

## What this changes about release safety

Release tags no longer block on anything. The workflow now builds,
uploads, and drafts unconditionally, so validating a release candidate
becomes a manual step — dispatch the suites against the tagged commit and
record them in the draft's Validation section (the scaffold now prompts
for exactly that).

Verified: workflow YAML parses; job graph has no dangling `needs`
(8 jobs); no remaining references to the gate, `v118`, or
`mixed_rollout` in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)