### PR TITLE
feat(sui-connector): opt-in SIP-58 address-balance gas for the notifier

### DIFF
--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -618,6 +618,27 @@ pub struct SuiConnectorConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notifier_client_key_pair: Option<KeyPairWithPath>,
 
+    /// Pay the notifier's gas from its SUI **Address Balance** (SIP-58)
+    /// instead of owned gas-coin objects. Submissions then carry no gas
+    /// `ObjectRef` at all (`ValidDuring` expiration, empty gas payment), which
+    /// removes the whole class of stale-gas-version wedges the coin path
+    /// fights: the transaction is valid regardless of how far this node's
+    /// fullnode view lags.
+    ///
+    /// Requirements before enabling:
+    /// - The target Sui network must have address-balance gas payments
+    ///   enabled (Sui protocol >= 108 on testnet, >= 124 on mainnet; always
+    ///   on for localnets at max version).
+    /// - The notifier address must hold its SUI in the ADDRESS BALANCE, not
+    ///   (only) in coin objects — deposit via the Sui CLI/SDK balance
+    ///   transfer. Each submission reserves the full gas budget from the
+    ///   balance for the transaction's validity window.
+    ///
+    /// Default `false`: the gas-coin path remains the production default
+    /// until this mode has been canaried on testnet.
+    #[serde(default)]
+    pub notifier_gas_from_address_balance: bool,
+
     /// Override the last processed EventID for sui module `ika_system`.
     /// When set, SuiSyncer will start from this cursor (exclusively) instead of the one in storage.
     /// If the cursor is not found in storage or override, the query will start from genesis.
@@ -1293,6 +1314,7 @@ mod tests {
             ika_dwallet_coordinator_object_id: ObjectID::ZERO,
             verified_cache_retention_checkpoints: None,
             notifier_client_key_pair: None,
+            notifier_gas_from_address_balance: false,
             sui_ika_system_module_last_processed_event_id_override: None,
         }
     }

