### PR TITLE
fix(committee): fail loudly when a committee cannot recover BLS-basis aliases

### DIFF
--- a/crates/ika-types/src/committee.rs
+++ b/crates/ika-types/src/committee.rs
@@ -335,11 +335,30 @@ impl Committee {
         match self.expanded_keys.get(authority) {
             Some(v) => Ok(v),
             None => Err(IkaError::InvalidCommittee(format!(
-                "Authority #{} not found, committee size {}",
+                "Authority #{} has no BLS protocol key in this committee ({} of {} members \
+                 carry one; a consensus-basis committee that verifies BLS certs must be \
+                 built with new_with_protocol_keys)",
                 authority,
-                self.expanded_keys.len()
+                self.expanded_keys.len(),
+                self.voting_rights.len()
             ))),
         }
+    }
+
+    /// Voting members with no entry in `expanded_keys` — their BLS-basis
+    /// alias is unrecoverable, so [`Committee::name_translation`] cannot map
+    /// prior-epoch items named under the BLS basis back to them. Empty for
+    /// every correctly built committee: BLS-basis names decode into
+    /// `expanded_keys` in [`Committee::load_inner`], and consensus-basis
+    /// committees carry the chain-read map via
+    /// [`Committee::new_with_protocol_keys`]. Non-empty means a
+    /// consensus-basis committee was mis-built through [`Committee::new`].
+    fn members_without_bls_protocol_key(&self) -> Vec<AuthorityName> {
+        self.voting_rights
+            .iter()
+            .filter(|(name, _)| !self.expanded_keys.contains_key(name))
+            .map(|(name, _)| *name)
+            .collect()
     }
 
     /// Maps each member's name under EITHER identity basis to the name this
