### PR TITLE
ci(upgrade-test): trigger on authority.rs and authority/** changes

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -62,6 +62,15 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "crates/ika-core/Cargo.toml"
+      # authority.rs holds the protocol-upgrade activation decision
+      # (capability tally / effective threshold); authority/** holds the
+      # per-epoch store — epoch-close timing, EndOfPublish accounting,
+      # reconfiguration state. Both are exactly what the mixed-binary
+      # scenarios assert, and were previously missing from this filter:
+      # the #1917 close-timing fix would have merged without v125_rollout
+      # ever running had it not been dispatched by hand.
+      - "crates/ika-core/src/authority.rs"
+      - "crates/ika-core/src/authority/**"
       - "crates/ika-core/src/dwallet_mpc/**"
       - "crates/ika-core/src/dwallet_session_request.rs"
       - "crates/ika-core/src/request_protocol_data.rs"


### PR DESCRIPTION
Closes the blind spot demonstrated during #1920.

The Upgrade Test's `pull_request` path filter covered `crates/ika-core/src/dwallet_mpc/**` but not the authority module — so the two code areas the mixed-binary scenarios most directly assert never triggered the suite:

- **`crates/ika-core/src/authority/**`** — the per-epoch store: epoch-close timing, EndOfPublish accounting, reconfiguration state. This is demonstrated risk, not hypothetical: #1920 changed epoch-close timing and would have merged with `v125_rollout` never having run. It ran only because it was dispatched by hand — twice, once per push.
- **`crates/ika-core/src/authority.rs`** — the protocol-upgrade activation decision itself (`tally_protocol_upgrade_votes`, `is_protocol_version_supported_v1`, the buffer-stake threshold). An upgrade-vote change skipping the *upgrade test* is the same gap one file up, caught while auditing the first.

Filter-only change plus an in-file comment recording why these entries exist; no workflow logic touched. YAML validated.

Deliberately **not** added: `consensus_handler.rs`, `epoch_tasks/**`, and other epoch-adjacent files. They influence *when* messages are emitted rather than what the close/upgrade decisions compute, and widening the filter to everything epoch-adjacent converges on "run the expensive suite on every ika-core change" — a real cost on a self-hosted runner (~1–2h per run). If that trade is wanted, it's a one-line follow-up.

Note: this PR itself modifies `.github/workflows/upgrade-test.yaml`, which is already in the filter — so the suite will trigger here and double as a live check of the edited filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)