### PR TITLE
fix(consensus-adapter): delete the writer-less pending_consensus_transactions recovery path (#1935 triage)

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -1086,15 +1086,6 @@ pub struct AuthorityEpochTables {
     /// transaction whose effects were lost.
     consensus_message_processed: DBMap<SequencedConsensusTransactionKey, bool>,
 
-    /// Map stores pending transactions that this authority submitted to consensus
-    ///
-    /// write-discipline: none — the table has no writer on this branch (the
-    /// persist in `ConsensusAdapter::submit` is commented out), so its only
-    /// consumer, `get_all_pending_consensus_transactions` (consensus-adapter
-    /// resubmit-on-restart), always reads empty.
-    #[default_options_override_fn = "pending_consensus_transactions_table_default_config"]
-    pending_consensus_transactions: DBMap<ConsensusTransactionKey, ConsensusTransaction>,
-
     /// The following table is used to store a single value (the corresponding key is a constant). The value
     /// represents the index of the latest consensus message this authority processed, running hash of
     /// transactions, and accumulated stats of consensus output.
@@ -1655,12 +1646,6 @@ pub struct AuthorityEpochTables {
     pub(crate) network_reconfiguration_output_digests: DBMap<ObjectID, [u8; 32]>,
 }
 
-fn pending_consensus_transactions_table_default_config() -> DBOptions {
-    default_db_options()
-        .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan(1 << 10)
-}
-
 fn verified_dwallet_checkpoint_messages_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
@@ -1736,14 +1721,6 @@ impl AuthorityEpochTables {
 
     pub fn path(epoch: EpochId, parent_path: &Path) -> PathBuf {
         parent_path.join(format!("{EPOCH_DB_PREFIX}{epoch}"))
-    }
-
-    pub fn get_all_pending_consensus_transactions(&self) -> IkaResult<Vec<ConsensusTransaction>> {
-        Ok(self
-            .pending_consensus_transactions
-            .safe_iter()
-            .map(|item| item.map(|(_k, v)| v))
-            .collect::<Result<Vec<_>, _>>()?)
     }
 
     pub fn get_last_consensus_index(&self) -> IkaResult<Option<ExecutionIndices>> {
@@ -2446,14 +2423,6 @@ impl AuthorityPerEpochStore {
                 })
             }
         }
-    }
-
-    pub fn get_all_pending_consensus_transactions(&self) -> Vec<ConsensusTransaction> {
-        // The except() here is on purpose, because the epoch can't run without it.
-        self.tables()
-            .expect("recovery should not cross epoch boundary")
-            .get_all_pending_consensus_transactions()
-            .expect("failed to get pending consensus transactions")
     }
 
     /// Returns true if all messages with the given keys were processed by consensus.

--- a/crates/ika-core/src/consensus_adapter.rs
+++ b/crates/ika-core/src/consensus_adapter.rs
@@ -293,22 +293,6 @@ impl ConsensusAdapter {
         self.consensus_throughput_profiler.store(Some(profiler))
     }
 
-    // todo - this probably need to hold some kind of lock to make sure epoch does not change while we are recovering
-    pub fn submit_recovered(self: &Arc<Self>, epoch_store: &Arc<AuthorityPerEpochStore>) {
-        // Currently narwhal worker might lose transactions on restart, so we need to resend them
-        // todo - get_all_pending_consensus_transactions is called twice when
-        // initializing AuthorityPerEpochStore and here, should not be a big deal but can be optimized
-        let recovered = epoch_store.get_all_pending_consensus_transactions();
-
-        debug!(
-            "Submitting {:?} recovered pending consensus transactions to consensus",
-            recovered.len()
-        );
-        for transaction in recovered {
-            self.submit_unchecked(&[transaction], epoch_store);
-        }
-    }
-
     fn await_submit_delay(
         &self,
         _committee: &Committee,
@@ -420,6 +404,13 @@ impl ConsensusAdapter {
         )
     }
 
