### PR TITLE
fix(node): derive every node self-identity from the epoch store's name (#1937 follow-up)

### DIFF
--- a/crates/ika-core/src/authority.rs
+++ b/crates/ika-core/src/authority.rs
@@ -40,7 +40,7 @@ use crate::epoch::committee_store::CommitteeStore;
 use ika_config::node::AuthorityOverloadConfig;
 use ika_types::{
     committee::Committee,
-    crypto::{AuthorityName, AuthoritySignature},
+    crypto::AuthoritySignature,
     error::{IkaError, IkaResult},
 };
 use sui_types::base_types::*;
@@ -241,10 +241,14 @@ impl AuthorityStateTrait for AuthorityState {
 }
 
 pub struct AuthorityState {
-    // Fixed size, static, identity of the authority
-    /// The name of this authority.
-    pub name: AuthorityName,
-    /// The signature key of the authority.
+    // Deliberately no `name` field: `AuthorityName` is per-epoch, not static
+    // — its basis is the BLS protocol key below protocol v6 and the consensus
+    // key from v6, so the node's committee identity lives on
+    // `AuthorityPerEpochStore::name` (re-derived for each epoch's basis at
+    // reconfiguration). A name minted once at startup goes stale at the
+    // activation boundary and misreports membership against later committees.
+    /// The BLS signature key of the authority (static; signs aggregate stake
+    /// certificates regardless of which key the committee is named by).
     pub secret: StableSyncAuthoritySigner,
 
     pub(crate) perpetual_tables: Arc<AuthorityPerpetualTables>,
@@ -273,12 +277,10 @@ pub struct AuthorityState {
 /// Repeating valid commands should produce no changes and return no error.
 impl AuthorityState {
     pub fn is_validator(&self, epoch_store: &AuthorityPerEpochStore) -> bool {
-        // Against the EPOCH STORE's name, not `self.name`: `self.name` is
-        // minted once at startup, while `AuthorityName`'s basis (BLS protocol
-        // key below protocol v6, consensus key from v6) is a property of the
-        // epoch. Comparing the startup name against a later epoch's committee
-        // makes a sitting validator conclude it is no longer a member the
-        // moment the basis flips.
+        // The epoch store's name: `AuthorityName`'s basis (BLS protocol key
+        // below protocol v6, consensus key from v6) is a property of the
+        // epoch, so membership is only meaningful for a name derived under
+        // the same epoch as the committee it is checked against.
         epoch_store.committee().authority_exists(&epoch_store.name)
     }
 
@@ -327,7 +329,6 @@ impl AuthorityState {
     }
 
     pub async fn new(
-        name: AuthorityName,
         secret: StableSyncAuthoritySigner,
         supported_protocol_versions: SupportedProtocolVersions,
         perpetual_tables: Arc<AuthorityPerpetualTables>,
@@ -355,7 +356,6 @@ impl AuthorityState {
         let epoch = epoch_store.epoch();
 
         Arc::new(AuthorityState {
-            name,
             secret,
             perpetual_tables,
             execution_lock: RwLock::new(epoch),
@@ -686,12 +686,13 @@ impl AuthorityState {
         );
         fail_point!("before-open-new-epoch-store");
         // Re-derive our own committee identity for the NEW epoch's basis
-        // rather than carrying `self.name` forward. `AuthorityName` is the
-        // BLS protocol key below protocol v6 and the consensus key from v6,
-        // so at the activation boundary a name minted for the previous epoch
-        // is simply absent from the new committee — the node would conclude
-        // it is "no longer a validator" and silently drop out of its own
-        // committee (observed in the v1.2.5 -> v6 upgrade rehearsal).
+        // rather than carrying the outgoing epoch's name forward.
+        // `AuthorityName` is the BLS protocol key below protocol v6 and the
+        // consensus key from v6, so at the activation boundary a name minted
+        // for the previous epoch is simply absent from the new committee —
+        // the node would conclude it is "no longer a validator" and silently
+        // drop out of its own committee (observed in the v1.2.5 -> v6
+        // upgrade rehearsal).
         let name = self.config.authority_name(
             epoch_start_configuration
                 .epoch_start_state()

--- a/crates/ika-core/src/dwallet_checkpoints/mod.rs
+++ b/crates/ika-core/src/dwallet_checkpoints/mod.rs
@@ -1034,7 +1034,7 @@ impl DWalletCheckpointSignatureAggregator {
                 sequence_number=local_checkpoint_message.sequence_number,
                 ?digests_by_stake_messages,
                 remaining_stake=self.signatures_by_digest.uncommitted_stake(),
-                local_validator=?self.state.name,
+                local_validator=?epoch_store.name,
                 ?digest_to_validators,
                 ?local_checkpoint_message,
                 ?committee,

--- a/crates/ika-core/src/system_checkpoints/mod.rs
+++ b/crates/ika-core/src/system_checkpoints/mod.rs
@@ -963,7 +963,7 @@ impl SystemCheckpointSignatureAggregator {
                 sequence_number=local_checkpoint_message.sequence_number,
                 ?digests_by_stake_messages,
                 remaining_stake=self.signatures_by_digest.uncommitted_stake(),
-                local_validator=?self.state.name,
+                local_validator=?epoch_store.name,
                 ?digest_to_validators,
                 ?local_checkpoint_message,
                 ?committee,

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -253,7 +253,14 @@ pub struct IkaNode {
 impl fmt::Debug for IkaNode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("IkaNode")
-            .field("name", &self.state.name.concise())
+            .field(
+                "name",
+                &self
+                    .state
+                    .load_epoch_store_one_call_per_task()
+                    .name
+                    .concise(),
+            )
             .finish()
     }
 }
@@ -420,7 +427,6 @@ impl IkaNode {
             dwallet_checkpoint_store.clone(),
             system_checkpoint_store.clone(),
         );
-        let authority_name = config.protocol_public_key();
         let archive_readers =
             ArchiveReaderBalancer::new(config.archive_reader_config(), &prometheus_registry)?;
         let (trusted_peer_change_tx, trusted_peer_change_rx) = watch::channel(Default::default());
@@ -867,6 +873,20 @@ impl IkaNode {
             // Built before the bootstrap reads (see the transport gate); reuse.
             p2p
         } else {
+            // state_sync's pull mode ("notifier") is committee membership
+            // under THIS epoch's name basis — `epoch_store.name`, the
+            // consensus key from protocol v6. The BLS protocol key is absent
+            // from a consensus-basis committee, so deriving this from it
+            // would make a validator restarting after the v6 flip boot
+            // state-sync as a pull-mode non-committee node.
+            let is_state_sync_notifier =
+                !epoch_store.committee().authority_exists(&epoch_store.name);
+            info!(
+                name = ?epoch_store.name.concise(),
+                consensus_key_identity,
+                is_state_sync_notifier,
+                "state-sync boot identity"
+            );
             Self::create_p2p_network(
                 &config,
                 state_sync_store.clone(),
@@ -874,7 +894,7 @@ impl IkaNode {
                 trusted_peer_change_rx,
                 archive_readers.clone(),
                 &prometheus_registry,
-                !epoch_store.committee().authority_exists(&authority_name),
+                is_state_sync_notifier,
                 on_chain_checkpoint_cursors.clone(),
                 perpetual_tables.clone(),
                 sui_state_mirror_server,
@@ -1091,7 +1111,6 @@ impl IkaNode {
 
         info!("create authority state");
         let state = AuthorityState::new(
-            authority_name,
             secret,
             config.supported_protocol_versions.unwrap(),
             perpetual_tables.clone(),
@@ -1895,7 +1914,10 @@ impl IkaNode {
         let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
             &committee,
             consensus_config,
-            state.name,
+            // The epoch store's name, not a startup-minted one: the adapter's
+            // committee is this epoch's, and the name basis (BLS below
+            // protocol v6, consensus key from v6) is a property of the epoch.
+            epoch_store.name,
             connection_monitor_status.clone(),
             &registry_service.default_registry(),
             epoch_store.protocol_config().clone(),
@@ -2359,7 +2381,14 @@ impl IkaNode {
 
             let transaction =
                 ConsensusTransaction::new_capability_notification_v1(AuthorityCapabilitiesV1::new(
-                    self.state.name,
+                    // MUST be this epoch's name: consensus attributes the
+                    // submission under the epoch committee's basis, and
+                    // `verify_consensus_transaction` drops a capability whose
+                    // `authority` field disagrees with that attribution — a
+                    // BLS-basis name here silences every capability vote (and
+                    // with it all future upgrades) once the committee is
+                    // consensus-key-named.
+                    cur_epoch_store.name,
                     cur_epoch_store.get_chain_identifier().chain(),
                     self.config
                         .supported_protocol_versions

--- a/crates/ika-upgrade-test/src/scenario.rs
+++ b/crates/ika-upgrade-test/src/scenario.rs
@@ -133,6 +133,15 @@ pub enum Step {
         needle: String,
         present: bool,
     },
+    /// Assert ONE validator's `node.log` contains `needle`. Logs are
+    /// truncated on each (re)start, so this is the probe for a boot-time
+    /// decision of a specific validator — the whole-cluster
+    /// [`Step::ExpectLogLine`] would demand the line of validators whose
+    /// last boot predates the condition under test.
+    ExpectLogLineOnValidator {
+        index: usize,
+        needle: String,
+    },
 }
 
 impl std::fmt::Display for Step {
@@ -210,6 +219,12 @@ impl std::fmt::Display for Step {
             Step::ExpectLogLine { needle, present } => {
                 let polarity = if *present { "present" } else { "absent" };
                 write!(f, "expect_log_line_{polarity}({needle:?})")
+            }
+            Step::ExpectLogLineOnValidator { index, needle } => {
+                write!(
+                    f,
+                    "expect_log_line_present_on_validator({index}, {needle:?})"
+                )
             }
         }
     }
@@ -528,6 +543,21 @@ impl Scenario {
         self.steps.push(Step::ExpectLogLine {
             needle: needle.into(),
             present: false,
+        });
+        self
+    }
+
+    /// Assert the validator at `index`'s `node.log` contains `needle`. See
+    /// [`Step::ExpectLogLineOnValidator`] for when to prefer this over the
+    /// whole-cluster assertion.
+    pub fn expect_log_line_present_on_validator(
+        mut self,
+        index: usize,
+        needle: impl Into<String>,
+    ) -> Self {
+        self.steps.push(Step::ExpectLogLineOnValidator {
+            index,
+            needle: needle.into(),
         });
         self
     }
@@ -925,6 +955,28 @@ impl Scenario {
                         needle = needle.as_str(),
                         present = *present,
                         "log-line assertion passed on every expected validator"
+                    );
+                }
+                Step::ExpectLogLineOnValidator { index, needle } => {
+                    let c = cluster
+                        .as_ref()
+                        .context("ExpectLogLineOnValidator before StartAll")?;
+                    let proc = c
+                        .validators
+                        .get(*index)
+                        .with_context(|| format!("validator index {index} out of range"))?;
+                    let log = std::fs::read_to_string(proc.log_path()).with_context(|| {
+                        format!("read validator log {}", proc.log_path().display())
+                    })?;
+                    ensure!(
+                        log.contains(needle.as_str()),
+                        "expected {needle:?} to be present in {}, but it was absent",
+                        proc.log_path().display(),
+                    );
+                    tracing::info!(
+                        index = *index,
+                        needle = needle.as_str(),
+                        "per-validator log-line assertion passed"
                     );
                 }
                 Step::RunWorkload { label } => {

--- a/crates/ika-upgrade-test/tests/v125_v6_upgrade.rs
+++ b/crates/ika-upgrade-test/tests/v125_v6_upgrade.rs
@@ -36,6 +36,12 @@
 //!    resolve under the other basis (`expect_committee_size(4)`).
 //! 4. **Users keep being served** across the flip, on state (RocksDB, network
 //!    key) created by the literal v1.2.5 release under BLS-basis names.
+//! 5. **A restart against the consensus-basis committee re-joins as a
+//!    member.** One validator is rebooted after the flip and must derive its
+//!    startup identity under the epoch's basis — a BLS-derived startup name is
+//!    absent from a v6 committee, which would boot state-sync in pull mode as
+//!    a non-member ("notifier") — and must then carry its duties across the
+//!    next epoch boundary.
 //!
 //! Genesis is protocol v5 (`ProtocolVersion::MIN`), which the deployed
 //! v1.2.5 release supports; the current build advertises `MIN..=MAX` = 5..=6,
@@ -138,7 +144,7 @@ async fn v125_upgrade_activates_v6_and_flips_authority_names() {
         // must survive the flip.
         .run_workload("v125-at-v5-pre-flip")
         // ── Full committee swap: every validator moves to the current build. ─
-        .stop_and_swap(&[0, 1, 2, 3], current)
+        .stop_and_swap(&[0, 1, 2, 3], current.clone())
         .expect_all_validators_healthy()
         // With n=4 the default 50% buffer stake requires all four capability
         // votes at the tally, and a fresh capability can land just after it;
@@ -179,9 +185,31 @@ async fn v125_upgrade_activates_v6_and_flips_authority_names() {
         .expect_reconfiguration_output_version_at_least(4)
         .expect_log_line_absent("node recognized itself as malicious")
         .expect_log_line_absent("recognized_self_as_malicious")
+        // ── Restart-after-flip: reboot one validator (same binary) against
+        //    the now consensus-basis committee. Startup must derive the
+        //    node's identity under the EPOCH's basis; a BLS-derived startup
+        //    name is absent from a v6 committee, so the node would boot
+        //    state-sync in pull mode as a non-member ("notifier").
+        .stop_and_swap(&[1], current)
+        .expect_all_validators_healthy()
+        // The restarted validator's boot-identity line (its log truncates on
+        // restart, so only the post-flip boot is visible): consensus-key
+        // basis AND recognized committee membership.
+        .expect_log_line_present_on_validator(
+            1,
+            "consensus_key_identity=true is_state_sync_notifier=false",
+        )
         // Users must still be served after the flip, on the v1.2.5-origin
-        // network key and against dWallets created before it.
+        // network key and against dWallets created before it — with the
+        // restarted member back in the committee.
         .run_workload("post-flip-at-v6")
+        // Re-joining means carrying duties across the NEXT boundary
+        // (mpc_data announcement, freeze, reshare), not merely reporting
+        // membership at boot: the epoch cannot advance without the restarted
+        // member's participation converging.
+        .wait_for_epoch(5)
+        .wait_for_all_validators_local_epoch(5)
+        .expect_all_validators_healthy()
         // Whole-run backstops: a late diverging output or a consensus
         // submission failure is a hard failure even if every polled gate
         // above happened to pass.
@@ -191,12 +219,15 @@ async fn v125_upgrade_activates_v6_and_flips_authority_names() {
         .await
         .expect(
             "literal v1.2.5 committee must upgrade to protocol v6, flip authority names to \
-             the consensus key, and keep converging and serving across the boundary",
+             the consensus key, keep converging and serving across the boundary, and \
+             re-admit a restarted validator as a committee member",
         );
 
     tracing::info!(
         "v125 -> v6 upgrade PASSED: literal v1.2.5 committee crossed v5 -> v6, authority \
          names flipped to the consensus key, both boundary and steady-state reshares \
-         converged, and users were served throughout"
+         converged, users were served throughout, and a validator restarted after the \
+         flip re-joined as a committee member (not a notifier) and crossed the next \
+         epoch boundary"
     );
 }

--- a/dev-docs/specs/committee-consensus-keys.md
+++ b/dev-docs/specs/committee-consensus-keys.md
@@ -82,6 +82,27 @@ decision. Two known gaps come with it:
    THIS, not an incident. It self-heals the following epoch, when the member
    announces under its new identity.
 
+**Node-side naming discipline.** A node's own `AuthorityName` is
+per-epoch state, never process state: it lives on
+`AuthorityPerEpochStore::name` (derived by `NodeConfig::authority_name`
+from the basis recorded on the epoch's `EpochStartSystem` — at boot and
+again at every reconfiguration), and `AuthorityState` deliberately
+carries no name field. Every self-identifying value the node emits must
+read the epoch store's name: the state-sync notifier decision at boot,
+`ConsensusAdapter`'s own-position lookup, capability notifications,
+checkpoint-signature attribution, and log fields. A name minted once at
+process start (historically the BLS protocol key) is absent from a
+consensus-basis committee, with two concrete failure modes: a validator
+restarting after the flip boots state-sync in pull mode as a non-member,
+and a capability notification naming the BLS key is dropped by
+`verify_consensus_transaction` (consensus attributes the submission
+under the committee's basis), silencing the node's upgrade vote — on a
+whole fleet of startup-minted names, no post-v6 protocol or Move
+upgrade can ever pass. Restart-after-flip is covered by the
+`v125_v6_upgrade` scenario: one validator reboots after activation and
+must log a consensus-basis, committee-member state-sync boot identity,
+then cross the next epoch boundary.
+
 **Why the 48-byte container is not ambiguous across bases.** A
 consensus-basis name is the 32-byte Ed25519 key followed by 16 zero bytes;
 a BLS-basis name is a valid BLS12-381 G1 point. For the two to collide an


### PR DESCRIPTION
## Summary

Audit follow-up requested in #1937 (the "any other product path that grew a second identity basis" sweep). #1911 made `AuthorityName` per-epoch (BLS protocol key below protocol v6, consensus key from v6) and made the epoch store's name basis-aware — but `AuthorityState.name` was still minted once at startup from `protocol_public_key()` (always BLS) and never updated. Two live consequences on a v6 network:

1. **Restart-after-flip boots state-sync in pull mode.** The `is_notifier` argument to `create_p2p_network` compared the BLS startup name against a consensus-basis committee; a validator restarting after the v5→v6 flip found itself "absent" and booted state-sync as a non-committee pull node.
2. **Every capability vote silently dropped — all future upgrades blocked.** The capability notification in `monitor_reconfiguration` carried the BLS `state.name`; `verify_consensus_transaction` drops a capability whose `authority` field disagrees with the consensus-attributed (committee-basis) author. On a v6 committee every validator's vote was discarded **at the receiver** while the sender saw success — no post-v6 protocol or Move-contract upgrade could ever tally.

Latent: `ConsensusAdapter.authority` (its `submission_position` path panics in `get_position_in_list` under a consensus-basis committee) and three log sites printing a name that appears in no v6 committee log.

## Fix

**`AuthorityState.name` is deleted.** Its "fixed, static identity" contract broke at the flip, it had zero load-bearing internal uses, and every consumer wants the per-epoch name. All consumers now read `AuthorityPerEpochStore::name` (re-derived under each epoch's recorded basis at boot and reconfiguration): the state-sync notifier derivation (now a named local with a boot-identity info line), the `ConsensusAdapter` authority, capability notifications, the `IkaNode` Debug name, and both split-brain log sites. The remaining `protocol_public_key()` call sites were audited: the trusted-peer refresher self-excludes under both bases (safe) and the boot banner is config-level identity, not committee membership.

## Coverage

`v125_v6_upgrade` now restarts validator 1 after the flip (same-binary `stop_and_swap`), asserts its post-restart log reports `consensus_key_identity=true is_state_sync_notifier=false` (new `expect_log_line_present_on_validator` scenario step — the whole-cluster log step would demand the line of validators whose last boot predates the flip), then crosses to epoch 5 with all validators local so the restarted member's announcement/freeze/reshare duties are exercised, not just its boot report.

Spec updated in the same PR: `dev-docs/specs/committee-consensus-keys.md` (node-side naming discipline).

## Validation

- `cargo clippy --release --all-targets -p ika-core -p ika-node -p ika-upgrade-test` clean; all `ika-upgrade-test` unit tests pass.
- Fix run (must pass): [run 30301089098](https://github.com/dwallet-labs/ika/actions/runs/30301089098) — `v125_v6_upgrade` on this branch.
- Test-testing fault run (must FAIL at the new log assertion): [run 30301149258](https://github.com/dwallet-labs/ika/actions/runs/30301149258) — branch `claude/bold-taussig-0f7389-fault` reintroduces the BLS-basis derivation with the log line kept, so the restarted validator logs `is_state_sync_notifier=true`.

Verdicts will be reported on this PR.

Fixes the node-side portion of the #1937 audit; the harness-side registration fix is #1938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)