### PR TITLE
fix(dwallet-mpc): stop flagging pre-adoption internal-presign replays as should-never-happen

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -7,7 +7,7 @@ use crate::dwallet_mpc::integration_tests::utils::{
     TEST_PRESIGN_POOL_MINIMUM_SIZE, apply_test_presign_pool_overrides, build_test_state,
     create_test_protocol_config_guard,
 };
-use crate::dwallet_mpc::mpc_manager::ParkedInternalPresignRequest;
+use crate::dwallet_mpc::mpc_manager::{InternalPresignCompletionKey, ParkedInternalPresignRequest};
 use crate::dwallet_mpc::mpc_session::SessionStatus;
 use crate::dwallet_mpc::{NetworkOwnedAddressSignRequest, ValidatorMpcKeysByPartyId};
 use dwallet_mpc_types::dwallet_mpc::{DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm};
@@ -1483,6 +1483,48 @@ async fn test_internal_presign_multi_key_install_lag_keeps_identifiers_uniform()
                 "validator {service_index}: an unresolvable adopted key must not fail a session"
             );
         }
+    }
+
+    // === Phase 5: completion-path classification ===
+    // A completed internal-presign output whose key does not resolve moves no
+    // counter either way, so the ONLY difference between "genuine invariant
+    // violation" and "ordinary pre-adoption replay after a restart" is how
+    // it is classified. Pin both directions: K2 is adopted-but-unresolvable
+    // (the real should-never-happen), while an identical unresolvable key
+    // that was never adopted is the post-restart replay shape — the one that
+    // used to raise a false `should_never_happen=true` alarm on every
+    // binary-swap restart (a burst of them in the v1.2.5 upgrade scenario).
+    let never_adopted_id = ObjectID::random();
+    for (service_index, service) in test_state.dwallet_mpc_services.iter().enumerate() {
+        let manager = service.dwallet_mpc_manager();
+        assert!(
+            manager
+                .internal_presign_network_key_id(&never_adopted_id)
+                .is_none(),
+            "validator {service_index}: the never-adopted key must be unresolvable, so the two \
+             cases differ only by adoption"
+        );
+        assert_eq!(
+            manager.classify_internal_presign_completion(&k2_id),
+            InternalPresignCompletionKey::AdoptedUnresolvable,
+            "validator {service_index}: an ADOPTED key that cannot resolve is a genuine \
+             should-never-happen"
+        );
+        assert_eq!(
+            manager.classify_internal_presign_completion(&never_adopted_id),
+            InternalPresignCompletionKey::NotAdopted,
+            "validator {service_index}: a not-yet-adopted key is an ordinary pre-adoption \
+             replay, not an invariant violation"
+        );
+        // The installed, adopted keys still resolve — the classification did
+        // not turn the healthy path into a silent skip.
+        assert!(
+            matches!(
+                manager.classify_internal_presign_completion(&k0_id),
+                InternalPresignCompletionKey::Resolved(_)
+            ),
+            "validator {service_index}: an installed adopted key must still resolve"
+        );
     }
 
     info!(

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -281,6 +281,21 @@ enum PriorCertKeysOutcome {
     RetryLater,
 }
 
+/// How a completed internal-presign output's network key resolves for the
+/// per-pool counter bookkeeping — see
+/// [`DWalletMPCManager::classify_internal_presign_completion`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum InternalPresignCompletionKey {
+    /// The key resolves to its content-derived id; the counter may advance.
+    Resolved(NetworkKeyId),
+    /// The key is adopted but does not resolve — a should-never-happen
+    /// (adoption defers an unmapped key).
+    AdoptedUnresolvable,
+    /// The key is not adopted on this process yet: the ordinary
+    /// pre-adoption consensus replay after a restart.
+    NotAdopted,
+}
+
 /// The correct way to use the manager is to create it along with all other Ika components
 /// at the start of each epoch.
 /// Ensuring it is destroyed when the epoch ends and providing a clean slate for each new epoch.
