### PR TITLE
fix(epoch-tasks): ack a joiner announcement relay only once observed in consensus output (#1943)

### DIFF
--- a/crates/ika-core/src/epoch_tasks/announcement_relay.rs
+++ b/crates/ika-core/src/epoch_tasks/announcement_relay.rs
@@ -19,11 +19,16 @@
 //!    `JoinerPubkeyProvider`. Rejection here stops spam from
 //!    abusing us as a one-way pipe.
 //! 3. Consensus submission of the wrapped
-//!    `ConsensusTransaction::new_validator_mpc_data_announcement`.
+//!    `ConsensusTransaction::new_relayed_validator_mpc_data_announcement`.
+//! 4. A bounded wait until the announcement is observed in consensus
+//!    output — the joiner counts `Accepted` responses and stops
+//!    fanning out, so the ack must mean "sequenced", not "handed to
+//!    a background submitter" (issue #1943).
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::blob_cache::BlobCache;
 use crate::consensus_adapter::SubmitToConsensus;
+use crate::consensus_handler::SequencedConsensusTransactionKey;
 use crate::validator_metadata::{
     JoinerAnnouncementVerdict, PeerBlobVerdict, verify_joiner_announcement,
     verify_peer_blob_for_relay,
@@ -32,12 +37,23 @@ use ika_network::mpc_artifacts::AnnouncementRelay;
 use ika_types::messages_consensus::ConsensusTransaction;
 use ika_types::validator_metadata::SignedValidatorMpcDataAnnouncement;
 use std::sync::{Arc, Weak};
+use std::time::Duration;
 use tracing::{debug, info};
+
+/// How long `relay` waits for the relayed announcement to be observed
+/// in consensus output before telling the joiner to retry. Under a
+/// healthy consensus, sequencing takes well under a second; the slack
+/// covers submission backpressure. On expiry the joiner gets a
+/// `Rejected` and its fan-out loop keeps trying — over-waiting here
+/// only ties up an RPC slot, while under-waiting only costs a
+/// redundant, verify-time-deduped re-relay.
+const SEQUENCING_ACK_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct ConsensusBackedAnnouncementRelay {
     epoch_store: Weak<AuthorityPerEpochStore>,
     consensus_adapter: Arc<dyn SubmitToConsensus>,
     blob_cache: Arc<BlobCache>,
+    sequencing_ack_timeout: Duration,
 }
 
 impl ConsensusBackedAnnouncementRelay {
@@ -50,7 +66,16 @@ impl ConsensusBackedAnnouncementRelay {
             epoch_store,
             consensus_adapter,
             blob_cache,
+            sequencing_ack_timeout: SEQUENCING_ACK_TIMEOUT,
         }
+    }
+
+    /// Test hook: shrink the sequencing-ack bound so the timeout path
+    /// is exercisable without a 30s wait.
+    #[cfg(test)]
+    fn with_sequencing_ack_timeout(mut self, sequencing_ack_timeout: Duration) -> Self {
+        self.sequencing_ack_timeout = sequencing_ack_timeout;
+        self
     }
 }
 
@@ -134,6 +159,7 @@ impl AnnouncementRelay for ConsensusBackedAnnouncementRelay {
         // rather than each member fetching them peer-to-peer.
         let tx =
             ConsensusTransaction::new_relayed_validator_mpc_data_announcement(announcement, blob);
+        let sequencing_key = SequencedConsensusTransactionKey::External(tx.key());
         self.consensus_adapter
             .submit_to_consensus(&[tx], &epoch_store)
             .await
@@ -143,16 +169,36 @@ impl AnnouncementRelay for ConsensusBackedAnnouncementRelay {
         // accepted + forwarded it. Bounded: an honest joiner stops fanning
         // out once `min_accepts` relayers accept.
         //
-        // KNOWN GAP (#1943): returning Ok here acks the joiner at SUBMIT level —
-        // `submit_to_consensus` only hands the tx to an in-memory retry
-        // task, and this handler keeps no record and never re-submits. A
-        // relayer that dies between this ack and sequencing loses the
-        // relay permanently; if every acking relayer does, the joiner's
-        // announcement never reaches consensus while its fanout loop
-        // believes it succeeded, and the joiner is excludable at the
-        // freeze. Fix direction: await the tx's processed notification
-        // (bounded) before acking, so a timeout keeps the joiner fanning
-        // out.
+        // Ack only once the announcement is OBSERVED in consensus output,
+        // not when the submission task takes it: `submit_to_consensus`
+        // only hands the tx to an in-memory retry loop that dies with the
+        // process, this handler keeps no record, and the joiner — who
+        // can't read consensus — permanently stops fanning out after
+        // `min_accepts` acks. A submit-level ack therefore let a relayer
+        // crash inside the ack-to-sequencing window silently lose the
+        // announcement (issue #1943). The key is shared by every relayer
+        // of this announcement, so anyone's copy landing releases us; on
+        // timeout the joiner gets a `Rejected` and keeps fanning out, and
+        // any late-landing duplicate dedups at verify time.
+        match tokio::time::timeout(
+            self.sequencing_ack_timeout,
+            epoch_store.consensus_messages_processed_notify(vec![sequencing_key]),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                return Err(format!(
+                    "waiting for relayed announcement to sequence failed: {e}"
+                ));
+            }
+            Err(_elapsed) => {
+                return Err(format!(
+                    "relayed announcement not observed in consensus within {:?}; joiner should retry",
+                    self.sequencing_ack_timeout
+                ));
+            }
+        }
         info!(
             joiner = ?joiner,
             epoch = joiner_epoch,
@@ -161,5 +207,166 @@ impl AnnouncementRelay for ConsensusBackedAnnouncementRelay {
             "relayed joiner mpc_data announcement into consensus"
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authority::AuthorityMetrics;
+    use crate::authority::authority_per_epoch_store::{
+        ConsensusStats, ExecutionIndices, ExecutionIndicesWithStats,
+    };
+    use crate::authority::authority_perpetual_tables::AuthorityPerpetualTables;
+    use crate::authority::epoch_start_configuration::EpochStartConfiguration;
+    use crate::consensus_handler::{ConsensusCommitInfo, SequencedConsensusTransaction};
+    use crate::dwallet_checkpoints::DWalletCheckpointService;
+    use crate::epoch::epoch_metrics::EpochMetrics;
+    use crate::system_checkpoints::SystemCheckpointService;
+    use crate::validator_metadata::{
+        StaticJoinerPubkeyProvider, derive_mpc_data_blob, sign_validator_mpc_data_announcement,
+    };
+    use dwallet_rng::RootSeed;
+    use fastcrypto::ed25519::{Ed25519KeyPair, Ed25519PrivateKey};
+    use fastcrypto::traits::{KeyPair as _, ToFromBytes};
+    use ika_network::mpc_artifacts::{InMemoryBlobStore, mpc_data_blob_hash};
+    use ika_types::committee::Committee;
+    use ika_types::crypto::AuthorityName;
+    use ika_types::digests::ChainIdentifier;
+    use ika_types::messages_dwallet_mpc::IkaNetworkConfig;
+    use ika_types::sui::epoch_start_system::EpochStartSystem;
+    use prometheus::Registry;
+
+    struct NoopAdapter;
+    #[async_trait::async_trait]
+    impl SubmitToConsensus for NoopAdapter {
+        async fn submit_to_consensus(
+            &self,
+            _transactions: &[ConsensusTransaction],
+            _epoch_store: &Arc<AuthorityPerEpochStore>,
+        ) -> ika_types::error::IkaResult {
+            Ok(())
+        }
+    }
+
+    /// A current-epoch (epoch 0) store whose relayer would accept a
+    /// joiner announcement for epoch 1, plus that signed announcement
+    /// and its (real, decode-valid) mpc_data blob.
+    fn relay_fixture() -> (
+        Arc<AuthorityPerEpochStore>,
+        SignedValidatorMpcDataAnnouncement,
+        Vec<u8>,
+        ConsensusBackedAnnouncementRelay,
+    ) {
+        let (committee, _keys) = Committee::new_simple_test_committee_of_size(1);
+        let committee = Arc::new(committee);
+        let member = *committee.names().next().unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        let epoch_store = AuthorityPerEpochStore::new(
+            member,
+            committee,
+            dir.path(),
+            None,
+            EpochMetrics::new(&Registry::new()),
+            EpochStartConfiguration::new(EpochStartSystem::new_for_testing_with_epoch(0)).unwrap(),
+            ChainIdentifier::default(),
+            IkaNetworkConfig::new_for_testing(),
+        )
+        .unwrap();
+        std::mem::forget(dir); // keep the DB path alive for the test
+
+        let joiner = AuthorityName::new([7; 48]);
+        let joiner_keypair =
+            Ed25519KeyPair::from(Ed25519PrivateKey::from_bytes(&[3u8; 32]).unwrap());
+        epoch_store.install_joiner_pubkey_provider(Box::new(
+            StaticJoinerPubkeyProvider::from_iter([(joiner, joiner_keypair.public().clone())]),
+        ));
+
+        let blob = derive_mpc_data_blob(&RootSeed::new([7; 32])).expect("derive blob");
+        let digest = mpc_data_blob_hash(&blob);
+        let signed = sign_validator_mpc_data_announcement(
+            joiner,
+            1, // relays are accepted for next_epoch == current + 1
+            42,
+            digest,
+            &joiner_keypair,
+        )
+        .expect("sign announcement");
+
+        let perpetual_dir = tempfile::TempDir::new().unwrap();
+        let perpetual = Arc::new(AuthorityPerpetualTables::open(perpetual_dir.path(), None));
+        std::mem::forget(perpetual_dir);
+        let relay = ConsensusBackedAnnouncementRelay::new(
+            Arc::downgrade(&epoch_store),
+            Arc::new(NoopAdapter),
+            BlobCache::new(InMemoryBlobStore::new(), perpetual),
+        );
+        (epoch_store, signed, blob, relay)
+    }
+
+    /// The core of issue #1943: `Accepted` must mean "the announcement
+    /// was observed in consensus output", not "handed to the in-memory
+    /// submitter". The relay must stay pending until the announcement's
+    /// consensus key is processed, then resolve Ok.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn relay_acks_only_after_announcement_is_sequenced() {
+        let (epoch_store, signed, blob, relay) = relay_fixture();
+
+        let handle = {
+            let signed = signed.clone();
+            let blob = blob.clone();
+            tokio::spawn(async move { relay.relay(signed, blob).await })
+        };
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            !handle.is_finished(),
+            "relay acked before the announcement was sequenced — the joiner \
+             would stop fanning out on a submit-level ack"
+        );
+
+        // The announcement lands: drive the same tx through the real
+        // commit boundary, which marks its key processed and notifies.
+        let tx = ConsensusTransaction::new_relayed_validator_mpc_data_announcement(signed, blob);
+        epoch_store
+            .process_consensus_transactions_and_commit_boundary(
+                vec![SequencedConsensusTransaction::new_test(tx)],
+                &ExecutionIndicesWithStats {
+                    index: ExecutionIndices {
+                        last_committed_round: 1,
+                        sub_dag_index: 0,
+                        transaction_index: 0,
+                    },
+                    hash: 0,
+                    stats: ConsensusStats::default(),
+                },
+                &None::<Arc<DWalletCheckpointService>>,
+                &None::<Arc<SystemCheckpointService>>,
+                &ConsensusCommitInfo::new_for_test(1, 1_000, true),
+                &Arc::new(AuthorityMetrics::new(&Registry::new())),
+            )
+            .await
+            .unwrap();
+
+        let result = tokio::time::timeout(Duration::from_secs(10), handle)
+            .await
+            .expect("relay must resolve once the announcement is sequenced")
+            .unwrap();
+        assert_eq!(result, Ok(()));
+    }
+
+    /// If the announcement never lands, the relay must reject rather
+    /// than ack, so the joiner keeps fanning out to other relayers.
+    #[tokio::test]
+    async fn relay_times_out_when_announcement_never_sequences() {
+        let (_epoch_store, signed, blob, relay) = relay_fixture();
+        let relay = relay.with_sequencing_ack_timeout(Duration::from_millis(50));
+        let err = relay
+            .relay(signed, blob)
+            .await
+            .expect_err("relay must reject when the announcement never sequences");
+        assert!(
+            err.contains("not observed in consensus"),
+            "unexpected rejection reason: {err}"
+        );
     }
 }


### PR DESCRIPTION
Closes #1943 — the second of the two restart-redelivery gaps found by the #1935 triage (#1939 documented it as a `KNOWN GAP` comment; this PR replaces that comment with the fix).

## The bug

The relay is the ONLY path a joiner's mpc_data announcement enters consensus, and its ack chain trusted the wrong milestone:

- `ConsensusBackedAnnouncementRelay::relay` returned `Ok` right after `submit_to_consensus` — which only hands the tx to an in-memory retry task that dies with the process. The RPC server turns that `Ok` into `Accepted`.
- The joiner counts `Accepted`s and permanently stops fanning out at `min_accepts`; it cannot read consensus to verify (it isn't a participant).

A relayer that crashed (or was restarted) between acking and its relay tx being sequenced lost the relay permanently and invisibly: the relayer keeps no record, the joiner already counted the ack, and no other committee member saw anything to re-relay. If every acking relayer hit the window, the joiner's announcement never reached consensus while its fan-out loop believed it succeeded — the joiner is then excludable at the freeze and misses the epoch.

## The fix

`relay()` now acks only after the announcement is **observed in consensus output**: after submitting, it waits (bounded, 30s) on `consensus_messages_processed_notify` for the relayed tx's consensus key, and returns `Err` on timeout so the joiner's retry loop keeps fanning out. Properties that make this the minimal correct fix:

- The consensus key — `RelayedValidatorMpcDataAnnouncement(joiner, epoch, timestamp_ms)` — is shared by every relayer of the same joiner announcement, so *anyone's* copy landing releases the wait. The notify primitive registers before checking current state, so an already-landed announcement resolves immediately.
- On timeout the joiner sees `Rejected` and keeps trying; a late-landing duplicate from the timed-out relayer dedups at verify time. Over-waiting only ties up an RPC slot; under-waiting only costs a redundant re-relay — both directions are safe.
- All re-drive stays on the joiner side, where the retry loop already exists; the relayer stays a stateless RPC handler.

## Tests

- `relay_acks_only_after_announcement_is_sequenced` — the core property: `relay()` (real epoch store, installed joiner pubkey provider, real derived mpc_data blob) must still be pending 200ms after submission, then resolve `Ok` once the same tx is driven through the real `process_consensus_transactions_and_commit_boundary`. On the pre-fix code this fails at the still-pending assertion (relay acked instantly).
- `relay_times_out_when_announcement_never_sequences` — with a 50ms bound and nothing sequenced, `relay()` must reject with the retry-inducing reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
