### PR TITLE
docs(git-guard): document the hook's two known limits

### DIFF
--- a/.claude/hooks/git-guard.sh
+++ b/.claude/hooks/git-guard.sh
@@ -6,6 +6,12 @@
 #   - git push targeting dev / main / master
 #   - git commit while ON dev / main / master
 #   - git commit including .rs files while `cargo fmt --all --check` is dirty
+# Known limits (see dev-docs/learnings/pitfalls.md, "Repo guard hooks"):
+#   - Runs BEFORE the command: checks keyed on repo state (staged index,
+#     current branch) see pre-command state, so a compound command that
+#     mutates that state first slips through. Backstop, not contract.
+#   - The fmt gate discards cargo's output/exit detail: a cargo missing
+#     from this hook's PATH is reported as "rustfmt is dirty".
 set -uo pipefail
 
 input=$(cat)

--- a/dev-docs/learnings/pitfalls.md
+++ b/dev-docs/learnings/pitfalls.md
@@ -304,6 +304,36 @@ rule, not the instance.
   wrong removal. Verify those paths (`cargo simtest`, the wasm build,
   `--features <f>`) or leave the dep.
 
+## Repo guard hooks
+
+- **A PreToolUse guard checks repo state BEFORE the command runs — any
+  check keyed on mutable repo state can be sidestepped by a compound
+  command that mutates that state first.** `.claude/hooks/git-guard.sh`
+  gates commits containing `.rs` files on `cargo fmt --all --check`, but
+  it detects them via `git diff --cached` *at hook time*: staging and
+  committing in one command (`git add … && git commit …`, or
+  `git commit -a`) presents an empty index and the gate never fires. The
+  commit-on-protected-branch check shares the class (it reads the
+  current branch, which the same compound command could switch first).
+  The command-string checks (`--no-verify`, push targets) don't — the
+  string is immutable. → Rule: treat state-keyed guard checks as a
+  backstop, not the contract — run `cargo fmt --all` before committing
+  regardless (CLAUDE.md: Git Workflow), and never cite a green guard as
+  evidence the gated property held.
+- **git-guard reports ANY `cargo fmt` failure as "rustfmt is dirty",
+  including cargo failing to launch.** The fmt gate runs
+  `cargo fmt --all --check >/dev/null 2>&1`, discarding output and exit
+  detail, so a cargo that is absent from the hook's PATH (the hook
+  inherits the agent process environment, not a login shell —
+  `~/.cargo/bin` may be missing from it) blocks every Rust commit with a
+  formatting message even though `cargo fmt --all --check` is clean in
+  your terminal. Cost a fresh-workstation session real diagnosis time;
+  resolved by putting cargo/rustfmt on a directory the hook's PATH does
+  include (e.g. symlinks in `~/.local/bin`). → Rule: when a gate blocks
+  with a tool's verdict, first prove the tool actually RAN in the gate's
+  environment (re-run the gate's exact command with output visible)
+  before debugging the verdict itself.
+
 ## Process & forensics
 
 - **Verify the chain/config you're querying is the one the system


### PR DESCRIPTION
## What

Documents two non-obvious behaviors of `.claude/hooks/git-guard.sh`, both verified against the script:

1. **Pre-command state evaluation.** As a PreToolUse hook it checks repo state *before* the command runs: the fmt gate keys on `git diff --cached` and the protected-branch block on `git symbolic-ref` at hook time. A compound command that mutates that state first (`git add … && git commit …`, `git commit -a`, or a branch switch chained before a commit) is evaluated against the pre-command state and slips through. The command-string checks (`--no-verify`, push targets) don't share this, since the string is immutable.
2. **Misleading fmt-gate failure mode.** The gate runs `cargo fmt --all --check >/dev/null 2>&1`, so a cargo that fails to *launch* (missing from the hook's inherited PATH — it's not a login shell, `~/.cargo/bin` may be absent) blocks every Rust commit with "rustfmt is dirty" even when formatting is clean in the developer's terminal. This burned real diagnosis time on a fresh workstation; the fix there was symlinking cargo/rustfmt into `~/.local/bin`.

## Where

- `dev-docs/learnings/pitfalls.md` — new "Repo guard hooks" section, instance → general rule per the folder's style.
- `.claude/hooks/git-guard.sh` — a short "Known limits" note in the header comment pointing at the pitfalls entry, so the next hook editor sees it without hunting.

No behavior change — comments and docs only.

## Possible follow-up (not in this PR)

The second limit is fixable in the hook itself: distinguish "cargo failed to run" (e.g. exit 127 / `command -v cargo` miss) from "check reported dirty" and emit different messages. Left out to keep this PR docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETbwnyhPwPBbENBixqVRBK