### PR TITLE
docs(specs): record the sequenced-level relay ack in the announcements spec (#1943 follow-up)

### DIFF
--- a/dev-docs/specs/validator-mpc-data-announcements.md
+++ b/dev-docs/specs/validator-mpc-data-announcements.md
@@ -50,6 +50,12 @@ which bytes* deterministic in consensus order.
    current-committee peers. Each receiver verifies the signature
    against the joiner's next-epoch consensus pubkey from chain, then
    relays it into consensus as `RelayedValidatorMpcDataAnnouncement`.
+   A relayer's `Accepted` response means the relayed announcement was
+   **observed in consensus output** (bounded wait; timeout →
+   `Rejected`), not merely handed to the relayer's submitter — the
+   joiner cannot read consensus and permanently stops fanning out
+   after `min_accepts` acceptances, so a weaker ack would let a
+   relayer crash silently strand the announcement (issue #1943).
    Joiners announce as early as possible so peers cache the blob; the
    reconfiguration never blocks waiting for a missing joiner (see
    freeze rules below — a joiner that misses the freeze window is


### PR DESCRIPTION
Follow-up to #1946 (fix for #1943), which merged before its spec note landed. The relay's `Accepted` now means the relayed announcement was observed in consensus output (bounded wait; timeout → `Rejected`) — the contract the joiner's `min_accepts` counting rests on. Per the same-PR spec rule this should have ridden #1946; this is the smallest possible catch-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)