### PR TITLE
chore(ocs): drop the dead genesis-bytes loader and fix stale bootstrap docs

### DIFF
--- a/crates/ika-core/src/sui_connector/setup.rs
+++ b/crates/ika-core/src/sui_connector/setup.rs
@@ -128,11 +128,10 @@ pub enum SetupError {
 
 /// What the operator gave us for OCS bootstrap, post-disambiguation:
 ///
-/// - `Hydrated`: perpetual tables already have committees; ignore the
-///   anchor entirely (we've already verified past it).
-/// - `Anchor(digest)`: fetch this digest's summary and bootstrap from
-///   its `end_of_epoch_data`.
+/// - `Hydrated`: perpetual tables already have committees; ignore any
+///   configured genesis seed (we've already verified past it).
 /// - `UnsafeGenesis(committee)`: install this committee[0] directly.
+/// - `Genesis`: bootstrap committee[0] from the verified `sui_genesis` blob.
 pub enum BootstrapPlan {
     Hydrated,
     /// Localnet/test: install this epoch-0 committee directly.

--- a/crates/ika-sui-client/src/genesis.rs
+++ b/crates/ika-sui-client/src/genesis.rs
@@ -54,8 +54,6 @@ pub enum GenesisError {
         #[source]
         source: anyhow::Error,
     },
-    #[error("failed to decode embedded Sui genesis blob: {0}")]
-    Decode(#[source] anyhow::Error),
     #[error(
         "Sui genesis chain identifier mismatch for {chain}: blob's genesis \
          checkpoint digest is {got}, but the binary's compiled-in identifier \
@@ -96,16 +94,6 @@ pub fn load_and_verify_sui_genesis(
         path: path.display().to_string(),
         source,
     })?;
-    verify_genesis(genesis, chain)
-}
-
-/// Decode a Sui genesis blob from in-memory bytes (e.g. release-embedded via
-/// `include_bytes!`) and verify it against the compiled-in chain identifier.
-pub fn load_and_verify_sui_genesis_bytes(
-    bytes: &[u8],
-    chain: SuiChainIdentifier,
-) -> Result<SuiGenesisBootstrap, GenesisError> {
-    let genesis: Genesis = bcs::from_bytes(bytes).map_err(|e| GenesisError::Decode(e.into()))?;
     verify_genesis(genesis, chain)
 }
 
@@ -451,32 +439,6 @@ mod tests {
             matches!(err, GenesisError::ChainMismatch { .. }),
             "expected ChainMismatch, got {err:?}"
         );
-    }
-
-    #[test]
-    fn bytes_and_path_loaders_agree() {
-        let from_path = load_and_verify_sui_genesis(FIXTURE, SuiChainIdentifier::Custom).unwrap();
-        let bytes = std::fs::read(FIXTURE).unwrap();
-        let from_bytes =
-            load_and_verify_sui_genesis_bytes(&bytes, SuiChainIdentifier::Custom).unwrap();
-        assert_eq!(from_path.chain_identifier, from_bytes.chain_identifier);
-    }
-
-    #[test]
-    fn corrupt_genesis_bytes_fail_closed() {
-        // Garbage / truncated bytes must not deserialize into a Genesis — the
-        // loader fails closed rather than bootstrapping from junk.
-        let garbage = b"not a valid Sui genesis blob";
-        let err = load_and_verify_sui_genesis_bytes(garbage, SuiChainIdentifier::Custom)
-            .expect_err("garbage bytes must be rejected");
-        assert!(matches!(err, GenesisError::Decode(_)), "got {err:?}");
-
-        // A truncated prefix of a real blob is also rejected.
-        let real = std::fs::read(FIXTURE).unwrap();
-        let truncated = &real[..real.len() / 2];
-        let err = load_and_verify_sui_genesis_bytes(truncated, SuiChainIdentifier::Custom)
-            .expect_err("a truncated blob must be rejected");
-        assert!(matches!(err, GenesisError::Decode(_)), "got {err:?}");
     }
 
     #[test]

--- a/dev-docs/plans/ocs-genesis-anchor-removal.md
+++ b/dev-docs/plans/ocs-genesis-anchor-removal.md
@@ -1,9 +1,43 @@
 # OCS: replace the trusted anchor with a genesis-rooted committee chain (plan)
 
-**Status:** proposed — design approved, not yet implemented.
-**Branch:** `feat/ocs-genesis-anchor-removal` (off `dev`, after #1744 landed the OCS subsystem).
+**Status:** implemented — see "Implementation outcome" below for the
+deliberate deviations from this plan's removal list.
 **Depends on:** the OCS verified-Sui-reads subsystem
 ([`../specs/ocs-verified-sui-reads.md`](../specs/ocs-verified-sui-reads.md)).
+
+## Implementation outcome
+
+Shipped as planned: the `sui_genesis` config and verified blob loader
+(`crates/ika-sui-client/src/genesis.rs`), the `SuiCheckpointArchive`
+verified fallback with per-chain public defaults, the genesis-rooted
+`resolve_bootstrap_plan`, and the deletion of the operator-pinned anchor
+(`sui_trusted_anchor`, `compiled_in_trusted_anchor()`,
+`verify_anchor_summary()`, `CommitteeBootstrap::EndOfEpoch`).
+
+Deliberate deviations from the "removed" list below — all three config
+fields were **kept**:
+
+- `sui_unsafe_genesis_committee` stays: swarm/test tooling that boots
+  against an externally started Sui localnet can only obtain
+  `committee[0]` over RPC (`fetch_genesis_committee`); a genesis blob
+  cannot be reconstructed over RPC. `sui_genesis` takes priority
+  whenever both are configured, and the unsafe path logs a loud
+  not-for-production warning.
+- `allow_unverified_committee_fallback` stays: the premise "the Remote
+  Store makes every EOP checkpoint available" does not hold on the
+  default config — the default archive is the public HTTPS store
+  (~30-day retention; full history needs the requester-pays buckets),
+  and Devnet/Custom get no default archive at all. A gap that both the
+  fullnode and the archive miss still needs the opt-in degraded path.
+  Default remains `false` (fail closed with `ProofChainBroken`).
+- `auto_reanchor_on_format_change` stays, re-rooted: it wipes persisted
+  committee state that no longer deserializes (a Sui bump changing the
+  on-disk BCS layout) and re-bootstraps from the genesis blob — the
+  genesis-rooted successor of "re-anchor", needed because perpetual
+  committee state always wins over the configured genesis seed.
+
+Also deviating: the mainnet/testnet genesis blobs are **not** embedded
+in the release; `sui_genesis` is a path-only config today.
 
 ## What this changes, in one sentence
 


### PR DESCRIPTION
## Summary

Cleanups found while auditing whether the OCS bootstrap config fields (`sui_unsafe_genesis_committee`, `allow_unverified_committee_fallback`, `auto_reanchor_on_format_change`) are still needed now that `sui_genesis` is the trust root. Conclusion: **all three are live and needed** — each covers a case the genesis blob can't (RPC-only localnet bootstrap where a blob can't be reconstructed; pruned end-of-epoch checkpoints the ~30-day default archive misses; persisted-committee format rot that blocks boot because perpetual state wins over the config seed). What was actually stale:

- **Remove `load_and_verify_sui_genesis_bytes`** (and its now-orphaned `GenesisError::Decode` variant + its two tests): the "release-embedded via `include_bytes!`" loader has no production caller — genesis embedding was never implemented and `sui_genesis` is path-only config. Dead public API; trivially restorable from history if embedding lands.
- **Fix the `BootstrapPlan` doc comment** in `sui_connector/setup.rs`, which still described an `Anchor(digest)` variant deleted along with the operator-pinned anchor.
- **Update `dev-docs/plans/ocs-genesis-anchor-removal.md`** from "proposed — not yet implemented" to implemented, recording the deliberate deviations from its removal list (the three kept config fields, with the reasons above, and the not-embedded genesis blob) so the next reader doesn't re-run this audit.

No behavior change.

## Test plan

- `cargo test --release -p ika-sui-client genesis::` — 9 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gnBnDikdJPTom3jSESiga