@@ -353,7 +372,30 @@ impl Committee {
     /// itself; at the boundary this is what stops those lookups from silently
     /// missing every member. Derived from the committee's own key maps, so it
     /// needs no chain read.
+    ///
+    /// Logs a should-never-happen error when a member's BLS alias is
+    /// unrecoverable (no `expanded_keys` entry): every caller falls back to
+    /// identity on a missing entry, so without the log a consensus-basis
+    /// committee mis-built through [`Committee::new`] would silently
+    /// reinstate the boundary misses this map exists to prevent.
     pub fn name_translation(&self) -> HashMap<AuthorityName, AuthorityName> {
+        let missing_bls = self.members_without_bls_protocol_key();
+        if !missing_bls.is_empty() {
+            tracing::error!(
+                should_never_happen = true,
+                epoch = self.epoch,
+                members = self.voting_rights.len(),
+                missing = missing_bls.len(),
+                missing_members = ?missing_bls.iter().map(|name| name.concise()).collect::<Vec<_>>(),
+                "committee carries no BLS protocol key for some voting members, so their \
+                 BLS-basis aliases are unrecoverable and translation for them degrades to \
+                 identity — prior-epoch handoff-cert lookups (mpc_data carry-forward, \
+                 prior-cert key ingest, blob repair) will silently miss them at the \
+                 protocol-v6 identity-basis boundary. A committee with consensus-basis \
+                 names must be built with Committee::new_with_protocol_keys (chain-carried \
+                 BLS keys), never Committee::new"
+            );
+        }
         self.voting_rights
             .iter()
             .flat_map(|(name, _)| {
@@ -398,7 +440,7 @@ impl Committee {
             None => Err(IkaError::InvalidCommittee(format!(
                 "Authority #{} not found, committee size {}",
                 authority,
-                self.expanded_keys.len()
+                self.voting_rights.len()
             ))),
         }
     }
@@ -841,6 +883,117 @@ pub struct ValidatorEncryptionKeysAndProofs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::crypto::NetworkKeyPair;
+
+    /// `size` validators, each with a BLS protocol keypair and a seeded
+    /// Ed25519 consensus keypair, named under the CONSENSUS basis (the
+    /// protocol-v6 identity): `(consensus-basis name, consensus pubkey,
+    /// BLS pubkey)` per member.
+    fn consensus_basis_members(
+        size: usize,
+    ) -> Vec<(AuthorityName, NetworkPublicKey, AuthorityPublicKey)> {
+        let mut rng = StdRng::from_seed([7; 32]);
+        random_committee_key_pairs_of_size(size)
+            .iter()
+            .map(|bls| {
+                let consensus = NetworkKeyPair::generate(&mut rng).public().clone();
+                (
+                    AuthorityName::from_consensus_key(&consensus),
+                    consensus,
+                    bls.public().clone(),
+                )
+            })
+            .collect()
+    }
+
+    fn consensus_basis_voting_rights(
+        members: &[(AuthorityName, NetworkPublicKey, AuthorityPublicKey)],
+    ) -> Vec<(AuthorityName, StakeUnit)> {
+        members.iter().map(|(name, _, _)| (*name, 1)).collect()
+    }
+
+    fn consensus_keys_of(
+        members: &[(AuthorityName, NetworkPublicKey, AuthorityPublicKey)],
+    ) -> HashMap<AuthorityName, NetworkPublicKey> {
+        members
+            .iter()
+            .map(|(name, consensus, _)| (*name, consensus.clone()))
+            .collect()
+    }
+
+    fn protocol_keys_of(
+        members: &[(AuthorityName, NetworkPublicKey, AuthorityPublicKey)],
+    ) -> HashMap<AuthorityName, AuthorityPublicKey> {
+        members
+            .iter()
+            .map(|(name, _, bls)| (*name, bls.clone()))
+            .collect()
+    }
+
+    /// A BLS-basis committee decodes every member's BLS key from its name,
+    /// so translation aliases every member under both carried bases and the
+    /// missing-BLS-alias detector stays empty.
+    #[test]
+    fn bls_basis_committee_translates_every_member_to_itself() {
+        let (committee, _keys) = Committee::new_simple_test_committee_of_size(4);
+        assert!(committee.members_without_bls_protocol_key().is_empty());
+        let translation = committee.name_translation();
+        for name in committee.names() {
+            assert_eq!(translation.get(name), Some(name));
+        }
+    }
+
+    /// A consensus-basis committee built the required way
+    /// (`new_with_protocol_keys`) aliases each member's BLS-basis name to
+    /// its consensus-basis name — the protocol-v6 boundary translation.
+    #[test]
+    fn consensus_basis_committee_with_protocol_keys_translates_bls_aliases() {
+        let members = consensus_basis_members(4);
+        let committee = Committee::new_with_protocol_keys(
+            5,
+            consensus_basis_voting_rights(&members),
+            HashMap::new(),
+            consensus_keys_of(&members),
+            protocol_keys_of(&members),
+            3,
+            2,
+        );
+        assert!(committee.members_without_bls_protocol_key().is_empty());
+        let translation = committee.name_translation();
+        for (name, _, bls) in &members {
+            assert_eq!(translation.get(&AuthorityName::from(bls)), Some(name));
+            assert_eq!(translation.get(name), Some(name));
+        }
+    }
+
+    /// The same membership mis-built through `Committee::new`: consensus-basis
+    /// names decode as no BLS key, so every member's BLS alias is
+    /// unrecoverable — the silently-degraded state `name_translation` now
+    /// reports via its should-never-happen error log, whose predicate is
+    /// asserted here.
+    #[test]
+    fn consensus_basis_committee_via_new_has_no_recoverable_bls_aliases() {
+        let members = consensus_basis_members(4);
+        let committee = Committee::new(
+            5,
+            consensus_basis_voting_rights(&members),
+            HashMap::new(),
+            consensus_keys_of(&members),
+            3,
+            2,
+        );
+        assert_eq!(
+            committee.members_without_bls_protocol_key(),
+            members.iter().map(|(name, _, _)| *name).collect::<Vec<_>>()
+        );
+        let translation = committee.name_translation();
+        for (_, _, bls) in &members {
+            assert!(
+                !translation.contains_key(&AuthorityName::from(bls)),
+                "a mis-built committee cannot know the BLS alias"
+            );
+        }
+    }
 
     #[test]
     fn legacy_committee_record_decodes_via_fallback() {

--- a/dev-docs/specs/committee-consensus-keys.md
+++ b/dev-docs/specs/committee-consensus-keys.md
@@ -27,7 +27,20 @@ zero-padded consensus key, and the BLS keys are then carried explicitly
 too (`Committee::new_with_protocol_keys` — a consensus-basis name cannot
 be decoded into a BLS key, and BLS aggregate-certificate verification
 still needs it; `Committee::load_inner`'s name-decode is lossy, failing
-closed at `public_key()` instead of panicking).
+closed at `public_key()` instead of panicking). The lossy decode makes
+the split wiring-dependent: a consensus-basis committee mis-built through
+`Committee::new` carries an EMPTY `expanded_keys` with no construction
+error. `public_key()` on it fails closed per lookup, and
+`name_translation()` — whose callers all fall back to identity on a
+missing entry, so a degraded map would silently reinstate the boundary
+misses it exists to prevent — logs a `should_never_happen` error naming
+every member whose BLS alias is unrecoverable. Both production
+`Committee::new` sites that can carry consensus-basis names are safe by
+audit, not by type: the `SuiSyncer::new_committee` committees feed only
+the reconfiguration MPC input, and the prior-committee fetch
+(`pubkey_provider_updater.rs`) verifies handoff certs through
+`consensus_key()` only — neither reaches `public_key()` or
+`name_translation()`.
 
 **Identity-basis rule (v6 flip).** The basis of a committee's names is
 decided by the protocol version its builder evaluates
@@ -150,13 +163,12 @@ not count toward quorum.
 
 ## Where committees are built
 
-Three sites populate `consensus_keys`, all from chain:
+Two sites populate `consensus_keys`, both from chain:
 
 - **`EpochStartSystem::get_ika_committee`** (`ika-types/src/sui/epoch_start_system.rs`)
   — the current epoch's committee, from each active validator's
   `consensus_pubkey`. This is the CHAIN view; see the two-committee-objects
   warning in [`../learnings/pitfalls.md`](../learnings/pitfalls.md).
-- **`SuiSyncer::new_committee`** — the next epoch's committee.
 - **The prior-committee fetch** (`sui_connector/pubkey_provider_updater.rs`)
   — reconstructs the *previous* committee for handoff-certificate
   verification, reading each member's
@@ -164,6 +176,11 @@ Three sites populate `consensus_keys`, all from chain:
   the name from the `previous_committee` snapshot (invariant 2). Members
   absent from that snapshot, or whose `validator_info` fails `verify()`,
   are skipped (invariant 3).
+
+`SuiSyncer::new_committee` (the next-epoch committee assembled for the
+reconfiguration MPC input) deliberately carries an EMPTY map: that
+committee never verifies consensus-key-signed messages (invariant 4) —
+handoff verification uses the epoch store's `get_ika_committee` committee.
 
 `StaticConsensusPubkeyProvider` exists for tests and as the empty default
 before the syncer is up. It is not a production source.


### PR DESCRIPTION
## Summary

Audit follow-up requested in #1937 (related: #1938, #1911). #1911 split committee construction: `Committee::new_with_protocol_keys` carries the BLS protocol keys from the chain read, while `Committee::new` still derives `expanded_keys` by decoding the names. Under consensus-basis names (protocol v6) nothing decodes, `expanded_keys` is silently empty, and `name_translation()` — the v6 boundary-translation mechanism — degrades to identity with no error: all three callers (`authority_per_epoch_store` mpc_data carry-forward, `mpc_manager` prior-cert key ingest, `peer_blob_fetcher`) fall back to identity on a missing entry, silently reinstating exactly the boundary misses #1911 fixed. Today the safety is wiring-dependent: both production epoch-store committees come from `new_with_protocol_keys`, but nothing asserts that.

## The guard (option b of the audit, sharpened)

`name_translation()` now logs a `should_never_happen` error naming every voting member whose BLS alias is unrecoverable (no `expanded_keys` entry). The predicate is exact:

- BLS-basis names always decode into `expanded_keys` in `load_inner` → silent.
- Consensus-basis committees built with `new_with_protocol_keys` carry the full chain-read map (`build_ika_committee` populates it for every member) → silent.
- A consensus-basis committee mis-built through `Committee::new` → fires, naming the members.

It deliberately checks only BLS-alias coverage, not `consensus_keys` coverage — the freeze tests (and legacy/test committees generally) legitimately carry empty `consensus_keys`, and the boundary items that matter at the v6 flip are BLS-named.

**Why not a construction-time signal (option a):** `Committee::new` legitimately builds consensus-basis committees today — the `SuiSyncer::new_committee` reconfiguration-input committees and the prior-committee handoff fetch (`pubkey_provider_updater.rs`) — so any unconditional signal in `new` cries wolf every sync tick under v6, and distinguishing the cases needs a signature change across ~13 call sites. A restored `debug_assert` is dead weight under this repo's release-mode test convention. The translation site is the choke point where misuse becomes harmful, and erroring there (vs logging) would turn a latent wiring bug into a freeze-path liveness failure — worse than the loud log plus the existing fail-closed behavior.

**Audit of the risky call sites (option c):** neither `sui_syncer.rs` committee (both key maps empty; feeds only the reconfiguration MPC input) nor the `pubkey_provider_updater.rs` prior committee (verifies handoff certs via `consensus_key()` only) reaches `public_key()` or `name_translation()`. `new_at_next_epoch_for_testing` currently has no callers. Recorded in the spec as safe **by audit, not by type**.

## Diagnostics sharpened on the same misuse

- `public_key()` miss now reports "N of M members carry a BLS key" plus a pointer to `new_with_protocol_keys` (previously "committee size 0", implying an empty committee).
- `class_groups_public_key_and_proof()` no longer reports `expanded_keys.len()` — the wrong map — as the committee size.

## Spec

`dev-docs/specs/committee-consensus-keys.md` updated in the same PR: the wiring-dependence, the guard, and the by-audit status of the two `Committee::new` consensus-basis sites. Also fixed a stale claim found while editing: the spec said three sites populate `consensus_keys` including `SuiSyncer::new_committee`, but the syncer deliberately passes an empty map (handoff verification uses the epoch store's committee) — now two sites, with the syncer's empty map documented as deliberate.

## Validation

- New unit tests pin the predicate across all three committee shapes (BLS-basis via `new`, consensus-basis via `new_with_protocol_keys` — including BLS-alias → consensus-name translation — and consensus-basis mis-built via `new`).
- `cargo test --release -p ika-types committee::` 5/5.
- `cargo test --release -p ika-core -- authority_per_epoch_store::tests mpc_manager::tests` 21/21 — the freeze/carry-forward tests exercise `name_translation()` and confirm the guard stays silent on every legitimate committee shape (no false positives).
- `cargo clippy --release -p ika-types --all-targets --all-features` clean; `cargo fmt --all` no-op beyond the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)