### PR TITLE
fix(presign-pool): make pool fills and global-presign serves replay-idempotent (#1928)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,21 +276,31 @@ already validated, branch names, and in-flight CI run IDs/URLs.
   the commit/round semantics ika's freeze and epoch-close logic rely on
   (leader rounds, commit boundaries) live in Sui's `consensus/core`, not
   in ika (see the upstream reference above)
-- **Protocol v5 ONLY (`MIN_PROTOCOL_VERSION = MAX_PROTOCOL_VERSION = 5`)**:
-  mainnet and testnet both run protocol v5, and the binary supports
-  nothing older — protocol v3/v4 support, the v3→v4 migration
-  scaffolding (issue #1751), the backward-compatible (class-groups-only)
-  network DKG/reconfiguration parties, and pre-aggregation (V3-tagged)
-  output PRODUCTION are all removed. Everything formerly v4/v5-gated
-  (off-chain validator metadata, the cross-epoch handoff, deferred epoch
-  close, aggregated network-key outputs) is unconditionally on. What
-  REMAINS constrained: the networks persist pre-v5 state (V1-tagged
-  chain DKG anchors, V2/V3-tagged outputs), so old `Versioned*` enum
-  variants must stay (BCS variant indices are wire format) and their
-  DECODE paths must keep working; and MPC outputs must reach
-  byte-identical quorum across a mixed-binary committee, so
-  serialization changes to active paths need a new protocol version
-  gate, never a binary-driven flip.
+- **Protocol v5–v6 (`MIN_PROTOCOL_VERSION = 5`, `MAX_PROTOCOL_VERSION = 6`)**:
+  the binary supports nothing older than v5 — protocol v3/v4 support, the
+  v3→v4 migration scaffolding (issue #1751), the backward-compatible
+  (class-groups-only) network DKG/reconfiguration parties, and
+  pre-aggregation (V3-tagged) output PRODUCTION are all removed.
+  Everything formerly v4/v5-gated (off-chain validator metadata, the
+  cross-epoch handoff, deferred epoch close, aggregated network-key
+  outputs) is unconditionally on. **v6 gates one flag,
+  `consensus_key_authority_names`**: `AuthorityName` becomes the Ed25519
+  consensus key (zero-padded into the same 48-byte container, so the wire
+  encoding is unchanged) instead of the BLS protocol key, which stays on
+  chain and on `Committee` for BLS checkpoint-certificate verification.
+  v6 is ADVERTISED, so the capability vote carries a network to it once a
+  quorum upgrades — the flip is live on rollout, not a separate decision.
+  Its known boundary limitation (the next-epoch committee is assembled
+  under the current epoch's version but consumed under its own, so the two
+  disagree at the single activation boundary) is why the first flip
+  attempt wedged: `dev-docs/specs/committee-consensus-keys.md`. v7 is
+  planned for `noa_checkpoints`. What REMAINS constrained: the networks
+  persist pre-v5 state (V1-tagged chain DKG anchors, V2/V3-tagged
+  outputs), so old `Versioned*` enum variants must stay (BCS variant
+  indices are wire format) and their DECODE paths must keep working; and
+  MPC outputs must reach byte-identical quorum across a mixed-binary
+  committee, so serialization changes to active paths need a new protocol
+  version gate, never a binary-driven flip.
 - **NOA not live**: the network-owned-address (NOA) system — both NOA
   signing AND the NOA checkpoint system (`crates/ika-core/src/noa_checkpoints/`)
   — is under active development and not deployed at all. No backward

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -290,8 +290,25 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
     /// Concurrency safety: This method is only called from the MPC manager
     /// during consensus round processing, which is single-threaded (one round
     /// at a time). There is no concurrent access to the presign pool.
+    ///
+    /// Self-committing and NOT idempotent — see the note on the inherent
+    /// method. Work that is replayed from a consensus round stream must use
+    /// `serve_global_presign` / `assign_noa_presign` / `assign_presign`.
     fn pop_presign(
         &self,
+        signature_algorithm: DWalletSignatureAlgorithm,
+        dwallet_network_encryption_key_id: ObjectID,
+    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>>;
+
+    /// Serves a global presign request out of the internal pool atomically and
+    /// idempotently: an already-served sequence number returns the SAME presign
+    /// without popping, otherwise the pop and the record of what it served land
+    /// in ONE committed batch (they must not be separable — a replayed request
+    /// that re-pops binds a different presign than its peers). Returns `None`
+    /// only when the pool is empty.
+    fn serve_global_presign(
+        &self,
+        session_sequence_number: u64,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
     ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>>;
@@ -599,6 +616,20 @@ impl AuthorityPerEpochStoreTrait for AuthorityPerEpochStore {
     ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
         let tables = self.tables()?;
         tables.pop_presign(signature_algorithm, dwallet_network_encryption_key_id)
+    }
+
+    fn serve_global_presign(
+        &self,
+        session_sequence_number: u64,
+        signature_algorithm: DWalletSignatureAlgorithm,
+        dwallet_network_encryption_key_id: ObjectID,
+    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
+        let tables = self.tables()?;
+        tables.serve_global_presign(
+            session_sequence_number,
+            signature_algorithm,
+            dwallet_network_encryption_key_id,
+        )
     }
 
     fn next_idle_status_update(
@@ -1220,6 +1251,35 @@ pub struct AuthorityEpochTables {
     /// Value is the count.
     internal_presign_pool_sizes: DBMap<(DWalletSignatureAlgorithm, ObjectID), u64>,
 
+    /// Pool slots already filled from an internal-presign output, keyed exactly
+    /// like the pool entry the fill creates: `(signature algorithm, network
+    /// encryption key ID, session sequence number)`. Written in the SAME batch
+    /// as the fill it records.
+    ///
+    /// The DWallet MPC service replays every consensus round of the epoch after
+    /// a restart (its round cursor is in-memory and starts unset), so the same
+    /// internal-presign output reaches quorum again and would be absorbed a
+    /// second time — on top of a pool that was NOT reset. Absorbing twice both
+    /// double-counts `internal_presign_pool_sizes` (an inflated count reads as a
+    /// full pool and suppresses top-ups until the pool physically starves) and
+    /// resurrects presigns that were already served, which would hand the same
+    /// presign to a second on-chain presign id.
+    filled_presign_pool_slots: DBMap<(DWalletSignatureAlgorithm, ObjectID, u64), ()>,
+
+    /// Presign served to each global presign request, keyed by the request's
+    /// consensus-assigned session sequence number. Written in the SAME batch as
+    /// the pop that produced it, and read back instead of popping when the
+    /// request is seen again.
+    ///
+    /// The pop cannot stand alone: the replayed pool is not the pool the
+    /// original run popped from (surviving entries whose sequence number is
+    /// lower than the head at that round win the pop, and internal presign
+    /// sessions in one batch complete in consensus order, not sequence order),
+    /// so a bare re-pop serves a DIFFERENT presign than the never-crashed peers
+    /// put in their checkpoint message for the same presign id. Per-epoch, like
+    /// `noa_assigned_presigns`, whose idempotency this mirrors.
+    served_global_presigns: DBMap<u64, (SessionIdentifier, u16, Vec<u8>)>,
+
     /// Idle status updates by consensus round.
     #[default_options_override_fn = "internal_sessions_status_updates_table_default_config"]
     idle_status_updates: DBMap<Round, Vec<IdleStatusUpdate>>,
@@ -1495,6 +1555,14 @@ impl AuthorityEpochTables {
 
     /// Inserts presigns into the pool for the given signature algorithm and network encryption key.
     /// The presigns are keyed by (network_encryption_key_id, session_sequence_number).
+    ///
+    /// Idempotent per pool slot: the second and later calls for a given
+    /// `(signature_algorithm, dwallet_network_encryption_key_id,
+    /// session_sequence_number)` are no-ops. This is load-bearing, not
+    /// defensive — the DWallet MPC service replays the whole epoch's consensus
+    /// rounds after a restart, so every internal-presign output that already
+    /// filled a slot reaches quorum a second time against a pool that was not
+    /// reset. See `filled_presign_pool_slots`.
     pub fn insert_presigns(
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
@@ -1503,6 +1571,22 @@ impl AuthorityEpochTables {
         session_identifier: SessionIdentifier,
         presigns: Vec<Vec<u8>>,
     ) -> IkaResult<()> {
+        let slot_key = (
+            signature_algorithm,
+            dwallet_network_encryption_key_id,
+            session_sequence_number,
+        );
+        if self.filled_presign_pool_slots.contains_key(&slot_key)? {
+            debug!(
+                ?signature_algorithm,
+                ?dwallet_network_encryption_key_id,
+                session_sequence_number,
+                ?session_identifier,
+                "internal presign output re-absorbed after a replay; pool slot already filled"
+            );
+            return Ok(());
+        }
+
         let num_presigns = presigns.len() as u64;
         let table = self.presign_pool_table(signature_algorithm);
         let key = (dwallet_network_encryption_key_id, session_sequence_number);
@@ -1520,13 +1604,16 @@ impl AuthorityEpochTables {
             .get(&size_key)?
             .unwrap_or(0);
 
-        // Batch both writes atomically to prevent size counter drift.
+        // Batch all three writes atomically: a fill that landed without its
+        // slot marker would be re-absorbed on the next replay, and a marker
+        // that landed without its fill would lose the presigns entirely.
         let mut batch = table.batch();
         batch.insert_batch(table, [(&key, &(session_identifier, blended_presigns))])?;
         batch.insert_batch(
             &self.internal_presign_pool_sizes,
             [(&size_key, &(current_size + num_presigns))],
         )?;
+        batch.insert_batch(&self.filled_presign_pool_slots, [(&slot_key, &())])?;
         batch.write()?;
 
         Ok(())
@@ -1546,10 +1633,60 @@ impl AuthorityEpochTables {
             .unwrap_or(0))
     }
 
+    /// Serves a global presign request out of the internal pool, atomically and
+    /// idempotently.
+    ///
+    /// If this request's sequence number was already served, returns the SAME
+    /// presign without popping. Otherwise pops the pool head and records the
+    /// serve in the SAME committed batch as the pop.
+    ///
+    /// Both halves are load-bearing. The request stream is a per-epoch table
+    /// that the DWallet MPC service replays in full after a restart, so a bare
+    /// `pop_presign` here re-pops on replay — and the replayed pool is not the
+    /// pool the original run popped from, because the surviving entries were
+    /// never cleared. An entry whose sequence number is lower than the head at
+    /// that round wins the replayed pop even though it did not exist yet when
+    /// the round was first processed (internal presign sessions in one batch
+    /// complete in consensus order, not sequence order, so a lower sequence
+    /// number filling later is ordinary). The replayed request would then be
+    /// answered with a different presign than the never-crashed peers put in
+    /// their checkpoint message for the same presign id: byte-divergent
+    /// checkpoints from an honest validator. Mirrors `assign_noa_presign`.
+    pub fn serve_global_presign(
+        &self,
+        session_sequence_number: u64,
+        signature_algorithm: DWalletSignatureAlgorithm,
+        dwallet_network_encryption_key_id: ObjectID,
+    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
+        if let Some(served) = self.served_global_presigns.get(&session_sequence_number)? {
+            return Ok(Some(served));
+        }
+        let Some((mut batch, session_identifier, blending_index, presign)) =
+            self.prepare_pop_presign(signature_algorithm, dwallet_network_encryption_key_id)?
+        else {
+            return Ok(None);
+        };
+        batch.insert_batch(
+            &self.served_global_presigns,
+            [(
+                &session_sequence_number,
+                &(session_identifier, blending_index, presign.clone()),
+            )],
+        )?;
+        batch.write()?;
+        Ok(Some((session_identifier, blending_index, presign)))
+    }
+
     /// Pops a single presign from the pool for the given signature algorithm and network
     /// encryption key. Returns the session identifier, the presign's blending index, and presign
     /// bytes, or None if the pool is empty. Presigns are consumed in order of session sequence
     /// number (lowest first).
+    ///
+    /// Self-committing and NOT idempotent: the pool advances the moment this
+    /// returns. Any caller whose work is replayed from a consensus round stream
+    /// must instead pop through a method that records what it popped in the pop's
+    /// own batch (`serve_global_presign`, `assign_noa_presign`, `assign_presign`),
+    /// or the replay binds a different presign than its peers did.
     pub fn pop_presign(
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
@@ -6748,6 +6885,153 @@ mod tests {
         assert_eq!(presign, vec![20u8]);
 
         assert!(tables.pop_presign(algorithm, key_id).unwrap().is_none());
+    }
+
+    /// One replayed consensus round's effect on the presign pool: either an
+    /// internal-presign output reaching quorum (a fill), or a global presign
+    /// request being served out of the pool.
+    enum PresignPoolRound {
+        Fill {
+            session_sequence_number: u64,
+            presigns: Vec<Vec<u8>>,
+        },
+        Serve {
+            request_sequence_number: u64,
+        },
+    }
+
+    /// Replays a round stream against a pool, returning what each `Serve` round
+    /// served — `None` when the pool had nothing left to serve, which is itself
+    /// a divergence from a run that served that round.
+    fn replay_presign_pool_rounds(
+        tables: &AuthorityEpochTables,
+        signature_algorithm: DWalletSignatureAlgorithm,
+        dwallet_network_encryption_key_id: ObjectID,
+        rounds: &[PresignPoolRound],
+    ) -> Vec<Option<Vec<u8>>> {
+        rounds
+            .iter()
+            .filter_map(|round| match round {
+                PresignPoolRound::Fill {
+                    session_sequence_number,
+                    presigns,
+                } => {
+                    tables
+                        .insert_presigns(
+                            signature_algorithm,
+                            dwallet_network_encryption_key_id,
+                            *session_sequence_number,
+                            make_session_id([*session_sequence_number as u8; 32]),
+                            presigns.clone(),
+                        )
+                        .unwrap();
+                    None
+                }
+                PresignPoolRound::Serve {
+                    request_sequence_number,
+                } => Some(
+                    tables
+                        .serve_global_presign(
+                            *request_sequence_number,
+                            signature_algorithm,
+                            dwallet_network_encryption_key_id,
+                        )
+                        .unwrap()
+                        .map(|(_, _, presign)| presign),
+                ),
+            })
+            .collect()
+    }
+
+    /// The DWallet MPC service replays EVERY consensus round of the epoch after
+    /// a restart (its round cursor is in-memory and starts unset), but the
+    /// presign pool is durable per-epoch state that the replay does NOT start
+    /// from empty. A fill whose session sequence number is LOWER than one
+    /// already in the pool — normal, since a batch of concurrently instantiated
+    /// internal presign sessions completes in consensus order, not sequence
+    /// order — survives the crash and is visible to pops replayed at rounds
+    /// BEFORE its own fill round. A bare re-pop there binds a different presign
+    /// than the original run did, so this validator's checkpoint message stops
+    /// matching its never-crashed peers'.
+    #[tokio::test]
+    async fn presign_pool_replay_after_crash_serves_the_same_presigns() {
+        let signature_algorithm = DWalletSignatureAlgorithm::ECDSASecp256k1;
+        let key_id = ObjectID::random();
+
+        let rounds = vec![
+            PresignPoolRound::Fill {
+                session_sequence_number: 2,
+                presigns: vec![vec![0xb0], vec![0xb1]],
+            },
+            PresignPoolRound::Serve {
+                request_sequence_number: 10,
+            },
+            PresignPoolRound::Serve {
+                request_sequence_number: 11,
+            },
+            // Sequence number 1 reaches output quorum only now, after 2's.
+            PresignPoolRound::Fill {
+                session_sequence_number: 1,
+                presigns: vec![vec![0xa0], vec![0xa1]],
+            },
+            PresignPoolRound::Serve {
+                request_sequence_number: 12,
+            },
+        ];
+
+        // Control: a validator that never crashed.
+        let control = create_tables();
+        let control_served =
+            replay_presign_pool_rounds(&control, signature_algorithm, key_id, &rounds);
+
+        // Crashed validator: the same stream, then a restart that replays the
+        // whole epoch from round zero on top of the pool that survived.
+        let crashed = create_tables();
+        replay_presign_pool_rounds(&crashed, signature_algorithm, key_id, &rounds);
+        let replayed_served =
+            replay_presign_pool_rounds(&crashed, signature_algorithm, key_id, &rounds);
+
+        assert_eq!(
+            replayed_served, control_served,
+            "a replayed round must bind the same presign it bound before the crash; \
+             binding a different one byte-diverges this validator's checkpoint message \
+             from its never-crashed peers"
+        );
+        // A request that arrives AFTER the replay must draw a presign that was
+        // never served before: a replay that re-absorbed its fills would have
+        // resurrected already-served presigns and handed one to a second
+        // on-chain presign id.
+        let fresh_request_sequence_number = 13;
+        let crashed_fresh = crashed
+            .serve_global_presign(fresh_request_sequence_number, signature_algorithm, key_id)
+            .unwrap()
+            .map(|(_, _, presign)| presign);
+        let control_fresh = control
+            .serve_global_presign(fresh_request_sequence_number, signature_algorithm, key_id)
+            .unwrap()
+            .map(|(_, _, presign)| presign);
+        assert!(
+            !control_served.contains(&crashed_fresh),
+            "the replay must not resurrect an already-served presign into the pool: \
+             {crashed_fresh:?} was already served to an earlier request"
+        );
+        assert_eq!(
+            crashed_fresh, control_fresh,
+            "a post-replay request must be served the same presign a never-crashed \
+             validator serves it"
+        );
+
+        assert_eq!(
+            crashed
+                .presign_pool_size(signature_algorithm, key_id)
+                .unwrap(),
+            control
+                .presign_pool_size(signature_algorithm, key_id)
+                .unwrap(),
+            "the pool size counter must converge with a never-crashed validator's; \
+             an inflated counter reads as a full pool, suppresses internal presign \
+             top-ups, and starves the pool"
+        );
     }
 
     #[tokio::test]

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -1541,7 +1541,17 @@ impl DWalletMPCService {
                         return false;
                     }
 
-                    match self.epoch_store.pop_presign(
+                    // Atomic + idempotent (see `serve_global_presign`): pops the
+                    // pool head and records what it served in ONE committed
+                    // batch, or returns the presign already served for this
+                    // sequence number without popping. A bare `pop_presign`
+                    // here would re-pop when this loop replays the epoch's
+                    // rounds after a restart — against a pool the replay never
+                    // reset — and answer the request with a different presign
+                    // than the never-crashed peers put in their checkpoint
+                    // message for the same presign id.
+                    match self.epoch_store.serve_global_presign(
+                        request.session_sequence_number,
                         request.signature_algorithm,
                         request.dwallet_network_encryption_key_id,
                     ) {

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -45,6 +45,9 @@ type PresignPrivateOutputs = Arc<Mutex<HashMap<(commitment::CommitmentSizedNumbe
 /// Assigned presigns keyed by (signature_algorithm, session_identifier, blending_index).
 type AssignedPresigns =
     Arc<Mutex<HashMap<(DWalletSignatureAlgorithm, SessionIdentifier, u16), AssignedPresign>>>;
+/// Presign served to each global presign request, keyed by the request's session
+/// sequence number. Value: (presign session id, blending index, presign bytes).
+type ServedGlobalPresigns = Arc<Mutex<HashMap<u64, (SessionIdentifier, u16, Vec<u8>)>>>;
 
 /// A testing implementation of the `AuthorityPerEpochStoreTrait`.
 /// Records all received data for testing purposes.
@@ -74,6 +77,10 @@ pub(crate) struct TestingAuthorityPerEpochStore {
     /// NOA presigns assigned in consensus order, keyed by demand-id digest.
     /// Value: (presign session id, blending index, raw presign bytes, network key id).
     pub(crate) noa_assigned_presigns: Arc<Mutex<HashMap<[u8; 32], NoaAssignedPresign>>>,
+    /// Presign served to each global presign request, keyed by the request's
+    /// session sequence number. Mirrors the real store's `served_global_presigns`:
+    /// a re-seen request is answered from here instead of popping again.
+    pub(crate) served_global_presigns: ServedGlobalPresigns,
     /// Presign pool keyed by (signature algorithm, dwallet_network_encryption_key_id)
     /// Each entry contains a vector of (SessionIdentifier, presign_bytes)
     pub(crate) presign_pools: TestPresignPool,
@@ -159,6 +166,7 @@ impl TestingAuthorityPerEpochStore {
             round_to_noa_observations: Arc::new(Mutex::new(HashMap::from([(0, vec![])]))),
             round_to_noa_presign_demands: Arc::new(Mutex::new(HashMap::from([(0, vec![])]))),
             noa_assigned_presigns: Arc::new(Mutex::new(HashMap::new())),
+            served_global_presigns: Arc::new(Mutex::new(HashMap::new())),
             presign_pools: Arc::new(Mutex::new(Default::default())),
             used_presigns: Arc::new(Mutex::new(HashMap::new())),
             presign_private_outputs: Arc::new(Mutex::new(HashMap::new())),
@@ -312,6 +320,33 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
         let mut pools = self.presign_pools.lock().unwrap();
         let key = (signature_algorithm, dwallet_network_encryption_key_id);
         Ok(pools.get_mut(&key).and_then(|pool| pool.pop()))
+    }
+
+    fn serve_global_presign(
+        &self,
+        session_sequence_number: u64,
+        signature_algorithm: DWalletSignatureAlgorithm,
+        dwallet_network_encryption_key_id: ObjectID,
+    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
+        if let Some(served) = self
+            .served_global_presigns
+            .lock()
+            .unwrap()
+            .get(&session_sequence_number)
+            .cloned()
+        {
+            return Ok(Some(served));
+        }
+        let Some(served) =
+            self.pop_presign(signature_algorithm, dwallet_network_encryption_key_id)?
+        else {
+            return Ok(None);
+        };
+        self.served_global_presigns
+            .lock()
+            .unwrap()
+            .insert(session_sequence_number, served.clone());
+        Ok(Some(served))
     }
 
     fn mark_presign_as_used(

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -76,6 +76,11 @@ them has a bug — determine which before changing either.
   peers: the continuous feed of active/next/previous committee +
   `pending_active_set` into anemo `known_peers`, the inbound-dial
   bootstrap, and the `ExtendedField` BCS framing the read depends on.
+- [`specs/internal-presign-pool.md`](specs/internal-presign-pool.md) —
+  the internal presign pool: fill and drain paths, why out-of-sequence
+  fills make a restart's full-epoch round replay bind different presigns
+  than never-crashed peers, and the fill/serve idempotency rule that
+  keeps a restarted validator's checkpoint messages byte-identical.
 
 ### playbooks/ — how to run and debug this system
 - [`playbooks/ci-suites.md`](playbooks/ci-suites.md) — running the heavy

--- a/dev-docs/specs/README.md
+++ b/dev-docs/specs/README.md
@@ -59,3 +59,8 @@ here.
   the continuous committee + `pending_active_set` feed into anemo
   `known_peers`, the inbound-dial bootstrap, and the `ExtendedField` BCS
   framing the read depends on.
+- [`internal-presign-pool.md`](internal-presign-pool.md) — how the
+  internal presign pool is filled and drained, why out-of-sequence fills
+  make a restart's full-epoch replay bind different presigns than peers,
+  and the fill/serve idempotency rule that keeps a restarted validator's
+  checkpoint messages byte-identical.

--- a/dev-docs/specs/internal-presign-pool.md
+++ b/dev-docs/specs/internal-presign-pool.md
@@ -1,0 +1,110 @@
+# The internal presign pool and its replay contract
+
+How the internal presign pool is filled and drained, and the rule that keeps
+a validator that restarted mid-epoch serving the same presigns as the peers
+that did not (issue #1928). Actors: the internal-presign top-up loop and
+output handler in `DWalletMPCManager`, the global-presign and NOA-demand
+drains in `DWalletMPCService`, and the pool tables in
+`AuthorityEpochTables`.
+
+## What the pool is
+
+Per (signature algorithm, network encryption key) FIFO of precomputed
+presigns, held in per-epoch RocksDB tables (`internal_presign_pool_*`, keyed
+`(network_encryption_key_id, session_sequence_number)`, value
+`(SessionIdentifier, Vec<(blending_index, presign_bytes)>)`), plus a
+denormalized count per pool in `internal_presign_pool_sizes`.
+
+**Fill.** `instantiate_internal_presign_sessions` starts a batch of internal
+presign MPC sessions whenever a pool is below its configured minimum (or
+below its maximum while the network is idle). When such a session's output
+reaches quorum in the consensus stream, `record_internal_presign_output`
+writes its presigns into the pool slot named by that session's per-pool
+sequence number.
+
+**Drain.** Two consumers, both driven by consensus-sequenced requests:
+
+- global presign requests — `DWalletMPCService` serves each request from the
+  pool head and puts the presign bytes into a `RespondDWalletPresign`
+  checkpoint message;
+- NOA sign demands — each demand is assigned a presign, recorded in
+  `noa_assigned_presigns` and read back at sign-session instantiation.
+
+The pool is drained lowest-sequence-number-first, and within a slot in
+blending-index order.
+
+## The determinism requirement
+
+The pool is network-uniform: every validator fills slot *n* of a pool from
+the same quorum-agreed output, and drains in the same consensus-delivered
+request order. So every validator binds the same presign to the same request,
+and the checkpoint messages built from those presigns are byte-identical
+across the committee. A validator that binds a different presign to a request
+than its peers signs a checkpoint nobody else signs — an honest validator
+producing a divergent computation, the false-malicious class.
+
+## Fills complete out of sequence order
+
+A top-up batch starts *s* sessions at once. They finish in consensus order,
+not sequence order, so slot *n+1* is routinely filled before slot *n*. This is
+normal and network-uniform (every validator sees the same completion order),
+and the drain still takes the lowest sequence number present. It matters only
+because it is what makes replay unsafe — see below.
+
+## The replay contract
+
+**`DWalletMPCService` replays every consensus round of the epoch after a
+restart.** Its round cursor (`last_read_consensus_round`) is in-memory and
+starts unset, so a restarted validator re-reads the whole per-epoch round
+stream — re-absorbing every internal presign output and re-draining every
+global presign request and NOA demand.
+
+**The pool is NOT reset for that replay.** It is durable per-epoch state, so
+the replay runs against a pool holding whatever survived the crash. That
+breaks the naive assumption that re-executing the same rounds reproduces the
+same decisions:
+
+- a slot filled late in the epoch, still holding presigns at crash time, is
+  visible to drains replayed at rounds *before* its own fill round. When its
+  sequence number is lower than the head at that round — routine, given
+  out-of-order fills — the replayed drain takes it, and the request is bound
+  to a different presign than the original run bound;
+- a fill absorbed twice double-counts `internal_presign_pool_sizes`. The
+  count feeds the top-up decision, so an inflated count reads as a full pool,
+  suppresses top-ups, and starves the pool while its own gauge reports it
+  healthy;
+- a fill absorbed twice also resurrects presigns that were already served,
+  which can hand one presign to a second on-chain presign id.
+
+**Therefore both directions must be idempotent, and each must record its
+idempotency marker in the same committed batch as the state it guards:**
+
+| operation | idempotency key | marker table |
+|---|---|---|
+| fill (`insert_presigns`) | `(signature algorithm, network key id, session sequence number)` — the slot | `filled_presign_pool_slots` |
+| global presign serve (`serve_global_presign`) | request's session sequence number | `served_global_presigns` |
+| NOA demand assign (`assign_noa_presign`) | demand id digest | `noa_assigned_presigns` |
+
+A repeated fill is a no-op. A repeated serve or assign returns the presign it
+returned the first time, without touching the pool. Replay is then a no-op on
+the pool by construction, and the restarted validator's checkpoint messages
+match its peers' regardless of where it crashed.
+
+The batching is load-bearing in both directions: a pool mutation that landed
+without its marker is re-applied on the next replay, and a marker that landed
+without its mutation loses the presigns (fill) or serves a presign the pool
+never gave up (drain).
+
+`pop_presign` is the bare, self-committing pop. It is correct only for
+callers whose work is never replayed from the round stream — in practice,
+tests. Production drains go through the recorded variants above.
+
+## What this does not fix
+
+The per-pool *session ordinal* counters (`instantiated_internal_presign_sessions`
+/ the next-sequence-number counters) are in-memory and rebuilt by replay, and
+a validator whose first top-up of a pool lands more than one batch lifecycle
+behind its peers starts that pool's ordinal stream offset and never converges
+(issue #1830). That is a separate defect with a separate heal
+(fast-forwarding the ordinal from the completed sequence numbers observed in
+consensus outputs); pool-slot and serve idempotency does not address it.


### PR DESCRIPTION
Fixes #1928.

## Step one: the caller inventory

| site | driver | verdict |
|---|---|---|
| `dwallet_mpc_service.rs` global presign requests (`pop_presign`) | the replayed consensus round stream | **unsafe** — self-committing pop, re-run on every restart |
| `dwallet_mpc_service.rs` NOA demands (`assign_noa_presign`) | same | already atomic + idempotent by demand digest |
| `assign_presign` | — | no production callers (tests only) |

The issue proposed routing the pop through `ConsensusCommitOutput`. That isn't the right vehicle: the pop does **not** run inside consensus commit processing. It runs in the `DWalletMPCService` loop, whose round cursor (`last_read_consensus_round`) is in-memory and starts at `None` — so a restart replays **every** consensus round of the epoch, not just the one commit that was in flight.

## The bug

The pool is durable per-epoch state, and the replay does not reset it. Re-executing the rounds therefore does not reproduce the original decisions:

1. **Drain side.** A slot filled late in the epoch, still holding presigns at crash time, is visible to drains replayed at rounds *before* its own fill round. When its sequence number is lower than the head at that round, the replayed drain takes it. That condition is routine, not exotic: a top-up batch starts *s* internal presign sessions at once and they reach output quorum in consensus order, not sequence order, so slot *n+1* filling before slot *n* is ordinary. The replayed request is then answered with a **different presign** than the never-crashed peers put in their `RespondDWalletPresign` checkpoint message for the same presign id — byte-divergent checkpoints from an honest validator, the false-malicious class.

2. **Fill side.** `insert_presigns` was unconditional, so the replay absorbed every internal-presign output a second time. That double-counts `internal_presign_pool_sizes` (roughly doubling it per restart), and the count drives the top-up decision — an inflated count reads as a full pool, suppresses top-ups, and starves the pool while its own gauge reports it healthy. It also resurrects presigns that were already served, which can hand one presign to a second on-chain presign id.

Fixing only (1) would have been net-negative: without (2), replay keeps resurrecting served presigns into a pool no longer drained in lockstep.

## The fix

Both operations record an idempotency marker **in the same committed batch** as the state it guards:

| operation | idempotency key | marker table |
|---|---|---|
| `insert_presigns` | `(signature algorithm, network key id, session sequence number)` — the pool slot | `filled_presign_pool_slots` |
| `serve_global_presign` (new) | request's session sequence number | `served_global_presigns` |

A repeated fill is a no-op. A repeated serve returns the presign it returned the first time, without touching the pool. Replay becomes a no-op on the pool by construction. This mirrors the `assign_noa_presign` pattern already in the file. `pop_presign` stays as the bare self-committing pop, now documented as unusable from any replayed path.

Two new per-epoch DBMaps; no wire format changes, no protocol version gate. On a mid-epoch binary upgrade the markers start empty, so the first restart after the upgrade behaves exactly as `main` does today and every restart after it is clean.

## Verification

- New `presign_pool_replay_after_crash_serves_the_same_presigns` drives a round stream (out-of-sequence fill included) through a control store and a crashed-then-replayed store and compares what each round served, the pool counters, and what a post-replay request draws.
- **Fault-validated** per `dev-docs/playbooks/test-testing.md` — each half of the fix reverted independently:
  - serve idempotency off → `left: [Some([161]), None, None]` vs `right: [Some([176]), Some([177]), Some([160])]`. The replay serves `a1` where peers served `b0`, then runs the pool dry: exactly the P→P′ shift the issue predicts.
  - fill idempotency off → pool counter `5` vs `1`, the double-count.
- `authority::authority_per_epoch_store` module 22/22 green; `presign_consensus` 4/4; `validator_restart` 4/4; `cargo clippy --release -p ika-core --all-targets --all-features` clean.

## Scope

This does not address #1830 — the per-pool *session ordinal* counters are a separate in-memory divergence with a separate heal (fast-forwarding from completed sequence numbers observed in consensus outputs). #1928 hypothesized this window might be #1830's substrate; it is a distinct defect, and the spec says so.

Behavioral spec added at `dev-docs/specs/internal-presign-pool.md`.

This touches MPC state that feeds checkpoint content, so the cluster and upgrade suites should go green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKgoPYkWZUQwM5fgxY5ofZ