+    /// Hands the transaction to an in-memory background task that retries
+    /// until it is sequenced by consensus — nothing is persisted, so an
+    /// in-flight transaction is lost if the process dies. That loss is
+    /// deliberate: every `ConsensusTransactionKind` submitter owns its own
+    /// restart story (regeneration, a re-submit-until-observed loop, or the
+    /// consensus replay re-driving it), so a restart-lost submission is
+    /// re-derived at the application layer, never replayed from here.
     pub fn submit_batch(
         self: &Arc<Self>,
         transactions: &[ConsensusTransaction],
@@ -427,7 +418,6 @@ impl ConsensusAdapter {
     ) -> IkaResult<JoinHandle<()>> {
         fp_ensure!(transactions.len() == 1, IkaError::InvalidTxKindInSoftBundle);
 
-        //epoch_store.insert_pending_consensus_transactions(transactions, lock)?;
         Ok(self.submit_unchecked(transactions, epoch_store))
     }
 
@@ -449,7 +439,6 @@ impl ConsensusAdapter {
         transactions: &[ConsensusTransaction],
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> JoinHandle<()> {
-        // Reconfiguration lock is dropped when pending_consensus_transactions is persisted, before it is handled by consensus
         let async_stage = self
             .clone()
             .submit_and_wait(transactions.to_vec(), epoch_store.clone());

--- a/crates/ika-core/src/dwallet_checkpoints/dwallet_checkpoint_output.rs
+++ b/crates/ika-core/src/dwallet_checkpoints/dwallet_checkpoint_output.rs
@@ -56,6 +56,14 @@ impl LogDWalletCheckpointOutput {
 
 #[async_trait]
 impl<T: SubmitToConsensus> DWalletCheckpointOutput for SubmitDWalletCheckpointToConsensus<T> {
+    /// This is the only submission of our signature for this checkpoint:
+    /// the builder never re-invokes the output for an already-built height,
+    /// and `submit_to_consensus` only hands the tx to an in-memory retry
+    /// task. A process death before sequencing therefore loses the
+    /// signature for good. Deliberate: certification needs a stake quorum,
+    /// not any specific signer, so one validator's lost signature is
+    /// absorbed — and if our own aggregator never certifies the height,
+    /// the certified checkpoint still arrives via state sync.
     #[instrument(level = "debug", skip_all)]
     async fn dwallet_checkpoint_created(
         &self,

--- a/crates/ika-core/src/epoch_tasks/announcement_relay.rs
+++ b/crates/ika-core/src/epoch_tasks/announcement_relay.rs
@@ -143,7 +143,7 @@ impl AnnouncementRelay for ConsensusBackedAnnouncementRelay {
         // accepted + forwarded it. Bounded: an honest joiner stops fanning
         // out once `min_accepts` relayers accept.
         //
-        // KNOWN GAP: returning Ok here acks the joiner at SUBMIT level —
+        // KNOWN GAP (#1943): returning Ok here acks the joiner at SUBMIT level —
         // `submit_to_consensus` only hands the tx to an in-memory retry
         // task, and this handler keeps no record and never re-submits. A
         // relayer that dies between this ack and sequencing loses the

--- a/crates/ika-core/src/epoch_tasks/announcement_relay.rs
+++ b/crates/ika-core/src/epoch_tasks/announcement_relay.rs
@@ -142,6 +142,17 @@ impl AnnouncementRelay for ConsensusBackedAnnouncementRelay {
         // without this record the committee side has no trace of having
         // accepted + forwarded it. Bounded: an honest joiner stops fanning
         // out once `min_accepts` relayers accept.
+        //
+        // KNOWN GAP: returning Ok here acks the joiner at SUBMIT level —
+        // `submit_to_consensus` only hands the tx to an in-memory retry
+        // task, and this handler keeps no record and never re-submits. A
+        // relayer that dies between this ack and sequencing loses the
+        // relay permanently; if every acking relayer does, the joiner's
+        // announcement never reaches consensus while its fanout loop
+        // believes it succeeded, and the joiner is excludable at the
+        // freeze. Fix direction: await the tx's processed notification
+        // (bounded) before acking, so a timeout keeps the joiner fanning
+        // out.
         info!(
             joiner = ?joiner,
             epoch = joiner_epoch,

--- a/crates/ika-core/src/epoch_tasks/mpc_data_announcement_sender.rs
+++ b/crates/ika-core/src/epoch_tasks/mpc_data_announcement_sender.rs
@@ -224,6 +224,19 @@ pub struct MpcDataAnnouncementSender {
     /// `verify_consensus_transaction` doesn't drop the re-emits —
     /// without this, only the first emit per (authority, epoch)
     /// would reach the strict-superset gate.
+    ///
+    /// KNOWN GAP: both this counter and
+    /// `last_emitted_validated_peers_count` are in-memory only, so a
+    /// mid-epoch restart resets them to 0. If an earlier emit landed
+    /// (its key is durably in `consensus_message_processed`) and a
+    /// later, wider re-emit was lost with the process, the restarted
+    /// sender re-emits the wider set under an already-processed
+    /// sequence number — every node drops it at verify time, and
+    /// since each later growth bumps the counter by one, every
+    /// re-emit stays dropped until the counter climbs past the
+    /// pre-restart maximum. Fix direction: initialize both counters
+    /// from this validator's own recorded ready signal in the
+    /// per-epoch store.
     next_sequence_number: std::sync::atomic::AtomicU64,
     /// Number of announcement submissions so far this epoch. Used
     /// only to bound logging: the first submission (and every 30th

--- a/crates/ika-core/src/epoch_tasks/mpc_data_announcement_sender.rs
+++ b/crates/ika-core/src/epoch_tasks/mpc_data_announcement_sender.rs
@@ -225,7 +225,7 @@ pub struct MpcDataAnnouncementSender {
     /// without this, only the first emit per (authority, epoch)
     /// would reach the strict-superset gate.
     ///
-    /// KNOWN GAP: both this counter and
+    /// KNOWN GAP (#1942): both this counter and
     /// `last_emitted_validated_peers_count` are in-memory only, so a
     /// mid-epoch restart resets them to 0. If an earlier emit landed
     /// (its key is durably in `consensus_message_processed`) and a

--- a/crates/ika-core/src/system_checkpoints/system_checkpoint_output.rs
+++ b/crates/ika-core/src/system_checkpoints/system_checkpoint_output.rs
@@ -56,6 +56,10 @@ impl LogSystemCheckpointOutput {
 
 #[async_trait]
 impl<T: SubmitToConsensus> SystemCheckpointOutput for SubmitSystemCheckpointToConsensus<T> {
+    /// This is the only submission of our signature for this checkpoint —
+    /// same restart-loss decision as `SubmitDWalletCheckpointToConsensus::
+    /// dwallet_checkpoint_created`: a signature lost to process death is
+    /// never re-sent; quorum certification and state sync absorb it.
     #[instrument(level = "debug", skip_all)]
     async fn system_checkpoint_created(
         &self,

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -1245,8 +1245,6 @@ impl IkaNode {
                 stranded_network_keys.clone(),
             )
             .await?;
-            // This is only needed during cold start.
-            components.consensus_adapter.submit_recovered(&epoch_store);
 
             Some(components)
         } else {
@@ -2357,6 +2355,14 @@ impl IkaNode {
                 .current_protocol_version
                 .set(config.version.as_u64() as i64);
 
+            // One-shot per epoch: a capability notification lost to process
+            // death before sequencing is never re-sent within the epoch (the
+            // consensus adapter persists nothing), leaving this validator's
+            // stake out of that epoch's protocol-upgrade tally. Deliberate:
+            // any process start re-enters this loop and regenerates the
+            // notification with a fresh, higher `generation`, which the
+            // `generation >=` guard in `record_capabilities_v1` prefers —
+            // regeneration supersedes anything a replay could deliver.
             let transaction =
                 ConsensusTransaction::new_capability_notification_v1(AuthorityCapabilitiesV1::new(
                     self.state.name,

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -129,10 +129,10 @@ pub enum ConsensusTransactionKey {
     /// signature inside V2 is not separately keyed; the consumer
     /// routes it through the handoff aggregator after extraction.
     EndOfPublishV2(AuthorityName),
-    // WIRE/DB-FORMAT DISCIPLINE: BCS-serialized as the key of persisted
-    // DBMaps (pending_consensus_transactions, consensus_message_processed)
-    // and rebuilt across binary upgrades - variants are APPEND-ONLY, same
-    // as ConsensusTransactionKind above.
+    // WIRE/DB-FORMAT DISCIPLINE: BCS-serialized as part of the key of the
+    // persisted `consensus_message_processed` DBMap and rebuilt across
+    // binary upgrades - variants are APPEND-ONLY, same as
+    // ConsensusTransactionKind above.
     /// A NOA sign presign demand, keyed by its `demand_id` digest ONLY (not
     /// authority), so redundant announcements of the same demand from different
     /// validators collapse to a single consensus transaction.


### PR DESCRIPTION
Closes #1935.

## The decision the issue asked for

#1935 found `pending_consensus_transactions` half-disabled: the persist in `ConsensusAdapter::submit_batch` commented out (since the initial fork import — it has never run in this repo), while `submit_recovered` still read the always-empty table at startup. The issue asked for a triage: enumerate every `ConsensusTransactionKind` variant, determine which (if any) had this recovery table as its only restart redelivery path, then either restore the persist or delete the scaffolding.

**Verdict: delete.** Every live variant already owns its restart story at the application layer, and for the state-carrying kinds a table replay would be actively wrong, not just redundant.

## Per-variant triage

| Variant | Restart redelivery | Mechanism |
|---|---|---|
| `DWalletMPCMessage` / `DWalletMPCOutput` / `DWalletInternalMPCOutput` | structural | `DWalletMPCService` replays the epoch's full consensus stream from round 0 (`last_read_consensus_round: None`); sessions rebuild in-memory and the advanceable round is recomputed and re-submitted. There is no "already sent" state to get wrong. |
| `EndOfPublishV2` | re-submit loop | `HandoffSignatureSender` 1s tick; trigger is chain-derived (watch re-asserted by the syncer), stop is the durable `end_of_publish` row written through the commit batch. |
| `ValidatorMpcDataAnnouncement` | re-submit loop | 2s tick until `get_validator_mpc_data_announcement` confirms; the cached announcement reuses the stored `timestamp_ms` so post-restart re-submits keep the same consensus key. |
| `GlobalPresignRequest` | demand loop | re-sent every service iteration until the request is seen back **from consensus** (`sent_presign_sequence_numbers` is populated only by our own request arriving in a commit). |
| `CapabilityNotificationV1` | regeneration | one-shot per epoch, but every process start regenerates with a fresh, higher `generation` that `record_capabilities_v1`'s `generation >=` guard prefers. A table-recovered copy would be stale — strictly worse than what restart already does. |
| `IdleStatusUpdate` | regeneration | edge-triggered on flip; `last_sent_idle_status` resets to `None` on restart, so the current status is re-sent with a fresh nonce. A replayed copy would carry a stale `is_idle`. |
| `SuiChainObservationUpdate` | n/a | dead path today (observation source is hardcoded `None`, existing FIXME). |
| `NOAObservation` / `NOAPresignDemand` | re-derivation / demand loop | NOA store is deliberately in-memory and re-derived from consensus replay; demand announcement is retried against the durable `has_noa_assigned_presign` gate and any single validator's announcement suffices (keyed by demand digest). Feature not live. |
| `EndOfPublish` (V1) | n/a | decode-only, never emitted. |
| `DWalletCheckpointSignature` / `SystemCheckpointSignature` | **none — accepted** | see below. |
| `EpochMpcDataReadySignal` | **gap — tracked separately** | see below. |
| `RelayedValidatorMpcDataAnnouncement` | **gap — tracked separately** | see below. |

### The accepted loss: checkpoint signatures

A signature submitted for a built checkpoint is not re-sent after restart (the builder resumes strictly after the last built height and never re-invokes the output). This PR makes that a stated decision rather than an accident, with a doc comment at both submitters: certification needs a stake quorum, not any particular signer, so one validator's lost signature is absorbed; if our own aggregator can't certify a height, the certified checkpoint arrives via state sync. Certification stalls only if in-flight-signature loss is simultaneous and wide enough to break quorum — the same exposure upstream Sui accepted (see precedent below).

### Two real gaps found by the audit (pre-existing, not created by this PR)

Neither is fixed here — each is better fixed at its own layer than by resurrecting a table whose replay semantics are wrong for half the variants. Both carry `KNOWN GAP` comments at the code site, citing their tracking issues:

1. **`EpochMpcDataReadySignal`** (#1942): the re-emit gates (`next_sequence_number`, `last_emitted_validated_peers_count`) are in-memory and reset to 0 on restart. If seq=0 landed and a wider seq=1 died with the process, the restarted sender re-emits the wider set as seq=0 — dropped everywhere by the `consensus_message_processed` dedup — and then goes quiet until the set grows further. Fix direction: initialize the counters from this validator's own recorded ready signal.
2. **`RelayedValidatorMpcDataAnnouncement`** (#1943): the relayer acks the joiner at submit level (one-shot handler, no record, no re-submit), and the joiner's bounded fanout stops on acks it cannot verify against consensus. Correlated relayer restarts inside the ack-to-sequencing window lose the joiner's announcement invisibly. Fix direction: ack only after the tx's processed notification.

## Upstream precedent

Sui deleted the identical mechanism: the recovery path had already been reduced to a state-derived `recover_end_of_publish` check, and the `pending_consensus_transactions` DBMap itself (including the same `optimize_for_large_values_no_scan` options fn) was removed in sui#25319 (April 2026). The pinned `mainnet-v1.73.2` retains only the same stale comment ika carried at `submit_unchecked` — also removed here.

## What changed

- `consensus_adapter.rs`: deleted `submit_recovered`, the commented-out persist, and the stale reconfiguration-lock comment; `submit_batch` now documents the durability contract (in-memory retry until sequenced; restart-loss owned per-kind by each submitter).
- `authority_per_epoch_store.rs`: deleted the `pending_consensus_transactions` DBMap, its options fn, and both `get_all_pending_consensus_transactions` readers. The `write-discipline: none` annotation from #1933 dissolves with the table (54 fields remain, check green).
- `ika-node/src/lib.rs`: deleted the cold-start `submit_recovered` call; documented the capability notification's regeneration-on-restart story at its submitter.
- `messages_consensus.rs`: `ConsensusTransactionKey` DB-format comment now cites only `consensus_message_processed` (the key type itself is unchanged — it remains the processed-marker key, so BCS discipline still applies).
- Checkpoint-signature submitters (both): restart-loss decision documented.
- `mpc_data_announcement_sender.rs` / `announcement_relay.rs`: `KNOWN GAP` notes for the two findings above.

DB compatibility: removing the DBMap field is safe for a mid-epoch restart on an upgraded binary — typed_store's `populate_missing_cfs` opens any on-disk column family not declared in the struct with default options, and per-epoch DBs are pruned at reconfiguration. Downgrade is equally safe (missing CFs are created on open). No wire-format change: the table was local-only and provably always empty.

## Verification

- `cargo check` and `cargo clippy --all-targets` on `ika-types`, `ika-core`, `ika-node`: clean (clippy covers test targets, so no test references the removed symbols)
- `./scripts/check-epoch-table-write-discipline.sh`: OK (54 fields)
- repo-wide grep: zero references to the table, its readers, or `submit_recovered` remain
- consensus-reviewer pass over the diff: safe to merge, all lenses clean; it independently confirmed the CF-name (not position) keying in typed_store's derive, the `generation >=` guard claim, the builder resume bound, and that both KNOWN GAP comments describe real pre-existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
