### PR TITLE
Export invariant violations as a Prometheus metric

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,10 @@ jobs:
         # commit-batched or written directly (and why that is safe).
         # See dev-docs/conventions/epoch-table-write-discipline.md.
         run: ./scripts/check-epoch-table-write-discipline.sh
+      - name: Invariant violation metric coverage
+        # Every should-never-happen log must increment the fleet-visible
+        # invariant violation counter through the shared macro.
+        run: ./scripts/check-invariant-violation-markers.sh
       - name: Sui version consistency
         # The Sui pin lives in several places that don't update together;
         # see dev-docs/conventions/sui-version-bump.md.

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -2011,8 +2011,8 @@ impl AuthorityEpochTables {
         if presigns.is_empty() {
             // This shouldn't happen, but handle it gracefully: remove the
             // corrupted entry and decrement the size counter atomically.
-            error!(
-                should_never_happen = true,
+            ika_types::report_invariant_violation!(
+                "presign_pool_empty_entry",
                 ?signature_algorithm,
                 ?dwallet_network_encryption_key_id,
                 "prepare_pop_presign: found entry with empty presigns vec, removing"

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/sign.rs
@@ -33,7 +33,6 @@ use mpc::{GuaranteedOutputDeliveryRoundResult, Party, Weight, WeightedThresholdA
 use rand_core::SeedableRng;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tracing::error;
 use twopc_mpc::secp256k1::class_groups::NON_FUNDAMENTAL_DISCRIMINANT_LIMBS;
 use twopc_mpc::sign;
 
@@ -1984,12 +1983,12 @@ pub fn compute_sign<P: twopc_mpc::sign::Protocol>(
             ) {
                 Ok(signature) => Ok(signature),
                 Err(e) => {
-                    error!(
+                    ika_types::report_invariant_violation!(
+                        "sign_output_deserialize",
                         session_identifier=?session_id,
                         ?e,
                         ?malicious_parties,
                         signature_algorithm=?sign_data.signature_algorithm,
-                        should_never_happen = true,
                         "failed to deserialize sign session result "
                     );
 
@@ -2051,12 +2050,12 @@ pub fn compute_dwallet_dkg_and_sign<P: twopc_mpc::sign::Protocol>(
             ) {
                 Ok(signature) => Ok(signature),
                 Err(e) => {
-                    error!(
+                    ika_types::report_invariant_violation!(
+                        "dkg_and_sign_output_deserialize",
                         session_identifier=?session_id,
                         ?e,
                         ?malicious_parties,
                         ?signature_algorithm,
-                        should_never_happen = true,
                         "failed to deserialize sign session result "
                     );
 

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -612,8 +612,8 @@ impl DWalletMPCService {
         while let Ok(request) = self.network_owned_address_sign_requests_receiver.try_recv() {
             let message_hash: [u8; 32] = DefaultHash::digest(&request.message).into();
             if self.submitted_noa_sign_messages.contains(&message_hash) {
-                error!(
-                    should_never_happen = true,
+                ika_types::report_invariant_violation!(
+                    "duplicate_noa_sign_request",
                     message_len = request.message.len(),
                     curve = ?request.curve,
                     algorithm = ?request.signature_algorithm,
@@ -667,9 +667,9 @@ impl DWalletMPCService {
                         // so the `contains` guard above suppresses re-logs) and
                         // announce anyway — the consensus-ordered drain is
                         // idempotent, so a redundant announcement is harmless.
-                        error!(
+                        ika_types::report_invariant_violation!(
+                            "noa_assigned_presign_read",
                             error=?e,
-                            should_never_happen = true,
                             "failed to read NOA assigned-presign state during announcement; announcing anyway"
                         );
                     }
@@ -1405,8 +1405,8 @@ impl DWalletMPCService {
             let consensus_round = mpc_messages_consensus_round;
 
             if self.last_read_consensus_round >= Some(consensus_round) {
-                error!(
-                    should_never_happen = true,
+                ika_types::report_invariant_violation!(
+                    "consensus_round_not_ascending",
                     consensus_round,
                     last_read_consensus_round=?self.last_read_consensus_round,
                     "consensus round must be in a ascending order"
@@ -1607,9 +1607,9 @@ impl DWalletMPCService {
                                 Err(e) => {
                                     // Serialization of a valid presign output should never fail.
                                     // If it does, the data is corrupted and retrying won't help.
-                                    error!(
+                                    ika_types::report_invariant_violation!(
+                                        "presign_output_serialize",
                                         error=?e,
-                                        should_never_happen = true,
                                         "failed to serialize presign output — data corruption"
                                     );
                                     panic!("failed to serialize presign output: {e:?}");
@@ -1621,9 +1621,9 @@ impl DWalletMPCService {
                             true
                         }
                         Err(e) => {
-                            error!(
+                            ika_types::report_invariant_violation!(
+                                "internal_presign_pool_pop",
                                 error=?e,
-                                should_never_happen = true,
                                 "failed to pop presign from internal pool"
                             );
                             // Keep in queue for retry (return true)
@@ -1700,9 +1700,9 @@ impl DWalletMPCService {
                         Ok(Some(_)) => false,
                         Ok(None) => true,
                         Err(e) => {
-                            error!(
+                            ika_types::report_invariant_violation!(
+                                "noa_presign_assignment",
                                 error=?e,
-                                should_never_happen = true,
                                 "failed to assign presign for NOA demand — keeping for retry"
                             );
                             true
@@ -1947,8 +1947,8 @@ impl DWalletMPCService {
             // sessions below the message threshold network-wide and wedging
             // the epoch close (locked-set sessions could never complete).
             let Some(session) = self.dwallet_mpc_manager.sessions.get(&session_identifier) else {
-                error!(
-                    should_never_happen = true,
+                ika_types::report_invariant_violation!(
+                    "computation_session_missing",
                     ?session_identifier,
                     validator=?validator_name,
                     ?computation_result_data,
@@ -2258,8 +2258,8 @@ impl DWalletMPCService {
                 }
                 Err(err) => match request.session_type {
                     SessionType::InternalPresign | SessionType::NetworkOwnedAddressSign => {
-                        error!(
-                            should_never_happen = true,
+                        ika_types::report_invariant_violation!(
+                            "internal_session_failed",
                             session_identifier=?session.session_identifier,
                             session_type=?request.session_type,
                             error=?err,
@@ -2467,8 +2467,8 @@ impl DWalletMPCService {
                     dwallet_network_encryption_key_id,
                 } => {
                     if session_request.session_sequence_number.is_none() {
-                        error!(
-                            should_never_happen = true,
+                        ika_types::report_invariant_violation!(
+                            "internal_presign_sequence_missing",
                             ?session_identifier,
                             "internal presign session missing session_sequence_number",
                         );
@@ -2489,8 +2489,8 @@ impl DWalletMPCService {
                     ))
                 }
                 _ => {
-                    error!(
-                        should_never_happen = true,
+                    ika_types::report_invariant_violation!(
+                        "internal_presign_protocol_mismatch",
                         session_identifier=?session_identifier,
                         "mismatch between session type and protocol data during MPC output creation",
                     );
@@ -2515,8 +2515,8 @@ impl DWalletMPCService {
                     ))
                 }
                 _ => {
-                    error!(
-                        should_never_happen = true,
+                    ika_types::report_invariant_violation!(
+                        "noa_sign_protocol_mismatch",
                         session_identifier=?session_identifier,
                         "mismatch between session type and protocol data during MPC output creation",
                     );
@@ -2640,9 +2640,9 @@ impl DWalletMPCService {
                         match bcs::from_bytes(&output) {
                             Ok(parsed) => parsed,
                             Err(e) => {
-                                error!(
+                                ika_types::report_invariant_violation!(
+                                    "dkg_and_sign_checkpoint_deserialize",
                                     error = ?e,
-                                    should_never_happen = true,
                                     "Failed to deserialize dwallet dkg + sign output"
                                 );
                                 return vec![];
@@ -2669,8 +2669,8 @@ impl DWalletMPCService {
                 vec![tx]
             }
             ProtocolData::InternalPresign { .. } => {
-                error!(
-                    should_never_happen = true,
+                ika_types::report_invariant_violation!(
+                    "internal_presign_checkpoint",
                     "received an internal presign session for checkpointing"
                 );
                 vec![]
@@ -2691,8 +2691,8 @@ impl DWalletMPCService {
                 vec![tx]
             }
             ProtocolData::NetworkOwnedAddressSign { .. } => {
-                error!(
-                    should_never_happen = true,
+                ika_types::report_invariant_violation!(
+                    "noa_sign_checkpoint",
                     "received an network-owned-address sign session for checkpointing"
                 );
                 vec![]

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -3951,8 +3951,8 @@ impl DWalletMPCManager {
                     InternalPresignCompletionKey::AdoptedUnresolvable => {
                         ika_types::report_invariant_violation!(
                             "internal_presign_output_key_id_missing",
-                        ?dwallet_network_encryption_key_id,
-                        "completed internal presign output for an ADOPTED key with no resolvable \
+                            ?dwallet_network_encryption_key_id,
+                            "completed internal presign output for an ADOPTED key with no resolvable \
                          NetworkKeyId; completion counter not advanced"
                         );
                     }

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -1148,10 +1148,10 @@ impl DWalletMPCManager {
             let Ok(sender_party_id) =
                 authority_name_to_party_id_from_committee(&self.committee, &update.authority)
             else {
-                error!(
+                ika_types::report_invariant_violation!(
+                    "idle_update_unknown_authority",
                     sender_authority=?update.authority,
                     consensus_round,
-                    should_never_happen = true,
                     "got an idle status update for an authority without party ID",
                 );
                 continue;
@@ -1165,10 +1165,10 @@ impl DWalletMPCManager {
             let Ok(sender_party_id) =
                 authority_name_to_party_id_from_committee(&self.committee, &observation.authority)
             else {
-                error!(
+                ika_types::report_invariant_violation!(
+                    "chain_observation_unknown_authority",
                     sender_authority=?observation.authority,
                     consensus_round,
-                    should_never_happen = true,
                     "got a chain observation update for an authority without party ID",
                 );
                 continue;
@@ -1209,10 +1209,10 @@ impl DWalletMPCManager {
             let Ok(sender_party_id) =
                 authority_name_to_party_id_from_committee(&self.committee, &sender_authority)
             else {
-                error!(
+                ika_types::report_invariant_violation!(
+                    "presign_request_unknown_authority",
                     sender_authority=?sender_authority,
                     consensus_round,
-                    should_never_happen = true,
                     "got a presign request for an authority without party ID",
                 );
                 continue;
@@ -1498,8 +1498,8 @@ impl DWalletMPCManager {
                 // `assemble_committee_mpc_data_off_chain` never returns this
                 // variant (it belongs to the pre-assembly decision); guard
                 // defensively rather than panic.
-                error!(
-                    should_never_happen = true,
+                ika_types::report_invariant_violation!(
+                    "prior_cert_everything_excluded",
                     prior_epoch,
                     "off-chain assembly returned EverythingExcluded for a non-empty \
                      prior-cert pair set"
@@ -2028,10 +2028,10 @@ impl DWalletMPCManager {
             let Ok(sender_party_id) =
                 authority_name_to_party_id_from_committee(&self.committee, &sender_authority)
             else {
-                error!(
+                ika_types::report_invariant_violation!(
+                    "noa_observation_unknown_authority",
                     sender_authority=?sender_authority,
                     consensus_round,
-                    should_never_happen = true,
                     "got an NOA observation for an authority without party ID",
                 );
                 continue;
@@ -2292,7 +2292,12 @@ impl DWalletMPCManager {
                 let is_expected_error_class = e.is_network_key_data_not_ready()
                     || matches!(e, DwalletMPCError::VssShamirCacheUnavailable(_));
                 if is_internal && !is_expected_error_class {
-                    error!(should_never_happen = true, error=?e, ?request, "create internal session input from dWallet request with error");
+                    ika_types::report_invariant_violation!(
+                        "internal_session_input",
+                        error=?e,
+                        ?request,
+                        "create internal session input from dWallet request with error"
+                    );
                 } else {
                     error!(error=?e, ?request, "create session input from dWallet request with error");
                 }
@@ -2374,8 +2379,8 @@ impl DWalletMPCManager {
             // `None` is a should-never-happen — skip the key rather than fall
             // back to a divergent identity axis.
             let Some(network_key_id) = self.internal_presign_network_key_id(&key_id) else {
-                error!(
-                    should_never_happen = true,
+                ika_types::report_invariant_violation!(
+                    "internal_presign_key_id_missing",
                     ?key_id,
                     "adopted network key has no resolvable NetworkKeyId in the internal-presign \
                      top-up loop; skipping its pools this iteration"
@@ -2720,7 +2725,12 @@ impl DWalletMPCManager {
             }
             Err(e) if e.is_network_key_data_not_ready() => Err(Box::new(request)),
             Err(e) => {
-                error!(should_never_happen = true, error=?e, ?request, "create internal session input from dWallet request with error");
+                ika_types::report_invariant_violation!(
+                    "internal_presign_session_input",
+                    error=?e,
+                    ?request,
+                    "create internal session input from dWallet request with error"
+                );
                 self.new_session(
                     &session_identifier,
                     SessionStatus::Failed,
@@ -2817,10 +2827,10 @@ impl DWalletMPCManager {
                 .map(|id| id.0.to_vec())
                 .unwrap_or_else(|_| key_data.network_dkg_output().as_bytes().to_vec()),
             Err(e) => {
-                error!(
+                ika_types::report_invariant_violation!(
+                    "noa_sign_network_key_missing",
                     ?dwallet_network_encryption_key_id,
                     error = ?e,
-                    should_never_happen = true,
                     "Failed to get network encryption key data for network-owned-address sign session"
                 );
                 return false;
@@ -2842,9 +2852,9 @@ impl DWalletMPCManager {
         let wrapped_presign = match bcs::to_bytes(&versioned) {
             Ok(bytes) => bytes,
             Err(e) => {
-                error!(
+                ika_types::report_invariant_violation!(
+                    "noa_sign_presign_wrap",
                     error = ?e,
-                    should_never_happen = true,
                     "Failed to wrap presign for network-owned-address sign session"
                 );
                 return false;
@@ -3102,8 +3112,8 @@ impl DWalletMPCManager {
                 let should_advance = match request.session_type {
                     SessionType::User => {
                         if request.session_sequence_number.is_none() {
-                            error!(
-                                should_never_happen = true,
+                            ika_types::report_invariant_violation!(
+                                "user_session_sequence_missing",
                                 session_identifier = ?request.session_identifier,
                                 "User session missing session_sequence_number",
                             );
@@ -3167,8 +3177,8 @@ impl DWalletMPCManager {
                     request,
                 } = &session.status
                 else {
-                    error!(
-                        should_never_happen = true,
+                    ika_types::report_invariant_violation!(
+                        "inactive_computation_session",
                         session_identifier=?session.session_identifier,
                         "session is not active, cannot perform cryptographic computation",
                     );
@@ -3938,12 +3948,14 @@ impl DWalletMPCManager {
                             *completed += 1;
                         }
                     }
-                    InternalPresignCompletionKey::AdoptedUnresolvable => error!(
-                        should_never_happen = true,
+                    InternalPresignCompletionKey::AdoptedUnresolvable => {
+                        ika_types::report_invariant_violation!(
+                            "internal_presign_output_key_id_missing",
                         ?dwallet_network_encryption_key_id,
                         "completed internal presign output for an ADOPTED key with no resolvable \
                          NetworkKeyId; completion counter not advanced"
-                    ),
+                        );
+                    }
                     // Deduped to once per key: a restart replays a burst of
                     // these, but a key that is NEVER adopted starves its
                     // pool for the epoch, so the first one must not be
@@ -3998,10 +4010,10 @@ impl DWalletMPCManager {
                     .network_owned_address_sign_output_sender
                     .try_send(sign_output)
                 {
-                    error!(
+                    ika_types::report_invariant_violation!(
+                        "noa_sign_output_channel",
                         ?session_identifier,
                         error = ?e,
-                        should_never_happen = true,
                         "Failed to send network-owned-address sign output to channel"
                     );
                 }
@@ -4020,8 +4032,8 @@ impl DWalletMPCManager {
         let presigns = match bcs::from_bytes::<Vec<P::Presign>>(&public_output) {
             Ok(presigns) => presigns,
             Err(e) => {
-                error!(
-                    should_never_happen = true,
+                ika_types::report_invariant_violation!(
+                    "internal_presign_output_deserialize",
                     error = ?e,
                     "failed to deserialize an internal presign output"
                 );
@@ -4036,8 +4048,8 @@ impl DWalletMPCManager {
         {
             Ok(presigns) => presigns,
             Err(e) => {
-                error!(
-                    should_never_happen = true,
+                ika_types::report_invariant_violation!(
+                    "internal_presign_output_serialize",
                     error = ?e,
                     "failed to serialize an internal presign output"
                 );

--- a/crates/ika-core/src/dwallet_mpc/mpc_session.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session.rs
@@ -1301,8 +1301,8 @@ impl DWalletMPCManager {
                 request.protocol_data.is_global_presign()
         {
             if request.session_sequence_number.is_none() {
-                error!(
-                    should_never_happen = true,
+                ika_types::report_invariant_violation!(
+                    "internal_presign_sequence_missing_on_insert",
                     session_identifier = ?request.session_identifier,
                     "internal presign session missing session_sequence_number",
                 );

--- a/crates/ika-core/src/noa_checkpoints/local_store.rs
+++ b/crates/ika-core/src/noa_checkpoints/local_store.rs
@@ -7,7 +7,7 @@ use ika_types::noa_checkpoint::{
     CertifiedNOACheckpointMessage, CounterpartyChain, NOACheckpointKind, NOACheckpointMessage,
     NOACheckpointTxRef, NOACheckpointTxStatus,
 };
-use tracing::{error, warn};
+use tracing::warn;
 
 // === NOACheckpointLocalStore ===
 
@@ -187,10 +187,10 @@ impl<K: NOACheckpointKind> NOACheckpointLocalStore<K> {
             None | Some(NOACheckpointTxStatus::RetryPending)
                 | Some(NOACheckpointTxStatus::SubmitFailed)
         ) {
-            error!(
+            ika_types::report_invariant_violation!(
+                "noa_mark_submitted_transition",
                 current_status = ?tx_state.finalization_status,
                 ?tx_ref,
-                should_never_happen = true,
                 "mark_submitted: unexpected status transition",
             );
             panic!(
@@ -216,10 +216,10 @@ impl<K: NOACheckpointKind> NOACheckpointLocalStore<K> {
             tx_state.finalization_status,
             None | Some(NOACheckpointTxStatus::SubmitFailed)
         ) {
-            error!(
+            ika_types::report_invariant_violation!(
+                "noa_mark_submit_failed_transition",
                 current_status = ?tx_state.finalization_status,
                 ?tx_ref,
-                should_never_happen = true,
                 "mark_submit_failed: unexpected status transition",
             );
             panic!(
@@ -241,10 +241,10 @@ impl<K: NOACheckpointKind> NOACheckpointLocalStore<K> {
                 state.finalization_status,
                 Some(NOACheckpointTxStatus::Pending)
             ) {
-                error!(
+                ika_types::report_invariant_violation!(
+                    "noa_mark_confirmed_transition",
                     current_status = ?state.finalization_status,
                     ?tx_ref,
-                    should_never_happen = true,
                     "mark_confirmed_locally: unexpected status transition",
                 );
                 panic!(
@@ -272,10 +272,10 @@ impl<K: NOACheckpointKind> NOACheckpointLocalStore<K> {
                     | Some(NOACheckpointTxStatus::RetryPending)
                     | Some(NOACheckpointTxStatus::SubmitFailed)
             ) {
-                error!(
+                ika_types::report_invariant_violation!(
+                    "noa_mark_finalized_transition",
                     current_status = ?state.finalization_status,
                     ?tx_ref,
-                    should_never_happen = true,
                     "mark_finalized: unexpected status transition",
                 );
                 panic!(
@@ -364,10 +364,10 @@ impl<K: NOACheckpointKind> NOACheckpointLocalStore<K> {
             tx_state.finalization_status,
             Some(NOACheckpointTxStatus::Pending) | Some(NOACheckpointTxStatus::SubmitFailed)
         ) {
-            error!(
+            ika_types::report_invariant_violation!(
+                "noa_initiate_retry_transition",
                 current_status = ?tx_state.finalization_status,
                 ?tx_ref,
-                should_never_happen = true,
                 "initiate_tx_retry: unexpected status transition",
             );
             panic!(

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -1073,8 +1073,8 @@ where
             .iter()
             .map(|(id, (name, _))| {
                 let mpc_data = committee_mpc_data.get(id).ok_or_else(|| {
-                    error!(
-                        should_never_happen = true,
+                    ika_types::report_invariant_violation!(
+                        "chain_fallback_mpc_data_missing",
                         authority = ?name,
                         validator_id = ?id,
                         "committee member has no decodable on-chain mpc_data record; \
@@ -1088,8 +1088,8 @@ where
                 let key_and_proof =
                     bcs::from_bytes::<ClassGroupsEncryptionKeyAndProof>(&mpc_data.mpc_data_bytes())
                         .map_err(|e| {
-                            error!(
-                                should_never_happen = true,
+                            ika_types::report_invariant_violation!(
+                                "chain_fallback_mpc_data_decode",
                                 authority = ?name,
                                 validator_id = ?id,
                                 error = ?e,

--- a/crates/ika-network/src/discovery/mod.rs
+++ b/crates/ika-network/src/discovery/mod.rs
@@ -25,7 +25,7 @@ use tokio::{
     sync::oneshot,
     task::{AbortHandle, JoinSet},
 };
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 const TIMEOUT: Duration = Duration::from_secs(1);
 const ONE_DAY_MILLISECONDS: u64 = 24 * 60 * 60 * 1_000;
@@ -590,8 +590,8 @@ fn update_known_peers(
             //     "Failed to convert anemo PeerId {:?} to Ed25519PublicKey",
             //     peer_info.peer_id
             // );
-            error!(
-                should_never_happen = true,
+            ika_types::report_invariant_violation!(
+                "discovery_peer_id_invalid",
                 ?peer_info,
                 "Failed to convert anemo PeerId to Ed25519PublicKey"
             );

--- a/crates/ika-node/src/node_runner.rs
+++ b/crates/ika-node/src/node_runner.rs
@@ -143,6 +143,7 @@ pub fn run_node_with_name(
     let metrics_rt = runtimes.metrics.enter();
     let registry_service = mysten_metrics::start_prometheus_server(config.metrics_address);
     let prometheus_registry = registry_service.default_registry();
+    ika_types::metrics::init_invariant_violation_metric(&prometheus_registry);
 
     // Initialize logging
     let (_guard, filter_handle) = telemetry_subscribers::TelemetryConfig::new()

--- a/crates/ika-sui-client/src/grpc_backend.rs
+++ b/crates/ika-sui-client/src/grpc_backend.rs
@@ -326,8 +326,8 @@ impl SuiClientInner for GrpcSuiClient {
                 if info.next_epoch_mpc_data_bytes.is_some()
                     && info.previous_mpc_data_bytes.is_some()
                 {
-                    tracing::error!(
-                        should_never_happen = true,
+                    ika_types::report_invariant_violation!(
+                        "grpc_validator_mpc_data_overlap",
                         validator_id=?validator.id,
                         "Validator can't have both previous and next epoch MPC data bytes, using current data from epoch",
                     );

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -548,8 +548,8 @@ where
                                 .sui_rpc_errors
                                 .with_label_values(&["epoch_start_missing_mpc_data"])
                                 .inc();
-                            error!(
-                                should_never_happen = true,
+                            ika_types::report_invariant_violation!(
+                                "epoch_start_mpc_data_missing",
                                 validator_id = ?validator.id,
                                 validator_name = %info.name,
                                 "active committee member has no decodable on-chain \
@@ -1310,8 +1310,8 @@ impl SuiClientInner for SuiSdkClient {
                 if info.next_epoch_mpc_data_bytes.is_some()
                     && info.previous_mpc_data_bytes.is_some()
                 {
-                    error!(
-                        should_never_happen = true,
+                    ika_types::report_invariant_violation!(
+                        "jsonrpc_validator_mpc_data_overlap",
                         validator_id=?validator.id,
                         "Validator can't have both previous and next epoch MPC data bytes, using current data from epoch",
                     );

--- a/crates/ika-types/src/committee.rs
+++ b/crates/ika-types/src/committee.rs
@@ -381,8 +381,8 @@ impl Committee {
     pub fn name_translation(&self) -> HashMap<AuthorityName, AuthorityName> {
         let missing_bls = self.members_without_bls_protocol_key();
         if !missing_bls.is_empty() {
-            tracing::error!(
-                should_never_happen = true,
+            crate::report_invariant_violation!(
+                "committee_bls_aliases_missing",
                 epoch = self.epoch,
                 members = self.voting_rights.len(),
                 missing = missing_bls.len(),

--- a/crates/ika-types/src/metrics.rs
+++ b/crates/ika-types/src/metrics.rs
@@ -1,6 +1,42 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
+use once_cell::sync::OnceCell;
+use prometheus::{IntCounterVec, Registry, register_int_counter_vec_with_registry};
+
+static INVARIANT_VIOLATIONS_TOTAL: OnceCell<IntCounterVec> = OnceCell::new();
+
+pub fn init_invariant_violation_metric(registry: &Registry) {
+    INVARIANT_VIOLATIONS_TOTAL.get_or_init(|| {
+        register_int_counter_vec_with_registry!(
+            "ika_invariant_violations_total",
+            "Invariant violations that should never happen, by bounded call-site identifier",
+            &["site"],
+            registry,
+        )
+        .expect("invariant violation metric registration must succeed")
+    });
+}
+
+#[doc(hidden)]
+pub fn record_invariant_violation(site: &'static str) {
+    if let Some(metric) = INVARIANT_VIOLATIONS_TOTAL.get() {
+        metric.with_label_values(&[site]).inc();
+    }
+}
+
+/// Records a broken invariant in both Prometheus and the structured logs.
+///
+/// The site must be a literal so the `site` label's cardinality is bounded by
+/// the number of call sites in the binary.
+#[macro_export]
+macro_rules! report_invariant_violation {
+    ($site:literal, $($field:tt)+) => {{
+        $crate::metrics::record_invariant_violation($site);
+        tracing::error!(should_never_happen = true, $($field)+);
+    }};
+}
+
 pub struct LimitsMetrics {}
 
 impl LimitsMetrics {
@@ -23,5 +59,38 @@ impl BytecodeVerifierMetrics {
     pub const TIMEOUT_TAG: &'static str = "failed";
     pub fn new(_registry: &prometheus::Registry) -> Self {
         Self {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus::Registry;
+
+    use super::init_invariant_violation_metric;
+
+    #[test]
+    fn invariant_violation_macro_increments_only_for_marked_events() {
+        let registry = Registry::new();
+        init_invariant_violation_metric(&registry);
+        assert!(
+            registry
+                .gather()
+                .iter()
+                .all(|family| family.name() != "ika_invariant_violations_total"),
+            "counter vector must not export a series before a site fires"
+        );
+
+        crate::report_invariant_violation!("metrics_test", "marked event");
+        tracing::error!("ordinary error");
+
+        let metric_family = registry
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "ika_invariant_violations_total")
+            .expect("invariant violation metric must be exported");
+        let metric = metric_family.get_metric();
+        assert_eq!(metric.len(), 1);
+        assert_eq!(metric[0].get_counter().value(), 1.0);
+        assert_eq!(metric[0].get_label()[0].value(), "metrics_test");
     }
 }

--- a/crates/ika-types/src/sui/epoch_start_system.rs
+++ b/crates/ika-types/src/sui/epoch_start_system.rs
@@ -285,8 +285,8 @@ fn build_ika_committee(
                 // then silently drops this member from every MPC public input
                 // seeded from it (the class-groups map must never be partial
                 // for a non-excluded member).
-                error!(
-                    should_never_happen = true,
+                crate::report_invariant_violation!(
+                    "persisted_epoch_start_mpc_data_missing",
                     authority = ?name,
                     "active committee member has no mpc_data record in the \
                      persisted EpochStartSystem; its class-groups key is \

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -75,6 +75,14 @@ cross-binary malicious-detection test asserts exclusion programmatically
 instead of matching a log line. Log-level discipline itself lives in
 [`logging.md`](logging.md).
 
+`ika_invariant_violations_total{site}` shadows every structured
+`should_never_happen = true` error across the node. Call sites use
+`report_invariant_violation!` with a stable literal `site`; the macro emits the
+error and increments the counter together. Dynamic values must remain log
+fields, never label values. The counter vector does not create a series until a
+site fires, so an absent series means zero violations. CI rejects bare
+`should_never_happen = true` markers outside the macro.
+
 Per-authority output observations are collected protocol-generically but
 **exported only for an allow-listed set of protocols** (currently network-key
 reconfiguration; see `OUTPUT_OBSERVATION_EXPORT_PROTOCOLS` in `mpc_manager.rs`).
@@ -284,6 +292,7 @@ ika_highest_synced_dwallet_checkpoint
 ika_highest_synced_system_checkpoint
 ika_highest_verified_dwallet_checkpoint
 ika_highest_verified_system_checkpoint
+ika_invariant_violations_total
 ika_joiner_bootstrap_outcomes_total
 ika_last_certified_dwallet_checkpoint
 ika_last_certified_dwallet_checkpoint_age

--- a/dev-docs/playbooks/production-alerts.md
+++ b/dev-docs/playbooks/production-alerts.md
@@ -1,12 +1,25 @@
-# Production alerts — the failure modes that don't page by themselves
+# Production alerts — failure modes that don't page by themselves
 
-The v4 off-chain pipeline has three designed halt/block modes. They are
-safety-first BY DESIGN (a stopped validator beats one running with wrong
-parameters), which means the node looks healthy from the outside while
-blocked — no crash, no restart loop. The metrics exist; what must live
-in the alerting config are the rules below.
+Several safety-first failures leave the process running but unable to make
+progress, while broken-invariant events can be hidden in an operator's private
+logs. The metrics exist; what must live in the alerting config are the rules
+below.
 
-## Alert 1: prepare-then-start barrier blocked
+## Alert 1: broken invariant observed
+
+```promql
+sum by (host, site) (increase(ika_invariant_violations_total[10m])) > 0
+# no for-duration: fire immediately
+```
+
+Any event is investigation-worthy by definition; there is no benign threshold.
+The bounded `site` label identifies the failing call site, and the matching
+structured log carries the dynamic context. The counter is not pre-populated,
+so an absent series means that site has recorded zero violations. **Operator
+action**: inspect the matching `should_never_happen = true` log on the affected
+host and correlate it with subsystem metrics around the event timestamp.
+
+## Alert 2: prepare-then-start barrier blocked
 
 ```promql
 ika_handoff_prepare_waiting == 1
@@ -22,7 +35,7 @@ missing input; `ika_handoff_prepare_retries_total` and the duration
 histogram quantify the wait. See `../specs/handoff.md`
 ("Prepare-then-start barrier").
 
-## Alert 2: off-chain assembly permanently wedged
+## Alert 3: off-chain assembly permanently wedged
 
 ```promql
 ika_off_chain_assembly_wedged != 0
@@ -38,7 +51,7 @@ announcement/ready-signal logs for why attestation coverage collapsed
 (propagation outage, mass restart inside the announcement window);
 recovery requires operator intervention, not waiting.
 
-## Alert 3 (log-based): joiner bootstrap fail-closed halt
+## Alert 4 (log-based): joiner bootstrap fail-closed halt
 
 There is no gauge for this one — the node **halts** when every
 current-committee peer served a handoff certificate and none verified

--- a/scripts/check-invariant-violation-markers.sh
+++ b/scripts/check-invariant-violation-markers.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Keep should-never-happen logs coupled to their Prometheus counter.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if matches="$(
+    rg -n 'should_never_happen\s*=\s*true' crates \
+        --glob '*.rs' \
+        --glob '!**/ika-types/src/metrics.rs'
+)"; then
+    echo "ERROR: bare should_never_happen marker bypasses report_invariant_violation!:"
+    echo "$matches"
+    exit 1
+fi
+
+if ! rg -q 'tracing::error!\(should_never_happen\s*=\s*true' \
+    crates/ika-types/src/metrics.rs; then
+    echo "ERROR: report_invariant_violation! no longer emits should_never_happen = true"
+    exit 1
+fi
+
+echo "invariant violation markers OK"

--- a/scripts/check-invariant-violation-markers.sh
+++ b/scripts/check-invariant-violation-markers.sh
@@ -3,17 +3,19 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-if matches="$(
-    rg -n 'should_never_happen\s*=\s*true' crates \
-        --glob '*.rs' \
-        --glob '!**/ika-types/src/metrics.rs'
-)"; then
+matches="$(
+    grep -RInE --include='*.rs' \
+        'should_never_happen[[:space:]]*=[[:space:]]*true[[:space:]]*,' crates \
+        | grep -v '^crates/ika-types/src/metrics.rs:' \
+        || true
+)"
+if [[ -n "$matches" ]]; then
     echo "ERROR: bare should_never_happen marker bypasses report_invariant_violation!:"
     echo "$matches"
     exit 1
 fi
 
-if ! rg -q 'tracing::error!\(should_never_happen\s*=\s*true' \
+if ! grep -Eq 'tracing::error!\(should_never_happen[[:space:]]*=[[:space:]]*true[[:space:]]*,' \
     crates/ika-types/src/metrics.rs; then
     echo "ERROR: report_invariant_violation! no longer emits should_never_happen = true"
     exit 1


### PR DESCRIPTION
## Summary

- add `report_invariant_violation!` to emit the existing structured error and increment `ika_invariant_violations_total{site}` with a literal, bounded site label
- migrate all 46 existing `should_never_happen = true` sites and add a CI drift guard
- document metric inventory and immediate per-host alerting guidance

## Verification

- `cargo test --release -p ika-types invariant_violation_macro_increments_only_for_marked_events`
- `cargo check --release -p ika-node`
- `cargo clippy --all-targets --all-features`
- `cargo fmt --all -- --check`
- `./scripts/check-invariant-violation-markers.sh`
- `./scripts/check-metric-names.sh`

Fixes #1923