@@ -466,6 +481,16 @@ pub(crate) struct DWalletMPCManager {
     /// would re-warn per republish; warn once per distinct local digest,
     /// debug thereafter.
     warned_cert_digest_mismatches: HashSet<(ObjectID, [u8; 32])>,
+
+    /// Keys already reported as carrying an internal-presign completion
+    /// while not yet adopted here. Consensus replays a burst of such
+    /// completions after a restart, so the report is deduped to once per
+    /// key (debug thereafter): a skip may be correct, but a *silent* skip
+    /// never is — if a key is never adopted (its background `NetworkKeyId`
+    /// derivation failed, or its overlay entry carries no DKG output), the
+    /// top-up loop never runs for it and that key's presign pool starves
+    /// for the epoch, and this is the recurring evidence of it.
+    reported_unadopted_internal_presign_completions: HashSet<ObjectID>,
 
     /// Keys whose background `NetworkKeyId` derivation has been spawned by
     /// the adoption pass, memoized by the digest of the exact derivation
@@ -762,6 +787,7 @@ impl DWalletMPCManager {
             last_cert_read_warn: None,
             last_prior_cert_keys_warn: None,
             warned_cert_digest_mismatches: HashSet::new(),
+            reported_unadopted_internal_presign_completions: HashSet::new(),
             network_key_id_derivations_spawned: HashMap::new(),
             stranded_network_keys,
             warned_cryptographic_data_generation_failures: HashSet::new(),
@@ -2510,6 +2536,46 @@ impl DWalletMPCManager {
         }
     }
 
+    /// How a completed internal-presign output's key resolves for counter
+    /// bookkeeping. The three cases move no counter differently — only the
+    /// `Resolved` arm advances one — but they mean very different things
+    /// operationally, so they are classified here rather than at the log
+    /// site, where the distinction would be untestable.
+    ///
+    /// Why `NotAdopted` is safe to pass over: resolution is **monotone within
+    /// a process** — the `ObjectID → NetworkKeyId` mapping is a never-cleared
+    /// process-global static (`network_key_id_mapping::register` only
+    /// inserts) and installed keys are never evicted, so resolution can go
+    /// `None → Some` but never `Some → None`. The only writer of
+    /// `instantiated_internal_presign_sessions` is the top-up loop, which
+    /// skips unresolvable keys. So "unresolvable now" implies "never
+    /// resolved in this process", implies this process never instantiated a
+    /// batch for that id: `instantiated` is 0 by construction and the
+    /// saturating `completed < instantiated` guard would decline the
+    /// increment even if the key resolved. Nothing is lost by not counting.
+    pub(crate) fn classify_internal_presign_completion(
+        &self,
+        dwallet_network_encryption_key_id: &ObjectID,
+    ) -> InternalPresignCompletionKey {
+        match self.internal_presign_network_key_id(dwallet_network_encryption_key_id) {
+            Some(network_key_id) => InternalPresignCompletionKey::Resolved(network_key_id),
+            // Adoption defers an unmapped key, so an ADOPTED key that does
+            // not resolve is a genuine invariant violation.
+            None if self
+                .adopted_network_key_data
+                .contains_key(dwallet_network_encryption_key_id) =>
+            {
+                InternalPresignCompletionKey::AdoptedUnresolvable
+            }
+            // Ordinarily a post-restart replay: consensus redelivers outputs
+            // of sessions the PREVIOUS process instantiated, while this
+            // process's mapping still lacks the key (it is outside the
+            // compiled-in seeds — every localnet/CI DKG — until the
+            // background derivation lands with adoption, seconds later).
+            None => InternalPresignCompletionKey::NotAdopted,
+        }
+    }
+
     /// The key's flip-invariant, content-derived `NetworkKeyId` — the identity
     /// bound into internal presign session identifiers and the key of the
     /// per-pool sequence/guard counters. Read from the installed key data when
@@ -3856,28 +3922,52 @@ impl DWalletMPCManager {
                 // `instantiated` — the top-up skip compares them for
                 // equality and would block the pool permanently. Keyed by the
                 // same content-derived `NetworkKeyId` the top-up loop uses.
-                if let Some(network_key_id) =
-                    self.internal_presign_network_key_id(&dwallet_network_encryption_key_id)
+                match self.classify_internal_presign_completion(&dwallet_network_encryption_key_id)
                 {
-                    let instantiated = self
-                        .instantiated_internal_presign_sessions
-                        .get(&(network_key_id, curve, signature_algorithm))
-                        .copied()
-                        .unwrap_or(0);
-                    let completed = self
-                        .completed_internal_presign_sessions
-                        .entry((network_key_id, curve, signature_algorithm))
-                        .or_insert(0);
-                    if *completed < instantiated {
-                        *completed += 1;
+                    InternalPresignCompletionKey::Resolved(network_key_id) => {
+                        let instantiated = self
+                            .instantiated_internal_presign_sessions
+                            .get(&(network_key_id, curve, signature_algorithm))
+                            .copied()
+                            .unwrap_or(0);
+                        let completed = self
+                            .completed_internal_presign_sessions
+                            .entry((network_key_id, curve, signature_algorithm))
+                            .or_insert(0);
+                        if *completed < instantiated {
+                            *completed += 1;
+                        }
                     }
-                } else {
-                    error!(
+                    InternalPresignCompletionKey::AdoptedUnresolvable => error!(
                         should_never_happen = true,
                         ?dwallet_network_encryption_key_id,
-                        "completed internal presign output for a key with no resolvable \
+                        "completed internal presign output for an ADOPTED key with no resolvable \
                          NetworkKeyId; completion counter not advanced"
-                    );
+                    ),
+                    // Deduped to once per key: a restart replays a burst of
+                    // these, but a key that is NEVER adopted starves its
+                    // pool for the epoch, so the first one must not be
+                    // silent.
+                    InternalPresignCompletionKey::NotAdopted => {
+                        if self
+                            .reported_unadopted_internal_presign_completions
+                            .insert(dwallet_network_encryption_key_id)
+                        {
+                            info!(
+                                ?dwallet_network_encryption_key_id,
+                                "completed internal presign output for a key not adopted here yet \
+                                 (ordinarily a pre-adoption consensus replay after a restart); \
+                                 completion counter not advanced. If this key is never adopted, \
+                                 its internal presign pool will not refill this epoch"
+                            );
+                        } else {
+                            debug!(
+                                ?dwallet_network_encryption_key_id,
+                                "completed internal presign output for a key not adopted here yet; \
+                                 completion counter not advanced"
+                            );
+                        }
+                    }
                 }
             }
             DWalletInternalMPCOutputKind::NetworkOwnedAddressSign {


### PR DESCRIPTION
Fixes the `should_never_happen` bursts surfaced by the `v125_churn` investigation in #1919.

## The symptom

Every binary-swap restart produced 20–30 of these per validator:

```
ERROR completed internal presign output for a key with no resolvable NetworkKeyId;
completion counter not advanced  should_never_happen=true
```

## Root cause (from the failing runs' node logs)

Validator-1's timeline:

| time | event |
|---|---|
| 22:30:30 | process starts (binary swap) |
| 22:30:52 | **error burst** |
| 22:30:55 | `adopting a network key whose ObjectID has no NetworkKeyId mapping (not seeded, never instantiated here) — deferring` |
| 22:30:56 | `derived and registered the NetworkKeyId from locally-held key data` |

Consensus replays completions of sessions the **previous process** instantiated, while this process's `ObjectID → NetworkKeyId` mapping — a process-global static rebuilt from the compiled-in seeds — hasn't learned the key yet. Every localnet/CI DKG key sits outside those seeds until the background derivation lands with adoption, seconds later. So the key legitimately does not resolve; the code assumed it always would.

## No counter was ever corrupted

Worth stating plainly, because the log message implies data loss. Resolution is **monotone within a process**: `network_key_id_mapping::register` only inserts (never clears) and installed keys are never evicted, so resolution goes `None → Some` but never back. The only writer of `instantiated_internal_presign_sessions` is the top-up loop, which skips unresolvable keys. Therefore "unresolvable now" ⇒ "never resolved in this process" ⇒ this process never instantiated a batch for that id ⇒ `instantiated == 0`, and the saturating `completed < instantiated` guard would have declined the increment **even if the key had resolved**. The defect was the diagnosis, not the bookkeeping — a `should_never_happen` alarm firing on the most routine operation there is, which trains operators to ignore the flag.

## The fix

Classify into `Resolved` / `AdoptedUnresolvable` / `NotAdopted`:

- `error!(should_never_happen)` is now reserved for **AdoptedUnresolvable** — the genuine invariant break, since adoption defers an unmapped key.
- **NotAdopted** logs `info!` **once per key** (deduped, mirroring the existing `warned_cert_digest_mismatches` pattern), `debug!` for the burst that follows. A skip may be correct, but a *silent* skip never is: a key that is never adopted — failed background derivation, or an overlay entry with no DKG output — never enters the top-up loop and **starves that key's presign pool for the epoch**. This is the recurring evidence of that state.
- Counter behavior is byte-for-byte unchanged.

The classification is a returned value rather than inline logging **specifically so it is testable** — the two non-counting arms differ only in log severity, so no counter-based test could distinguish them.

## Test plan

- New Phase 5 in `test_internal_presign_multi_key_install_lag_keeps_identifiers_uniform` pins all three classes on every validator, reusing the existing adopted-but-unresolvable fixture.
- **Test-tested** per `dev-docs/playbooks/test-testing.md`: injecting the pre-fix behavior fails it with `a not-yet-adopted key is an ordinary pre-adoption replay, not an invariant violation`; reverting restores green.
- Counter invariance stays guarded by the pre-existing `test_internal_presign_stale_batch_expiry`, which asserts `instantiated == completed` through the real output path.
- Full `internal_presign` integration suite: **6 passed**. `cargo check --release --all-targets -p ika-core` clean.
- Reviewed by the `consensus-reviewer` agent (determinism, epoch-boundary, silent-skip lenses). Its findings on my first draft — an orphaned doc comment, a safety comment asserting the wrong property, and the silent `debug!` skip — are fixed in this commit. It confirmed the classification feeds only `tracing` macros, so the per-validator variation in `adopted_network_key_data` has no consensus-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gnBnDikdJPTom3jSESiga