### PR TITLE
docs: refresh README to current positioning and fix dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,107 @@
 <p align="center">
-<img src="https://github.com/dwallet-labs/dwallet-network/blob/main/dashboards/logo.svg" alt="Logo" width="500" height="300">
+<img src="./dashboards/logo.svg" alt="Ika Logo" width="500" height="300">
 </p>
 
 # Welcome to Ika
 
-Ika is a decentralized platform empowering Web3 builders to create protocols that operate natively across any blockchain
-with zero-trust security (eliminating the risk of trusted third parties that can be hacked or act maliciously). At the
-core of this architecture is the **_dWallet_**, a programmable and transferable zero-trust signing mechanism that ensures user
-consent is cryptographically enforced, allowing developers to build secure, decentralized applications that operate
-across the entire Web3 ecosystem.
+Ika is the fastest zero-trust MPC network — a decentralized signature network
+that lets Web3 builders create protocols operating natively across any
+blockchain, with no bridging, wrapping, or trusted intermediaries. Ika is live
+on mainnet in beta, coordinated on [Sui](https://sui.io), and live in
+pre-alpha for builders on [Solana](https://solana.com).
+
+> **Ika is currently in live beta.** Using it involves many risks. We strongly
+> recommend reading the [Ika Whitepaper](https://docs.ika.xyz/whitepaper.pdf)
+> before building on or using the network.
+
+At the core of Ika is the **_dWallet_** — a decentralized, programmable, and
+transferable signing mechanism with an address on any network. Every signature
+requires both the user and a 2/3 threshold of the Ika network, so user consent
+is cryptographically enforced and no party — not even the network itself — can
+sign alone.
 
 ## Unique Value of dWallets
 
-The dWallet is an innovative Web3 building block that has the following attributes:
+- _Noncollusive_: the user is always required to generate a signature.
+- _Massively decentralized_: besides the user, a 2/3 threshold of a network of
+  100+ nodes is required to generate a signature.
+- _Multi-chain_: using the default authentication method of every blockchain —
+  the signature — dWallets offer universal, native interoperability without
+  the cross-chain risks of wrapping, bridging, or messaging. With ECDSA and
+  EdDSA support, dWallets natively control assets and accounts on Bitcoin,
+  Ethereum, Solana, and virtually any other chain.
+- _Cryptographically secure_: security is based on cryptography, not hardware
+  or trust assumptions.
 
-- _Noncollusive_: The user is always required to generate a signature.
-- _Massively decentralized_: Beside the user, a 2/3 threshold of a network that can include hundreds of
-  nodes, is also required to generate a signature.
-- _Multi-Chain_: Using the default authentication method of blockchains - the signature - dWallets can offer universal
-  and native multi-chain interoperability, without the cross-chain risks of wrapping, bridging or messaging.
-- _cryptographically secure_: The security of dWallets is based on cryptography, instead of hardware or trust
-  assumptions.
+Builders on [Sui](https://sui.io) and [Solana](https://solana.com) can use
+dWallets natively, utilizing Ika as a composable modular signature network
+that adds powerful multi-chain capabilities to their protocols — native-asset
+DeFi, multi-chain custody, treasury management, wallet infrastructure, and
+policy enforcement for AI agents.
 
-dWallets are the only way that exists today for Web3 builders to achieve secure, multi-chain interoperability, without
-compromising on the core Web3 values of user ownership and decentralization.
+## Cryptography of dWallets — 2PC-MPC
 
-Builders on [Solana Network](https://solana.com) and [Sui Network](https://sui.io) can use dWallets natively and utilize Ika as a composable
-modular signature network, adding powerful multi-chain access control capabilities to their protocol.
+dWallets utilize [2PC-MPC](https://eprint.iacr.org/2024/253), a two-party
+threshold signing protocol designed specifically for dWallets, where the
+second party is fully emulated by a network of n parties. Ika's open-source
+cryptography libraries live in
+[dwallet-labs/inkrypto](https://github.com/dwallet-labs/inkrypto).
 
-## Cryptography of dWallets - 2PC-MPC
-
-dWallets utilize the [2PC-MPC protocol](https://github.com/dwallet-labs/crypto/tree/main?tab=readme-ov-file#2pc-mpc),
-a two-party ECDSA protocol we designed specifically for dWallets, where the second party is fully emulated by a
-network of n parties.
-
-Besides its novel structure, enabling the zero-trust nature of dWallets, and the autonomy and flexibility of a
-permissionless Ika, the 2PC-MPC protocol also dramatically improves upon the state of the art, allowing Ika to be
-scalable & massively-decentralized.
-
-The 2PC-MPC protocol achieves linear-scaling in communication - O(n) - and due to novel aggregation & amortization
-techniques, an amortized cost per-party that remains constant up to thousands of parties - _practically_ O(1) in
-computation for the network, allowing it to scale and achieve decentralization, whilst being _asymptotically_ O(1) for
-the user: meaning the size of the network doesn't have any impact on the user as its computation and communication is
-constant.
+Beyond its novel structure — which enables the zero-trust nature of dWallets
+and the autonomy of a permissionless network — 2PC-MPC dramatically improves
+on the state of the art: linear-scaling O(n) communication and, through novel
+aggregation & amortization techniques, practically O(1) amortized computation
+per party up to thousands of parties. For the user it is asymptotically O(1):
+network size has no impact on the user's computation or communication. This is
+what lets Ika deliver sub-second signing latency at scale while remaining
+massively decentralized.
 
 ## Ika Overview
 
-Ika is a decentralized platform, that was forked from [Sui](https://github.com/MystenLabs/sui), and similarly to Sui it
-is maintained by a permissionless set of authorities that play a role similar to validators or miners in other
-blockchain systems. Changes that were made to Ika include disabling smart contracts, implementing 2PC-MPC, and using the
-communication in [Sui's consensus Mysticeti](https://github.com/MystenLabs/mysticeti) for the MPC protocol between the
-nodes.
+Ika was originally forked from [Sui](https://github.com/MystenLabs/sui), and
+while much of the codebase has since diverged, like Sui it is maintained by a
+permissionless set of authorities that play a role similar to validators or
+miners in other blockchain systems. Changes made to Ika include disabling
+smart contracts, implementing 2PC-MPC, and using
+[Sui's Mysticeti consensus](https://github.com/MystenLabs/sui/tree/main/consensus)
+for the MPC protocol communication between nodes.
 
-Ika is natively coordinated on Sui, and dWallets on Ika are controlled by DWalletCap objects on Sui. Soon Ika will be 
-natively coordinated on Solana, and dWallets will be controlled by Solana accounts.
+Ika is natively coordinated on Sui: dWallets are controlled by objects on Sui
+and can be governed by Sui smart contracts. Solana coordination is live in
+pre-alpha for builders, bringing dWallets under the control of Solana
+programs.
 
-Ika has a native token on Sui called IKA that is used to pay for gas, and is also used as delegated stake
-on authorities within an epoch. Authorities are periodically reconfigured according to the stake delegated to them. In any
-epoch, the set of authorities is [Byzantine fault tolerant](http://pmg.csail.mit.edu/papers/osdi99.pdf). At the end of the
-epoch, fees collected through all transactions processed are distributed to authorities according to their contribution to
-the operation of the system. Authorities can in turn share some of the fees as rewards to users that delegated stakes to them.
+Ika has a native token, IKA, used to pay network fees and as delegated stake
+on authorities. Authorities are periodically reconfigured according to the
+stake delegated to them; within any epoch the authority set is
+[Byzantine fault tolerant](http://pmg.csail.mit.edu/papers/osdi99.pdf). Fees
+collected during an epoch are distributed to authorities according to their
+contribution, and authorities can share rewards with their delegators.
 
 Sui is based on a number of state-of-the-art
 [peer-reviewed works](https://github.com/MystenLabs/sui/blob/main/docs/content/concepts/research-papers.mdx)
-and years of open source development that we are building upon with the Ika.
+and years of open-source development that Ika builds upon.
 
 ## More About Ika
 
-Use the following links to learn more about Ika and its ecosystem:
-
-- Learn more about working with dWallets in the [Ika Documentation](https://docs.dwallet.io/).
-- Find out more about the Ika community on the [community](https://ika.xyz/community/) page.
+- [Ika Whitepaper](https://docs.ika.xyz/whitepaper.pdf) — read before using
+  the network.
+- [Ika Documentation](https://docs.ika.xyz) — learn to build with dWallets.
+- [ika.xyz](https://ika.xyz) — the Ika website and blog.
+- [@ikadotxyz](https://x.com/ikadotxyz) — follow Ika on X.
 
 ## Acknowledgement
 
 As a fork of Sui, much of Ika's code base is heavily based on the code created
-by [Mysten Labs, Inc.](https://mystenlabs.com) & [Facebook, Inc.](https://facebook.com) and its affiliates, including in
-this very file. We are grateful for the high quality and serious work that allowed us to build our Ika technology upon
-this infrastructure.
+by [Mysten Labs, Inc.](https://mystenlabs.com) & [Facebook, Inc.](https://facebook.com)
+and its affiliates, including in this very file. We are grateful for the high
+quality and serious work that allowed us to build Ika upon this
+infrastructure.
 
 ## Code Flow Diagrams
 
-We created a few Figma diagrams to help auditors make sense of our code:
+Diagrams of the dWallet MPC flows:
+https://www.figma.com/board/ISrirOSeSr9YyS6U4MTUyT/Flows-Diagrams?node-id=0-1&t=lZ0v3xQtJhWreFuf-1
 
-Diagrams of the different dWallet MPC flows can be found
-here: https://www.figma.com/board/ISrirOSeSr9YyS6U4MTUyT/Flows-Diagrams?node-id=0-1&t=lZ0v3xQtJhWreFuf-1.
-
-Diagrams of our State Sync mechanism can be found
-here: https://www.figma.com/board/uzpZ7ToOQ8DWcID2vOUlwt/State-Sync-Overview?node-id=0-1&t=fnWiOtTlWT7ZYV93-1.
+Diagrams of the State Sync mechanism:
+https://www.figma.com/board/uzpZ7ToOQ8DWcID2vOUlwt/State-Sync-Overview?node-id=0-1&t=fnWiOtTlWT7ZYV93-1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Welcome to Ika
 
-Ika is the fastest zero-trust MPC network — a decentralized signature network
+Ika is the fastest zero-trust MPC network - a decentralized signature network
 that lets Web3 builders create protocols operating natively across any
 blockchain, with no bridging, wrapping, or trusted intermediaries. Ika is live
 on mainnet in beta, coordinated on [Sui](https://sui.io), and live in
@@ -14,10 +14,10 @@ pre-alpha for builders on [Solana](https://solana.com).
 > recommend reading the [Ika Whitepaper](https://docs.ika.xyz/whitepaper.pdf)
 > before building on or using the network.
 
-At the core of Ika is the **_dWallet_** — a decentralized, programmable, and
+At the core of Ika is the **_dWallet_** - a decentralized, programmable, and
 transferable signing mechanism with an address on any network. Every signature
 requires both the user and a 2/3 threshold of the Ika network, so user consent
-is cryptographically enforced and no party — not even the network itself — can
+is cryptographically enforced and no party, not even the network itself, can
 sign alone.
 
 ## Unique Value of dWallets
@@ -25,8 +25,8 @@ sign alone.
 - _Noncollusive_: the user is always required to generate a signature.
 - _Massively decentralized_: besides the user, a 2/3 threshold of a network
   that can scale to hundreds of nodes is required to generate a signature.
-- _Multi-chain_: using the default authentication method of every blockchain —
-  the signature — dWallets offer universal, native interoperability without
+- _Multi-chain_: using the default authentication method of every blockchain -
+  the signature - dWallets offer universal, native interoperability without
   the cross-chain risks of wrapping, bridging, or messaging. With ECDSA and
   EdDSA support, dWallets natively control assets and accounts on Bitcoin,
   Ethereum, Solana, and virtually any other chain.
@@ -35,11 +35,11 @@ sign alone.
 
 Builders on [Sui](https://sui.io) and [Solana](https://solana.com) can use
 dWallets natively, utilizing Ika as a composable modular signature network
-that adds powerful multi-chain capabilities to their protocols — native-asset
+that adds powerful multi-chain capabilities to their protocols: native-asset
 DeFi, multi-chain custody, treasury management, wallet infrastructure, and
 policy enforcement for AI agents.
 
-## Cryptography of dWallets — 2PC-MPC
+## Cryptography of dWallets: 2PC-MPC
 
 dWallets utilize [2PC-MPC](https://eprint.iacr.org/2024/253), a two-party
 threshold signing protocol designed specifically for dWallets, where the
@@ -47,8 +47,8 @@ second party is fully emulated by a network of n parties. Ika's open-source
 cryptography libraries live in
 [dwallet-labs/inkrypto](https://github.com/dwallet-labs/inkrypto).
 
-Beyond its novel structure — which enables the zero-trust nature of dWallets
-and the autonomy of a permissionless network — 2PC-MPC dramatically improves
+Beyond its novel structure, which enables the zero-trust nature of dWallets
+and the autonomy of a permissionless network, 2PC-MPC dramatically improves
 on the state of the art: linear-scaling O(n) communication and, through novel
 aggregation & amortization techniques, practically O(1) amortized computation
 per party up to thousands of parties. For the user it is asymptotically O(1):
@@ -84,11 +84,11 @@ and years of open-source development that Ika builds upon.
 
 ## More About Ika
 
-- [Ika Whitepaper](https://docs.ika.xyz/whitepaper.pdf) — read before using
+- [Ika Whitepaper](https://docs.ika.xyz/whitepaper.pdf) - read before using
   the network.
-- [Ika Documentation](https://docs.ika.xyz) — learn to build with dWallets.
-- [ika.xyz](https://ika.xyz) — the Ika website and blog.
-- [@ikadotxyz](https://x.com/ikadotxyz) — follow Ika on X.
+- [Ika Documentation](https://docs.ika.xyz) - learn to build with dWallets.
+- [ika.xyz](https://ika.xyz) - the Ika website.
+- [@ikadotxyz](https://x.com/ikadotxyz) - follow Ika on X.
 
 ## Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ sign alone.
 ## Unique Value of dWallets
 
 - _Noncollusive_: the user is always required to generate a signature.
-- _Massively decentralized_: besides the user, a 2/3 threshold of a network of
-  100+ nodes is required to generate a signature.
+- _Massively decentralized_: besides the user, a 2/3 threshold of a network
+  that can scale to hundreds of nodes is required to generate a signature.
 - _Multi-chain_: using the default authentication method of every blockchain —
   the signature — dWallets offer universal, native interoperability without
   the cross-chain risks of wrapping, bridging, or messaging. With ECDSA and


### PR DESCRIPTION
## Summary

Refreshes the README, which predated mainnet launch, and fixes several dead links:

- **Status**: Ika is live on mainnet in **beta** (coordinated on Sui) and live in **pre-alpha for builders on Solana**; adds a prominent risk notice recommending the [whitepaper](https://docs.ika.xyz/whitepaper.pdf) before use.
- **Dead links fixed**:
  - 2PC-MPC link pointed to `dwallet-labs/crypto` (now private + archived) → replaced with the [ePrint paper](https://eprint.iacr.org/2024/253) and [dwallet-labs/inkrypto](https://github.com/dwallet-labs/inkrypto)
  - `docs.dwallet.io` (does not resolve) → `docs.ika.xyz`
  - `ika.xyz/community` (404) → replaced with website + X links
  - Logo hotlinked the old `dwallet-network` repo → in-repo `dashboards/logo.svg`
  - Mysticeti link pointed to the archived research repo → `sui/consensus`
- **Tech accuracy**: 2PC-MPC no longer described as ECDSA-only (EdDSA is live on mainnet); "originally forked from Sui" wording to reflect divergence.

## Test plan

- [x] All URLs verified to resolve (whitepaper PDF returns 200, docs.ika.xyz 200, ePrint title confirmed)
- [x] Markdown rendering checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KE6CaYg3ppu3uxxG5LtvJP