--- a/crates/ika-core/src/sui_connector/mod.rs
+++ b/crates/ika-core/src/sui_connector/mod.rs
@@ -22,19 +22,24 @@ use ika_types::messages_dwallet_mpc::{
 use ika_types::sui::{
     DWalletCoordinator, DWalletCoordinatorInner, System, SystemInner, SystemInnerTrait,
 };
+use move_core_types::ident_str;
 use shared_crypto::intent::{Intent, IntentMessage};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
+use sui_json_rpc_types::{SuiExecutionStatus, SuiTransactionBlockEffectsAPI};
+use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::crypto::{Signature, SuiKeyPair};
 use sui_types::digests::{
     ChainIdentifier as SuiNetworkChainIdentifier, get_mainnet_chain_identifier,
     get_testnet_chain_identifier,
 };
+use sui_types::gas_coin::GAS;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{
-    GasData, ProgrammableTransaction, Transaction, TransactionData, TransactionDataV1,
-    TransactionExpiration, TransactionKind,
+    Argument, Command, GasData, ProgrammableTransaction, Transaction, TransactionData,
+    TransactionDataV1, TransactionExpiration, TransactionKind,
 };
 use tokio::sync::watch;
 use tokio::sync::watch::{Receiver, Sender};
@@ -468,16 +473,49 @@ impl SuiConnectorService {
             // a panic, with the network's epoch close blocked the whole time
             // — the issue-#1892 outage shape. Refuse to boot with the exact
             // remediation instead: a writer that cannot pay must not run.
-            let address_balance = sui_client
-                .get_sui_address_balance(sui_address)
+            let funds = sui_client.get_sui_funds(sui_address).await.map_err(|e| {
+                anyhow!(
+                    "notifier_gas_from_address_balance is set but the funds of \
+                     {sui_address} could not be read (does the target Sui network \
+                     have accumulators/address-balance gas enabled?): {e}"
+                )
+            })?;
+
+            // Migration sweep: an operator flipping the flag on an existing
+            // notifier still holds its funds as coin objects, which
+            // address-balance gas cannot spend. Deposit them into the address
+            // balance automatically (split off the sweep tx's own gas, then
+            // `coin::send_funds`). Best-effort: a failed sweep only warns —
+            // the preflight below still decides whether the writer can run.
+            let mut address_balance = funds.in_address_balance;
+            if funds.in_coin_objects >= SWEEP_MIN_COIN_TOTAL {
+                match sweep_gas_coins_into_address_balance(
+                    &sui_client,
+                    &sui_key,
+                    sui_address,
+                    funds.in_coin_objects,
+                )
                 .await
-                .map_err(|e| {
-                    anyhow!(
-                        "notifier_gas_from_address_balance is set but the address balance \
-                         of {sui_address} could not be read (does the target Sui network \
-                         have accumulators/address-balance gas enabled?): {e}"
-                    )
-                })?;
+                {
+                    Ok(swept) => {
+                        info!(
+                            swept,
+                            "Swept gas-coin objects into the notifier's address balance"
+                        );
+                        // Count the swept funds directly instead of re-reading:
+                        // the read goes through a fullnode view that can lag
+                        // the just-finalized sweep and would flunk the
+                        // preflight spuriously.
+                        address_balance = address_balance.saturating_add(swept);
+                    }
+                    Err(e) => warn!(
+                        error = ?e,
+                        in_coin_objects = funds.in_coin_objects,
+                        "failed to sweep gas coins into the address balance; \
+                         continuing to the balance preflight without them"
+                    ),
+                }
+            }
             if address_balance < NOTIFIER_GAS_BUDGET {
                 anyhow::bail!(
                     "notifier_gas_from_address_balance is set but {sui_address} holds only \
@@ -506,13 +544,10 @@ impl SuiConnectorService {
             tokio::spawn(async move {
                 loop {
                     tokio::time::sleep(Duration::from_secs(60)).await;
-                    if let Ok(balance) = balance_sui_client
-                        .get_sui_address_balance(sui_address)
-                        .await
-                    {
+                    if let Ok(funds) = balance_sui_client.get_sui_funds(sui_address).await {
                         balance_metrics
                             .gas_coin_balance
-                            .set(i64::try_from(balance).unwrap_or(i64::MAX));
+                            .set(i64::try_from(funds.in_address_balance).unwrap_or(i64::MAX));
                     }
                 }
             });
@@ -560,6 +595,100 @@ impl CheckpointMessageSuiNotify for SuiConnectorService {
     ) -> IkaResult {
         Ok(())
     }
+}
+
+/// Gas budget for the one-shot boot sweep that deposits coin objects into
+/// the address balance. The unswept remainder (this budget minus actual
+/// fees) is left behind as a small coin.
+const SWEEP_GAS_BUDGET: u64 = 200_000_000;
+
+/// Don't bother sweeping coin totals below this (1 SUI): repeatedly
+/// re-depositing sweep-fee dust on every boot is churn, not funding.
+const SWEEP_MIN_COIN_TOTAL: u64 = 1_000_000_000;
+
+/// A sweep pays gas with the very coins it sweeps; Sui caps gas payments at
+/// 256 objects per transaction.
+const SWEEP_MAX_GAS_COINS: usize = 256;
+
+/// Deposit the notifier's gas-coin objects into its SIP-58 address balance.
+/// Returns the amount deposited (MIST). The sweep transaction uses ALL owned
+/// gas coins as its own gas payment (Sui merges them into the first), splits
+/// off everything above the sweep's own gas budget, and deposits the split
+/// via `coin::send_funds` — the gas coin itself cannot be passed by value to
+/// a Move call, hence split-then-deposit rather than depositing the coin.
+async fn sweep_gas_coins_into_address_balance<C: SuiClientInner>(
+    sui_client: &Arc<SuiClient<C>>,
+    sui_key: &SuiKeyPair,
+    sui_address: SuiAddress,
+    coin_total: u64,
+) -> anyhow::Result<u64> {
+    let gas_coins = sui_client.get_gas_objects(sui_address).await;
+    if gas_coins.is_empty() {
+        anyhow::bail!("coin balance is {coin_total} MIST but no gas-coin objects were listed");
+    }
+    if gas_coins.len() > SWEEP_MAX_GAS_COINS {
+        // The subset's value is unknown, so a correct split amount can't be
+        // computed. This does not happen to a writer address in practice.
+        anyhow::bail!(
+            "{} gas coins exceed the {SWEEP_MAX_GAS_COINS}-object gas payment cap;              consolidate them manually",
+            gas_coins.len()
+        );
+    }
+    let sweep_amount = coin_total.saturating_sub(SWEEP_GAS_BUDGET);
+    if sweep_amount == 0 {
+        anyhow::bail!("coin balance {coin_total} MIST does not exceed the sweep gas budget");
+    }
+    let computation_price = sui_client.get_reference_gas_price_until_success().await;
+    let tx_data = sweep_transaction_data(sui_address, gas_coins, sweep_amount, computation_price)?;
+    let signature = Signature::new_secure(
+        &IntentMessage::new(Intent::sui_transaction(), &tx_data),
+        sui_key,
+    );
+    let transaction = Transaction::from_data(tx_data, vec![signature]);
+    let response = sui_client
+        .execute_transaction_block_with_effects(transaction)
+        .await
+        .map_err(|e| anyhow!("sweep submission failed: {e}"))?;
+    if !response.errors.is_empty() {
+        anyhow::bail!("sweep transaction failed: {:?}", response.errors);
+    }
+    if let Some(effects) = &response.effects
+        && let SuiExecutionStatus::Failure { error } = effects.status()
+    {
+        anyhow::bail!("sweep transaction executed but aborted: {error:?}");
+    }
+    Ok(sweep_amount)
+}
+
+/// The sweep transaction: all owned gas coins as payment (merged into the
+/// first by the protocol), `SplitCoins(GasCoin, [sweep_amount])`, and
+/// `coin::send_funds<SUI>(split, sender)` to deposit into the sender's own
+/// address balance. Ordinary gas-coin payment — the sweep exists precisely
+/// because the address balance may be empty.
+fn sweep_transaction_data(
+    sender: SuiAddress,
+    gas_coins: Vec<ObjectRef>,
+    sweep_amount: u64,
+    computation_price: u64,
+) -> anyhow::Result<TransactionData> {
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    let amount_arg = ptb.pure(sweep_amount)?;
+    let deposit_coin = ptb.command(Command::SplitCoins(Argument::GasCoin, vec![amount_arg]));
+    let recipient_arg = ptb.pure(sender)?;
+    ptb.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        ident_str!("coin").into(),
+        ident_str!("send_funds").into(),
+        vec![GAS::type_tag()],
+        vec![deposit_coin, recipient_arg],
+    );
+    Ok(TransactionData::new_programmable(
+        sender,
+        gas_coins,
+        ptb.finish(),
+        SWEEP_GAS_BUDGET,
+        computation_price,
+    ))
 }
 
 /// The writer's fixed gas budget. Under address-balance gas the full budget
@@ -691,6 +820,40 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn sweep_transaction_splits_gas_and_deposits_to_sender_balance() {
+        let sender = SuiAddress::random_for_testing_only();
+        let gas_coins = vec![sui_types::base_types::random_object_ref()];
+        let tx_data = sweep_transaction_data(sender, gas_coins.clone(), 5_000, 750).unwrap();
+
+        let v1 = tx_data.as_v1();
+        assert_eq!(v1.sender, sender);
+        // Ordinary gas-coin payment: the sweep runs precisely when the
+        // address balance may be empty.
+        assert_eq!(v1.gas_data.payment, gas_coins);
+        assert_eq!(v1.gas_data.budget, SWEEP_GAS_BUDGET);
+        assert_eq!(v1.expiration, TransactionExpiration::None);
+
+        let TransactionKind::ProgrammableTransaction(pt) = &v1.kind else {
+            panic!("sweep must be a programmable transaction");
+        };
+        // SplitCoins off the (merged) gas coin, then coin::send_funds<SUI>.
+        assert!(matches!(
+            &pt.commands[0],
+            Command::SplitCoins(Argument::GasCoin, amounts) if amounts.len() == 1
+        ));
+        let Command::MoveCall(call) = &pt.commands[1] else {
+            panic!("second command must be the send_funds deposit");
+        };
+        assert_eq!(call.package, SUI_FRAMEWORK_PACKAGE_ID);
+        assert_eq!(call.module.as_str(), "coin");
+        assert_eq!(call.function.as_str(), "send_funds");
+        assert_eq!(
+            call.type_arguments,
+            vec![sui_types::type_input::TypeInput::from(GAS::type_tag())]
+        );
     }
 
     #[tokio::test]

--- a/crates/ika-core/src/sui_connector/mod.rs
+++ b/crates/ika-core/src/sui_connector/mod.rs
@@ -409,7 +409,7 @@ impl SuiConnectorService {
     async fn prepare_for_sui(
         sui_connector_config: SuiConnectorConfig,
         sui_client: Arc<SuiClient<SuiBackend>>,
-        _sui_connector_metrics: Arc<SuiConnectorMetrics>,
+        sui_connector_metrics: Arc<SuiConnectorMetrics>,
     ) -> anyhow::Result<Option<SuiNotifier>> {
         let Some(sui_key_path) = sui_connector_config.notifier_client_key_pair else {
             return Ok(None);
@@ -457,13 +457,66 @@ impl SuiConnectorService {
         let sui_network_chain_identifier = if gas_from_address_balance {
             let chain_identifier = sui_client.get_sui_chain_identifier().await.map_err(|e| {
                 anyhow!(
-                    "notifier_gas_from_address_balance is set but the chain identifier                      could not be resolved (required for ValidDuring expirations): {e}"
+                    "notifier_gas_from_address_balance is set but the chain identifier \
+                     could not be resolved (required for ValidDuring expirations): {e}"
                 )
             })?;
+
+            // Preflight the ADDRESS BALANCE (not coin objects — plain coin
+            // transfers don't fund it). An underfunded balance would
+            // otherwise surface as an hour of failed submissions followed by
+            // a panic, with the network's epoch close blocked the whole time
+            // — the issue-#1892 outage shape. Refuse to boot with the exact
+            // remediation instead: a writer that cannot pay must not run.
+            let address_balance = sui_client
+                .get_sui_address_balance(sui_address)
+                .await
+                .map_err(|e| {
+                    anyhow!(
+                        "notifier_gas_from_address_balance is set but the address balance \
+                         of {sui_address} could not be read (does the target Sui network \
+                         have accumulators/address-balance gas enabled?): {e}"
+                    )
+                })?;
+            if address_balance < NOTIFIER_GAS_BUDGET {
+                anyhow::bail!(
+                    "notifier_gas_from_address_balance is set but {sui_address} holds only \
+                     {address_balance} MIST in its ADDRESS BALANCE — below one gas budget \
+                     ({} MIST). Deposit SUI into the address balance (coin-object \
+                     transfers do not fund it), or unset the flag to fall back to gas \
+                     coins.",
+                    NOTIFIER_GAS_BUDGET,
+                );
+            }
+            sui_connector_metrics
+                .gas_coin_balance
+                .set(i64::try_from(address_balance).unwrap_or(i64::MAX));
             info!(
                 ?chain_identifier,
-                "Notifier pays gas from its SUI address balance (SIP-58)"
+                address_balance, "Notifier pays gas from its SUI address balance (SIP-58)"
             );
+
+            // Keep the writer-funds gauge live: refresh from the address
+            // balance once a minute. (In coin mode this gauge currently has
+            // no writer at all; here funds exhaustion is otherwise invisible
+            // until submissions start failing, so the gauge is the alert
+            // surface for topping up the balance.)
+            let balance_sui_client = sui_client.clone();
+            let balance_metrics = sui_connector_metrics.clone();
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                    if let Ok(balance) = balance_sui_client
+                        .get_sui_address_balance(sui_address)
+                        .await
+                    {
+                        balance_metrics
+                            .gas_coin_balance
+                            .set(i64::try_from(balance).unwrap_or(i64::MAX));
+                    }
+                }
+            });
+
             Some(chain_identifier)
         } else {
             None

--- a/crates/ika-core/src/sui_connector/mod.rs
+++ b/crates/ika-core/src/sui_connector/mod.rs
@@ -28,8 +28,14 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::crypto::{Signature, SuiKeyPair};
-use sui_types::digests::{get_mainnet_chain_identifier, get_testnet_chain_identifier};
-use sui_types::transaction::{ProgrammableTransaction, Transaction, TransactionData};
+use sui_types::digests::{
+    ChainIdentifier as SuiNetworkChainIdentifier, get_mainnet_chain_identifier,
+    get_testnet_chain_identifier,
+};
+use sui_types::transaction::{
+    GasData, ProgrammableTransaction, Transaction, TransactionData, TransactionDataV1,
+    TransactionExpiration, TransactionKind,
+};
 use tokio::sync::watch;
 use tokio::sync::watch::{Receiver, Sender};
 use tokio::task::JoinHandle;
@@ -59,6 +65,25 @@ pub mod verified_transport;
 pub struct SuiNotifier {
     sui_key: SuiKeyPair,
     sui_address: SuiAddress,
+    /// SIP-58 mode: pay gas from the notifier address's SUI balance instead
+    /// of owned gas-coin objects. Submissions carry an empty gas payment and
+    /// a `ValidDuring` expiration; the entire stale-gas-version machinery is
+    /// bypassed. Opt-in via `notifier_gas_from_address_balance`.
+    gas_from_address_balance: bool,
+    /// The chain's full genesis-rooted identifier, resolved once at boot.
+    /// `Some` exactly when `gas_from_address_balance` (a `ValidDuring`
+    /// expiration embeds it and validators compare the full identifier).
+    sui_network_chain_identifier: Option<SuiNetworkChainIdentifier>,
+}
+
+impl SuiNotifier {
+    pub(crate) fn gas_from_address_balance(&self) -> bool {
+        self.gas_from_address_balance
+    }
+
+    pub(crate) fn sui_address(&self) -> SuiAddress {
+        self.sui_address
+    }
 }
 
 pub struct SuiConnectorService {
@@ -423,9 +448,32 @@ impl SuiConnectorService {
         );
 
         let sui_address = SuiAddress::from(&sui_key.public());
+
+        // SIP-58 address-balance gas: resolve the chain's FULL identifier once
+        // (a `ValidDuring` expiration embeds it verbatim). Fail the boot
+        // loudly if it can't be resolved — a writer silently unable to build
+        // transactions is exactly the failure shape issue #1892 is about.
+        let gas_from_address_balance = sui_connector_config.notifier_gas_from_address_balance;
+        let sui_network_chain_identifier = if gas_from_address_balance {
+            let chain_identifier = sui_client.get_sui_chain_identifier().await.map_err(|e| {
+                anyhow!(
+                    "notifier_gas_from_address_balance is set but the chain identifier                      could not be resolved (required for ValidDuring expirations): {e}"
+                )
+            })?;
+            info!(
+                ?chain_identifier,
+                "Notifier pays gas from its SUI address balance (SIP-58)"
+            );
+            Some(chain_identifier)
+        } else {
+            None
+        };
+
         Ok(Some(SuiNotifier {
             sui_key,
             sui_address,
+            gas_from_address_balance,
+            sui_network_chain_identifier,
         }))
     }
 
@@ -461,29 +509,84 @@ impl CheckpointMessageSuiNotify for SuiConnectorService {
     }
 }
 
+/// The writer's fixed gas budget. Under address-balance gas the full budget
+/// is reserved from the balance for the transaction's validity window, so the
+/// balance must comfortably cover `budget x in-flight transactions` (the
+/// writer submits serially: one).
+const NOTIFIER_GAS_BUDGET: u64 = 10_000_000_000;
+
 pub(crate) async fn build_sui_transaction<C: SuiClientInner>(
-    signer: SuiAddress,
+    sui_notifier: &SuiNotifier,
     pt: ProgrammableTransaction,
     sui_client: &Arc<SuiClient<C>>,
     gas_payment: Vec<ObjectRef>,
-    sui_key: &SuiKeyPair,
 ) -> Transaction {
     let computation_price = sui_client.get_reference_gas_price_until_success().await;
 
-    let tx_data = TransactionData::new_programmable(
-        signer,
-        gas_payment,
-        pt,
-        10_000_000_000,
-        computation_price,
-    );
+    let tx_data = if sui_notifier.gas_from_address_balance {
+        let sui_epoch = sui_client.get_sui_epoch_until_success().await;
+        let chain_identifier = sui_notifier
+            .sui_network_chain_identifier
+            .expect("gas_from_address_balance implies a resolved chain identifier (set at boot)");
+        balance_gas_transaction_data(
+            sui_notifier.sui_address,
+            pt,
+            computation_price,
+            sui_epoch,
+            chain_identifier,
+            rand::random(),
+        )
+    } else {
+        TransactionData::new_programmable(
+            sui_notifier.sui_address,
+            gas_payment,
+            pt,
+            NOTIFIER_GAS_BUDGET,
+            computation_price,
+        )
+    };
 
     let signature = Signature::new_secure(
         &IntentMessage::new(Intent::sui_transaction(), &tx_data),
-        sui_key,
+        &sui_notifier.sui_key,
     );
 
     Transaction::from_data(tx_data, vec![signature])
+}
+
+/// SIP-58 address-balance-gas transaction: an EMPTY gas payment is the
+/// protocol-level trigger for paying from the sender's address balance, and
+/// the `ValidDuring` expiration supplies the replay protection that gas-coin
+/// version bumps used to provide. `min_epoch == max_epoch` (single-epoch
+/// validity) is accepted under every protocol regime; a submission racing a
+/// Sui epoch boundary simply expires and the caller's retry rebuilds it
+/// against the new epoch.
+fn balance_gas_transaction_data(
+    sender: SuiAddress,
+    pt: ProgrammableTransaction,
+    computation_price: u64,
+    sui_epoch: u64,
+    chain_identifier: SuiNetworkChainIdentifier,
+    nonce: u32,
+) -> TransactionData {
+    TransactionData::V1(TransactionDataV1 {
+        kind: TransactionKind::ProgrammableTransaction(pt),
+        sender,
+        gas_data: GasData {
+            payment: vec![],
+            owner: sender,
+            price: computation_price,
+            budget: NOTIFIER_GAS_BUDGET,
+        },
+        expiration: TransactionExpiration::ValidDuring {
+            min_epoch: Some(sui_epoch),
+            max_epoch: Some(sui_epoch),
+            min_timestamp: None,
+            max_timestamp: None,
+            chain: chain_identifier,
+            nonce,
+        },
+    })
 }
 
 #[cfg(test)]
@@ -500,6 +603,41 @@ mod tests {
     async fn example_func_err() -> anyhow::Result<()> {
         info!("example_func_err");
         Err(anyhow::anyhow!(""))
+    }
+
+    #[test]
+    fn balance_gas_transaction_has_no_gas_objects_and_is_replay_protected() {
+        let sender = SuiAddress::random_for_testing_only();
+        let pt = sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder::new()
+            .finish();
+        let tx_data =
+            balance_gas_transaction_data(sender, pt, 750, 42, get_testnet_chain_identifier(), 7);
+
+        let v1 = tx_data.as_v1();
+        // An empty gas payment on a programmable transaction IS the SIP-58
+        // trigger for paying gas from the sender's address balance.
+        assert!(sui_types::transaction::is_gas_paid_from_address_balance(
+            &v1.gas_data,
+            &v1.kind
+        ));
+        assert_eq!(v1.sender, sender);
+        assert_eq!(v1.gas_data.owner, sender);
+        assert_eq!(v1.gas_data.price, 750);
+        assert_eq!(v1.gas_data.budget, NOTIFIER_GAS_BUDGET);
+        // Single-epoch validity: replay-protected under every protocol regime
+        // (validators retain executed digests across the expiry range).
+        assert!(v1.expiration.is_replay_protected());
+        assert!(matches!(
+            v1.expiration,
+            TransactionExpiration::ValidDuring {
+                min_epoch: Some(42),
+                max_epoch: Some(42),
+                min_timestamp: None,
+                max_timestamp: None,
+                nonce: 7,
+                ..
+            }
+        ));
     }
 
     #[tokio::test]

--- a/crates/ika-core/src/sui_connector/mod.rs
+++ b/crates/ika-core/src/sui_connector/mod.rs
@@ -739,10 +739,16 @@ pub(crate) async fn build_sui_transaction<C: SuiClientInner>(
 /// SIP-58 address-balance-gas transaction: an EMPTY gas payment is the
 /// protocol-level trigger for paying from the sender's address balance, and
 /// the `ValidDuring` expiration supplies the replay protection that gas-coin
-/// version bumps used to provide. `min_epoch == max_epoch` (single-epoch
-/// validity) is accepted under every protocol regime; a submission racing a
-/// Sui epoch boundary simply expires and the caller's retry rebuilds it
-/// against the new epoch.
+/// version bumps used to provide. The window is `[current, current + 1]`:
+/// a submission built just before a Sui epoch boundary stays valid into the
+/// next epoch instead of expiring mid-flight and costing a rebuild-retry.
+/// The one-epoch extension is the maximum `is_replay_protected` allows, and
+/// multi-epoch expiration is enabled from Sui protocol 105 — strictly below
+/// every network's address-balance-gas enablement, so wherever this
+/// transaction is legal at all, the window is too. Cost: an abandoned
+/// signed-but-never-executed transaction can hold its balance reservation
+/// for up to two epochs instead of one (irrelevant to a serial writer with
+/// normal float).
 fn balance_gas_transaction_data(
     sender: SuiAddress,
     pt: ProgrammableTransaction,
@@ -762,7 +768,7 @@ fn balance_gas_transaction_data(
         },
         expiration: TransactionExpiration::ValidDuring {
             min_epoch: Some(sui_epoch),
-            max_epoch: Some(sui_epoch),
+            max_epoch: Some(sui_epoch.saturating_add(1)),
             min_timestamp: None,
             max_timestamp: None,
             chain: chain_identifier,
@@ -806,14 +812,15 @@ mod tests {
         assert_eq!(v1.gas_data.owner, sender);
         assert_eq!(v1.gas_data.price, 750);
         assert_eq!(v1.gas_data.budget, NOTIFIER_GAS_BUDGET);
-        // Single-epoch validity: replay-protected under every protocol regime
-        // (validators retain executed digests across the expiry range).
+        // The [current, current+1] window survives a Sui epoch boundary and
+        // is the maximum extension is_replay_protected allows (validators
+        // retain executed digests across the expiry range).
         assert!(v1.expiration.is_replay_protected());
         assert!(matches!(
             v1.expiration,
             TransactionExpiration::ValidDuring {
                 min_epoch: Some(42),
-                max_epoch: Some(42),
+                max_epoch: Some(43),
                 min_timestamp: None,
                 max_timestamp: None,
                 nonce: 7,

--- a/crates/ika-core/src/sui_connector/setup.rs
+++ b/crates/ika-core/src/sui_connector/setup.rs
@@ -573,6 +573,7 @@ mod tests {
             ika_dwallet_coordinator_object_id: ObjectID::random(),
             verified_cache_retention_checkpoints: None,
             notifier_client_key_pair: None,
+            notifier_gas_from_address_balance: false,
             sui_ika_system_module_last_processed_event_id_override: None,
         }
     }

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -71,6 +71,11 @@ const ONE_HOUR_IN_SECONDS: u64 = 60 * 60;
 /// response), so no separate fullnode observability wait is needed.
 #[derive(Default)]
 struct NotifierSubmitState {
+    /// SIP-58 mode (mirrors `SuiNotifier::gas_from_address_balance`): the
+    /// writer pays gas from its address balance, transactions carry no gas
+    /// `ObjectRef`, and ALL of the caching/recovery below is bypassed — the
+    /// stale-gas-version failure class does not exist without gas objects.
+    gas_from_address_balance: bool,
     gas_coins: Option<Vec<ObjectRef>>,
     /// The gas ref(s) handed to the most recent submission, so a failure can
     /// learn which version was rejected without threading it back through the
@@ -94,6 +99,9 @@ impl NotifierSubmitState {
     /// the tx failed for an unrelated reason, and clearing it would force
     /// an unnecessary (and possibly stale) fullnode re-fetch.
     fn handle_possible_stale_gas_rejection(&mut self, error_message: &str) {
+        if self.gas_from_address_balance {
+            return;
+        }
         let is_stale_gas = error_message.contains("unavailable for consumption")
             || error_message.contains("needs to be rebuilt");
         if is_stale_gas {
@@ -183,11 +191,16 @@ where
             dwallet_coordinator_object_sender,
             dwallet_checkpoint_store,
             system_checkpoint_store,
+            notifier_tx_lock: Arc::new(tokio::sync::Mutex::new(NotifierSubmitState {
+                gas_from_address_balance: sui_notifier
+                    .as_ref()
+                    .is_some_and(SuiNotifier::gas_from_address_balance),
+                ..Default::default()
+            })),
             sui_notifier,
             sui_client,
             reader,
             metrics,
-            notifier_tx_lock: Arc::new(tokio::sync::Mutex::new(NotifierSubmitState::default())),
         }
     }
 
@@ -946,14 +959,8 @@ where
             );
         }
 
-        let transaction = super::build_sui_transaction(
-            sui_notifier.sui_address,
-            ptb.finish(),
-            sui_client,
-            gas_coins,
-            &sui_notifier.sui_key,
-        )
-        .await;
+        let transaction =
+            super::build_sui_transaction(sui_notifier, ptb.finish(), sui_client, gas_coins).await;
 
         Ok(Self::submit_tx_to_sui(notifier_tx_lock, transaction, sui_client).await?)
     }
@@ -999,14 +1006,8 @@ where
             );
         }
 
-        let transaction = super::build_sui_transaction(
-            sui_notifier.sui_address,
-            ptb.finish(),
-            sui_client,
-            gas_coins,
-            &sui_notifier.sui_key,
-        )
-        .await;
+        let transaction =
+            super::build_sui_transaction(sui_notifier, ptb.finish(), sui_client, gas_coins).await;
 
         Ok(Self::submit_tx_to_sui(notifier_tx_lock, transaction, sui_client).await?)
     }
@@ -1025,6 +1026,10 @@ where
         // Fast path: the authoritative ref carried by the prior tx's effects.
         {
             let mut state = notifier_tx_lock.lock().await;
+            // SIP-58 address-balance gas: transactions carry no gas objects.
+            if state.gas_from_address_balance {
+                return vec![];
+            }
             if let Some(gas) = state.gas_coins.clone() {
                 state.last_used_gas = Some(gas.clone());
                 return gas;
@@ -1131,15 +1136,19 @@ where
             .into());
         };
 
-        // The tx executed (effects are present), so the gas coin advanced
-        // to a new version regardless of move success/abort. Cache that
-        // authoritative ref for the next tx instead of re-reading the
-        // notifier fullnode, which lags under load and yields stale gas
-        // versions that get rejected and stall epoch advance.
-        state.gas_coins = Some(vec![tx_effects.gas_object().reference.to_object_ref()]);
-        // The cached ref is now authoritative again; drop any stale-version
-        // floor a prior rejection left so a future re-fetch isn't over-gated.
-        state.min_gas_version = None;
+        if !state.gas_from_address_balance {
+            // The tx executed (effects are present), so the gas coin advanced
+            // to a new version regardless of move success/abort. Cache that
+            // authoritative ref for the next tx instead of re-reading the
+            // notifier fullnode, which lags under load and yields stale gas
+            // versions that get rejected and stall epoch advance. (Under
+            // address-balance gas there is no gas object; the effects'
+            // gas_object is a placeholder and must not be cached.)
+            state.gas_coins = Some(vec![tx_effects.gas_object().reference.to_object_ref()]);
+            // The cached ref is now authoritative again; drop any stale-version
+            // floor a prior rejection left so a future re-fetch isn't over-gated.
+            state.min_gas_version = None;
+        }
 
         if let SuiExecutionStatus::Failure { error } = tx_effects.status() {
             return Err(IkaError::SuiClientTxFailureGeneric(
@@ -1213,14 +1222,8 @@ where
             vec![coordinator_arg, system_current_status_info],
         );
 
-        let transaction = super::build_sui_transaction(
-            sui_notifier.sui_address,
-            ptb.finish(),
-            sui_client,
-            gas_coins,
-            &sui_notifier.sui_key,
-        )
-        .await;
+        let transaction =
+            super::build_sui_transaction(sui_notifier, ptb.finish(), sui_client, gas_coins).await;
 
         Ok(Self::submit_tx_to_sui(notifier_tx_lock, transaction, sui_client).await?)
     }
@@ -1277,14 +1280,8 @@ where
             vec![coordinator_arg, system_current_status_info],
         );
 
-        let transaction = super::build_sui_transaction(
-            sui_notifier.sui_address,
-            ptb.finish(),
-            sui_client,
-            gas_coins,
-            &sui_notifier.sui_key,
-        )
-        .await;
+        let transaction =
+            super::build_sui_transaction(sui_notifier, ptb.finish(), sui_client, gas_coins).await;
 
         Ok(Self::submit_tx_to_sui(notifier_tx_lock, transaction, sui_client).await?)
     }
@@ -1349,14 +1346,8 @@ where
             vec![system_arg, advance_epoch_approver, clock_arg],
         );
 
-        let transaction = super::build_sui_transaction(
-            sui_notifier.sui_address,
-            ptb.finish(),
-            sui_client,
-            gas_coins,
-            &sui_notifier.sui_key,
-        )
-        .await;
+        let transaction =
+            super::build_sui_transaction(sui_notifier, ptb.finish(), sui_client, gas_coins).await;
 
         Ok(Self::submit_tx_to_sui(notifier_tx_lock, transaction, sui_client).await?)
     }
@@ -1421,19 +1412,21 @@ where
             args,
         );
 
-        ptb.command(sui_types::transaction::Command::MergeCoins(
-            Argument::GasCoin,
-            vec![gas_fee_reimbursement_sui],
-        ));
+        if sui_notifier.gas_from_address_balance() {
+            // No gas coin object exists to merge into (SIP-58 balance gas):
+            // send the reimbursement to the writer's address as an owned coin
+            // instead. It accumulates as small coins the operator can sweep
+            // into the address balance.
+            ptb.transfer_arg(sui_notifier.sui_address(), gas_fee_reimbursement_sui);
+        } else {
+            ptb.command(sui_types::transaction::Command::MergeCoins(
+                Argument::GasCoin,
+                vec![gas_fee_reimbursement_sui],
+            ));
+        }
 
-        let transaction = super::build_sui_transaction(
-            sui_notifier.sui_address,
-            ptb.finish(),
-            sui_client,
-            gas_coins,
-            &sui_notifier.sui_key,
-        )
-        .await;
+        let transaction =
+            super::build_sui_transaction(sui_notifier, ptb.finish(), sui_client, gas_coins).await;
 
         match Self::submit_tx_to_sui(notifier_tx_lock, transaction, sui_client).await {
             Ok(result) => Ok(result),
@@ -1502,14 +1495,8 @@ where
             args,
         );
 
-        let transaction = super::build_sui_transaction(
-            sui_notifier.sui_address,
-            ptb.finish(),
-            sui_client,
-            gas_coins,
-            &sui_notifier.sui_key,
-        )
-        .await;
+        let transaction =
+            super::build_sui_transaction(sui_notifier, ptb.finish(), sui_client, gas_coins).await;
 
         match Self::submit_tx_to_sui(notifier_tx_lock, transaction, sui_client).await {
             Ok(_) => Ok(()),

--- a/crates/ika-sui-client/src/grpc.rs
+++ b/crates/ika-sui-client/src/grpc.rs
@@ -369,6 +369,15 @@ impl SuiWriter for SuiGrpcClient {
         Ok(refs)
     }
 
+    async fn get_sui_address_balance(&self, address: SuiAddress) -> Result<u64, TransportError> {
+        let rpc = self.rpc.clone();
+        let balance = rpc
+            .get_balance(address, &GasCoin::type_())
+            .await
+            .map_err(Self::rpc_err)?;
+        Ok(balance.address_balance.unwrap_or(0))
+    }
+
     async fn execute_transaction(
         &self,
         tx: &Transaction,

--- a/crates/ika-sui-client/src/grpc.rs
+++ b/crates/ika-sui-client/src/grpc.rs
@@ -384,6 +384,15 @@ impl SuiWriter for SuiGrpcClient {
         })
     }
 
+    async fn get_sui_chain_identifier(
+        &self,
+    ) -> Result<sui_types::digests::ChainIdentifier, TransportError> {
+        let rpc = self.rpc.clone();
+        // The inner client already returns the typed, full identifier
+        // (service-info chain id parsed as the genesis checkpoint digest).
+        rpc.get_chain_identifier().await.map_err(Self::rpc_err)
+    }
+
     async fn execute_transaction(
         &self,
         tx: &Transaction,

--- a/crates/ika-sui-client/src/grpc.rs
+++ b/crates/ika-sui-client/src/grpc.rs
@@ -23,7 +23,7 @@ use sui_types::transaction::Transaction;
 
 use crate::transport::{
     CheckpointSummaryStream, DynamicFieldEntry, DynamicFieldPage, SubmittedTransaction,
-    SuiTransport, SuiWriter, TransportError,
+    SuiFundsBreakdown, SuiTransport, SuiWriter, TransportError,
 };
 
 pub struct SuiGrpcClient {
@@ -369,13 +369,19 @@ impl SuiWriter for SuiGrpcClient {
         Ok(refs)
     }
 
-    async fn get_sui_address_balance(&self, address: SuiAddress) -> Result<u64, TransportError> {
+    async fn get_sui_funds(
+        &self,
+        address: SuiAddress,
+    ) -> Result<SuiFundsBreakdown, TransportError> {
         let rpc = self.rpc.clone();
         let balance = rpc
             .get_balance(address, &GasCoin::type_())
             .await
             .map_err(Self::rpc_err)?;
-        Ok(balance.address_balance.unwrap_or(0))
+        Ok(SuiFundsBreakdown {
+            in_address_balance: balance.address_balance.unwrap_or(0),
+            in_coin_objects: balance.coin_balance.unwrap_or(0),
+        })
     }
 
     async fn execute_transaction(

--- a/crates/ika-sui-client/src/grpc.rs
+++ b/crates/ika-sui-client/src/grpc.rs
@@ -16,7 +16,7 @@ use sui_rpc_api::client::ExecutedTransaction;
 use sui_rpc_api::proto::sui::rpc::v2 as proto;
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest};
 use sui_types::full_checkpoint_content::CheckpointData;
-use sui_types::gas_coin::GasCoin;
+use sui_types::gas_coin::{GAS, GasCoin};
 use sui_types::messages_checkpoint::{CertifiedCheckpointSummary, CheckpointSequenceNumber};
 use sui_types::object::Object;
 use sui_types::transaction::Transaction;
@@ -374,8 +374,11 @@ impl SuiWriter for SuiGrpcClient {
         address: SuiAddress,
     ) -> Result<SuiFundsBreakdown, TransportError> {
         let rpc = self.rpc.clone();
+        // NB: GetBalance takes the COIN type (`0x2::sui::SUI`, `GAS::type_()`),
+        // not the coin OBJECT type (`Coin<SUI>`, `GasCoin::type_()`) — the
+        // latter silently reads as a zero balance of a nonexistent coin type.
         let balance = rpc
-            .get_balance(address, &GasCoin::type_())
+            .get_balance(address, &GAS::type_())
             .await
             .map_err(Self::rpc_err)?;
         Ok(SuiFundsBreakdown {

--- a/crates/ika-sui-client/src/grpc_backend.rs
+++ b/crates/ika-sui-client/src/grpc_backend.rs
@@ -41,7 +41,7 @@ use crate::grpc::SuiGrpcClient;
 use crate::transport::{
     SuiFundsBreakdown, SuiTransport, SuiWriter, TransportError, dynamic_field_child_owned_by,
 };
-use sui_types::digests::{ChainIdentifier as SuiNetworkChainIdentifier, CheckpointDigest};
+use sui_types::digests::ChainIdentifier as SuiNetworkChainIdentifier;
 
 /// Error surface of the gRPC backend. Satisfies the
 /// `SuiClientInner::Error` bound (`Into<anyhow::Error> + Send + Sync +
@@ -220,15 +220,11 @@ impl SuiClientInner for GrpcSuiClient {
     }
 
     async fn get_sui_chain_identifier(&self) -> Result<SuiNetworkChainIdentifier, Self::Error> {
-        // The gRPC service-info chain id IS the full genesis checkpoint
-        // digest (Base58) — parse it back into the typed identifier.
-        let chain_id = self.transport.get_chain_identifier().await?;
-        let digest: CheckpointDigest = chain_id.parse().map_err(|e| {
-            TransportError::Encoding(format!(
-                "service-info chain id {chain_id:?} is not a checkpoint digest: {e}"
-            ))
-        })?;
-        Ok(SuiNetworkChainIdentifier::from(digest))
+        // Typed read through the writer uplink: the transport's STRING
+        // identifier goes through `Display`, which is the 4-byte short id
+        // and cannot be turned back into the full identifier `ValidDuring`
+        // needs. Every balance-gas node is a writer, so the uplink exists.
+        Ok(self.writer()?.get_sui_chain_identifier().await?)
     }
 
     async fn get_sui_funds(&self, address: SuiAddress) -> Result<SuiFundsBreakdown, Self::Error> {

--- a/crates/ika-sui-client/src/grpc_backend.rs
+++ b/crates/ika-sui-client/src/grpc_backend.rs
@@ -38,7 +38,9 @@ use sui_types::transaction::{ObjectArg, SharedObjectMutability, Transaction};
 
 use crate::SuiClientInner;
 use crate::grpc::SuiGrpcClient;
-use crate::transport::{SuiTransport, SuiWriter, TransportError, dynamic_field_child_owned_by};
+use crate::transport::{
+    SuiFundsBreakdown, SuiTransport, SuiWriter, TransportError, dynamic_field_child_owned_by,
+};
 use sui_types::digests::{ChainIdentifier as SuiNetworkChainIdentifier, CheckpointDigest};
 
 /// Error surface of the gRPC backend. Satisfies the
@@ -229,8 +231,8 @@ impl SuiClientInner for GrpcSuiClient {
         Ok(SuiNetworkChainIdentifier::from(digest))
     }
 
-    async fn get_sui_address_balance(&self, address: SuiAddress) -> Result<u64, Self::Error> {
-        Ok(self.writer()?.get_sui_address_balance(address).await?)
+    async fn get_sui_funds(&self, address: SuiAddress) -> Result<SuiFundsBreakdown, Self::Error> {
+        Ok(self.writer()?.get_sui_funds(address).await?)
     }
 
     async fn get_reference_gas_price(&self) -> Result<u64, Self::Error> {

--- a/crates/ika-sui-client/src/grpc_backend.rs
+++ b/crates/ika-sui-client/src/grpc_backend.rs
@@ -229,6 +229,10 @@ impl SuiClientInner for GrpcSuiClient {
         Ok(SuiNetworkChainIdentifier::from(digest))
     }
 
+    async fn get_sui_address_balance(&self, address: SuiAddress) -> Result<u64, Self::Error> {
+        Ok(self.writer()?.get_sui_address_balance(address).await?)
+    }
+
     async fn get_reference_gas_price(&self) -> Result<u64, Self::Error> {
         Ok(self.writer()?.get_reference_gas_price().await?)
     }

--- a/crates/ika-sui-client/src/grpc_backend.rs
+++ b/crates/ika-sui-client/src/grpc_backend.rs
@@ -39,6 +39,7 @@ use sui_types::transaction::{ObjectArg, SharedObjectMutability, Transaction};
 use crate::SuiClientInner;
 use crate::grpc::SuiGrpcClient;
 use crate::transport::{SuiTransport, SuiWriter, TransportError, dynamic_field_child_owned_by};
+use sui_types::digests::{ChainIdentifier as SuiNetworkChainIdentifier, CheckpointDigest};
 
 /// Error surface of the gRPC backend. Satisfies the
 /// `SuiClientInner::Error` bound (`Into<anyhow::Error> + Send + Sync +
@@ -210,6 +211,22 @@ impl SuiClientInner for GrpcSuiClient {
 
     async fn get_chain_identifier(&self) -> Result<String, Self::Error> {
         Ok(self.transport.get_chain_identifier().await?)
+    }
+
+    async fn get_sui_epoch(&self) -> Result<u64, Self::Error> {
+        Ok(self.transport.get_current_epoch().await?)
+    }
+
+    async fn get_sui_chain_identifier(&self) -> Result<SuiNetworkChainIdentifier, Self::Error> {
+        // The gRPC service-info chain id IS the full genesis checkpoint
+        // digest (Base58) — parse it back into the typed identifier.
+        let chain_id = self.transport.get_chain_identifier().await?;
+        let digest: CheckpointDigest = chain_id.parse().map_err(|e| {
+            TransportError::Encoding(format!(
+                "service-info chain id {chain_id:?} is not a checkpoint digest: {e}"
+            ))
+        })?;
+        Ok(SuiNetworkChainIdentifier::from(digest))
     }
 
     async fn get_reference_gas_price(&self) -> Result<u64, Self::Error> {

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -24,6 +24,7 @@ use itertools::Itertools;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
+use sui_json_rpc_types::CheckpointId;
 use sui_json_rpc_types::{EventFilter, Page, SuiEvent};
 use sui_json_rpc_types::{
     EventPage, SuiObjectDataOptions, SuiTransactionBlockResponse,
@@ -36,6 +37,7 @@ use sui_types::TypeTag;
 use sui_types::base_types::{EpochId, ObjectRef};
 use sui_types::clock::Clock;
 use sui_types::collection_types::{Entry, Table};
+use sui_types::digests::ChainIdentifier as SuiNetworkChainIdentifier;
 use sui_types::dynamic_field::Field;
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::Owner;
@@ -785,6 +787,38 @@ where
         }
     }
 
+    /// Current SUI epoch, retried until it succeeds — the `ValidDuring`
+    /// anchor for address-balance-gas submissions (same retry-forever
+    /// contract as `get_reference_gas_price_until_success`; both feed
+    /// transaction construction on the writer path).
+    pub async fn get_sui_epoch_until_success(&self) -> u64 {
+        loop {
+            let Ok(Ok(epoch)) =
+                retry_with_max_elapsed_time!(self.inner.get_sui_epoch(), Duration::from_secs(30))
+            else {
+                self.sui_client_metrics
+                    .sui_rpc_errors
+                    .with_label_values(&["get_sui_epoch_until_success"])
+                    .inc();
+                error!("Failed to get the current SUI epoch");
+                continue;
+            };
+            return epoch;
+        }
+    }
+
+    /// The chain's genesis-rooted `ChainIdentifier` (full identifier, as
+    /// `ValidDuring` requires).
+    pub async fn get_sui_chain_identifier(&self) -> IkaResult<SuiNetworkChainIdentifier> {
+        self.inner.get_sui_chain_identifier().await.map_err(|e| {
+            self.sui_client_metrics
+                .sui_rpc_errors
+                .with_label_values(&["get_sui_chain_identifier"])
+                .inc();
+            IkaError::SuiClientInternalError(format!("Can't get_sui_chain_identifier: {e}"))
+        })
+    }
+
     pub async fn get_latest_checkpoint_sequence_number(&self) -> IkaResult<u64> {
         self.inner
             .get_latest_checkpoint_sequence_number()
@@ -966,6 +1000,15 @@ pub trait SuiClientInner: Send + Sync {
 
     async fn get_chain_identifier(&self) -> Result<String, Self::Error>;
 
+    /// Current SUI epoch — the `ValidDuring` window anchor for
+    /// address-balance-gas transactions (SIP-58).
+    async fn get_sui_epoch(&self) -> Result<u64, Self::Error>;
+
+    /// The chain's genesis-rooted `ChainIdentifier`. `ValidDuring` carries it
+    /// verbatim and validators compare the FULL identifier, so the 4-byte
+    /// short id alone is not enough on chains without a compiled-in constant.
+    async fn get_sui_chain_identifier(&self) -> Result<SuiNetworkChainIdentifier, Self::Error>;
+
     async fn get_reference_gas_price(&self) -> Result<u64, Self::Error>;
 
     async fn get_latest_checkpoint_sequence_number(&self) -> Result<u64, Self::Error>;
@@ -1081,6 +1124,29 @@ impl SuiClientInner for SuiSdkClient {
 
     async fn get_chain_identifier(&self) -> Result<String, Self::Error> {
         self.read_api().get_chain_identifier().await
+    }
+
+    async fn get_sui_epoch(&self) -> Result<u64, Self::Error> {
+        Ok(self
+            .governance_api()
+            .get_latest_sui_system_state()
+            .await?
+            .epoch)
+    }
+
+    async fn get_sui_chain_identifier(&self) -> Result<SuiNetworkChainIdentifier, Self::Error> {
+        // Mainnet/testnet resolve from the short id to the compiled-in full
+        // identifier; other chains (localnet) fall back to the genesis
+        // checkpoint digest, which unpruned local fullnodes always serve.
+        let short_id = self.read_api().get_chain_identifier().await?;
+        if let Some(chain_identifier) = SuiNetworkChainIdentifier::from_chain_short_id(&short_id) {
+            return Ok(chain_identifier);
+        }
+        let genesis = self
+            .read_api()
+            .get_checkpoint(CheckpointId::SequenceNumber(0))
+            .await?;
+        Ok(SuiNetworkChainIdentifier::from(genesis.digest))
     }
 
     async fn get_reference_gas_price(&self) -> Result<u64, Self::Error> {
@@ -1725,6 +1791,14 @@ impl SuiClientInner for SuiBackend {
 
     async fn get_chain_identifier(&self) -> Result<String, Self::Error> {
         dispatch_backend!(self, get_chain_identifier())
+    }
+
+    async fn get_sui_epoch(&self) -> Result<u64, Self::Error> {
+        dispatch_backend!(self, get_sui_epoch())
+    }
+
+    async fn get_sui_chain_identifier(&self) -> Result<SuiNetworkChainIdentifier, Self::Error> {
+        dispatch_backend!(self, get_sui_chain_identifier())
     }
 
     async fn get_reference_gas_price(&self) -> Result<u64, Self::Error> {

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -819,6 +819,20 @@ where
         })
     }
 
+    /// SUI in `address`'s ADDRESS BALANCE (SIP-58), in MIST.
+    pub async fn get_sui_address_balance(&self, address: SuiAddress) -> IkaResult<u64> {
+        self.inner
+            .get_sui_address_balance(address)
+            .await
+            .map_err(|e| {
+                self.sui_client_metrics
+                    .sui_rpc_errors
+                    .with_label_values(&["get_sui_address_balance"])
+                    .inc();
+                IkaError::SuiClientInternalError(format!("Can't get_sui_address_balance: {e}"))
+            })
+    }
+
     pub async fn get_latest_checkpoint_sequence_number(&self) -> IkaResult<u64> {
         self.inner
             .get_latest_checkpoint_sequence_number()
@@ -1009,6 +1023,10 @@ pub trait SuiClientInner: Send + Sync {
     /// short id alone is not enough on chains without a compiled-in constant.
     async fn get_sui_chain_identifier(&self) -> Result<SuiNetworkChainIdentifier, Self::Error>;
 
+    /// SUI held in `address`'s ADDRESS BALANCE (SIP-58), in MIST — the funds
+    /// address-balance-gas submissions draw on. Coin objects are excluded.
+    async fn get_sui_address_balance(&self, address: SuiAddress) -> Result<u64, Self::Error>;
+
     async fn get_reference_gas_price(&self) -> Result<u64, Self::Error>;
 
     async fn get_latest_checkpoint_sequence_number(&self) -> Result<u64, Self::Error>;
@@ -1147,6 +1165,11 @@ impl SuiClientInner for SuiSdkClient {
             .get_checkpoint(CheckpointId::SequenceNumber(0))
             .await?;
         Ok(SuiNetworkChainIdentifier::from(genesis.digest))
+    }
+
+    async fn get_sui_address_balance(&self, address: SuiAddress) -> Result<u64, Self::Error> {
+        let balance = self.coin_read_api().get_balance(address, None).await?;
+        Ok(u64::try_from(balance.funds_in_address_balance).unwrap_or(u64::MAX))
     }
 
     async fn get_reference_gas_price(&self) -> Result<u64, Self::Error> {
@@ -1799,6 +1822,10 @@ impl SuiClientInner for SuiBackend {
 
     async fn get_sui_chain_identifier(&self) -> Result<SuiNetworkChainIdentifier, Self::Error> {
         dispatch_backend!(self, get_sui_chain_identifier())
+    }
+
+    async fn get_sui_address_balance(&self, address: SuiAddress) -> Result<u64, Self::Error> {
+        dispatch_backend!(self, get_sui_address_balance(address))
     }
 
     async fn get_reference_gas_price(&self) -> Result<u64, Self::Error> {

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -61,6 +61,7 @@ pub mod ika_protocol_transactions;
 pub mod ika_validator_transactions;
 pub mod metrics;
 pub mod transport;
+pub use transport::SuiFundsBreakdown;
 
 #[macro_export]
 macro_rules! retry_with_max_elapsed_time {
@@ -819,18 +820,15 @@ where
         })
     }
 
-    /// SUI in `address`'s ADDRESS BALANCE (SIP-58), in MIST.
-    pub async fn get_sui_address_balance(&self, address: SuiAddress) -> IkaResult<u64> {
-        self.inner
-            .get_sui_address_balance(address)
-            .await
-            .map_err(|e| {
-                self.sui_client_metrics
-                    .sui_rpc_errors
-                    .with_label_values(&["get_sui_address_balance"])
-                    .inc();
-                IkaError::SuiClientInternalError(format!("Can't get_sui_address_balance: {e}"))
-            })
+    /// SUI held by `address`, split into address balance vs. coin objects.
+    pub async fn get_sui_funds(&self, address: SuiAddress) -> IkaResult<SuiFundsBreakdown> {
+        self.inner.get_sui_funds(address).await.map_err(|e| {
+            self.sui_client_metrics
+                .sui_rpc_errors
+                .with_label_values(&["get_sui_funds"])
+                .inc();
+            IkaError::SuiClientInternalError(format!("Can't get_sui_funds: {e}"))
+        })
     }
 
     pub async fn get_latest_checkpoint_sequence_number(&self) -> IkaResult<u64> {
@@ -1023,9 +1021,9 @@ pub trait SuiClientInner: Send + Sync {
     /// short id alone is not enough on chains without a compiled-in constant.
     async fn get_sui_chain_identifier(&self) -> Result<SuiNetworkChainIdentifier, Self::Error>;
 
-    /// SUI held in `address`'s ADDRESS BALANCE (SIP-58), in MIST — the funds
-    /// address-balance-gas submissions draw on. Coin objects are excluded.
-    async fn get_sui_address_balance(&self, address: SuiAddress) -> Result<u64, Self::Error>;
+    /// SUI held by `address`, split into its ADDRESS BALANCE (SIP-58 — what
+    /// address-balance-gas submissions draw on) and its owned coin objects.
+    async fn get_sui_funds(&self, address: SuiAddress) -> Result<SuiFundsBreakdown, Self::Error>;
 
     async fn get_reference_gas_price(&self) -> Result<u64, Self::Error>;
 
@@ -1167,9 +1165,20 @@ impl SuiClientInner for SuiSdkClient {
         Ok(SuiNetworkChainIdentifier::from(genesis.digest))
     }
 
-    async fn get_sui_address_balance(&self, address: SuiAddress) -> Result<u64, Self::Error> {
+    async fn get_sui_funds(&self, address: SuiAddress) -> Result<SuiFundsBreakdown, Self::Error> {
         let balance = self.coin_read_api().get_balance(address, None).await?;
-        Ok(u64::try_from(balance.funds_in_address_balance).unwrap_or(u64::MAX))
+        let in_address_balance =
+            u64::try_from(balance.funds_in_address_balance).unwrap_or(u64::MAX);
+        let in_coin_objects = u64::try_from(
+            balance
+                .total_balance
+                .saturating_sub(balance.funds_in_address_balance),
+        )
+        .unwrap_or(u64::MAX);
+        Ok(SuiFundsBreakdown {
+            in_address_balance,
+            in_coin_objects,
+        })
     }
 
     async fn get_reference_gas_price(&self) -> Result<u64, Self::Error> {
@@ -1824,8 +1833,8 @@ impl SuiClientInner for SuiBackend {
         dispatch_backend!(self, get_sui_chain_identifier())
     }
 
-    async fn get_sui_address_balance(&self, address: SuiAddress) -> Result<u64, Self::Error> {
-        dispatch_backend!(self, get_sui_address_balance(address))
+    async fn get_sui_funds(&self, address: SuiAddress) -> Result<SuiFundsBreakdown, Self::Error> {
+        dispatch_backend!(self, get_sui_funds(address))
     }
 
     async fn get_reference_gas_price(&self) -> Result<u64, Self::Error> {

--- a/crates/ika-sui-client/src/transport.rs
+++ b/crates/ika-sui-client/src/transport.rs
@@ -228,6 +228,15 @@ pub trait SuiTransport: Send + Sync {
     ) -> Result<ExecutedTransaction, TransportError>;
 }
 
+/// SUI funds of an address, split by where they live (MIST).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SuiFundsBreakdown {
+    /// In the SIP-58 ADDRESS BALANCE — spendable as address-balance gas.
+    pub in_address_balance: u64,
+    /// In owned `Coin<SUI>` objects — spendable as gas-coin payments only.
+    pub in_coin_objects: u64,
+}
+
 /// The notifier's **writer** surface — building and submitting transactions.
 /// Kept separate from [`SuiTransport`] because only a node with a direct Sui
 /// uplink can do these: a read-only relay/peer transport never implements them.
@@ -248,10 +257,11 @@ pub trait SuiWriter: Send + Sync {
         &self,
         address: SuiAddress,
     ) -> Result<Vec<ObjectRef>, TransportError>;
-    /// The SUI held in `address`'s ADDRESS BALANCE (SIP-58 accumulator), in
-    /// MIST — the funds address-balance-gas submissions draw on. Coin
-    /// objects are NOT included.
-    async fn get_sui_address_balance(&self, address: SuiAddress) -> Result<u64, TransportError>;
+    /// The SUI held by `address`, split into its ADDRESS BALANCE (SIP-58
+    /// accumulator — what address-balance-gas submissions draw on) and its
+    /// owned coin objects.
+    async fn get_sui_funds(&self, address: SuiAddress)
+    -> Result<SuiFundsBreakdown, TransportError>;
     async fn execute_transaction(
         &self,
         tx: &Transaction,

--- a/crates/ika-sui-client/src/transport.rs
+++ b/crates/ika-sui-client/src/transport.rs
@@ -262,6 +262,13 @@ pub trait SuiWriter: Send + Sync {
     /// owned coin objects.
     async fn get_sui_funds(&self, address: SuiAddress)
     -> Result<SuiFundsBreakdown, TransportError>;
+    /// The chain's genesis-rooted `ChainIdentifier`, TYPED. The transport's
+    /// string `get_chain_identifier` goes through `Display`, which is the
+    /// 4-byte short id — useless for `ValidDuring`, which validators compare
+    /// against the FULL identifier.
+    async fn get_sui_chain_identifier(
+        &self,
+    ) -> Result<sui_types::digests::ChainIdentifier, TransportError>;
     async fn execute_transaction(
         &self,
         tx: &Transaction,

--- a/crates/ika-sui-client/src/transport.rs
+++ b/crates/ika-sui-client/src/transport.rs
@@ -248,6 +248,10 @@ pub trait SuiWriter: Send + Sync {
         &self,
         address: SuiAddress,
     ) -> Result<Vec<ObjectRef>, TransportError>;
+    /// The SUI held in `address`'s ADDRESS BALANCE (SIP-58 accumulator), in
+    /// MIST — the funds address-balance-gas submissions draw on. Coin
+    /// objects are NOT included.
+    async fn get_sui_address_balance(&self, address: SuiAddress) -> Result<u64, TransportError>;
     async fn execute_transaction(
         &self,
         tx: &Transaction,

--- a/crates/ika-swarm-config/src/node_config_builder.rs
+++ b/crates/ika-swarm-config/src/node_config_builder.rs
@@ -210,6 +210,7 @@ impl ValidatorConfigBuilder {
                 ika_dwallet_coordinator_object_id,
                 verified_cache_retention_checkpoints: None,
                 notifier_client_key_pair: None,
+                notifier_gas_from_address_balance: false,
                 sui_ika_system_module_last_processed_event_id_override: None,
             },
             db_path,
@@ -462,6 +463,7 @@ impl FullnodeConfigBuilder {
                 ika_dwallet_coordinator_object_id,
                 verified_cache_retention_checkpoints: None,
                 notifier_client_key_pair,
+                notifier_gas_from_address_balance: false,
                 sui_ika_system_module_last_processed_event_id_override: None,
             },
             metrics_address: self

--- a/crates/ika-swarm-config/src/node_config_builder.rs
+++ b/crates/ika-swarm-config/src/node_config_builder.rs
@@ -291,6 +291,9 @@ pub struct FullnodeConfigBuilder {
     /// transport, the shape every mainnet notifier/fullnode runs on rollout
     /// day.
     legacy_sui_rpc_only: bool,
+    /// Notifier pays gas from its SUI address balance (SIP-58) — see
+    /// `SuiConnectorConfig::notifier_gas_from_address_balance`.
+    notifier_gas_from_address_balance: bool,
 }
 
 impl FullnodeConfigBuilder {
@@ -305,6 +308,12 @@ impl FullnodeConfigBuilder {
 
     pub fn with_supported_protocol_versions(mut self, versions: SupportedProtocolVersions) -> Self {
         self.supported_protocol_versions = Some(versions);
+        self
+    }
+
+    /// Notifier pays gas from its SUI address balance (SIP-58).
+    pub fn with_notifier_gas_from_address_balance(mut self) -> Self {
+        self.notifier_gas_from_address_balance = true;
         self
     }
 
@@ -463,7 +472,7 @@ impl FullnodeConfigBuilder {
                 ika_dwallet_coordinator_object_id,
                 verified_cache_retention_checkpoints: None,
                 notifier_client_key_pair,
-                notifier_gas_from_address_balance: false,
+                notifier_gas_from_address_balance: self.notifier_gas_from_address_balance,
                 sui_ika_system_module_last_processed_event_id_override: None,
             },
             metrics_address: self

--- a/crates/ika-test-cluster/src/lib.rs
+++ b/crates/ika-test-cluster/src/lib.rs
@@ -1173,6 +1173,10 @@ pub struct IkaTestClusterBuilder {
     /// `with_sui_state_direct_count(_)`. Off by default (mirrored validators
     /// keep a direct gRPC fallback).
     peer_only_mirrored: bool,
+    /// When true, the notifier fullnode pays gas from its SUI ADDRESS BALANCE
+    /// (SIP-58) instead of gas-coin objects. Its funding still arrives as
+    /// coin objects, so boot exercises the automatic migration sweep too.
+    notifier_gas_from_address_balance: bool,
 }
 
 /// Cross-process mutex for the port-sensitive boot window. The Sui and
@@ -1229,7 +1233,15 @@ impl IkaTestClusterBuilder {
             ocs_genesis_anchor: true,
             sui_state_direct_count: None,
             peer_only_mirrored: false,
+            notifier_gas_from_address_balance: false,
         }
+    }
+
+    /// Notifier pays gas from its SUI address balance (SIP-58); boot sweeps
+    /// its coin-object funding into the balance first.
+    pub fn with_notifier_gas_from_address_balance(mut self) -> Self {
+        self.notifier_gas_from_address_balance = true;
+        self
     }
 
     /// Activate the OCS verified-state path: write the localnet's genesis
@@ -1596,7 +1608,12 @@ impl IkaTestClusterBuilder {
             .sign_and_execute_transaction(&fund_notifier_tx_data)
             .await;
         let mut notifier_rng = OsRng;
-        let notifier_config = FullnodeConfigBuilder::new().build(
+        let mut notifier_config_builder = FullnodeConfigBuilder::new();
+        if self.notifier_gas_from_address_balance {
+            notifier_config_builder =
+                notifier_config_builder.with_notifier_gas_from_address_balance();
+        }
+        let notifier_config = notifier_config_builder.build(
             &mut notifier_rng,
             &validator_initialization_configs,
             sui_rpc_url.clone(),

--- a/crates/ika-test-cluster/tests/notifier_balance_gas.rs
+++ b/crates/ika-test-cluster/tests/notifier_balance_gas.rs
@@ -1,0 +1,78 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! End-to-end SIP-58 address-balance gas on the writer path.
+//!
+//! The cluster boots with `notifier_gas_from_address_balance` enabled. The
+//! notifier's funding arrives as ordinary coin objects (the exact state of a
+//! production notifier when the flag is first flipped), so this drives the
+//! whole flag-on contract for real, against a live Sui localnet running at
+//! max protocol version (address-balance gas enabled):
+//!
+//! - boot: chain-identifier resolution, funds read, the automatic migration
+//!   sweep of coin objects into the address balance, and the balance
+//!   preflight — a failure in any of them aborts the notifier's boot and the
+//!   cluster build fails;
+//! - steady state: every dwallet/system checkpoint submission and every
+//!   epoch-switch call (`process_mid_epoch`, pricing, session lock,
+//!   `advance_epoch`) is an empty-gas-payment `ValidDuring` transaction paid
+//!   from the address balance — epochs closing AT ALL is therefore the
+//!   proof that balance-gas submission works end to end (there is no other
+//!   writer and no gas-coin fallback in this mode);
+//! - the checkpoint fee reimbursement takes the balance-mode branch
+//!   (transfer to the writer address) on every dwallet checkpoint.
+//!
+//! Two closes are required so at least one full epoch cycle (mid-epoch →
+//! pricing → lock → advance + checkpoints) runs on balance gas beyond the
+//! boot-adjacent first close.
+//!
+//! `#[tokio::test(flavor = "multi_thread")]` per CLAUDE.md "Picking a test
+//! type": real chain, real crypto at the epoch boundaries.
+
+use ika_test_cluster::IkaTestClusterBuilder;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn epochs_close_with_notifier_on_address_balance_gas() {
+    telemetry_subscribers::init_for_testing();
+
+    let cluster = IkaTestClusterBuilder::new()
+        .with_num_validators(4)
+        .with_epoch_duration_ms(30_000)
+        .with_notifier_gas_from_address_balance()
+        .build()
+        .await
+        .expect(
+            "cluster failed to boot with address-balance gas enabled — chain-id resolution, \
+             funds read, migration sweep, or balance preflight failed on the notifier",
+        );
+
+    // Two full closes on balance gas. Every write the close depends on is an
+    // empty-gas-payment ValidDuring transaction; there is nothing else that
+    // can advance the epoch.
+    cluster.wait_for_epoch(2).await;
+
+    // The funds gauge is only written in balance mode, seeded from the
+    // swept-in address balance: positive means the sweep funded the balance
+    // and the writer is metering it.
+    let notifier = cluster
+        .swarm
+        .fullnodes()
+        .next()
+        .expect("swarm runs exactly one notifier fullnode");
+    let notifier_handle = notifier.get_node_handle().expect("notifier is running");
+    let address_balance_gauge: f64 = notifier_handle.with(|node| {
+        node.registry_service_for_testing()
+            .default_registry()
+            .gather()
+            .iter()
+            .filter(|family| family.name() == "ika_sui_connector_gas_coin_balance")
+            .flat_map(|family| family.get_metric())
+            .map(|metric| metric.get_gauge().value())
+            .fold(0.0f64, f64::max)
+    });
+    assert!(
+        address_balance_gauge > 0.0,
+        "address-balance funds gauge is zero after two closes on balance gas — \
+         the sweep/preflight path did not fund or meter the balance"
+    );
+}

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -45,6 +45,11 @@ them has a bug — determine which before changing either.
   blocks the epoch close, and the two stall signals (the notifier's
   sync-stall self-report; validators' `checkpoint_writer_lag`
   blocked-reason attribution).
+- [`specs/notifier-balance-gas.md`](specs/notifier-balance-gas.md)
+  — the writer's two gas modes: default gas-coin payment (and the
+  stale-gas caching apparatus it requires) vs. opt-in SIP-58
+  address-balance gas (`ValidDuring`, no gas objects, no stale-version
+  failure class), with rollout preconditions.
 - [`specs/cross-binary-upgrade.md`](specs/cross-binary-upgrade.md) —
   the in-place protocol-version upgrade contract: the stake-weighted
   version vote, the wire/on-disk compatibility invariants for mixed

--- a/dev-docs/specs/notifier-balance-gas.md
+++ b/dev-docs/specs/notifier-balance-gas.md
@@ -1,0 +1,66 @@
+# Notifier gas modes (gas coins vs. SIP-58 address-balance gas)
+
+How the network's single writer pays for its Sui transactions, why the
+gas-coin path carries a whole caching/recovery apparatus, and the opt-in
+SIP-58 mode that deletes that failure class. Actors: the notifier's
+`sui_executor`/`build_sui_transaction`, the Sui chain's protocol flags.
+
+## Gas-coin mode (default)
+
+Each submission carries an owned gas-coin `ObjectRef` whose version must be
+exactly current. Because the notifier's fullnode view lags the validators,
+the executor maintains `NotifierSubmitState`: the post-transaction gas ref is
+cached from each transaction's effects, stale-gas rejections clear the cache
+and record a re-fetch version floor, and the gas coin must never be shared
+with any other spender (equivocation locks it for the epoch). This machinery
+exists solely to fight gas-object versioning; it has wedged epoch advance
+before and is the reason two writers can never share an address.
+
+## Address-balance mode (`notifier_gas_from_address_balance: true`)
+
+SIP-58: an **empty gas payment** on a programmable transaction pays gas from
+the sender's SUI address balance, and a `ValidDuring` expiration replaces the
+replay protection that gas-coin version bumps provided. Decision rules:
+
+1. **Construction** (`balance_gas_transaction_data`): empty `gas_data.payment`,
+   same fixed budget, expiration `ValidDuring { min_epoch == max_epoch ==
+   current SUI epoch, chain: full genesis-rooted ChainIdentifier, nonce:
+   random u32 }`. Single-epoch validity is accepted under every protocol
+   regime; a submission racing a Sui epoch boundary expires harmlessly and
+   the caller's retry rebuilds it against the new epoch.
+2. **Chain identifier** is resolved ONCE at boot (compiled-in for
+   mainnet/testnet via the short id; genesis checkpoint digest otherwise) and
+   a failure to resolve it fails the boot loudly — a writer silently unable
+   to build transactions is the issue-#1892 failure shape.
+3. **Current SUI epoch** is fetched per submission with the same
+   retry-forever contract as the reference gas price.
+4. **The whole gas-object apparatus is bypassed**: `next_gas_coins` returns
+   no refs, effects-based gas caching is skipped (the effects' gas object is
+   a placeholder), and stale-gas rejection handling is inert. The
+   stale-gas-version failure class does not exist without gas objects.
+5. **Checkpoint fee reimbursement** cannot `MergeCoins` into
+   `Argument::GasCoin` (none exists); it is transferred to the writer's
+   address as an owned coin instead, for the operator to sweep.
+
+## Preconditions and rollout
+
+- Sui protocol flags `enable_accumulators` + `enable_address_balance_gas_payments`:
+  testnet since protocol 108, mainnet since 124, localnets at max version.
+- The notifier address must hold SUI in its ADDRESS BALANCE (an explicit
+  balance deposit — plain coin transfers do not fund it). Each submission
+  reserves the full gas budget from the balance for its validity window; the
+  writer submits serially, so one budget of headroom suffices, plus float.
+- Default OFF. The intended rollout is a testnet canary of the flag before
+  any mainnet use; the gas-coin path stays the default until then.
+
+## Key invariants
+
+1. With the flag off, byte-identical behavior to the pre-SIP-58 writer.
+2. With the flag on, no transaction ever references a gas object — node-view
+   staleness cannot invalidate a submission.
+3. Every balance-gas transaction is replay-protected
+   (`TransactionExpiration::is_replay_protected`), pinned to the exact chain,
+   and unique per (inputs, epoch window, nonce).
+4. Reimbursement funds are never burned or stranded in either mode: merged
+   into the gas coin (coin mode) or transferred to the writer address
+   (balance mode).

--- a/dev-docs/specs/notifier-balance-gas.md
+++ b/dev-docs/specs/notifier-balance-gas.md
@@ -23,11 +23,14 @@ the sender's SUI address balance, and a `ValidDuring` expiration replaces the
 replay protection that gas-coin version bumps provided. Decision rules:
 
 1. **Construction** (`balance_gas_transaction_data`): empty `gas_data.payment`,
-   same fixed budget, expiration `ValidDuring { min_epoch == max_epoch ==
-   current SUI epoch, chain: full genesis-rooted ChainIdentifier, nonce:
-   random u32 }`. Single-epoch validity is accepted under every protocol
-   regime; a submission racing a Sui epoch boundary expires harmlessly and
-   the caller's retry rebuilds it against the new epoch.
+   same fixed budget, expiration `ValidDuring { min_epoch: current SUI epoch,
+   max_epoch: current + 1, chain: full genesis-rooted ChainIdentifier, nonce:
+   random u32 }`. The one-epoch extension keeps a submission built just
+   before a Sui epoch boundary valid instead of expiring mid-flight; it is
+   the maximum `is_replay_protected` allows, and multi-epoch expiration
+   (protocol 105) predates every network's address-balance-gas enablement.
+   Trade-off: an abandoned signed-but-never-executed transaction can hold
+   its balance reservation for up to two epochs instead of one.
 2. **Chain identifier** is resolved ONCE at boot (compiled-in for
    mainnet/testnet via the short id; genesis checkpoint digest otherwise) and
    a failure to resolve it fails the boot loudly — a writer silently unable

--- a/dev-docs/specs/notifier-balance-gas.md
+++ b/dev-docs/specs/notifier-balance-gas.md
@@ -42,14 +42,44 @@ replay protection that gas-coin version bumps provided. Decision rules:
    `Argument::GasCoin` (none exists); it is transferred to the writer's
    address as an owned coin instead, for the operator to sweep.
 
+## Boot-time behavior (preflight + migration sweep)
+
+With the flag on, `prepare_for_sui` runs, in order:
+
+1. **Chain identifier resolution** (fail boot loudly if unresolvable).
+2. **Funds read** (`get_sui_funds`: address balance vs. coin objects; an
+   unreadable balance — accumulators disabled on the target chain — fails
+   boot loudly).
+3. **Migration sweep**: if the address holds >= 1 SUI in coin objects (the
+   state every pre-SIP-58 notifier is in when the flag is first flipped),
+   deposit them into the address balance automatically: one transaction
+   using ALL owned gas coins as its own gas payment (the protocol merges
+   them into the first), `SplitCoins(GasCoin, [total - sweep budget])`, and
+   `coin::send_funds<SUI>(split, sender)`. The gas coin itself cannot be
+   passed by value to a Move call, hence split-then-deposit; the sweep
+   budget's unspent remainder stays behind as one small coin, below the
+   1-SUI re-sweep threshold (no churn). Best-effort: a failed sweep warns
+   and falls through to the preflight.
+4. **Balance preflight**: refuse to boot below one gas budget of address
+   balance (counting a just-swept amount directly rather than re-reading
+   through a possibly-lagging fullnode view), with the exact remediation in
+   the error. A writer that cannot pay must not take the writer role.
+5. **Funds gauge**: `ika_sui_connector_gas_coin_balance` is seeded and then
+   refreshed every 60s from the address balance (this gauge previously had
+   no writer at all), making balance drain alertable before submissions
+   fail. Mid-flight exhaustion still ends in the historical
+   hour-retry-then-panic path, same as coin-mode gas exhaustion.
+
 ## Preconditions and rollout
 
 - Sui protocol flags `enable_accumulators` + `enable_address_balance_gas_payments`:
   testnet since protocol 108, mainnet since 124, localnets at max version.
-- The notifier address must hold SUI in its ADDRESS BALANCE (an explicit
-  balance deposit — plain coin transfers do not fund it). Each submission
-  reserves the full gas budget from the balance for its validity window; the
-  writer submits serially, so one budget of headroom suffices, plus float.
+- The notifier address must hold SUI in its ADDRESS BALANCE — funded either
+  by the automatic boot sweep of its existing coin objects (above) or by an
+  explicit balance deposit (plain coin transfers do not fund it). Each
+  submission reserves the full gas budget from the balance for its validity
+  window; the writer submits serially, so one budget of headroom suffices,
+  plus float.
 - Default OFF. The intended rollout is a testnet canary of the flag before
   any mainnet use; the gas-coin path stays the default until then.
 


### PR DESCRIPTION
Follow-up to #1892/#1894/#1896, implementing the direction discussed on #1894: move the notifier's gas off owned coin objects onto SIP-58 **address-balance gas** — the building block for future same-identity writer redundancy (deterministically-constructed submissions from replicated notifier processes collapse to one tx digest), and an immediate deletion of the stale-gas failure class.

## What it does

New `notifier-gas-from-address-balance` config flag, **default OFF** (flag off = byte-identical writer behavior). When enabled, every writer submission (checkpoints + all epoch-switch calls) is built with:

- **empty gas payment** — the SIP-58 protocol trigger for paying gas from the sender's SUI address balance (`is_gas_paid_from_address_balance`);
- **`ValidDuring { min_epoch: current, max_epoch: current + 1 }`** — a submission built just before a Sui epoch boundary stays valid into the next epoch instead of expiring mid-flight; the one-epoch extension is the maximum `is_replay_protected` allows, and multi-epoch expiration (protocol 105) predates every network's balance-gas enablement, so the window is legal wherever the transaction is. Carries the chain's **full** genesis-rooted `ChainIdentifier` (resolved once at boot; compiled-in for mainnet/testnet, genesis-checkpoint digest for localnets; boot fails loudly if unresolvable) and a random `u32` nonce.

## Boot sequence with the flag on

1. **Chain-identifier resolution** — loud boot failure if unresolvable.
2. **Funds read** — new `get_sui_funds` API returns the address-balance / coin-object breakdown (gRPC `GetBalance` carries both fields; JSON-RPC derives the coin part). Unreadable (accumulators disabled on the target chain) ⇒ loud boot failure.
3. **Automatic migration sweep** — if the address holds ≥ 1 SUI in coin objects (the state of every existing notifier when the flag is first flipped), one transaction deposits them into the address balance: all owned gas coins as the sweep's own gas payment (protocol-merged into the first), `SplitCoins(GasCoin, total − sweep budget)`, then `coin::send_funds<SUI>(split, sender)` — split-then-deposit because the gas coin cannot be passed by-value to a Move call. The budget remainder stays as one small coin below the re-sweep threshold (no boot-loop churn). Best-effort: a failed sweep warns and falls through. **Net effect: flipping the flag on the live notifier is a zero-manual-step migration.**
4. **Balance preflight** — refuses to boot below one gas budget of address balance, with the exact remediation in the error; counts a just-swept amount directly rather than re-reading through a possibly-lagging fullnode view. A writer that cannot pay must not take the writer role (the alternative is an hour of failed submissions, a panic, and a blocked epoch close — the #1892 outage shape).
5. **Live funds gauge** — `ika_sui_connector_gas_coin_balance` (previously registered but never written by anything) is seeded at boot and refreshed every 60s from the address balance, so drain is alertable before submissions fail. Mid-flight exhaustion after a healthy boot still ends in the historical hour-retry-then-panic path, same as coin-mode gas exhaustion — the gauge is the alert window that was missing.

## What it deletes (when enabled)

No transaction references a gas object, so the entire `NotifierSubmitState` apparatus is bypassed: post-effects gas-ref caching, the `min_gas_version` re-fetch floor, and stale-gas rejection recovery — machinery that exists solely because the notifier's fullnode view lags the validators, and that has wedged epoch advance before. Node-view staleness can no longer invalidate a submission. The checkpoint fee reimbursement, which merged into `Argument::GasCoin`, is transferred to the writer address as an owned coin instead.

## Preconditions (documented on the flag + spec)

- Address-balance gas enabled on the target Sui network: **testnet since protocol 108, mainnet since 124** (verified in the pinned `mainnet-v1.73.2` protocol config); localnets at max version have it.
- Funding is handled by the boot sweep for a migrating notifier; a brand-new address needs an explicit balance deposit (plain coin transfers don't fund the balance). Each submission reserves the full 10-SUI budget for its validity window; the writer submits serially.

## Rollout intent

Testnet canary of the flag on the live notifier before any mainnet use; the gas-coin path remains the default until then. With #1894's stall metrics and #1896's sync floor in place, a misbehaving canary is loud within ~2 minutes and recoverable by flipping the flag back.

## Validation

- Unit tests pin both transaction contracts: the balance-gas submission (empty payment ⇒ balance-gas classification, `ValidDuring [current, current+1]`, `is_replay_protected()`, budget/sender/nonce) and the sweep (gas-coin payment, `SplitCoins(GasCoin, …)`, `coin::send_funds<SUI>` deposit to sender).
- **Flag-on end-to-end, green on CI**: `epochs_close_with_notifier_on_address_balance_gas` boots the cluster with the flag enabled — the notifier funded only with coin objects (the production migration state) — and passes: chain-id resolution, funds read, the automatic sweep (real transaction), the balance preflight, then two epoch closes where every checkpoint and epoch-switch submission is an empty-gas-payment `ValidDuring` transaction (no gas-coin fallback exists in this mode), with the funds gauge asserted positive. Run: https://github.com/dwallet-labs/ika/actions/runs/30161728015 — its first two attempts each caught a real client bug (short-id chain identifier via `Display`; `GetBalance` queried with the coin object type reading silently as zero), both surfaced as loud boot refusals by the preflight design.
- Flag-off default path: full cluster suite **green** — https://github.com/dwallet-labs/ika/actions/runs/30158782641 (re-run on the final head linked in comments).

Spec: `dev-docs/specs/notifier-balance-gas.md` (both gas modes, boot behavior, decision rules, invariants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cy7oBMwzsCfhvwvXn61Q8P