### PR TITLE
fix(dwallet-mpc): re-buffer NOA observations and presign demands whose consensus submit failed

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -422,6 +422,42 @@ impl DWalletMPCService {
         self.last_read_consensus_round
     }
 
+    #[cfg(any(test, feature = "test-utils"))]
+    #[allow(dead_code)]
+    pub(crate) async fn send_status_update_to_consensus_for_testing(&mut self, is_idle: bool) {
+        self.send_status_update_to_consensus(is_idle).await
+    }
+
+    #[cfg(any(test, feature = "test-utils"))]
+    #[allow(dead_code)]
+    pub(crate) fn buffer_noa_observation_for_testing(
+        &mut self,
+        observation: NOACheckpointTxObservation,
+    ) {
+        self.buffered_noa_observations.push(observation);
+    }
+
+    #[cfg(any(test, feature = "test-utils"))]
+    #[allow(dead_code)]
+    pub(crate) fn buffered_noa_observations_for_testing(&self) -> &[NOACheckpointTxObservation] {
+        &self.buffered_noa_observations
+    }
+
+    #[cfg(any(test, feature = "test-utils"))]
+    #[allow(dead_code)]
+    pub(crate) fn buffer_noa_presign_demand_for_testing(
+        &mut self,
+        demand: ConsensusNOAPresignDemand,
+    ) {
+        self.buffered_noa_presign_demands.push(demand);
+    }
+
+    #[cfg(any(test, feature = "test-utils"))]
+    #[allow(dead_code)]
+    pub(crate) fn buffered_noa_presign_demands_for_testing(&self) -> &[ConsensusNOAPresignDemand] {
+        &self.buffered_noa_presign_demands
+    }
+
     /// Wire up NOA checkpoint handlers for testing.
     ///
     /// `new_for_testing` creates a disconnected sign-output receiver (the connected one
@@ -845,16 +881,23 @@ impl DWalletMPCService {
             }
         }
 
-        // One message per buffered NOA observation.
+        // One message per buffered NOA observation. On submit failure, re-buffer
+        // the observation for the next status update: its producer is one-shot
+        // (the checkpoint handler marks a tx confirmed-locally / voted-failed
+        // BEFORE emitting the observation), so a dropped observation would never
+        // be re-emitted and this validator's finalize/fail vote would be silently
+        // lost. Retrying a submission that actually landed is harmless — the
+        // observation tally is a per-authority set.
         let noa_observations = std::mem::take(&mut self.buffered_noa_observations);
