### PR TITLE
chore(config): drop the dead aggregated_network_key_public_outputs accessor

### DIFF
--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -554,8 +554,9 @@ impl VersionedNetworkDkgOutput {
 ///   `twopc_mpc::decentralized_party::reconfiguration::PublicOutput`:
 ///   the same `PublicOutputCore` prefix with the trailing sharing output in
 ///   the aggregated shape (one summed randomizer-share ciphertext per
-///   receiver). Written when `aggregated_network_key_public_outputs()` is
-///   `true` (protocol v5); the producer upgrades the protocol's
+///   receiver). The ONLY format produced since `MIN_PROTOCOL_VERSION = 5`
+///   (the flag that gated the V3→V4 flip is true at every supported version
+///   and no longer read); the producer upgrades the protocol's
 ///   pre-aggregation output via `PublicOutput::upgrade()`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Hash)]
 pub enum VersionedDecryptionKeyReconfigurationOutput {

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -192,17 +192,25 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     off_chain_validator_metadata: bool,
 
-    // If true, network-key reconfiguration public outputs are persisted in
-    // the aggregated wire format (one summed randomizer-share ciphertext per
-    // receiver instead of every dealer's full PVSS dealing), tagged V4 in
-    // ika's versioned output enums. False keeps producing the pre-aggregation
-    // V3 wire format that testnet already persists. MPC outputs must reach
-    // byte-identical quorum and reconfiguration runs every epoch — including
-    // during a mixed-binary rollout — so the flip must happen at a protocol
-    // version boundary, never per-binary. Network DKG outputs are NOT gated
-    // by this flag: they are always persisted in the aggregated (V4) format,
-    // since no deployed network ever persisted a pre-aggregation fresh DKG
-    // output and no DKG session runs during a rollout window.
+    // Switched network-key reconfiguration public outputs to the aggregated
+    // wire format (one summed randomizer-share ciphertext per receiver
+    // instead of every dealer's full PVSS dealing), tagged V4 in ika's
+    // versioned output enums; false kept producing the pre-aggregation V3
+    // format. Set at version 5 and therefore true at every supported
+    // version, so nothing reads it anymore — V4 is the only format produced.
+    // V3-tagged outputs stay DECODABLE forever (testnet persisted them).
+    //
+    // Kept for the same reason as `off_chain_validator_metadata` above: the
+    // flag set is part of the BCS-serialized `ProtocolConfig` whose digest
+    // rides `AuthorityCapabilitiesV1` through consensus, so dropping a field
+    // changes every supported version's config digest relative to the
+    // binaries already deployed.
+    //
+    // The original reason this was a version flag rather than a binary
+    // switch still governs any FUTURE change here: MPC outputs must reach
+    // byte-identical quorum, and reconfiguration runs every epoch including
+    // during a mixed-binary rollout, so an output-format flip must happen at
+    // a protocol version boundary, never per-binary.
     #[serde(skip_serializing_if = "is_false")]
     aggregated_network_key_public_outputs: bool,
 }
@@ -461,16 +469,6 @@ impl ProtocolConfig {
 
     pub fn noa_checkpoints(&self) -> bool {
         self.feature_flags.noa_checkpoints
-    }
-
-    /// True iff network-key reconfiguration public outputs are persisted in
-    /// the aggregated wire format (V4-tagged in the versioned output enums)
-    /// instead of the pre-aggregation V3 format. Network DKG outputs are
-    /// always aggregated regardless of this flag. See the flag definition for
-    /// why the reconfiguration flip happens only at a protocol version
-    /// boundary.
-    pub fn aggregated_network_key_public_outputs(&self) -> bool {
-        self.feature_flags.aggregated_network_key_public_outputs
     }
 
     pub fn consensus_round_prober(&self) -> bool {
@@ -1183,10 +1181,6 @@ impl ProtocolConfig {
 
     pub fn set_noa_checkpoints_for_testing(&mut self, val: bool) {
         self.feature_flags.noa_checkpoints = val;
-    }
-
-    pub fn set_aggregated_network_key_public_outputs_for_testing(&mut self, val: bool) {
-        self.feature_flags.aggregated_network_key_public_outputs = val;
     }
 }
 

--- a/dev-docs/specs/fast-schnorr-vss.md
+++ b/dev-docs/specs/fast-schnorr-vss.md
@@ -58,8 +58,8 @@ VSS path is internal NOA-VSS.
   version-3 network-key DKG output**. A pre-version-3 key has no VSS cache.
   The full-shape output comes in two wire tags — V3 (pre-aggregation, what
   testnet persists at protocol v4) and V4 (aggregated). Reconfiguration
-  outputs flip V3→V4 at protocol v5 under
-  `aggregated_network_key_public_outputs()`; fresh network DKG outputs are V4
+  outputs flipped V3→V4 at protocol v5, so with `MIN_PROTOCOL_VERSION = 5`
+  V4 is the only format produced; fresh network DKG outputs are V4
   unconditionally (no deployed network persisted a pre-aggregation fresh DKG
   output). The cache derivation runs on the **aggregated** form either way (a
   V3 output is upgraded on first derivation), so recovering a Shamir share


### PR DESCRIPTION
Finishes what #1915 started, for the one remaining v5-era flag in the same class.

`aggregated_network_key_public_outputs` is set at protocol version 5, so with `MIN_PROTOCOL_VERSION = 5` it is true at every supported version. #1895 collapsed its call sites but left the accessor and its `_for_testing` setter behind — both have had **zero callers workspace-wide** since. Unlike the gates swept in #1915 there are no branches to collapse here, only dead surface to delete.

## Removed

- `ProtocolConfig::aggregated_network_key_public_outputs()`
- `ProtocolConfig::set_aggregated_network_key_public_outputs_for_testing()` — it existed so a test could flip the flag off and exercise V3 output production; that production path is gone, so there is nothing left for it to test.

## Kept

The `FeatureFlags` field, for the same reason as `off_chain_validator_metadata`: the flag set is part of the BCS-serialized `ProtocolConfig` whose digest rides `AuthorityCapabilitiesV1` through consensus and is what `tally_protocol_upgrade_votes` groups votes by. Snapshots are unchanged, confirming the digest did not move.

The field comment now also preserves the *reason* this was a version flag rather than a binary switch, because it still governs any future change: MPC outputs must reach byte-identical quorum, and reconfiguration runs every epoch including during a mixed-binary rollout, so an output-format flip must ride a protocol version boundary.

## Docs refreshed

Two references still described the flag as a live gate — `VersionedDecryptionKeyReconfigurationOutput::V4` and `dev-docs/specs/fast-schnorr-vss.md`. Both now say V4 is the only format produced, while keeping the "V3 stays decodable forever (testnet persisted them)" note intact.

## Verification

- `cargo clippy --workspace --all-targets --all-features` — clean
- `cargo test -p ika-protocol-config` — 6/6, snapshots byte-identical

Docs and dead-surface only; no executable path changes.

## Noted but deliberately not swept

The same audit turned up five more accessors with zero call sites: `consensus_round_prober`, `consensus_batched_block_sync`, `consensus_skip_gced_blocks_in_direct_finalization`, `consensus_zstd_compression`, `enforce_checkpoint_timestamp_monotonicity`. These are a different category — Mysticeti knobs mirrored from upstream Sui that appear never to have been wired into ika's consensus setup, rather than ika flags whose gates were collapsed. Whether they are dead or merely un-wired is a question for someone who knows the intent, so they are left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)