### PR TITLE
docs(epoch-store): declare the write discipline of every AuthorityEpochTables table

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,6 +91,11 @@ jobs:
         # is frozen in scripts/metric-name-allowlist.txt.
         # See dev-docs/conventions/metrics.md.
         run: ./scripts/check-metric-names.sh
+      - name: Epoch-table write discipline
+        # Every AuthorityEpochTables field must declare whether it is
+        # commit-batched or written directly (and why that is safe).
+        # See dev-docs/conventions/epoch-table-write-discipline.md.
+        run: ./scripts/check-epoch-table-write-discipline.sh
       - name: Sui version consistency
         # The Sui pin lives in several places that don't update together;
         # see dev-docs/conventions/sui-version-bump.md.

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -1035,6 +1035,39 @@ type PresignPoolTable = DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec
 type PreparedPresignPop = (DBBatch, SessionIdentifier, u16, Vec<u8>);
 
 /// AuthorityEpochTables contains tables that contain data that is only valid within an epoch.
+///
+/// WRITE DISCIPLINE — read before adding a table, a write site, or a
+/// consumer. This store deliberately holds two persistence patterns, and
+/// confusing them has produced real divergence bugs (#1829, #1917/#1920).
+/// Every field below therefore ends its doc comment with one
+/// `write-discipline:` line, in one of these forms:
+///
+/// - `write-discipline: commit-batched` — the only writer is
+///   `ConsensusCommitOutput::write_to_batch`, so the row lands in the same
+///   atomic batch as the processed-markers of the commit that produced it.
+///   A crash before that batch replays the whole commit and re-derives the
+///   row. This is the required discipline for anything a consensus-visible
+///   decision (close round, freeze partition, checkpoint content) reads.
+/// - `write-discipline: direct — safe because <reason>: <consumer>` — the
+///   row is written outside the commit batch, followed by the argument that
+///   makes the table's consumers survive that. Fixed vocabulary:
+///   `pure-function-of-table` (every consumer folds the WHOLE table, with no
+///   arrival-order or size cap), `idempotent-replay` (re-running the
+///   producing work rewrites the same key with the same value),
+///   `local-only` (nothing consensus-visible reads it — only this node's own
+///   scheduling, secrets, or operator overrides), `content-addressed` (the
+///   key is a hash of the value).
+/// - `write-discipline: direct — UNPROVEN (#NNNN)` — a direct write whose
+///   safety argument does not currently close. Tracked, not blessed.
+///
+/// The reason must name the consumer it protects, because this class of bug
+/// is born on the READER side: #1917 was a direct write that was fine until
+/// `all_voted` folded an arrival-order-capped view of an uncapped table.
+/// So a new consumer of a direct-written table is as much a change to this
+/// contract as a new write site. Full rule (including what to do when the
+/// reason no longer holds):
+/// `dev-docs/conventions/epoch-table-write-discipline.md`, enforced by
+/// `scripts/check-epoch-table-write-discipline.sh` in CI.
 #[derive(DBMapUtils)]
 #[allow(clippy::type_complexity)]
 pub struct AuthorityEpochTables {
@@ -1046,9 +1079,19 @@ pub struct AuthorityEpochTables {
     /// Entries in this table can be garbage collected whenever we can prove that we won't receive
     /// another handle_consensus_transaction call for the given digest. This probably means at
     /// epoch change.
+    ///
+    /// write-discipline: commit-batched — this IS the marker the other
+    /// commit-batched tables are made atomic with; a marker durable ahead of
+    /// its commit's effects would let `is_consensus_message_processed` skip a
+    /// transaction whose effects were lost.
     consensus_message_processed: DBMap<SequencedConsensusTransactionKey, bool>,
 
     /// Map stores pending transactions that this authority submitted to consensus
+    ///
+    /// write-discipline: none — the table has no writer on this branch (the
+    /// persist in `ConsensusAdapter::submit` is commented out), so its only
+    /// consumer, `get_all_pending_consensus_transactions` (consensus-adapter
+    /// resubmit-on-restart), always reads empty.
     #[default_options_override_fn = "pending_consensus_transactions_table_default_config"]
     pending_consensus_transactions: DBMap<ConsensusTransactionKey, ConsensusTransaction>,
 
@@ -1056,6 +1099,10 @@ pub struct AuthorityEpochTables {
     /// represents the index of the latest consensus message this authority processed, running hash of
     /// transactions, and accumulated stats of consensus output.
     /// This field is written by a single process (consensus handler).
+    ///
+    /// write-discipline: commit-batched — `get_last_consensus_stats` seeds the
+    /// consensus handler's replay cursor at startup, so a row durable ahead of
+    /// its commit's effects would skip that commit entirely.
     last_consensus_stats: DBMap<u64, ExecutionIndicesWithStats>,
 
     /// This table has information for the checkpoints for which we constructed all the data
@@ -1066,40 +1113,91 @@ pub struct AuthorityEpochTables {
     /// Non-empty list of transactions here might result in empty list when we are forming checkpoint.
     /// Because we don't want to create checkpoints with empty content(see CheckpointBuilder::write_checkpoint),
     /// the sequence number of checkpoint does not match height here.
+    ///
+    /// write-discipline: direct — safe because idempotent-replay: written by
+    /// the `DWalletMPCService` round loop, keyed by the consensus round it
+    /// derived the messages from, out of commit-batched inputs
+    /// (`dwallet_mpc_messages` / `dwallet_mpc_outputs` /
+    /// `verified_dwallet_checkpoint_messages`). A crash before the service's
+    /// cursor advances re-derives the same height with the same content. Its
+    /// only consumer is this node's checkpoint builder
+    /// (`process_pending_dwallet_checkpoint`).
     #[default_options_override_fn = "pending_checkpoints_table_default_config"]
     pending_dwallet_checkpoints: DBMap<DWalletCheckpointHeight, PendingDWalletCheckpoint>,
 
+    /// write-discipline: commit-batched — the `DWalletMPCService` replay walks
+    /// this table in lockstep with `dwallet_mpc_messages` and requires it to be
+    /// dense and round-aligned with the commits that produced it.
     #[default_options_override_fn = "verified_dwallet_checkpoint_messages_table_default_config"]
     verified_dwallet_checkpoint_messages:
         DBMap<DWalletCheckpointHeight, Vec<DWalletCheckpointMessageKind>>,
 
+    /// write-discipline: commit-batched — same round-alignment requirement as
+    /// `verified_dwallet_checkpoint_messages`, on the system-checkpoint stream.
     #[default_options_override_fn = "verified_system_checkpoint_messages_table_default_config"]
     verified_system_checkpoint_messages: DBMap<Round, Vec<SystemCheckpointMessageKind>>,
 
     /// Stores pending signatures
     /// The key in this table is checkpoint sequence number and an arbitrary integer
+    ///
+    /// write-discipline: direct — safe because local-only: the only consumer is
+    /// this node's signature aggregator (`dwallet_checkpoints`), whose output is
+    /// a stake-quorum certificate submitted to Sui. Which quorum subset it
+    /// aggregates, and when a peer's row lands, is not observable to peers and
+    /// feeds no consensus-visible decision.
     pub(crate) pending_dwallet_checkpoint_signatures:
         DBMap<(DWalletCheckpointSequenceNumber, u64), DWalletCheckpointSignatureMessage>,
 
     /// Maps sequence number to checkpoint summary, used by CheckpointBuilder to build checkpoint within epoch
+    ///
+    /// write-discipline: direct — safe because idempotent-replay: written in the
+    /// same batch that deletes the `pending_dwallet_checkpoints` entries it
+    /// consumed, so a crash before that batch rebuilds the identical summary
+    /// from the unchanged pending queue. Consumers
+    /// (`last_built_dwallet_checkpoint_message*`) read only this node's own
+    /// build progress.
     pub(crate) builder_dwallet_checkpoint_message_v1:
         DBMap<DWalletCheckpointSequenceNumber, BuilderDWalletCheckpointMessage>,
 
+    /// write-discipline: commit-batched for inserts (`write_to_batch`), so the
+    /// system-checkpoint builder never sees a pending entry for a commit whose
+    /// effects were lost. The build-time delete of the consumed prefix is
+    /// direct and local-only — it rides the same batch as the
+    /// `builder_system_checkpoint_v1` rows that replace it.
     #[default_options_override_fn = "pending_checkpoints_table_default_config"]
     pending_system_checkpoints: DBMap<SystemCheckpointHeight, PendingSystemCheckpoint>,
 
     /// Stores pending signatures
     /// The key in this table is ika system checkpoint sequence number and an arbitrary integer
+    ///
+    /// write-discipline: direct — safe because local-only: mirrors
+    /// `pending_dwallet_checkpoint_signatures` on the system-checkpoint
+    /// aggregator.
     pub(crate) pending_system_checkpoint_signatures:
         DBMap<(DWalletCheckpointSequenceNumber, u64), SystemCheckpointSignatureMessage>,
 
     /// Maps sequence number to ika system checkpoint summary, used by SystemCheckpointBuilder to build checkpoint within epoch
+    ///
+    /// write-discipline: direct — safe because idempotent-replay: mirrors
+    /// `builder_dwallet_checkpoint_message_v1` (written in the same batch that
+    /// deletes the pending entries it consumed).
     builder_system_checkpoint_v1: DBMap<DWalletCheckpointSequenceNumber, BuilderSystemCheckpoint>,
 
     /// Record of the capabilities advertised by each authority.
+    ///
+    /// write-discipline: direct — safe because pure-function-of-table:
+    /// `get_capabilities_v1` folds the WHOLE table into the protocol-upgrade
+    /// vote tally, with no arrival-order or size cap, and the
+    /// `generation >=` guard in `record_capabilities_v1` makes a replayed
+    /// receipt a no-op.
     authority_capabilities_v1: DBMap<AuthorityName, AuthorityCapabilitiesV1>,
 
     /// Validators that sent a EndOfPublish message in this epoch.
+    ///
+    /// write-discipline: commit-batched — the vote set must never run ahead of
+    /// the commit that sequenced it, or the aggregator rehydrates on restart
+    /// with votes the replayed commit has not re-counted and the close gate
+    /// fires at a different round than peers (#1917/#1920).
     end_of_publish: DBMap<AuthorityName, ()>,
 
     /// Single-entry (key `0`) record of the consensus leader round at which
@@ -1108,6 +1206,11 @@ pub struct AuthorityEpochTables {
     /// validator restarting mid-grace closes the epoch at the same round as
     /// its peers (the close — and the final checkpoint it builds — must be
     /// consensus-deterministic).
+    ///
+    /// write-discipline: commit-batched — must commit atomically with the
+    /// commit that observed the quorum; the close-grace consumer
+    /// (`should_close_epoch`) would otherwise anchor on a round no commit
+    /// re-derives.
     end_of_publish_quorum_round: DBMap<u64, u64>,
 
     /// Single-entry (key `0`) record of how many authorities were in the
@@ -1124,6 +1227,13 @@ pub struct AuthorityEpochTables {
     /// than a never-restarted peer holds; without this record a restarted
     /// validator could satisfy `all_voted`, skip the grace, and close the
     /// epoch at a different round than the rest of the committee. See #1917.
+    ///
+    /// write-discipline: commit-batched — written in the same batch as
+    /// `end_of_publish_quorum_round` so the anchor and the pinned count can
+    /// never disagree. This field is the canonical example of why the
+    /// discipline must name its reader: the value exists ONLY because the
+    /// `all_voted` consumer folds an arrival-order-capped view of the
+    /// uncapped `end_of_publish` table.
     end_of_publish_quorum_voted_count: DBMap<u64, u64>,
 
     /// Single-entry (key `0`) marker set when the deferred epoch-close
@@ -1131,6 +1241,10 @@ pub struct AuthorityEpochTables {
     /// on epoch-store open it restores `reconfig_state` to `RejectAllTx` so a
     /// restarted validator does not re-emit the close at a later commit
     /// (which would fork its checkpoint stream from peers).
+    ///
+    /// write-discipline: commit-batched — the marker and the close messages it
+    /// records must land or die together; the consumer is the epoch-store-open
+    /// `reconfig_state` restore.
     epoch_close_emitted: DBMap<u64, ()>,
 
     /// Single-entry (key `0`) record of the consensus leader round at which
@@ -1139,6 +1253,11 @@ pub struct AuthorityEpochTables {
     /// freeze grace; written atomically with the observing commit's batch so
     /// every validator (including one restarting mid-grace) freezes at the
     /// same round on the same signal set.
+    ///
+    /// write-discipline: commit-batched — same atomicity requirement as
+    /// `end_of_publish_quorum_round`; the freeze-grace consumer
+    /// (`freeze_mpc_data_if_first`'s caller) must anchor on a round every
+    /// validator re-derives from the same commit.
     mpc_data_ready_quorum_round: DBMap<u64, u64>,
 
     /// Single-entry (key `0`) record of the consensus leader round at which
@@ -1150,6 +1269,11 @@ pub struct AuthorityEpochTables {
     /// gauge never invents a freeze round from the current round. Absent
     /// when the freeze hasn't fired (or fired under a binary predating this
     /// table, in which case the gauge stays at its `-1` sentinel).
+    ///
+    /// write-discipline: commit-batched — written with the freeze partition it
+    /// timestamps. Its only consumer is the gauge re-seed, but batching costs
+    /// nothing here and keeps the observability claim ("this is the round the
+    /// frozen set was decided at") true by construction.
     mpc_data_freeze_round: DBMap<u64, u64>,
 
     /// Single-key (0) table holding the `commit_timestamp_ms` of the FIRST
@@ -1161,10 +1285,21 @@ pub struct AuthorityEpochTables {
     /// commit's timestamp is otherwise unrecoverable. Identical across
     /// honest validators up to consensus determinism; consumed only for
     /// emit timing, never for signal content.
+    ///
+    /// write-discipline: commit-batched — the anchor must be the timestamp of a
+    /// commit that actually persisted, so the ready-signal backstop deadline
+    /// consumer computes the same deadline before and after a restart.
     epoch_first_commit_timestamp_ms: DBMap<u64, u64>,
 
     /// Contains a single key, which overrides the value of
     /// ProtocolConfig::buffer_stake_for_protocol_upgrade_bps
+    ///
+    /// write-discipline: direct — safe because local-only: set and cleared by
+    /// this node's operator over the admin interface
+    /// (`AuthorityState::set_override_protocol_upgrade_buffer_stake`). It is a
+    /// deliberately per-node knob — the consumer,
+    /// `get_effective_buffer_stake_bps`, only shifts when THIS validator votes
+    /// to upgrade, and the protocol tolerates validators disagreeing on it.
     override_protocol_upgrade_buffer_stake: DBMap<u64, u64>,
 
     /// Holds all the DWallet MPC related messages that have been
@@ -1172,12 +1307,23 @@ pub struct AuthorityEpochTables {
     /// The key is the consensus round number,
     /// the value is the dWallet-mpc messages that have been received in that
     /// round.
+    ///
+    /// write-discipline: commit-batched — this is the dense per-round driver
+    /// the `DWalletMPCService` replay advances on; a round present here without
+    /// its commit's other streams trips the replay's round-equality check.
     #[default_options_override_fn = "dwallet_mpc_messages_table_default_config"]
     dwallet_mpc_messages: DBMap<Round, Vec<DWalletMPCMessage>>,
     /// Consensus round -> Output.
+    ///
+    /// write-discipline: commit-batched — replayed in lockstep with
+    /// `dwallet_mpc_messages` by the MPC service.
     #[default_options_override_fn = "dwallet_mpc_outputs_table_default_config"]
     dwallet_mpc_outputs: DBMap<Round, Vec<DWalletMPCOutput>>,
     /// Consensus round -> Output.
+    ///
+    /// write-discipline: commit-batched — same round-aligned replay as
+    /// `dwallet_mpc_outputs` (written only while `internal_presign_sessions`
+    /// is live, which the replay reads gate on identically).
     #[default_options_override_fn = "dwallet_internal_mpc_outputs_table_default_config"]
     dwallet_internal_mpc_outputs: DBMap<Round, Vec<DWalletInternalMPCOutput>>,
 
@@ -1186,16 +1332,37 @@ pub struct AuthorityEpochTables {
     /// Presigns are consumed in order (lowest session sequence number first) within a given key ID.
     /// Value is (SessionIdentifier, Vec<(blending_index, presign_bytes)>) - the session ID and
     /// list of presigns, each tagged with its blending index (position in the inserted vector).
+    ///
+    /// write-discipline: direct — UNPROVEN (#1928). `prepare_pop_presign` and
+    /// `insert_presigns` mutate the pool (and `internal_presign_pool_sizes`) in
+    /// their OWN batch, committed independently of the consensus commit that
+    /// consumed the presign. A crash between the pool batch and the commit
+    /// batch lets replay re-pop and hand the sign session a DIFFERENT presign
+    /// than peers bound to it — the false-malicious class — for any consumer
+    /// that requires pool-head determinism. The NOA path closed this by
+    /// batching the pop with an idempotent assignment record (see
+    /// `noa_assigned_presigns` / `assign_noa_presign`); the external
+    /// `assign_presign` path has not been audited to the same standard.
+    /// Do not add a consumer that assumes cross-validator pop identity until
+    /// #1928 lands.
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
     internal_presign_pool_ecdsa_secp256k1:
         DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `internal_presign_pool_ecdsa_secp256k1`.
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
     internal_presign_pool_ecdsa_secp256r1:
         DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `internal_presign_pool_ecdsa_secp256k1`.
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
     internal_presign_pool_eddsa: DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `internal_presign_pool_ecdsa_secp256k1`.
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
     internal_presign_pool_taproot: DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `internal_presign_pool_ecdsa_secp256k1`.
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
     internal_presign_pool_schnorrkel_substrate:
         DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
@@ -1206,38 +1373,69 @@ pub struct AuthorityEpochTables {
     /// presigns, consumed lowest-sequence-number-first within a given key ID. Kept
     /// separate from their AHE siblings because VSS presign bytes are a different
     /// format (a VSS sign must never pop an AHE presign, or vice versa).
+    ///
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `internal_presign_pool_ecdsa_secp256k1`.
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
     internal_presign_pool_taproot_vss:
         DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `internal_presign_pool_ecdsa_secp256k1`.
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
     internal_presign_pool_eddsa_vss:
         DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `internal_presign_pool_ecdsa_secp256k1`.
     #[default_options_override_fn = "internal_presign_pool_table_default_config"]
     internal_presign_pool_schnorrkel_substrate_vss:
         DBMap<(ObjectID, u64), (SessionIdentifier, Vec<(u16, Vec<u8>)>)>,
 
     /// Tracks the total count of presigns in each pool by (signature algorithm, network encryption key ID).
     /// Value is the count.
+    ///
+    /// write-discipline: direct — UNPROVEN (#1928): always written in the same
+    /// batch as the pool mutation it counts (so the counter cannot drift from
+    /// the pool), but that batch is the pool's own, not the commit's — so this
+    /// counter inherits the pool's re-pop exposure. `presign_pool_size` is a
+    /// local scheduling input, but the divergent-pool state it reports is the
+    /// suspected substrate of #1830.
     internal_presign_pool_sizes: DBMap<(DWalletSignatureAlgorithm, ObjectID), u64>,
 
     /// Idle status updates by consensus round.
+    ///
+    /// write-discipline: commit-batched — round-aligned with
+    /// `dwallet_mpc_messages` for the MPC service replay.
     #[default_options_override_fn = "internal_sessions_status_updates_table_default_config"]
     idle_status_updates: DBMap<Round, Vec<IdleStatusUpdate>>,
 
     /// Sui chain observation updates by consensus round.
+    ///
+    /// write-discipline: commit-batched — round-aligned with
+    /// `dwallet_mpc_messages` for the MPC service replay.
     #[default_options_override_fn = "internal_sessions_status_updates_table_default_config"]
     sui_chain_observation_updates: DBMap<Round, Vec<SuiChainObservationUpdate>>,
 
     /// Global presign requests by consensus round.
+    ///
+    /// write-discipline: commit-batched — round-aligned with
+    /// `dwallet_mpc_messages` for the MPC service replay.
     #[default_options_override_fn = "internal_sessions_status_updates_table_default_config"]
     global_presign_requests: DBMap<Round, Vec<ConsensusGlobalPresignRequest>>,
 
     /// NOA checkpoint observations by consensus round.
+    ///
+    /// write-discipline: commit-batched — round-aligned with
+    /// `dwallet_mpc_messages` for the MPC service replay.
     #[default_options_override_fn = "internal_sessions_status_updates_table_default_config"]
     noa_observations: DBMap<Round, Vec<ConsensusNOAObservation>>,
 
     /// NOA sign presign demands by consensus round. Drained in consensus order
     /// to assign each demand a presign identically on every validator.
+    ///
+    /// write-discipline: commit-batched — round-aligned with
+    /// `dwallet_mpc_messages`; the drain that assigns presigns walks this table
+    /// in consensus order, so a round persisted without its commit would let
+    /// two validators drain different demand sequences.
     #[default_options_override_fn = "internal_sessions_status_updates_table_default_config"]
     noa_presign_demands: DBMap<Round, Vec<ConsensusNOAPresignDemand>>,
 
@@ -1248,6 +1446,14 @@ pub struct AuthorityEpochTables {
     /// dropped on rotation) like `used_presigns`; the demand queue that feeds it
     /// is rebuilt empty when the per-epoch service restarts, and idempotency here
     /// makes re-drains safe.
+    ///
+    /// write-discipline: direct — safe because idempotent-replay: keyed by the
+    /// demand digest and written in the SAME batch as the pool pop and the
+    /// `used_presigns` marker (`assign_noa_presign`), so a re-drain after a
+    /// crash returns the recorded assignment instead of popping again. This is
+    /// the shape the raw pool tables lack (#1928): the consumer that needs
+    /// cross-validator identity — sign-session instantiation — reads THIS
+    /// table, never the pool head.
     noa_assigned_presigns: DBMap<[u8; 32], NoaAssignedPresign>,
 
     /// Tracks presigns that have been consumed for signing.
@@ -1255,27 +1461,57 @@ pub struct AuthorityEpochTables {
     /// the blended vector produced by the presign session that created it.
     /// Value: () - just marks it as used
     /// Once a presign is used, it should never be used again.
+    ///
+    /// write-discipline: direct — safe because idempotent-replay: a monotone
+    /// marker keyed by the presign it retires, written either inside
+    /// `assign_noa_presign`'s pop batch or standalone by
+    /// `mark_presign_as_used`. Re-writing it is a no-op, and the consumer
+    /// (`is_presign_used`) only ever gates THIS node's reuse of a presign it
+    /// already consumed.
     used_presigns: DBMap<(SessionIdentifier, u16), ()>,
 
     /// Assigned presigns pools for external presigns.
     /// Key: (SessionIdentifier, blending_index) - uniquely identifies this assigned presign
     /// Value: AssignedPresign - contains presign data, user verification key, dwallet_id (for non-global), and epoch
     /// These expire at the end of the epoch and are used for external sign requests.
+    ///
+    /// write-discipline: direct — UNPROVEN (#1928): the insert rides
+    /// `assign_presign`'s pop batch (so an assignment can never exist without
+    /// its pool removal), but that batch is the pool's own, not the consuming
+    /// commit's — so WHICH presign a replayed assignment binds inherits the
+    /// pool's re-pop exposure. Unlike `noa_assigned_presigns` the key is the
+    /// popped presign, not the request, so a re-pop yields a new row rather
+    /// than hitting an idempotence guard.
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
     assigned_presigns_ecdsa_secp256k1: DBMap<(SessionIdentifier, u16), AssignedPresign>,
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `assigned_presigns_ecdsa_secp256k1`.
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
     assigned_presigns_ecdsa_secp256r1: DBMap<(SessionIdentifier, u16), AssignedPresign>,
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `assigned_presigns_ecdsa_secp256k1`.
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
     assigned_presigns_eddsa: DBMap<(SessionIdentifier, u16), AssignedPresign>,
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `assigned_presigns_ecdsa_secp256k1`.
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
     assigned_presigns_taproot: DBMap<(SessionIdentifier, u16), AssignedPresign>,
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `assigned_presigns_ecdsa_secp256k1`.
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
     assigned_presigns_schnorrkel_substrate: DBMap<(SessionIdentifier, u16), AssignedPresign>,
-    // Fast Schnorr (VSS) assigned-presign pools (separate from AHE siblings).
+    /// Fast Schnorr (VSS) assigned-presign pools (separate from AHE siblings).
+    ///
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `assigned_presigns_ecdsa_secp256k1`.
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
     assigned_presigns_taproot_vss: DBMap<(SessionIdentifier, u16), AssignedPresign>,
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `assigned_presigns_ecdsa_secp256k1`.
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
     assigned_presigns_eddsa_vss: DBMap<(SessionIdentifier, u16), AssignedPresign>,
+    /// write-discipline: direct — UNPROVEN (#1928), see
+    /// `assigned_presigns_ecdsa_secp256k1`.
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
     assigned_presigns_schnorrkel_substrate_vss: DBMap<(SessionIdentifier, u16), AssignedPresign>,
 
@@ -1292,6 +1528,12 @@ pub struct AuthorityEpochTables {
     /// Self-prunes on epoch rotation (per-epoch physical DB drop). A missing row at
     /// sign time is a soft-fail that excludes this validator's contribution, not a
     /// hard error — the 2f+1 quorum absorbs it.
+    ///
+    /// write-discipline: direct — safe because local-only: this validator's own
+    /// secret share, never compared across validators. The consumer
+    /// (`get_presign_private_output`, at sign-party build) soft-fails on a
+    /// missing row, so a write lost to a crash costs one contribution, not
+    /// divergence.
     presign_private_outputs: DBMap<(CommitmentSizedNumber, u16), Vec<u8>>,
 
     /// Latest `ValidatorMpcDataAnnouncement` observed for each
@@ -1301,6 +1543,14 @@ pub struct AuthorityEpochTables {
     /// the strictly-newer-timestamp entry per validator wins (replays
     /// and duplicates are dropped). Off-chain consumers (later steps)
     /// freeze a snapshot of this table when 2f+1 ready signals land.
+    ///
+    /// write-discipline: direct — safe because local-only + idempotent-replay:
+    /// the strict-newer-timestamp guard in `insert_validator_mpc_data_announcement`
+    /// makes a replayed announcement a no-op, and no consensus-visible decision
+    /// reads it — `freeze_mpc_data_if_first` deliberately tallies the ready
+    /// signals ONLY (reading this table there would let a locally-dropped
+    /// relayed announcement shrink one validator's frozen set). Its consumers
+    /// are this node's blob fetcher and its own emitted `validated_peers`.
     pub(crate) validator_mpc_data_announcements: DBMap<AuthorityName, ValidatorMpcDataAnnouncement>,
 
     /// Map signer -> `EpochMpcDataReadySignal` for this epoch.
@@ -1309,6 +1559,14 @@ pub struct AuthorityEpochTables {
     /// when tallying per-announcer attestations. Re-broadcasts
     /// from the same signer are last-write-wins; in practice an
     /// honest validator only emits once per epoch.
+    ///
+    /// write-discipline: direct — safe because pure-function-of-table: every
+    /// consumer (`freeze_mpc_data_if_first`'s tally, the ready-quorum anchor)
+    /// folds the WHOLE table with no arrival-order or size cap, so a crash can
+    /// only leave it holding the replayed commit's own signals — which the
+    /// original run also counted before deciding. Adding a consumer that
+    /// snapshots or caps this table reintroduces the #1917 shape; the decision
+    /// it feeds must then be pinned through `ConsensusCommitOutput` instead.
     pub(crate) epoch_mpc_data_ready_signals:
         DBMap<AuthorityName, ika_types::validator_metadata::EpochMpcDataReadySignal>,
 
@@ -1327,6 +1585,9 @@ pub struct AuthorityEpochTables {
     /// partition lands atomically with the commit's processed-markers
     /// (issue #1829: a partial write latched a shrunken, divergent
     /// frozen set forever).
+    ///
+    /// write-discipline: commit-batched — see above; the freeze is
+    /// once-per-epoch and never revisited, so a partial write is permanent.
     pub(crate) frozen_validator_mpc_data_input_set: DBMap<AuthorityName, [u8; 32]>,
 
     /// Announcers that crossed the freeze gate's "announcement
@@ -1339,6 +1600,11 @@ pub struct AuthorityEpochTables {
     /// as "this validator is excluded from the working set for
     /// this epoch — same semantics as today's `bad chain mpc_data
     /// → ignore that validator`."
+    ///
+    /// write-discipline: commit-batched — the other half of the freeze
+    /// partition; must land in the same batch as
+    /// `frozen_validator_mpc_data_input_set` or the two disagree about who is
+    /// in the epoch's working set.
     pub(crate) epoch_excluded_validators: DBMap<AuthorityName, ()>,
 
     /// Per-signer Ed25519 signatures over this epoch's handoff
@@ -1349,6 +1615,19 @@ pub struct AuthorityEpochTables {
     /// `CertifiedHandoffAttestation` which is persisted forever in
     /// `AuthorityPerpetualTables` (perpetual persist lands in step
     /// 7c).
+    ///
+    /// write-discipline: direct — UNPROVEN (#1927). Two writers:
+    /// `record_handoff_signature` on the consensus `EndOfPublishV2` arm
+    /// (consensus-sequenced, but written out-of-band relative to the commit
+    /// batch) and the buffered drain in
+    /// `install_expected_handoff_attestation`, which runs at WALL-CLOCK local
+    /// install time. The close gate reads this table
+    /// (`handoff_signatures_meet_quorum`), so a validator whose install lags
+    /// its peers' signature commits can observe the gate satisfied at a
+    /// different round — the property #1920 removed from the `all_voted` half
+    /// of the same gate. The pure-function-of-table argument holds for the
+    /// consensus arm alone; the drain breaks it, because drained rows are not
+    /// attributable to any commit ≤ the evaluating one.
     pub(crate) handoff_signatures: DBMap<AuthorityName, fastcrypto::ed25519::Ed25519Signature>,
 
     /// Local cache of network DKG output digests for this epoch,
@@ -1357,12 +1636,22 @@ pub struct AuthorityEpochTables {
     /// consumed by the handoff trigger when assembling the
     /// attestation items list. Blob bytes go into the perpetual
     /// `mpc_artifact_blobs` table so peers can fetch them by digest.
+    ///
+    /// write-discipline: direct — safe because content-addressed: the value is
+    /// the Blake2b256 digest of the output bytes, so any rewrite of the same
+    /// logical output stores the same bytes and a replay is a no-op. The
+    /// cross-validator agreement the handoff-attestation consumer needs comes
+    /// from the canonical encoding of the output (see the DETERMINISM note on
+    /// `cache_protocol_output`), never from when the row landed.
     pub(crate) network_dkg_output_digests: DBMap<ObjectID, [u8; 32]>,
 
     /// Local cache of network reconfiguration output digests for
     /// this epoch — same shape and lifecycle as
     /// `network_dkg_output_digests`. Per-epoch (not perpetual)
     /// because a key's reconfig output is by definition per-epoch.
+    ///
+    /// write-discipline: direct — safe because content-addressed, exactly as
+    /// `network_dkg_output_digests`.
     pub(crate) network_reconfiguration_output_digests: DBMap<ObjectID, [u8; 32]>,
 }
 

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -116,6 +116,12 @@ them has a bug — determine which before changing either.
   conventions (new protocols auto-instrument through the exhaustive
   `[curve, signature_algorithm, key_role]` labels), and a generated name
   inventory.
+- [`conventions/epoch-table-write-discipline.md`](conventions/epoch-table-write-discipline.md)
+  — every `AuthorityEpochTables` field declares whether it is written
+  through the consensus commit batch or directly (and, if directly, the
+  reason its consumers survive that); the reader-side rule that #1917 was
+  actually born on, and the two currently-unproven tables. CI-enforced via
+  `scripts/check-epoch-table-write-discipline.sh`.
 - [`conventions/logging.md`](conventions/logging.md) — the `tracing`
   log-level discipline: hot MPC paths are `debug!`, once-per-epoch
   lifecycle events are `info!`; why an `info!` on the per-computation

--- a/dev-docs/conventions/epoch-table-write-discipline.md
+++ b/dev-docs/conventions/epoch-table-write-discipline.md
@@ -1,0 +1,103 @@
+# Epoch-table write discipline
+
+Every field of `AuthorityEpochTables`
+(`crates/ika-core/src/authority/authority_per_epoch_store.rs`) declares,
+in its doc comment, **how it is written** — one `write-discipline:` line.
+CI enforces the presence of that line
+(`scripts/check-epoch-table-write-discipline.sh`); review enforces that
+it is true.
+
+## The rule
+
+**Writing.** A new table, or a new write site for an existing one, must
+state its discipline in the table's doc comment:
+
+```rust
+/// write-discipline: commit-batched
+/// write-discipline: direct — safe because <reason>: <consumer it protects>
+/// write-discipline: direct — UNPROVEN (#issue)
+```
+
+**Reading.** A new consumer of a *direct-written* table must re-check
+the stated reason still holds for it, and say so in the PR description.
+This half is not optional and not secondary: #1917 was born on the
+reader side. The write (`record_end_of_publish_vote`) was fine for years;
+the bug arrived when `all_voted` started folding an **arrival-order-capped**
+view of an **uncapped** table, which silently invalidated the
+pure-function-of-table reason a screen away.
+
+If the reason no longer covers the new consumer, you have two options,
+in order of preference:
+
+1. Move the write into `ConsensusCommitOutput` so the row lands in the
+   commit's batch (the #1920 fix template), or
+2. Pin the consumed value at the deciding commit and persist *that*
+   through the commit batch (the `end_of_publish_quorum_voted_count`
+   template, for when the table itself cannot move).
+
+Do not weaken the consumer instead ("read it a bit later", "tolerate a
+one-vote difference") — every one of these decisions is compared across
+validators, so "usually equal" is a divergence with a longer fuse.
+
+## The two disciplines
+
+**`commit-batched`** — the only writer is
+`ConsensusCommitOutput::write_to_batch`. The row lands in the same atomic
+RocksDB batch as the processed-markers of the commit that produced it, so
+a crash before that batch replays the whole commit and re-derives the row.
+This is **required** for anything a consensus-visible decision reads: the
+close round, the freeze partition, checkpoint content, the MPC service's
+per-round replay streams.
+
+**`direct`** — written outside the commit batch, with a stated reason.
+Fixed vocabulary, so the reasons stay comparable:
+
+| reason | means | check it by asking |
+|---|---|---|
+| `pure-function-of-table` | every consumer folds the WHOLE table, no arrival-order or size cap | does any reader take a prefix, a snapshot, a count-at-a-moment, or stop early? |
+| `idempotent-replay` | re-running the producing work rewrites the same key with the same value | is the key derived from the input (round, digest, demand) rather than from the output? |
+| `local-only` | nothing consensus-visible reads it — this node's own scheduling, secrets, or operator overrides | would two validators disagreeing about this row's presence change anything either one broadcasts? |
+| `content-addressed` | the key is a hash of the value | can a rewrite ever store different bytes under the same key? |
+
+**`direct — UNPROVEN (#issue)`** — a direct write whose argument does not
+close. Tracked, not blessed. Two exist today: the presign pools (#1928,
+pops commit in their own batch, so a replay can bind a different presign
+than peers) and `handoff_signatures` (#1927, the buffered drain writes at
+wall-clock install time while the close gate reads the table). Adding a
+consumer that depends on the unproven property is a blocker, not a
+judgement call.
+
+## Why this class earns a convention
+
+Four findings in one month reduce to a reader/writer discipline mismatch
+on these tables:
+
+- **#1917 / #1920** — capped in-memory aggregator vs. uncapped table
+  rebuilt on restart → different close rounds.
+- **#1829** — freeze partition written per-row instead of in the commit
+  batch → a partial write latched a shrunken frozen set permanently.
+- **#1927** — signatures drained into the table at local install time,
+  read by a consensus-visible gate.
+- **#1928** — pool pops committed in their own batch, ahead of the commit
+  that consumed them.
+
+None of these was a hard bug to see once someone asked "who writes this,
+who reads it, and what happens if the process dies between them". The
+convention exists to make that the *default* question at the table
+definition, rather than something rediscovered per incident.
+
+## Checking your work
+
+```bash
+./scripts/check-epoch-table-write-discipline.sh          # CI check
+./scripts/check-epoch-table-write-discipline.sh --list   # field -> declaration inventory
+```
+
+The check is deliberately shallow — it verifies a line exists, not that
+it is true. It catches the failure mode where a table is added and the
+argument is never made at all.
+
+To find every direct write site for a table, grep the field name in
+`authority_per_epoch_store.rs`: any `.insert(`, `.remove(`,
+`insert_batch(&self.<field>` / `(&tables.<field>` outside
+`write_to_batch` is a direct write.

--- a/scripts/check-epoch-table-write-discipline.sh
+++ b/scripts/check-epoch-table-write-discipline.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Epoch-table write-discipline ratchet: every field of
+# `AuthorityEpochTables` must declare, in its doc comment, how it is
+# written — `commit-batched` (only via
+# `ConsensusCommitOutput::write_to_batch`) or `direct` with the argument
+# that makes its consumers survive an out-of-band write.
+#
+# Why a check and not just review: #1917 was a direct write whose safety
+# argument lived in a comment a screen away from the reader that
+# invalidated it. A missing line is the cheapest possible signal that a
+# new table (or a new writer) never had the argument made.
+#
+# Convention: dev-docs/conventions/epoch-table-write-discipline.md
+#
+# Usage:
+#   check-epoch-table-write-discipline.sh          # validate (CI)
+#   check-epoch-table-write-discipline.sh --list   # print each field + its declaration
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+python3 - "$@" <<'EOF'
+import pathlib
+import re
+import sys
+
+SOURCE = pathlib.Path("crates/ika-core/src/authority/authority_per_epoch_store.rs")
+STRUCT = "pub struct AuthorityEpochTables {"
+# A field declaration at struct indentation: `[pub(crate) ]name: Type` or a
+# `name:` whose type wrapped to the next line.
+FIELD = re.compile(r"^    (?:pub(?:\((?:crate|super)\))?\s+)?(?P<name>[a-z_][a-z0-9_]*)\s*:")
+DECLARATION = re.compile(r"write-discipline:\s*(?P<value>.+?)\s*$")
+
+lines = SOURCE.read_text().splitlines()
+try:
+    start = next(i for i, line in enumerate(lines) if line.strip() == STRUCT) + 1
+except StopIteration:
+    sys.exit(f"ERROR: `{STRUCT}` not found in {SOURCE} — update this script alongside the rename.")
+end = next(i for i in range(start, len(lines)) if lines[i] == "}")
+
+fields = []
+doc = []
+for line in lines[start:end]:
+    stripped = line.strip()
+    if stripped.startswith("///"):
+        doc.append(stripped[3:].strip())
+        continue
+    if stripped.startswith("#[") or stripped.startswith("//") or not stripped:
+        # Attributes and blank lines don't interrupt a doc block; a plain `//`
+        # comment isn't a declaration site, so it doesn't either.
+        continue
+    match = FIELD.match(line)
+    if match:
+        declaration = next(
+            (m.group("value") for m in map(DECLARATION.search, doc) if m), None
+        )
+        fields.append((match.group("name"), declaration))
+    doc = []
+
+if "--list" in sys.argv:
+    for name, declaration in fields:
+        print(f"{name}: {declaration or '<MISSING>'}")
+    print(f"# {len(fields)} fields in AuthorityEpochTables", file=sys.stderr)
+    sys.exit(0)
+
+missing = [name for name, declaration in fields if declaration is None]
+if missing:
+    print(
+        "ERROR: every AuthorityEpochTables field must declare its write discipline\n"
+        "in its doc comment (one `write-discipline:` line). Missing:",
+        file=sys.stderr,
+    )
+    for name in missing:
+        print(f"  {name}", file=sys.stderr)
+    print(
+        "\nUse one of:\n"
+        "  /// write-discipline: commit-batched\n"
+        "  /// write-discipline: direct - safe because <reason>: <consumer>\n"
+        "  /// write-discipline: direct - UNPROVEN (#issue)\n"
+        "See dev-docs/conventions/epoch-table-write-discipline.md",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(f"OK: all {len(fields)} AuthorityEpochTables fields declare a write discipline")
+EOF


### PR DESCRIPTION
Resolves #1929 (split from the #1926 audit, item 3). Convention + docs; no behavior change.

## What

`authority_per_epoch_store.rs` deliberately holds two persistence patterns — rows written through `ConsensusCommitOutput::write_to_batch` (atomic with the commit that produced them) and rows written directly — and nothing marked which table was which, or why the direct ones were safe. #1917 existed precisely because the safety argument lived in one comment (the aggregator cap) while the write discipline lived nowhere.

1. **A convention block on `AuthorityEpochTables` + one `write-discipline:` line per field.** All 55 fields. For direct writes the line carries the reason from a fixed vocabulary (`pure-function-of-table`, `idempotent-replay`, `local-only`, `content-addressed`) **and the consumer that reason protects**.
2. **`dev-docs/conventions/epoch-table-write-discipline.md`** — the review rule, including the reader-side half: a new consumer of a direct-written table must re-check the stated reason still holds. That is where #1917 was actually born (`all_voted` folded an arrival-order-capped view of an uncapped table), so a writer-only convention would not have caught it.
3. **`scripts/check-epoch-table-write-discipline.sh`**, wired into the CI conventions job next to `check-metric-names.sh`.

## Classification summary

- **commit-batched (22)**: processed markers, `last_consensus_stats`, the four EndOfPublish/close tables, the mpc_data ready/freeze anchors + freeze partition, the epoch-first-commit timestamp, and every round-keyed MPC service replay stream (messages, outputs, idle/observation/global-presign/NOA streams, verified checkpoint messages, pending system checkpoints).
- **direct, proven (13)**: capabilities (pure-function-of-table + generation guard), ready signals (pure-function-of-table), announcements (local-only + monotonic upsert), the checkpoint builder/pending/signature tables (idempotent-replay / local-only), `noa_assigned_presigns` + `used_presigns` (idempotent-replay), `presign_private_outputs` (local-only secret), the buffer-stake override (local-only operator knob), both network-output digest caches (content-addressed).
- **direct, UNPROVEN (19)**: the 9 internal presign pools + their size counter + the 8 assigned-presign pools (#1928 — pops commit in their own batch, so a replay can bind a different presign than peers), and `handoff_signatures` (#1927 — the buffered drain writes at wall-clock install time while the close gate reads the table). Deliberately marked rather than given an invented proof.
- **no writer (1)**: `pending_consensus_transactions` — the persist in `ConsensusAdapter::submit` is commented out, so `get_all_pending_consensus_transactions` (the restart-resubmit path) always reads empty. Recorded, not changed.

## Verification

- `./scripts/check-epoch-table-write-discipline.sh` → OK, 55/55; `--list` prints the inventory above.
- **Fault-validated** (the check is the new guard, so a green run alone proves nothing): deleted `idle_status_updates`' discipline line → check names that field and exits 1; restored → OK.
- `cargo check --release -p ika-core`, `cargo clippy --release -p ika-core --all-targets` (no new warnings), `cargo fmt --all -- --check`.

The check is deliberately shallow — it verifies the line exists, not that it is true. It catches the failure mode where a table is added and the argument is never made at all.

Related: #1926, #1917, #1920, #1927, #1928, #1829.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2XJjaqFLmR9FKXb3djjLA