-        for obs in &noa_observations {
+        for obs in noa_observations {
             let tx = ConsensusTransaction::new_noa_observation(self.name, obs.clone());
             if let Err(e) = self
                 .dwallet_submit_to_consensus
                 .submit_to_consensus(&[tx])
                 .await
             {
-                error!(error = ?e, consensus_round, "Failed to submit NOA observation");
+                error!(error = ?e, consensus_round, "Failed to submit NOA observation; re-buffering for retry");
+                self.buffered_noa_observations.push(obs);
             }
         }
 
@@ -862,12 +905,16 @@ impl DWalletMPCService {
         // for wire safety — the `NOAPresignDemand` consensus kind must never reach
         // a peer that predates it. Consensus dedups cross-validator duplicates by
         // the demand-id digest key, and the assignment drain is idempotent.
+        // On submit failure, re-buffer the demand for the next status update:
+        // `announced_noa_demand_digests` marks a demand announced when it is
+        // buffered, so a dropped demand would never be re-announced by this
+        // validator.
         if self.protocol_config.noa_checkpoints() {
             let noa_presign_demands = std::mem::take(&mut self.buffered_noa_presign_demands);
             for demand in noa_presign_demands {
                 let tx = ConsensusTransaction::new_noa_presign_demand(
                     demand.authority,
-                    demand.demand_id,
+                    demand.demand_id.clone(),
                     demand.signature_algorithm,
                     demand.network_encryption_key_id,
                 );
@@ -876,7 +923,8 @@ impl DWalletMPCService {
                     .submit_to_consensus(&[tx])
                     .await
                 {
-                    error!(error = ?e, consensus_round, "Failed to submit NOA presign demand");
+                    error!(error = ?e, consensus_round, "Failed to submit NOA presign demand; re-buffering for retry");
+                    self.buffered_noa_presign_demands.push(demand);
                 }
             }
         }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/noa_checkpoint.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/noa_checkpoint.rs
@@ -10,20 +10,28 @@
 //! - Failure/retry through consensus
 //! - Dual-handler (DWallet + System) simultaneous routing
 
+use std::slice::from_ref;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use async_trait::async_trait;
 use dwallet_mpc_types::dwallet_mpc::DWalletSignatureAlgorithm;
 use ika_types::message::DWalletCheckpointMessageKind;
+use ika_types::messages_consensus::ConsensusTransactionKind;
+use ika_types::messages_dwallet_mpc::ConsensusNOAPresignDemand;
 use ika_types::messages_system_checkpoints::SystemCheckpointMessageKind;
-use ika_types::noa_checkpoint::{SuiChainContext, SuiDWalletCheckpoint, SuiSystemCheckpoint};
+use ika_types::noa_checkpoint::{
+    NOACheckpointKindName, NOACheckpointTxObservation, NOACheckpointTxRef, NOAPresignDemandId,
+    SuiChainContext, SuiDWalletCheckpoint, SuiSystemCheckpoint,
+};
+use sui_types::base_types::ObjectID;
 use tracing::info;
 
 use crate::dwallet_mpc::integration_tests::network_dkg::create_network_key_test;
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::{
     IntegrationTestState, build_test_state, create_test_protocol_config_guard,
+    create_test_protocol_config_guard_with_noa_checkpoints,
 };
 use crate::noa_checkpoints::{NOAChainSubmitter, NOACheckpointHandler, TxExecutionStatus};
 
@@ -537,4 +545,100 @@ async fn test_noa_checkpoint_both_handlers() {
             i
         );
     }
+}
+
+// ── Test 5: consensus submit failure → re-buffer ───────────────────────────────
+
+/// A failed consensus submission must not drop buffered NOA observations or
+/// presign demands. Their producers are one-shot — the checkpoint handler marks
+/// a tx confirmed-locally / voted-failed BEFORE emitting its observation, and a
+/// presign demand is announced at most once per epoch — so a dropped item is
+/// never re-emitted and this validator's finalization vote (or demand
+/// announcement) would be silently lost. The service must re-buffer failed
+/// items and resend them once consensus submission recovers.
+#[tokio::test]
+#[cfg(test)]
+async fn test_noa_status_update_rebuffers_on_submit_failure() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
+
+    let mut test_state = build_test_state(1);
+    let authority = *test_state.committee.names().next().unwrap();
+    let collector = test_state.sent_consensus_messages_collectors[0].clone();
+    let service = &mut test_state.dwallet_mpc_services[0];
+
+    let tx_ref = NOACheckpointTxRef {
+        kind_name: NOACheckpointKindName::SuiDWallet,
+        sequence_number: 1,
+        tx_index: 0,
+        epoch: 1,
+    };
+    let observation = NOACheckpointTxObservation::Finalized(tx_ref.clone());
+    let demand = ConsensusNOAPresignDemand {
+        authority,
+        demand_id: NOAPresignDemandId::Checkpoint {
+            tx_ref,
+            retry_round: 0,
+        },
+        signature_algorithm: DWalletSignatureAlgorithm::EdDSA,
+        network_encryption_key_id: ObjectID::random(),
+    };
+    service.buffer_noa_observation_for_testing(observation.clone());
+    service.buffer_noa_presign_demand_for_testing(demand.clone());
+
+    // While consensus submission fails, both items must survive in their buffers.
+    collector.fail_submissions.store(true, Ordering::SeqCst);
+    service
+        .send_status_update_to_consensus_for_testing(false)
+        .await;
+
+    assert_eq!(
+        service.buffered_noa_observations_for_testing(),
+        from_ref(&observation),
+        "failed observation submission must re-buffer the observation"
+    );
+    assert_eq!(
+        service.buffered_noa_presign_demands_for_testing(),
+        from_ref(&demand),
+        "failed presign demand submission must re-buffer the demand"
+    );
+    assert!(
+        collector.submitted_messages.lock().unwrap().is_empty(),
+        "no message reaches consensus while submission fails"
+    );
+
+    // Once submission recovers, the retained items drain exactly once.
+    collector.fail_submissions.store(false, Ordering::SeqCst);
+    service
+        .send_status_update_to_consensus_for_testing(false)
+        .await;
+
+    assert!(
+        service.buffered_noa_observations_for_testing().is_empty(),
+        "observation buffer must drain after a successful submission"
+    );
+    assert!(
+        service
+            .buffered_noa_presign_demands_for_testing()
+            .is_empty(),
+        "presign demand buffer must drain after a successful submission"
+    );
+
+    let submitted = collector.submitted_messages.lock().unwrap();
+    let submitted_observations: Vec<_> = submitted
+        .iter()
+        .filter_map(|message| match &message.kind {
+            ConsensusTransactionKind::NOAObservation(msg) => Some(msg.observation.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(submitted_observations, vec![observation]);
+    let submitted_demands: Vec<_> = submitted
+        .iter()
+        .filter_map(|message| match &message.kind {
+            ConsensusTransactionKind::NOAPresignDemand(msg) => Some(msg.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(submitted_demands, vec![demand]);
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -14,7 +14,7 @@ use dwallet_rng::RootSeed;
 use ika_protocol_config::ProtocolConfig;
 use ika_types::committee::Committee;
 use ika_types::crypto::AuthorityName;
-use ika_types::error::IkaResult;
+use ika_types::error::{IkaError, IkaResult};
 use ika_types::handoff::CertifiedHandoffAttestation;
 use ika_types::message::DWalletCheckpointMessageKind;
 use ika_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
@@ -27,6 +27,7 @@ use ika_types::messages_dwallet_mpc::{
 };
 use ika_types::noa_checkpoint::CounterpartyChainKind;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use sui_types::base_types::{EpochId, ObjectID};
@@ -126,6 +127,9 @@ pub(crate) struct IntegrationTestState {
 #[derive(Clone)]
 pub(crate) struct TestingSubmitToConsensus {
     pub(crate) submitted_messages: Arc<Mutex<Vec<ConsensusTransaction>>>,
+    /// When set, every submission is rejected (and not recorded) — for tests
+    /// exercising the submit-failure retry paths.
+    pub(crate) fail_submissions: Arc<AtomicBool>,
 }
 
 /// A testing implementation of the `AuthorityStateTrait`.
@@ -645,6 +649,7 @@ impl TestingSubmitToConsensus {
     fn new() -> Self {
         Self {
             submitted_messages: Arc::new(Mutex::new(vec![])),
+            fail_submissions: Arc::new(AtomicBool::new(false)),
         }
     }
 }
@@ -652,6 +657,11 @@ impl TestingSubmitToConsensus {
 #[async_trait::async_trait]
 impl DWalletMPCSubmitToConsensus for TestingSubmitToConsensus {
     async fn submit_to_consensus(&self, messages: &[ConsensusTransaction]) -> IkaResult<()> {
+        if self.fail_submissions.load(Ordering::SeqCst) {
+            return Err(IkaError::ConsensusConnectionBroken(
+                "injected submit failure".to_string(),
+            ));
+        }
         self.submitted_messages
             .lock()
             .unwrap()


### PR DESCRIPTION
## Problem

`send_status_update_to_consensus` drains `buffered_noa_observations` and `buffered_noa_presign_demands` with `std::mem::take`, then submits each item to consensus individually. On a submit error it only logged — the taken items were dropped.

Both producers are one-shot, so the drop is permanent:

- The NOA checkpoint handler marks a tx confirmed-locally / voted-failed **before** emitting its observation (`poll_chain_status`), so a dropped observation is never re-emitted and this validator's finalize/fail vote is silently withheld — the checkpoint tx's resolution can then never reach quorum from this validator.
- A presign demand is announced at most once per epoch: `announced_noa_demand_digests` is written when the demand is buffered, so a dropped demand is never re-announced.

This is the in-process silent-drop path found by the issue #1935 restart-loss audit (distinct from restart loss itself). NOA is not yet live (`noa_checkpoints` is off at all shipped protocol versions), so there are no compatibility constraints.

## Fix

Re-buffer items whose submit failed, so the next status update retries them. Dedup behavior is unchanged — the digest guard already prevents double-buffering while an item sits in the buffer. Re-submission is idempotent on both paths:

- the observation tally (`handle_noa_observation_messages`) is a per-authority set, so a retry that duplicates an actually-landed submission is absorbed;
- consensus dedups demands by their demand-id digest, and the assignment drain is idempotent.

## Verification

- New test `test_noa_status_update_rebuffers_on_submit_failure` drives the status update against the testing submit-to-consensus mock with an injected failure switch, asserting both items survive the failed round (still buffered, nothing recorded) and drain exactly once on recovery.
- Fault-validated: with the two re-buffer pushes reverted, the test fails on the "must re-buffer the observation" assertion with `left: []` — it catches exactly this regression.
- Full `noa_checkpoint` module green at CI parallelism (`--test-threads=4`): 6/6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)