### PR TITLE
fix(ocs): assert the chain's anchor objects are typed by the compiled-in package

### DIFF
--- a/crates/ika-core/src/sui_connector/ocs_metrics.rs
+++ b/crates/ika-core/src/sui_connector/ocs_metrics.rs
@@ -72,6 +72,14 @@ pub struct OcsMetrics {
     // BagEventPump — omission detection via verified parent state.
     pub bag_omission_suspected_total: IntCounterVec, // labels: ["bag"]
 
+    /// A singleton anchor's on-chain type names a package other than the one
+    /// this binary compiled in for that role. Always fatal (the node refuses
+    /// to run — the constant is baked into the build), so any non-zero value
+    /// names the cause of a node that will not start. Scrape it from the
+    /// crash-loop window or the last scrape before exit; a node down for this
+    /// reason otherwise presents only as absent series.
+    pub identity_mismatch_total: IntCounterVec, // labels: ["anchor"]
+
     /// End-to-end verify latency on the consumer side (transport
     /// round-trip + proof verify). Captures what consumers actually
     /// experience.
@@ -186,6 +194,13 @@ impl OcsMetrics {
                 "ika_ocs_bag_omission_suspected_total",
                 "Bag walk returned fewer children than the verified parent's `Bag.size` claimed (suspected relay omission; could also be a benign race when entries are removed mid-walk — only a hard signal if it persists)",
                 &["bag"],
+                registry,
+            )
+            .unwrap(),
+            identity_mismatch_total: register_int_counter_vec_with_registry!(
+                "ika_ocs_identity_mismatch_total",
+                "A singleton anchor object's on-chain type names a package other than the one this binary compiled in for that role (System -> ika_system_package_id, DWalletCoordinator -> ika_dwallet_2pc_mpc_package_id). Always fatal: the node refuses to run, since a compiled-in constant cannot be fixed by retrying",
+                &["anchor"],
                 registry,
             )
             .unwrap(),

--- a/crates/ika-core/src/sui_connector/setup.rs
+++ b/crates/ika-core/src/sui_connector/setup.rs
@@ -36,7 +36,8 @@ use std::sync::Arc;
 
 use anemo::PeerId;
 use ika_config::node::{
-    SuiConnectorConfig, SuiDataSource, SuiStateMirrorPeer, resolve_sui_checkpoint_archive,
+    SuiConnectorConfig, SuiDataSource, SuiStateMirrorPeer, compiled_in_ika_identity,
+    resolve_sui_checkpoint_archive,
 };
 use ika_network::proof_provider::{
     LocalProofProvider, ProofCacheConfig, ProofProvider, ProofProviderMetrics,
@@ -444,18 +445,30 @@ pub async fn build_sui_connector_stack(
     // checkpoints) yet catches an unboundedly-falling-behind pusher.
     const CACHE_STALENESS_BOUND_CHECKPOINTS: u64 = 100;
     let staleness_bound = cache_first_reads.then_some(CACHE_STALENESS_BOUND_CHECKPOINTS);
-    let reader = Arc::new(
-        OcsVerifiedReader::new(
-            proof_provider.clone(),
-            committees.clone(),
-            metrics.clone(),
-            None,
-            state_cache.clone(),
-            cache_first_reads,
-            staleness_bound,
-        )
-        .with_changeset_index(changeset_index),
-    );
+    // Pin the compiled-in package identity for the two singleton anchors, so
+    // every verified read of them asserts the chain agrees with what this
+    // binary was built for. Sourced from `compiled_in_ika_identity` rather
+    // than the config fields because it is the ORIGINAL (defining) package —
+    // which is what a Sui type tag carries forever — and because it is `None`
+    // on localnet, where ids are generated per genesis and a config-supplied
+    // `ika_system_package_id` may legitimately name a later upgrade.
+    let reader_base = OcsVerifiedReader::new(
+        proof_provider.clone(),
+        committees.clone(),
+        metrics.clone(),
+        None,
+        state_cache.clone(),
+        cache_first_reads,
+        staleness_bound,
+    )
+    .with_changeset_index(changeset_index);
+    let reader = Arc::new(match compiled_in_ika_identity(cfg.sui_chain_identifier) {
+        Some(identity) => reader_base.with_expected_identity(
+            identity.ika_system_package_id,
+            identity.ika_dwallet_2pc_mpc_package_id,
+        ),
+        None => reader_base,
+    });
 
     // Publish the head epoch we booted at so dashboards can correlate
     // when this node started ratcheting.

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -220,6 +220,14 @@ where
                 match reader.verified_system_inner(id).await {
                     Ok(v) => return v,
                     Err(e) => {
+                        // A compiled-in/chain identity mismatch can never be
+                        // fixed by retrying — the constant is baked into this
+                        // build. Refuse to run rather than spin: silently
+                        // retrying forever is the very failure mode this
+                        // check exists to replace.
+                        if e.is_terminal() {
+                            panic!("{e}");
+                        }
                         attempts += 1;
                         let backoff = verified_read_retry_backoff(attempts);
                         if attempts <= 3 {
@@ -257,6 +265,11 @@ where
                 match reader.verified_dwallet_coordinator_inner(id).await {
                     Ok(v) => return v,
                     Err(e) => {
+                        // See `must_get_system_inner`: an identity mismatch is
+                        // permanent, so fail loudly instead of retrying.
+                        if e.is_terminal() {
+                            panic!("{e}");
+                        }
                         attempts += 1;
                         let backoff = verified_read_retry_backoff(attempts);
                         if attempts <= 3 {

--- a/crates/ika-core/src/sui_connector/verified_reader.rs
+++ b/crates/ika-core/src/sui_connector/verified_reader.rs
@@ -300,6 +300,24 @@ impl OcsVerifiedReader {
         }
     }
 
+    /// [`check_object_identity`] plus the metric, so a node that refuses to
+    /// start names the cause on its last scrape instead of presenting only as
+    /// absent series.
+    fn assert_anchor_identity(
+        &self,
+        kind: &'static str,
+        object: &Object,
+        object_id: ObjectID,
+        expected: Option<ObjectID>,
+    ) -> Result<(), ReaderError> {
+        check_object_identity(kind, object, object_id, expected).inspect_err(|_| {
+            self.metrics
+                .identity_mismatch_total
+                .with_label_values(&[kind])
+                .inc();
+        })
+    }
+
     /// Pin the compiled-in package identity for the two singleton anchors, so
     /// every verified read of them asserts the chain agrees. Left unset on
     /// localnet, where there is no compiled-in identity to check against.
@@ -970,7 +988,7 @@ impl OcsVerifiedReader {
         coordinator_id: ObjectID,
     ) -> Result<(DWalletCoordinator, DWalletCoordinatorInner), ReaderError> {
         let outer_obj = self.verified_anchor_object(coordinator_id).await?;
-        check_object_identity(
+        self.assert_anchor_identity(
             "DWalletCoordinator",
             &outer_obj.object,
             coordinator_id,
@@ -1006,7 +1024,7 @@ impl OcsVerifiedReader {
         system_id: ObjectID,
     ) -> Result<(System, SystemInner), ReaderError> {
         let outer_obj = self.verified_anchor_object(system_id).await?;
-        check_object_identity(
+        self.assert_anchor_identity(
             "System",
             &outer_obj.object,
             system_id,
@@ -1268,6 +1286,7 @@ fn clone_inclusion_proof(
 #[cfg(test)]
 mod identity_tests {
     use super::*;
+    use sui_types::object::Owner;
 
     const SYSTEM_OBJ: u8 = 0x11;
 
@@ -1354,6 +1373,84 @@ mod identity_tests {
         let err = check_identity_addresses("System", pkg(1), pkg(0xAA), Some(pkg(0xBB)))
             .expect_err("mismatch");
         assert_eq!(classify_verify_error(&err), "identity_mismatch");
+    }
+
+    // The tests below drive the real `check_object_identity`, so they cover the
+    // `type_().address()` extraction and not just the comparison. The only
+    // safely-constructible typed object in the pinned Sui is a gas coin
+    // (`0x2::coin::Coin<0x2::sui::SUI>`), whose top-level type address is the
+    // Sui framework — which is exactly what we need: an address that is
+    // definitively NOT an ika package.
+
+    fn framework_typed_object() -> Object {
+        Object::with_id_owner_version_for_testing(
+            ObjectID::from_single_byte(SYSTEM_OBJ),
+            SequenceNumber::from(1),
+            Owner::AddressOwner(ObjectID::from_single_byte(2).into()),
+        )
+    }
+
+    /// The end-to-end shape of #1908: the object on chain is typed by one
+    /// package, the binary compiled in another. Proves the extraction reads the
+    /// object's own top-level type address.
+    #[test]
+    fn object_typed_by_another_package_is_rejected() {
+        let object = framework_typed_object();
+        let ika_pkg = pkg(0xBB);
+
+        let err = check_object_identity(
+            "System",
+            &object,
+            ObjectID::from_single_byte(SYSTEM_OBJ),
+            Some(ika_pkg),
+        )
+        .expect_err("an object typed outside the compiled-in package must be rejected");
+
+        match err {
+            ReaderError::IdentityMismatch {
+                chain_package,
+                expected_package,
+                ..
+            } => {
+                // The gas coin's type is `0x2::coin::Coin<..>`, so the extracted
+                // address must be the framework — proving we read the object's
+                // type rather than, say, its id.
+                assert_eq!(
+                    chain_package,
+                    ObjectID::from_single_byte(2),
+                    "extracted address should be the type's package, not the object id"
+                );
+                assert_ne!(chain_package, ObjectID::from_single_byte(SYSTEM_OBJ));
+                assert_eq!(expected_package, ika_pkg);
+            }
+            other => panic!("expected IdentityMismatch, got {other:?}"),
+        }
+    }
+
+    /// Same extraction path, agreeing case: expectation set to the object's
+    /// actual defining package passes.
+    #[test]
+    fn object_typed_by_the_expected_package_passes() {
+        let object = framework_typed_object();
+        check_object_identity(
+            "System",
+            &object,
+            ObjectID::from_single_byte(SYSTEM_OBJ),
+            Some(ObjectID::from_single_byte(2)),
+        )
+        .expect("expectation matching the object's own type must pass");
+    }
+
+    #[test]
+    fn object_check_is_inert_without_a_compiled_in_identity() {
+        let object = framework_typed_object();
+        check_object_identity(
+            "System",
+            &object,
+            ObjectID::from_single_byte(SYSTEM_OBJ),
+            None,
+        )
+        .expect("localnet has no compiled-in identity to assert");
     }
 }
 

--- a/crates/ika-core/src/sui_connector/verified_reader.rs
+++ b/crates/ika-core/src/sui_connector/verified_reader.rs
@@ -117,6 +117,84 @@ pub enum ReaderError {
         anchored_seq: CheckpointSequenceNumber,
         verdict: &'static str,
     },
+    #[error(
+        "compiled-in identity does not match the chain's {kind} object: object {object_id} is \
+         typed by package {chain_package}, but this binary resolved {expected_package}. This \
+         binary was built with a wrong or wrong-role package id (a Sui type tag carries the \
+         ORIGINAL defining package forever — never a later upgrade id). Fix the compiled-in \
+         constant; retrying cannot resolve this."
+    )]
+    IdentityMismatch {
+        kind: &'static str,
+        object_id: ObjectID,
+        chain_package: ObjectID,
+        expected_package: ObjectID,
+    },
+}
+
+impl ReaderError {
+    /// A mismatch between the binary's compiled-in package identity and the
+    /// chain's is permanent — no amount of retrying changes a constant baked
+    /// into this build. Retry loops must treat it as terminal rather than
+    /// spinning forever (which is exactly the silent-failure mode this check
+    /// exists to replace).
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, ReaderError::IdentityMismatch { .. })
+    }
+}
+
+/// Assert that a fetched anchor object is typed by the package this binary
+/// compiled in for that role.
+///
+/// Sui type tags carry the **defining** package forever, so the system object
+/// stays `{original}::system::System` across every package upgrade — which is
+/// what makes this a stable equality check rather than something that needs
+/// bumping on each contract upgrade. It is also chain-authenticated: the type
+/// comes from OCS-verified state, not from the relay's say-so.
+///
+/// `expected` is `None` on localnet (Devnet/Custom), where ids are generated
+/// fresh at each genesis and there is no compiled-in identity to check against.
+fn check_object_identity(
+    kind: &'static str,
+    object: &Object,
+    object_id: ObjectID,
+    expected: Option<ObjectID>,
+) -> Result<(), ReaderError> {
+    // A package (not a Move object) can't carry a type tag; `move_object_contents`
+    // already rejects that case for these anchors, so treat it as nothing to check.
+    let Some(move_obj) = object.data.try_as_move() else {
+        return Ok(());
+    };
+    check_identity_addresses(
+        kind,
+        object_id,
+        ObjectID::from(move_obj.type_().address()),
+        expected,
+    )
+}
+
+/// The decision rule behind [`check_object_identity`], split out so it is
+/// unit-testable without constructing a typed `Object` (the only safe
+/// constructors in the pinned Sui wrap the caller's `StructTag` in an outer
+/// type, and the `unsafe` ones are denied workspace-wide).
+fn check_identity_addresses(
+    kind: &'static str,
+    object_id: ObjectID,
+    chain_package: ObjectID,
+    expected: Option<ObjectID>,
+) -> Result<(), ReaderError> {
+    let Some(expected_package) = expected else {
+        return Ok(());
+    };
+    if chain_package != expected_package {
+        return Err(ReaderError::IdentityMismatch {
+            kind,
+            object_id,
+            chain_package,
+            expected_package,
+        });
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone)]
@@ -186,6 +264,12 @@ pub struct OcsVerifiedReader {
     /// before the changeset receiver is wired — currency then falls back to the
     /// per-read high-water + freshness defenses.
     changeset_index: Option<SharedChangesetIndex>,
+    /// The package ids this binary compiled in for the two singleton anchors,
+    /// checked against each fetched object's type tag (see
+    /// [`check_object_identity`]). `None` on localnet, where ids are generated
+    /// per genesis. Set via [`Self::with_expected_identity`].
+    expected_system_package: Option<ObjectID>,
+    expected_coordinator_package: Option<ObjectID>,
 }
 
 impl OcsVerifiedReader {
@@ -211,7 +295,22 @@ impl OcsVerifiedReader {
             staleness_bound,
             anchor_refreshed_at: Mutex::new(HashMap::new()),
             changeset_index: None,
+            expected_system_package: None,
+            expected_coordinator_package: None,
         }
+    }
+
+    /// Pin the compiled-in package identity for the two singleton anchors, so
+    /// every verified read of them asserts the chain agrees. Left unset on
+    /// localnet, where there is no compiled-in identity to check against.
+    pub fn with_expected_identity(
+        mut self,
+        system_package: ObjectID,
+        coordinator_package: ObjectID,
+    ) -> Self {
+        self.expected_system_package = Some(system_package);
+        self.expected_coordinator_package = Some(coordinator_package);
+        self
     }
 
     /// Attach a changeset index (a mirrored / peer-only node) so verified reads
@@ -871,6 +970,12 @@ impl OcsVerifiedReader {
         coordinator_id: ObjectID,
     ) -> Result<(DWalletCoordinator, DWalletCoordinatorInner), ReaderError> {
         let outer_obj = self.verified_anchor_object(coordinator_id).await?;
+        check_object_identity(
+            "DWalletCoordinator",
+            &outer_obj.object,
+            coordinator_id,
+            self.expected_coordinator_package,
+        )?;
         let outer_bcs = move_object_contents(&outer_obj.object)?;
         let outer: DWalletCoordinator = bcs::from_bytes(outer_bcs)
             .map_err(|e| ReaderError::Decode(format!("DWalletCoordinator: {e}")))?;
@@ -901,6 +1006,12 @@ impl OcsVerifiedReader {
         system_id: ObjectID,
     ) -> Result<(System, SystemInner), ReaderError> {
         let outer_obj = self.verified_anchor_object(system_id).await?;
+        check_object_identity(
+            "System",
+            &outer_obj.object,
+            system_id,
+            self.expected_system_package,
+        )?;
         let outer_bcs = move_object_contents(&outer_obj.object)?;
         let outer: System =
             bcs::from_bytes(outer_bcs).map_err(|e| ReaderError::Decode(format!("System: {e}")))?;
@@ -1122,6 +1233,7 @@ fn classify_verify_error(e: &ReaderError) -> &'static str {
         ReaderError::UnsupportedVersion { .. } => "unsupported_version",
         ReaderError::DynamicFieldMembership { .. } => "dynamic_field_membership",
         ReaderError::NotCurrent { .. } => "not_current",
+        ReaderError::IdentityMismatch { .. } => "identity_mismatch",
     }
 }
 
@@ -1151,6 +1263,98 @@ fn clone_inclusion_proof(
 ) -> Option<sui_light_client::proof::ocs::OCSInclusionProof> {
     let bytes = bcs::to_bytes(p).ok()?;
     bcs::from_bytes(&bytes).ok()
+}
+
+#[cfg(test)]
+mod identity_tests {
+    use super::*;
+
+    const SYSTEM_OBJ: u8 = 0x11;
+
+    fn pkg(byte: u8) -> ObjectID {
+        ObjectID::from_single_byte(byte)
+    }
+
+    /// The #1908 failure mode: the binary compiled in a package id that tags
+    /// no live event (there, the system package's v2 UPGRADE id). The chain's
+    /// system object is typed by package A; this build resolved B.
+    #[test]
+    fn mismatched_system_package_is_rejected_and_names_both() {
+        let err = check_identity_addresses(
+            "System",
+            pkg(SYSTEM_OBJ),
+            /* chain   */ pkg(0xAA),
+            /* expected*/ Some(pkg(0xBB)),
+        )
+        .expect_err("a system object typed by a different package must be rejected");
+
+        match err {
+            ReaderError::IdentityMismatch {
+                kind,
+                object_id,
+                chain_package,
+                expected_package,
+            } => {
+                assert_eq!(kind, "System");
+                assert_eq!(object_id, pkg(SYSTEM_OBJ));
+                assert_eq!(chain_package, pkg(0xAA));
+                assert_eq!(expected_package, pkg(0xBB));
+            }
+            other => panic!("expected IdentityMismatch, got {other:?}"),
+        }
+
+        // The operator-facing message must carry BOTH values — the whole point
+        // is that it is actionable without a debugger.
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains(&pkg(0xAA).to_string()),
+            "message must name the chain's package: {rendered}"
+        );
+        assert!(
+            rendered.contains(&pkg(0xBB).to_string()),
+            "message must name the compiled-in package: {rendered}"
+        );
+    }
+
+    #[test]
+    fn matching_package_passes() {
+        check_identity_addresses("System", pkg(SYSTEM_OBJ), pkg(0xAA), Some(pkg(0xAA)))
+            .expect("a matching package id must pass");
+    }
+
+    /// Localnet generates ids per genesis, so there is no compiled-in identity
+    /// to check against — the check must be inert rather than fail closed.
+    #[test]
+    fn absent_expected_identity_skips_the_check() {
+        check_identity_addresses("System", pkg(SYSTEM_OBJ), pkg(0xAA), None)
+            .expect("no compiled-in identity means nothing to assert");
+    }
+
+    /// A mismatch is permanent — retry loops must not spin on it. Every other
+    /// error stays retryable (a pruned anchor resolves on the next tick).
+    #[test]
+    fn only_identity_mismatch_is_terminal() {
+        let mismatch = check_identity_addresses("System", pkg(1), pkg(0xAA), Some(pkg(0xBB)))
+            .expect_err("mismatch");
+        assert!(mismatch.is_terminal());
+
+        assert!(!ReaderError::MissingCommittee(7).is_terminal());
+        assert!(!ReaderError::Decode("boom".into()).is_terminal());
+        assert!(
+            !ReaderError::UnsupportedVersion {
+                kind: "System",
+                version: 9,
+            }
+            .is_terminal()
+        );
+    }
+
+    #[test]
+    fn mismatch_classifies_as_its_own_metric_label() {
+        let err = check_identity_addresses("System", pkg(1), pkg(0xAA), Some(pkg(0xBB)))
+            .expect_err("mismatch");
+        assert_eq!(classify_verify_error(&err), "identity_mismatch");
+    }
 }
 
 #[cfg(test)]

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -811,10 +811,28 @@ because the bytes came from a peer's disk rather than its fullnode.
     scrape before exit; a node down for this reason otherwise presents only as
     absent series.)
 
-    Note this asserts the object's **type**, which is distinct from the
-    *current executable* package: the system object's `package_id` FIELD names
-    the latest upgrade (mainnet: type `0xb874c9b5…`, `package_id`
-    `0xd69f947d…`) and is read at runtime, so no constant tracks upgrades.
+    **This asserts the object's TYPE, which is a different address from the
+    current executable package — both are live at once.** The object's type is
+    its ORIGINAL defining package and never moves; the `package_id` FIELD names
+    the latest upgrade and is read at runtime, which is why no constant here
+    tracks contract upgrades. Testnet shows both packages already upgraded and
+    the types still on the originals (checked 2026-07-25):
+
+    | anchor | type (asserted) | `package_id` field (executable) |
+    |---|---|---|
+    | `System` | `0xae71e386…` | `0xde05f49e…` |
+    | `DWalletCoordinator` | `0xf02f5960…` (dwallet **v1**) | `0x6573a6c1…` (**v2**) |
+
+    Event type tags follow the same rule: every sampled `system_inner` and
+    `coordinator_inner` event on testnet is tagged by the ORIGINAL package, and
+    **zero** are tagged by either executable — so
+    `ika_dwallet_2pc_mpc_package_id_v2` (which event filtering also accepts) is
+    defensive rather than load-bearing today.
+
+    The corollary is the reason there is **no `ika_system_package_id_v2`**, and
+    why one must not be added for this check: expecting a later upgrade id here
+    would assert against an address no anchor object is ever typed by — which
+    is precisely the #1908 defect this invariant exists to catch.
 
     This is a stable equality check, not something to bump on contract
     upgrades: a Sui type tag carries the **defining** package forever, so the

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -801,6 +801,30 @@ because the bytes came from a peer's disk rather than its fullnode.
    modification (or after its deletion/wrapping) returns `NotCurrent`. The
    backing changeset fold is contiguity-enforced, so a skipped modification
    is detectable, not silently dropped.
+10. **A verified read of either singleton anchor asserts that the chain's
+    object is typed by the package this binary compiled in for that role**
+    (`System` → `ika_system_package_id`, `DWalletCoordinator` →
+    `ika_dwallet_2pc_mpc_package_id`). Mismatch is `IdentityMismatch` and is
+    **terminal**: the node refuses to run rather than retrying, because no
+    amount of retrying changes a constant baked into the build.
+
+    This is a stable equality check, not something to bump on contract
+    upgrades: a Sui type tag carries the **defining** package forever, so the
+    system object stays `{original}::system::System` across every upgrade.
+    The expectation therefore comes from `compiled_in_ika_identity` (the
+    ORIGINAL package) and never from the config's `ika_system_package_id`,
+    which on a localnet may legitimately name a later upgrade. It is `None`
+    on Devnet/Custom, where ids are generated per genesis and there is
+    nothing to assert against.
+
+    Why it exists: #1908 shipped the system package's **v2 upgrade id** as the
+    compiled-in identity — a value matching zero live event type tags — and
+    because that PR removed the config escape hatch on public chains, the only
+    remedy was another release. The symptom was a fleet silently deaf to
+    system events. A unit test can pin what a human once verified; it cannot
+    catch the next drift between compiled identity and chain reality. This
+    turns that class of failure into a node that refuses to start with both
+    values in the error. See #1913.
 
 ## Residuals and known gaps
 

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -823,16 +823,42 @@ because the bytes came from a peer's disk rather than its fullnode.
     | `System` | `0xae71e386…` | `0xde05f49e…` |
     | `DWalletCoordinator` | `0xf02f5960…` (dwallet **v1**) | `0x6573a6c1…` (**v2**) |
 
-    Event type tags follow the same rule: every sampled `system_inner` and
-    `coordinator_inner` event on testnet is tagged by the ORIGINAL package, and
-    **zero** are tagged by either executable — so
-    `ika_dwallet_2pc_mpc_package_id_v2` (which event filtering also accepts) is
-    defensive rather than load-bearing today.
+    **An upgraded package holds a MIX of type addresses, so "the package id" is
+    not one value.** Sui records type identity per datatype in the package's
+    `TypeOrigin` table (`{module_name, datatype_name, package}`): a type
+    carried forward from the previous version keeps the ORIGINAL address, while
+    a type **first defined in the upgrade** carries the UPGRADE address. Both
+    networks show the same split (checked 2026-07-25):
 
-    The corollary is the reason there is **no `ika_system_package_id_v2`**, and
-    why one must not be added for this check: expecting a later upgrade id here
-    would assert against an address no anchor object is ever typed by — which
-    is precisely the #1908 defect this invariant exists to catch.
+    | package | types at original | types at upgrade |
+    |---|---|---|
+    | dwallet | 79 | **7** |
+    | ika_system | 36 | **0** |
+
+    The seven dwallet upgrade-defined types include five **events**
+    (`DWalletDKGRequestEvent`, `CompletedDWalletDKGEvent`,
+    `RejectedDWalletDKGEvent`, `SignDuringDKGRequestEvent`,
+    `UserSecretKeyShareEventType`). That is why
+    `ika_dwallet_2pc_mpc_package_id_v2` exists and why event filtering accepts
+    both addresses — it is **load-bearing**, not defensive: without it those DKG
+    events are dropped.
+
+    Two consequences:
+
+    - **This invariant is unaffected.** It asserts the type of the two
+      singleton ANCHOR objects, and those were created by the original
+      packages — their types sit in the original's `TypeOrigin` entries, and
+      `System::try_migrate` mutates the object in place (`&mut System`) rather
+      than recreating it, so an existing object's type can never move. Verified
+      directly on both networks. It must therefore expect ONLY the original:
+      accepting the upgrade id as well would admit exactly the #1908 defect
+      (a constant set to the upgrade id) that this check exists to catch.
+    - **`ika_system` is one upgrade away from needing a `_v2`.** It has no
+      upgrade-defined types today (36/36 original), so no constant is missing —
+      but the first system upgrade that defines a new event type would emit
+      events tagged by the upgrade address, with nothing configured to accept
+      them. That is the #1908 failure shape (a fleet silently deaf to system
+      events) reached by a different route.
 
     This is a stable equality check, not something to bump on contract
     upgrades: a Sui type tag carries the **defining** package forever, so the

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -804,9 +804,17 @@ because the bytes came from a peer's disk rather than its fullnode.
 10. **A verified read of either singleton anchor asserts that the chain's
     object is typed by the package this binary compiled in for that role**
     (`System` → `ika_system_package_id`, `DWalletCoordinator` →
-    `ika_dwallet_2pc_mpc_package_id`). Mismatch is `IdentityMismatch` and is
-    **terminal**: the node refuses to run rather than retrying, because no
-    amount of retrying changes a constant baked into the build.
+    `ika_dwallet_2pc_mpc_package_id`). Mismatch is `IdentityMismatch`, counted
+    as `ika_ocs_identity_mismatch_total{anchor}`, and is **terminal**: the node
+    refuses to run rather than retrying, because no amount of retrying changes
+    a constant baked into the build. (The counter names the cause on the last
+    scrape before exit; a node down for this reason otherwise presents only as
+    absent series.)
+
+    Note this asserts the object's **type**, which is distinct from the
+    *current executable* package: the system object's `package_id` FIELD names
+    the latest upgrade (mainnet: type `0xb874c9b5…`, `package_id`
+    `0xd69f947d…`) and is read at runtime, so no constant tracks upgrades.
 
     This is a stable equality check, not something to bump on contract
     upgrades: a Sui type tag carries the **defining** package forever, so the

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -853,12 +853,24 @@ because the bytes came from a peer's disk rather than its fullnode.
       directly on both networks. It must therefore expect ONLY the original:
       accepting the upgrade id as well would admit exactly the #1908 defect
       (a constant set to the upgrade id) that this check exists to catch.
-    - **`ika_system` is one upgrade away from needing a `_v2`.** It has no
-      upgrade-defined types today (36/36 original), so no constant is missing —
-      but the first system upgrade that defines a new event type would emit
-      events tagged by the upgrade address, with nothing configured to accept
-      them. That is the #1908 failure shape (a fleet silently deaf to system
-      events) reached by a different route.
+    - **`ika_system` needs no `_v2`, and adding one would be dead weight.**
+      Nothing consumes system events by package address: the only
+      event-address filter in the node is `sui_event_into_session_request`,
+      which matches the DWALLET package (both ids) and the sessions-manager
+      module. System state is read from the system OBJECT via verified reads,
+      not from address-filtered events. `ika_system_package_id`'s only other
+      consumer is the pusher's cache-fold relevance set, where an unmatched
+      object degrades to a cache miss and a verified network read — never a
+      wrong answer. An unused `_v2` constant would just be one more value that
+      can drift, which is the #1908 hazard itself.
+    - **The dwallet filter is where the constant hazard actually recurs.** It
+      enumerates `{ika_dwallet_2pc_mpc_package_id, …_v2}`, and five of the
+      seven v2-defined types are events — so the next dwallet upgrade that
+      defines a new event type silently loses those sessions until someone
+      remembers to add a `_v3`. This filter is live on BOTH paths (the legacy
+      JSON-RPC listener and `bag_event_pump` under OCS). The durable fix is to
+      derive the accepted set from the package's `TypeOrigin` table at runtime
+      rather than enumerating constants.
 
     This is a stable equality check, not something to bump on contract
     upgrades: a Sui type tag carries the **defining** package forever, so the


### PR DESCRIPTION
Closes #1913.

## Why

#1908 shipped the system package's **v2 upgrade id** as the compiled-in
`ika_system_package_id` — a value matching zero live event type tags — and
because that PR removed the config escape hatch on public chains, the only
remedy was another release. The symptom was a fleet silently deaf to system
events. #1910 corrected the constants and pinned them in a unit test, but a
unit test can only pin what a human once verified; it cannot catch the *next*
drift between compiled identity and chain reality.

## What

Every OCS-verified read of the two singleton anchors now asserts the chain's
object is typed by the package this binary compiled in for that role:

| anchor | expected package |
|---|---|
| `System` | `ika_system_package_id` |
| `DWalletCoordinator` | `ika_dwallet_2pc_mpc_package_id` |

The type comes from OCS-verified state, so the check is chain-authenticated,
and it costs one comparison on data the node already fetches.

Three details worth calling out:

- **Terminal, not retried.** `must_get_system_inner` /
  `must_get_dwallet_coordinator_inner` retry *forever*, so returning a plain
  error would spin with warnings — recreating the silent-failure mode this
  check exists to replace. `ReaderError::is_terminal()` marks the mismatch and
  those loops panic with both values plus remediation.
- **Checked on every read, not only at startup.** The first read happens at
  startup (so the issue's ask is covered), and keeping it on the steady-state
  path costs nothing while also catching a mid-life drift.
- **The expectation comes from `compiled_in_ika_identity`, not the config
  field.** A Sui type tag carries the **defining** package forever, so the
  system object stays `{original}::system::System` across upgrades — this is a
  stable equality check, not one to bump per contract upgrade. That function
  returns the original package and is `None` on Devnet/Custom, where ids are
  generated per genesis and a config-supplied `ika_system_package_id` may
  legitimately name a later upgrade (which would false-positive).

## Verified against the live networks first

So the assert cannot false-positive today:

| network | system object type | compiled-in | |
|---|---|---|---|
| mainnet | `0xb874c9b5…::system::System` | `0xb874c9b5…` | ✅ |
| testnet | `0xae71e386…::system::System` | `0xae71e386…` | ✅ |

## Tests

5 unit tests: the decision rule, the error naming **both** values, the
localnet skip, terminal-ness (and that no other error is terminal), and the
metric label.

One deliberate limitation: the comparison is split into
`check_identity_addresses` so it is testable without constructing a typed
`Object`. The safe Sui test constructors (`treasury_cap_for_testing`) wrap the
caller's `StructTag` in an outer type, making the top-level address `0x2`, and
the direct constructors are `unsafe` — denied workspace-wide. So the tests
cover the decision rule and error contents but not the `type_().address()`
extraction, which is the existing `push_worker.rs:554` pattern. Happy to add
cluster-level coverage instead if you'd rather have it end-to-end.

- `cargo test -p ika-core --lib identity_tests` — 5/5
- `cargo clippy -p ika-core --all-targets` clean; `cargo fmt --all` (verified
  no unrelated churn)

## Docs

`dev-docs/specs/ocs-verified-sui-reads.md` gains invariant 10, recording the
rule, why the type tag makes it upgrade-stable, and the #1908 backstory.

## Open question

Worth also emitting an `ika_ocs_identity_mismatch` counter, or is the
fail-closed panic sufficient? A node that refuses to start is visible by
absence, but a counter would name the cause on a dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)