### PR TITLE
fix(mpc): seed the internal-presign ordinal stream from persisted pool slots on restart (#1952)

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -54,6 +54,14 @@ name: Upgrade Test
 #                  sui-data-source — for all validators AND the notifier
 #                  (the legacy JSON-RPC transport nothing else covers). Full
 #                  lifecycle. Current build only.
+#   restart_spectator — the #1952 mid-epoch-restart gate: one validator is
+#                  restarted (same binary) far from an epoch boundary, in an
+#                  epoch with an established network key and ongoing
+#                  internal-presign volume, and must resume LIVE
+#                  registry-driven top-up instantiation within the epoch —
+#                  not merely stay consensus-healthy while peers absorb the
+#                  sessions. Current build only; production presign-pool
+#                  sizing (the sustained-volume ingredient).
 #
 # Each scenario binds the fixed Sui localnet ports (9000/9123) and chdirs the
 # process during publish, so only ONE runs per job — `--test-threads=1`, one
@@ -229,7 +237,7 @@ jobs:
           TEST: ${{ inputs.test || 'v125_rollout' }}
         run: |
           set -euo pipefail
-          ALL="smoke workload v125_rollout v125_v6_upgrade v125_churn malicious_v125 legacy_config"
+          ALL="smoke workload v125_rollout v125_v6_upgrade v125_churn malicious_v125 legacy_config restart_spectator"
           if [ "$TEST" = "all" ]; then
             SELECTED="$ALL"
           else
@@ -347,6 +355,7 @@ jobs:
             v125_churn)   RUN_FLAG=RUN_V125_CHURN ;;
             malicious_v125) RUN_FLAG=RUN_MALICIOUS_V125 ;;
             legacy_config) RUN_FLAG=RUN_LEGACY_CONFIG ;;
+            restart_spectator) RUN_FLAG=RUN_RESTART_SPECTATOR ;;
             *) echo "unknown test: $TEST" >&2; exit 1 ;;
           esac
           # Per-scenario OLD-binary defaults; explicit inputs override (an
@@ -508,10 +517,13 @@ jobs:
           set -uo pipefail
           export SUI_BIN="$HOME/.local/bin/sui"
           export "${RUN_FLAG}=1"
-          # Keep production pool sizing/timing for the rollout gate. The
-          # reduced-pool override remains a resource concession for the
-          # lighter scenarios, not compatibility evidence.
-          if [ "$TEST_NAME" = "v125_rollout" ]; then
+          # Keep production pool sizing/timing for the rollout gate and the
+          # restart-spectator gate (whose sustained internal-presign volume IS
+          # the ingredient under test — small pools fill and quiesce, and a
+          # quiet top-up loop can't prove resumption). The reduced-pool
+          # override remains a resource concession for the lighter scenarios,
+          # not compatibility evidence.
+          if [ "$TEST_NAME" = "v125_rollout" ] || [ "$TEST_NAME" = "restart_spectator" ]; then
             unset IKA_ENABLE_SMALL_PRESIGN_POOLS
           fi
           mkdir -p "$UPGRADE_TEST_DIR"

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -285,6 +285,21 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
         dwallet_network_encryption_key_id: ObjectID,
     ) -> IkaResult<u64>;
 
+    /// The highest internal-presign session sequence number that has ever
+    /// filled a pool slot for `(signature_algorithm, key)` this epoch, or
+    /// `None` if no fill landed yet. This is the persisted high-water mark of
+    /// the pool's ordinal stream: a process that restarts mid-epoch must seed
+    /// its in-memory `next_internal_presign_sequence_number` from it (#1952) —
+    /// seeding from 1 re-mints ordinals the committee already completed, and
+    /// the top-up loop then trails the live ordinal window by a constant
+    /// offset for the rest of the epoch (each dead mint is "released" only by
+    /// a live peer completion, so the gap never closes).
+    fn max_filled_presign_pool_slot(
+        &self,
+        signature_algorithm: DWalletSignatureAlgorithm,
+        dwallet_network_encryption_key_id: ObjectID,
+    ) -> IkaResult<Option<u64>>;
+
     /// Pop a presign from the internal pool for the given algorithm and key.
     ///
     /// Concurrency safety: This method is only called from the MPC manager
@@ -607,6 +622,15 @@ impl AuthorityPerEpochStoreTrait for AuthorityPerEpochStore {
     ) -> IkaResult<u64> {
         let tables = self.tables()?;
         tables.presign_pool_size(signature_algorithm, dwallet_network_encryption_key_id)
+    }
+
+    fn max_filled_presign_pool_slot(
+        &self,
+        signature_algorithm: DWalletSignatureAlgorithm,
+        dwallet_network_encryption_key_id: ObjectID,
+    ) -> IkaResult<Option<u64>> {
+        let tables = self.tables()?;
+        tables.max_filled_presign_pool_slot(signature_algorithm, dwallet_network_encryption_key_id)
     }
 
     fn pop_presign(
@@ -1899,6 +1923,35 @@ impl AuthorityEpochTables {
         batch.write()?;
 
         Ok(())
+    }
+
+    /// Highest `session_sequence_number` ever recorded in
+    /// `filled_presign_pool_slots` for `(signature_algorithm, key)`, or `None`
+    /// when the pool has no fill yet this epoch. One reverse seek over the
+    /// pool's slot-key range — the slot markers are written on every fill (and
+    /// re-confirmed by the post-restart consensus replay), so this is the
+    /// durable high-water mark of the pool's ordinal stream (#1952).
+    pub fn max_filled_presign_pool_slot(
+        &self,
+        signature_algorithm: DWalletSignatureAlgorithm,
+        dwallet_network_encryption_key_id: ObjectID,
+    ) -> IkaResult<Option<u64>> {
+        let lower = (
+            signature_algorithm,
+            dwallet_network_encryption_key_id,
+            u64::MIN,
+        );
+        let upper = (
+            signature_algorithm,
+            dwallet_network_encryption_key_id,
+            u64::MAX,
+        );
+        Ok(self
+            .filled_presign_pool_slots
+            .reversed_safe_iter_with_bounds(Some(lower), Some(upper))?
+            .next()
+            .transpose()?
+            .map(|((_, _, session_sequence_number), ())| session_sequence_number))
     }
 
     /// Returns the total number of presigns in the pool for the given signature algorithm

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -7,17 +7,26 @@ use crate::dwallet_mpc::integration_tests::utils::{
     TEST_PRESIGN_POOL_MINIMUM_SIZE, apply_test_presign_pool_overrides, build_test_state,
     create_test_protocol_config_guard,
 };
-use crate::dwallet_mpc::mpc_manager::{InternalPresignCompletionKey, ParkedInternalPresignRequest};
-use crate::dwallet_mpc::mpc_session::SessionStatus;
+use crate::dwallet_mpc::mpc_diagnostics::SessionOrigin;
+use crate::dwallet_mpc::mpc_manager::{
+    DWalletMPCManager, InternalPresignCompletionKey, ParkedInternalPresignRequest,
+};
+use crate::dwallet_mpc::mpc_session::{SessionComputationType, SessionStatus};
 use crate::dwallet_mpc::{NetworkOwnedAddressSignRequest, ValidatorMpcKeysByPartyId};
-use dwallet_mpc_types::dwallet_mpc::{DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm};
+use crate::dwallet_session_request::DWalletSessionRequest;
+use crate::validator_metadata::OffChainCommitteeBundles;
+use dwallet_mpc_types::dwallet_mpc::{
+    DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm, NetworkKeyId,
+};
+use dwallet_rng::RootSeed;
 use ika_protocol_config::ProtocolConfig;
+use ika_types::crypto::AuthorityName;
 use ika_types::message::DWalletCheckpointMessageKind;
 use ika_types::messages_dwallet_mpc::{
     DWalletNetworkEncryptionKeyData, DWalletNetworkEncryptionKeyState, SessionIdentifier,
     SessionType,
 };
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use sui_types::base_types::ObjectID;
 use tracing::info;
@@ -1531,5 +1540,517 @@ async fn test_internal_presign_multi_key_install_lag_keeps_identifiers_uniform()
         "Test completed: multi-key install lag parks internal presign batches with sequence \
          numbers consumed, and an unresolvable adopted key is skipped uniformly, keeping \
          identifier derivation committee-uniform"
+    );
+}
+
+/// The deterministic identifier every committee member derives for one
+/// internal-presign ordinal of a (key, curve, algorithm) pool.
+fn internal_presign_identifier_at(
+    epoch_id: u64,
+    ordinal: u64,
+    curve: DWalletCurve,
+    algorithm: DWalletSignatureAlgorithm,
+    network_key_object_id: ObjectID,
+    counter_network_key_id: NetworkKeyId,
+) -> SessionIdentifier {
+    DWalletSessionRequest::new_internal_presign(
+        epoch_id,
+        ordinal,
+        curve,
+        algorithm,
+        network_key_object_id,
+        &counter_network_key_id.0,
+    )
+    .session_identifier
+}
+
+/// Ordinals of one pool this manager MINTED itself (activated a local
+/// request — `SessionOrigin::LocalRequest`), as opposed to entries
+/// reconstructed from replayed consensus artifacts. Pool membership is proven
+/// by re-deriving the identifier from the bound ordinal: a session whose
+/// identifier matches is this pool's ordinal by construction.
+fn locally_minted_pool_ordinals(
+    manager: &DWalletMPCManager,
+    curve: DWalletCurve,
+    algorithm: DWalletSignatureAlgorithm,
+    network_key_object_id: ObjectID,
+    counter_network_key_id: NetworkKeyId,
+) -> BTreeSet<u64> {
+    manager
+        .sessions
+        .iter()
+        .filter(|(_, session)| session.origin == SessionOrigin::LocalRequest)
+        .filter_map(|(session_identifier, session)| {
+            let ordinal = session.session_sequence_number?;
+            (internal_presign_identifier_at(
+                manager.epoch_id,
+                ordinal,
+                curve,
+                algorithm,
+                network_key_object_id,
+                counter_network_key_id,
+            ) == *session_identifier)
+                .then_some(ordinal)
+        })
+        .collect()
+}
+
+/// Replaces validator 0's service with a fresh one over its EXISTING epoch
+/// store — the in-process mid-epoch restart. Every channel end is replaced (a
+/// fresh process re-creates them); the epoch store is the only survivor.
+/// `last_session_to_complete_in_current_epoch` is restored directly, exactly
+/// as the tests around network-key creation set it.
+fn restart_validator_zero(
+    test_state: &mut IntegrationTestState,
+    seeds: &HashMap<AuthorityName, RootSeed>,
+    bundles: &OffChainCommitteeBundles,
+) {
+    let authority = test_state.dwallet_mpc_services[0].name;
+    let (service, senders, collector, notify, sign_request_sender, sign_output_receiver) =
+        utils::create_dwallet_mpc_service_over_epoch_store(
+            &authority,
+            test_state.committee.clone(),
+            seeds[&authority].clone(),
+            bundles.clone(),
+            test_state.epoch_stores[0].clone(),
+        );
+    test_state.dwallet_mpc_services[0] = service;
+    test_state.sui_data_senders[0] = senders;
+    test_state.sent_consensus_messages_collectors[0] = collector;
+    test_state.notify_services[0] = notify;
+    test_state.network_owned_address_sign_request_senders[0] = sign_request_sender;
+    test_state.network_owned_address_sign_output_receivers[0] = sign_output_receiver;
+    test_state.dwallet_mpc_services[0]
+        .dwallet_mpc_manager_mut()
+        .last_session_to_complete_in_current_epoch = 400;
+}
+
+/// Regression test for issue #1952: `next_internal_presign_sequence_number`
+/// is in-memory, so a mid-epoch restart used to restart a pool's ordinal
+/// stream at 1 — every post-restart mint re-minted an ordinal the committee
+/// had already completed, each dead mint was "released" only by a live peer
+/// completion, and the validator trailed the live ordinal window (sitting out
+/// registry-driven instantiation) for the rest of the epoch. The fix lazily
+/// seeds a pool's counter on first touch from the persisted
+/// `filled_presign_pool_slots` high-water (+1), and the mint path
+/// fast-forwards across ordinals whose replayed sessions are already
+/// terminal.
+///
+/// Flow:
+/// 1. Live committee fills the EdDSA pool; capture the persisted high-water H
+///    and pin the live counter at H+1 (the rejoin target).
+/// 2. Restart validator 0 over its surviving epoch store. Its EdDSA pool is
+///    stuffed to max FIRST so the replay provably cannot mint for that pool
+///    under either top-up condition — proving the seed is LAZY (first-mint),
+///    not replay-driven.
+/// 3. Replay the persisted history; assert the counter is still unseeded and
+///    nothing was locally minted (history is reconstructed, never re-minted).
+/// 4. Drain every validator's EdDSA pool and drive live rounds: the restarted
+///    validator's first mint must land at EXACTLY H+1 (never 1), the pool's
+///    counter must read identically committee-wide after every round, every
+///    minted ordinal must bind to the same identifier on every peer, and the
+///    new ordinals' fills must advance the persisted high-water past H.
+/// 5. Coda (fast-forward): restart validator 0 once more with terminal
+///    sessions planted at the two ordinals PAST the persisted high-water (the
+///    shape where the seed read lags the replay frontier) and drive one
+///    top-up directly: the mint must skip the terminal ordinals without
+///    counting them against the batch guard, and park the live batch just
+///    past them.
+#[tokio::test]
+#[cfg(test)]
+async fn test_mid_epoch_restart_resumes_internal_presign_ordinals_from_pool_high_water() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard();
+
+    // Seeds are kept to rebuild validator 0 with the same identity (the same
+    // class-groups decryption shares) after the simulated restarts.
+    let (committee, seeds, bundles) = utils::build_committee_with_random_seeds(4);
+    let (
+        dwallet_mpc_services,
+        sui_data_senders,
+        sent_consensus_messages_collectors,
+        epoch_stores,
+        notify_services,
+        network_owned_address_sign_request_senders,
+        network_owned_address_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services_with_committee_and_seeds(
+        committee.clone(),
+        seeds.clone(),
+        bundles.clone(),
+    );
+    let mut test_state = IntegrationTestState {
+        dwallet_mpc_services,
+        sent_consensus_messages_collectors,
+        epoch_stores,
+        notify_services,
+        crypto_round: 1,
+        consensus_round: 1,
+        committee,
+        sui_data_senders,
+        network_owned_address_sign_request_senders,
+        network_owned_address_sign_output_receivers,
+    };
+
+    let (consensus_round, _network_key_bytes, network_key_id) =
+        create_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+
+    // EdDSA: single-round presign, so its pool provably fills (and its
+    // batches quorum-complete) within a few delivered rounds.
+    let (curve, algorithm) = (DWalletCurve::Curve25519, DWalletSignatureAlgorithm::EdDSA);
+    let epoch_id = test_state.dwallet_mpc_services[0]
+        .dwallet_mpc_manager()
+        .epoch_id;
+    let counter_network_key_id = test_state.dwallet_mpc_services[0]
+        .dwallet_mpc_manager()
+        .internal_presign_network_key_id(&network_key_id)
+        .expect("the DKG'd key must have a resolvable NetworkKeyId");
+    let counter_key = (counter_network_key_id, curve, algorithm);
+
+    // === Phase 1: live fills establish the persisted high-water ===
+    // Run until the pool has persisted fills AND the batch guard is closed:
+    // with every minted ordinal quorum-completed and deposited, the persisted
+    // high-water IS the last live ordinal.
+    let mut high_water = None;
+    for _ in 0..60 {
+        run_one_round_delivering_messages(&mut test_state).await;
+        let (instantiated, completed) =
+            presign_batch_counters(&test_state, 0, network_key_id, curve, algorithm);
+        high_water = test_state.epoch_stores[0]
+            .max_filled_presign_pool_slot(algorithm, network_key_id)
+            .expect("max_filled_presign_pool_slot");
+        if high_water.is_some() && instantiated > 0 && instantiated == completed {
+            break;
+        }
+    }
+    let high_water = high_water.expect("EdDSA fills should land within the phase 1 budget");
+
+    // Precondition tying the persisted high-water to the live counter: the
+    // restarted validator must rejoin exactly here.
+    let live_next = *test_state.dwallet_mpc_services[1]
+        .dwallet_mpc_manager()
+        .next_internal_presign_sequence_number
+        .get(&counter_key)
+        .expect("peers must have minted EdDSA ordinals in phase 1");
+    assert_eq!(
+        live_next,
+        high_water + 1,
+        "precondition: with the guard closed, the persisted high-water is one behind the live counter"
+    );
+
+    // What the production syncer re-fetches for a fresh process: the network
+    // key overlay (taken from a live peer's adopted view).
+    let network_key_data = test_state.dwallet_mpc_services[1]
+        .dwallet_mpc_manager()
+        .adopted_network_key_data
+        .get(&network_key_id)
+        .expect("peers must have adopted the network key")
+        .clone();
+
+    // === Phase 2: restart validator 0 over its surviving epoch store ===
+    // Stuff the restarting validator's EdDSA pool to max first: with the pool
+    // at/above both thresholds, neither top-up condition can fire during the
+    // replay, so an unseeded counter after the full replay proves the seed is
+    // lazy. Slot 1 keeps the persisted high-water untouched.
+    let stuffing: Vec<Vec<u8>> = (0..TEST_PRESIGN_POOL_MAXIMUM_SIZE)
+        .map(|index| vec![index as u8; 8])
+        .collect();
+    test_state.epoch_stores[0]
+        .insert_presigns(
+            algorithm,
+            network_key_id,
+            1,
+            SessionIdentifier::new(SessionType::InternalPresign, [77u8; 32]),
+            stuffing,
+        )
+        .expect("insert_presigns");
+
+    restart_validator_zero(&mut test_state, &seeds, &bundles);
+    assert!(
+        test_state.dwallet_mpc_services[0]
+            .dwallet_mpc_manager()
+            .next_internal_presign_sequence_number
+            .is_empty(),
+        "a fresh process must start with no in-memory ordinal state"
+    );
+    let _ = test_state.sui_data_senders[0]
+        .network_keys_sender
+        .send(Arc::new(HashMap::from([(
+            network_key_id,
+            network_key_data.clone(),
+        )])));
+
+    // Replay: the first iteration processes every persisted consensus round;
+    // the key install completes asynchronously on later ticks.
+    test_state.dwallet_mpc_services[0]
+        .run_service_loop_iteration()
+        .await;
+    utils::run_service_loops_until_network_key_installed(
+        &mut test_state.dwallet_mpc_services[0..1],
+        network_key_id,
+    )
+    .await;
+    assert_eq!(
+        test_state.dwallet_mpc_services[0].last_read_consensus_round(),
+        test_state.dwallet_mpc_services[1].last_read_consensus_round(),
+        "the replay must catch the restarted validator up to its peers"
+    );
+
+    {
+        let manager = test_state.dwallet_mpc_services[0].dwallet_mpc_manager();
+        assert!(
+            !manager
+                .next_internal_presign_sequence_number
+                .contains_key(&counter_key),
+            "the ordinal stream must be seeded on first MINT, not by the replay"
+        );
+        assert!(
+            locally_minted_pool_ordinals(
+                manager,
+                curve,
+                algorithm,
+                network_key_id,
+                counter_network_key_id
+            )
+            .is_empty(),
+            "the replay must reconstruct history, never mint"
+        );
+    }
+
+    // === Phase 3: the restarted validator rejoins the live ordinal window ===
+    // Drain every validator's EdDSA pool so the next delay-aligned round
+    // provably fires the same top-up committee-wide.
+    for epoch_store in &test_state.epoch_stores {
+        while epoch_store
+            .pop_presign(algorithm, network_key_id)
+            .expect("pop_presign")
+            .is_some()
+        {}
+    }
+
+    let mut resumed = false;
+    for _ in 0..40 {
+        run_one_round_delivering_messages(&mut test_state).await;
+
+        // Whenever the restarted validator's counter exists it must read
+        // identically on every live peer — a pre-fix restart reads ~1 here
+        // while the peers read H+1+k.
+        let restarted_next = test_state.dwallet_mpc_services[0]
+            .dwallet_mpc_manager()
+            .next_internal_presign_sequence_number
+            .get(&counter_key)
+            .copied();
+        if let Some(restarted_next) = restarted_next {
+            assert!(
+                restarted_next > high_water,
+                "the restarted validator's ordinal counter must resume past the persisted \
+                 high-water {high_water}, got {restarted_next}"
+            );
+            for peer_index in 1..test_state.dwallet_mpc_services.len() {
+                assert_eq!(
+                    test_state.dwallet_mpc_services[peer_index]
+                        .dwallet_mpc_manager()
+                        .next_internal_presign_sequence_number
+                        .get(&counter_key)
+                        .copied(),
+                    Some(restarted_next),
+                    "validator {peer_index}: the pool's ordinal counter diverged from the \
+                     restarted validator's"
+                );
+            }
+        }
+
+        let (instantiated, completed) =
+            presign_batch_counters(&test_state, 0, network_key_id, curve, algorithm);
+        let refilled_high_water = test_state.epoch_stores[0]
+            .max_filled_presign_pool_slot(algorithm, network_key_id)
+            .expect("max_filled_presign_pool_slot")
+            .unwrap_or(0);
+        if instantiated > 0 && instantiated == completed && refilled_high_water > high_water {
+            resumed = true;
+            break;
+        }
+    }
+    assert!(
+        resumed,
+        "the restarted validator must mint, complete, and persist fills at post-high-water ordinals"
+    );
+
+    let minted = locally_minted_pool_ordinals(
+        test_state.dwallet_mpc_services[0].dwallet_mpc_manager(),
+        curve,
+        algorithm,
+        network_key_id,
+        counter_network_key_id,
+    );
+    assert_eq!(
+        minted.first(),
+        Some(&(high_water + 1)),
+        "the first post-restart mint must land exactly one past the persisted high-water"
+    );
+    assert!(
+        minted.iter().all(|&ordinal| ordinal > high_water),
+        "post-restart mints re-used already-completed ordinals: {minted:?} (high-water {high_water})"
+    );
+    // Identifier uniformity: every ordinal the restarted validator minted is
+    // bound to the SAME identifier on every live peer — the committee-wide
+    // invariant a from-1 restart breaks.
+    for peer_index in 1..test_state.dwallet_mpc_services.len() {
+        let peer_manager = test_state.dwallet_mpc_services[peer_index].dwallet_mpc_manager();
+        for &ordinal in &minted {
+            let session_identifier = internal_presign_identifier_at(
+                epoch_id,
+                ordinal,
+                curve,
+                algorithm,
+                network_key_id,
+                counter_network_key_id,
+            );
+            assert_eq!(
+                peer_manager
+                    .sessions
+                    .get(&session_identifier)
+                    .and_then(|session| session.session_sequence_number),
+                Some(ordinal),
+                "validator {peer_index}: ordinal {ordinal} is not bound to the same session \
+                 identifier as on the restarted validator"
+            );
+        }
+    }
+
+    // === Coda: fast-forward across terminal ordinals past the seed ===
+    // The high-water is read ONCE, at the pool's first touch; fills whose
+    // replay lands after that read leave terminal sessions at ordinals PAST
+    // the seed. The mint path must skip them (they can never produce a
+    // completion again) without counting them against the batch guard.
+    let coda_high_water = test_state.epoch_stores[0]
+        .max_filled_presign_pool_slot(algorithm, network_key_id)
+        .expect("max_filled_presign_pool_slot")
+        .expect("phase 3 refilled the pool");
+    restart_validator_zero(&mut test_state, &seeds, &bundles);
+    while test_state.epoch_stores[0]
+        .pop_presign(algorithm, network_key_id)
+        .expect("pop_presign")
+        .is_some()
+    {}
+
+    let manager = test_state.dwallet_mpc_services[0].dwallet_mpc_manager_mut();
+    // Adopt directly — the coda drives the top-up loop below without service
+    // iterations, so no install ever completes: the live batch must PARK with
+    // its ordinals consumed (the install-lag shape covered above).
+    manager
+        .adopted_network_key_data
+        .insert(network_key_id, network_key_data.clone());
+    let terminal_ordinals = [coda_high_water + 1, coda_high_water + 2];
+    for &ordinal in &terminal_ordinals {
+        let session_identifier = internal_presign_identifier_at(
+            epoch_id,
+            ordinal,
+            curve,
+            algorithm,
+            network_key_id,
+            counter_network_key_id,
+        );
+        manager.new_session(
+            &session_identifier,
+            SessionStatus::Completed,
+            None,
+            SessionComputationType::MPC {
+                messages_by_consensus_round: HashMap::new(),
+            },
+        );
+    }
+
+    let batch_size = TEST_NETWORK_OWNED_ADDRESS_SIGN_PRESIGN_SESSIONS_TO_INSTANTIATE;
+    let coda_round = test_state.consensus_round as u64;
+    manager.instantiate_internal_presign_sessions(
+        coda_round,
+        TEST_PRESIGN_CONSENSUS_ROUND_DELAY * 100,
+        false,
+    );
+
+    assert_eq!(
+        manager
+            .next_internal_presign_sequence_number
+            .get(&counter_key)
+            .copied(),
+        Some(coda_high_water + 2 + batch_size + 1),
+        "the mint must seed at high-water+1, skip the two terminal ordinals, and mint the \
+         batch just past them"
+    );
+    assert_eq!(
+        manager
+            .instantiated_internal_presign_sessions
+            .get(&counter_key)
+            .copied()
+            .unwrap_or(0),
+        batch_size,
+        "only live mints may count against the batch guard — a fast-forwarded ordinal never \
+         produces a completion"
+    );
+    for &ordinal in &terminal_ordinals {
+        let session_identifier = internal_presign_identifier_at(
+            epoch_id,
+            ordinal,
+            curve,
+            algorithm,
+            network_key_id,
+            counter_network_key_id,
+        );
+        assert!(
+            matches!(
+                manager
+                    .sessions
+                    .get(&session_identifier)
+                    .map(|session| &session.status),
+                Some(SessionStatus::Completed)
+            ),
+            "ordinal {ordinal}: a terminal session must be skipped, not re-activated"
+        );
+    }
+    let parked_pool_ordinals: BTreeSet<u64> = manager
+        .internal_presign_requests_pending_for_network_key_data
+        .iter()
+        .filter_map(|ParkedInternalPresignRequest(request)| {
+            let ordinal = request.session_sequence_number?;
+            (internal_presign_identifier_at(
+                epoch_id,
+                ordinal,
+                curve,
+                algorithm,
+                network_key_id,
+                counter_network_key_id,
+            ) == request.session_identifier)
+                .then_some(ordinal)
+        })
+        .collect();
+    let expected_live_ordinals: BTreeSet<u64> =
+        (coda_high_water + 3..=coda_high_water + 2 + batch_size).collect();
+    assert_eq!(
+        parked_pool_ordinals, expected_live_ordinals,
+        "the live batch must park (no install on the fresh manager) at exactly the ordinals \
+         past the terminal run"
+    );
+
+    // The batch guard must see the parked live mints as in-flight: a second
+    // delay-aligned pass may not mint again until they complete.
+    manager.instantiate_internal_presign_sessions(
+        coda_round + TEST_PRESIGN_CONSENSUS_ROUND_DELAY,
+        TEST_PRESIGN_CONSENSUS_ROUND_DELAY * 101,
+        false,
+    );
+    assert_eq!(
+        manager
+            .next_internal_presign_sequence_number
+            .get(&counter_key)
+            .copied(),
+        Some(coda_high_water + 2 + batch_size + 1),
+        "the guard must hold while the parked live batch is outstanding"
+    );
+
+    info!(
+        "Test completed: a mid-epoch restart resumes the internal-presign ordinal stream from \
+         the persisted pool-slot high-water, and the mint path fast-forwards terminal ordinals \
+         without wedging the batch guard"
     );
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -84,6 +84,11 @@ pub(crate) struct TestingAuthorityPerEpochStore {
     /// Presign pool keyed by (signature algorithm, dwallet_network_encryption_key_id)
     /// Each entry contains a vector of (SessionIdentifier, presign_bytes)
     pub(crate) presign_pools: TestPresignPool,
+    /// Highest internal-presign session sequence number that filled each
+    /// pool, mirroring the real store's `filled_presign_pool_slots` high-water
+    /// mark (the #1952 restart ordinal-seed source).
+    pub(crate) filled_presign_slot_high_water:
+        Arc<Mutex<HashMap<(DWalletSignatureAlgorithm, ObjectID), u64>>>,
     /// Tracks which individual presigns have been consumed for signing.
     /// Keyed by (session_identifier, blending_index) to uniquely identify a single presign
     /// within the blended vector produced by a presign session.
@@ -168,6 +173,7 @@ impl TestingAuthorityPerEpochStore {
             noa_assigned_presigns: Arc::new(Mutex::new(HashMap::new())),
             served_global_presigns: Arc::new(Mutex::new(HashMap::new())),
             presign_pools: Arc::new(Mutex::new(Default::default())),
+            filled_presign_slot_high_water: Arc::new(Mutex::new(HashMap::new())),
             used_presigns: Arc::new(Mutex::new(HashMap::new())),
             presign_private_outputs: Arc::new(Mutex::new(HashMap::new())),
             assigned_presigns: Arc::new(Mutex::new(HashMap::new())),
@@ -273,10 +279,17 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
-        _session_sequence_number: u64,
+        session_sequence_number: u64,
         session_identifier: SessionIdentifier,
         presigns: Vec<Vec<u8>>,
     ) -> IkaResult<()> {
+        {
+            let mut high_water = self.filled_presign_slot_high_water.lock().unwrap();
+            let slot = high_water
+                .entry((signature_algorithm, dwallet_network_encryption_key_id))
+                .or_insert(session_sequence_number);
+            *slot = (*slot).max(session_sequence_number);
+        }
         let mut pools = self.presign_pools.lock().unwrap();
         let key = (signature_algorithm, dwallet_network_encryption_key_id);
         let pool = pools.entry(key).or_default();
@@ -310,6 +323,19 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
         let pools = self.presign_pools.lock().unwrap();
         let key = (signature_algorithm, dwallet_network_encryption_key_id);
         Ok(pools.get(&key).map_or(0, |pool| pool.len() as u64))
+    }
+
+    fn max_filled_presign_pool_slot(
+        &self,
+        signature_algorithm: DWalletSignatureAlgorithm,
+        dwallet_network_encryption_key_id: ObjectID,
+    ) -> IkaResult<Option<u64>> {
+        Ok(self
+            .filled_presign_slot_high_water
+            .lock()
+            .unwrap()
+            .get(&(signature_algorithm, dwallet_network_encryption_key_id))
+            .copied())
     }
 
     fn pop_presign(
@@ -858,9 +884,57 @@ fn create_dwallet_mpc_service(
     Sender<NetworkOwnedAddressSignRequest>,
     Receiver<NetworkOwnedAddressSignOutput>,
 ) {
+    let epoch_store = Arc::new(TestingAuthorityPerEpochStore::new());
+    let (
+        service,
+        sui_data_senders,
+        dwallet_submit_to_consensus,
+        checkpoint_notify,
+        sign_request_sender,
+        sign_output_receiver,
+    ) = create_dwallet_mpc_service_over_epoch_store(
+        authority_name,
+        committee,
+        seed,
+        bundles,
+        epoch_store.clone(),
+    );
+    (
+        service,
+        sui_data_senders,
+        dwallet_submit_to_consensus,
+        epoch_store,
+        checkpoint_notify,
+        sign_request_sender,
+        sign_output_receiver,
+    )
+}
+
+/// Builds one validator's service over a CALLER-supplied epoch store — the
+/// mid-epoch-restart shape (#1952): every in-memory structure starts fresh
+/// (session map, internal-presign ordinal counters and batch guards, the
+/// consensus-round cursor), while the store's consensus rounds, pool fills,
+/// and slot markers survive to be replayed. Channel deliveries are re-seeded
+/// exactly as at process start (the off-chain key bundles); durable-only
+/// context the production syncer re-fetches (the network key overlay,
+/// `last_session_to_complete_in_current_epoch`) is the caller's to restore.
+#[allow(clippy::type_complexity)]
+pub(crate) fn create_dwallet_mpc_service_over_epoch_store(
+    authority_name: &AuthorityName,
+    committee: Committee,
+    seed: RootSeed,
+    bundles: crate::validator_metadata::OffChainCommitteeBundles,
+    epoch_store: Arc<TestingAuthorityPerEpochStore>,
+) -> (
+    DWalletMPCService,
+    SuiDataSenders,
+    Arc<TestingSubmitToConsensus>,
+    Arc<TestingDWalletCheckpointNotify>,
+    Sender<NetworkOwnedAddressSignRequest>,
+    Receiver<NetworkOwnedAddressSignOutput>,
+) {
     let (sui_data_receivers, sui_data_senders) = SuiDataReceivers::new_for_testing();
     let dwallet_submit_to_consensus = Arc::new(TestingSubmitToConsensus::new());
-    let epoch_store = Arc::new(TestingAuthorityPerEpochStore::new());
     let checkpoint_notify = Arc::new(TestingDWalletCheckpointNotify::new());
     let (service, sign_request_sender, sign_output_receiver) = DWalletMPCService::new_for_testing(
         epoch_store.clone(),
@@ -894,7 +968,6 @@ fn create_dwallet_mpc_service(
         service,
         sui_data_senders,
         dwallet_submit_to_consensus,
-        epoch_store,
         checkpoint_notify,
         sign_request_sender,
         sign_output_receiver,

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -548,11 +548,22 @@ pub(crate) struct DWalletMPCManager {
     /// starts fresh at 1 whenever it starts, identically on every validator —
     /// PROVIDED the start skew stays under one batch lifecycle. A validator
     /// entering a pool only after a full batch quorum-completed elsewhere
-    /// (mid-epoch restart, very late install) is permanently ordinal-offset
-    /// for that pool; see the top-up loop comment for the scope and the
-    /// tracked fast-forward heal.
+    /// (mid-epoch restart, very late install) would otherwise be permanently
+    /// ordinal-offset for that pool (#1952): the counter is in-memory, so it
+    /// is seeded on first touch from the persisted
+    /// `filled_presign_pool_slots` high-water, and the mint path
+    /// fast-forwards across ordinals whose sessions are already terminal —
+    /// see `instantiate_internal_presign_session`.
     pub(crate) next_internal_presign_sequence_number:
         HashMap<(NetworkKeyId, DWalletCurve, DWalletSignatureAlgorithm), u64>,
+
+    /// Pools whose ordinal stream was seeded from a persisted fill high-water
+    /// (i.e. this process joined a pool mid-epoch — a restart or a very late
+    /// key install). Drained on each pool's first live mint to emit the
+    /// one-shot "resumed live instantiation" marker the #1952 regression
+    /// scenario gates on.
+    internal_presign_restart_seeded_pools:
+        HashSet<(NetworkKeyId, DWalletCurve, DWalletSignatureAlgorithm)>,
 
     /// Monotonically increasing count of instantiated internal presign sessions
     /// per (network_key, curve, signature_algorithm). Incremented when a
@@ -795,6 +806,7 @@ impl DWalletMPCManager {
             untracked_anomalies: HashSet::new(),
             last_failed_network_key_data: HashMap::new(),
             next_internal_presign_sequence_number: HashMap::new(),
+            internal_presign_restart_seeded_pools: HashSet::new(),
             instantiated_internal_presign_sessions: HashMap::new(),
             completed_internal_presign_sessions: HashMap::new(),
             internal_presign_batch_instantiated_at_round: HashMap::new(),
@@ -2009,6 +2021,15 @@ impl DWalletMPCManager {
         if deferred_unmapped_key {
             return;
         }
+        // Never memoize an EMPTY overlay (#1952): the syncer only publishes a
+        // new overlay Arc on a pass that fetched something, so a
+        // wholly-empty first publish would otherwise pin `Arc::ptr_eq` true
+        // for the rest of the epoch and this pass would never look again —
+        // even after keys appear downstream of a recovered registry read.
+        // The empty pass is O(1), so re-running it every tick costs nothing.
+        if overlay.is_empty() {
+            return;
+        }
         self.last_adoption_input = Some((overlay.clone(), cert.is_some()));
     }
 
@@ -2359,17 +2380,14 @@ impl DWalletMPCManager {
         // longer depends on when other keys are adopted or the iteration order.
         // Per-pool ordinals are START-TIME-INVARIANT: a key adopted at a
         // different round on different validators still derives identical
-        // session identifiers for its pool, as long as the skew stays under
-        // one batch lifecycle. A validator whose first top-up of a pool lags
-        // past a full batch's quorum completion (mid-epoch restart replaying
-        // rounds before adoption lands, a very late install) starts its
-        // ordinal stream offset from its peers' and never converges — it sits
-        // out that pool's live sessions for the rest of the epoch (peers'
-        // quorum keeps the pool serving; the loss is this validator's
-        // redundancy). The heal — fast-forwarding the pool counter from the
-        // completed sequence numbers observed in consensus outputs — is
-        // tracked as follow-up work; the same exposure existed with the old
-        // shared counter, with cross-pool blast radius on top.
+        // session identifiers for its pool. A validator whose first top-up of
+        // a pool lags past a full batch's quorum completion (mid-epoch
+        // restart, a very late install) would otherwise start its ordinal
+        // stream offset from its peers' and never converge (#1952); the heal
+        // is in `instantiate_internal_presign_session` — the counter seeds on
+        // first touch from the persisted `filled_presign_pool_slots`
+        // high-water, and the mint path fast-forwards across ordinals whose
+        // sessions are already terminal.
         let agreed_key_ids: BTreeSet<_> = self.adopted_network_key_data.keys().copied().collect();
         let mut pools_filled: Vec<String> = Vec::new();
         for key_id in agreed_key_ids {
@@ -2509,25 +2527,34 @@ impl DWalletMPCManager {
                     && current_pool_size < minimal_pool_size)
                     || (network_is_idle && current_pool_size < maximum_pool_size)
                 {
+                    let mut minted = 0u64;
                     for _ in 1..=sessions_to_instantiate {
-                        self.instantiate_internal_presign_session(
+                        // Only a mint that produced a live session (activated
+                        // or parked-for-retry) counts against the
+                        // instantiated/completed batch guard: a mint the
+                        // fast-forward resolved as already-completed history
+                        // will never produce a completion of its own, and
+                        // counting it would wedge the guard (#1952).
+                        if self.instantiate_internal_presign_session(
                             consensus_round,
                             network_key_id,
                             key_id,
                             curve,
                             signature_algorithm,
-                        );
-                        *self
-                            .instantiated_internal_presign_sessions
-                            .entry((network_key_id, curve, signature_algorithm))
-                            .or_insert(0) += 1;
+                        ) {
+                            minted += 1;
+                            *self
+                                .instantiated_internal_presign_sessions
+                                .entry((network_key_id, curve, signature_algorithm))
+                                .or_insert(0) += 1;
+                        }
                     }
                     self.internal_presign_batch_instantiated_at_round.insert(
                         (network_key_id, curve, signature_algorithm),
                         consensus_round,
                     );
                     pools_filled.push(format!(
-                        "{curve:?}/{signature_algorithm:?}={current_pool_size}(min{minimal_pool_size})+{sessions_to_instantiate}"
+                        "{curve:?}/{signature_algorithm:?}={current_pool_size}(min{minimal_pool_size})+{minted}"
                     ));
                 }
             }
@@ -2613,53 +2640,177 @@ impl DWalletMPCManager {
         dwallet_network_encryption_key_id: ObjectID,
         curve: DWalletCurve,
         signature_algorithm: DWalletSignatureAlgorithm,
-    ) {
-        // Consume the sequence number, keyed by the key's content-derived
-        // `NetworkKeyId` — the SAME identity bound into the session
-        // identifier below, so the counter and the identifier can never use
-        // divergent key axes. The counter is PER (`NetworkKeyId`, curve,
-        // algorithm) pool: a key adopted at a different round on different
-        // validators starts its own pool's stream fresh at 1 without
-        // perturbing any other pool's stream.
-        let sequence_entry = self
+    ) -> bool {
+        let counter_key = (network_key_id, curve, signature_algorithm);
+        // Seed the pool's ordinal stream on its first touch this process from
+        // the persisted fill high-water, NOT from 1 (#1952). The counter is
+        // in-memory, so a mid-epoch restart used to restart the stream at 1 —
+        // every minted ordinal was one the committee had already completed,
+        // and each dead mint was "released" only by a live peer completion
+        // advancing the pool-aggregated completed counter, so the offset to
+        // the live ordinal window never closed and the validator sat out
+        // registry-driven instantiation for the rest of the epoch. The
+        // `filled_presign_pool_slots` markers are written on every fill and
+        // re-confirmed by the post-restart consensus replay, so the
+        // high-water is always at-or-behind the replay frontier: the small
+        // remainder is covered by the fast-forward below.
+        if !self
             .next_internal_presign_sequence_number
-            .entry((network_key_id, curve, signature_algorithm))
-            .or_insert(1);
-        let session_sequence_number = *sequence_entry;
-        *sequence_entry += 1;
+            .contains_key(&counter_key)
+        {
+            let seed = match self.epoch_store.max_filled_presign_pool_slot(
+                signature_algorithm,
+                dwallet_network_encryption_key_id,
+            ) {
+                Ok(Some(high_water)) => {
+                    info!(
+                        ?curve,
+                        ?signature_algorithm,
+                        ?dwallet_network_encryption_key_id,
+                        high_water,
+                        "seeded internal-presign ordinal stream from the persisted \
+                         pool-slot high-water (mid-epoch restart resume)",
+                    );
+                    self.internal_presign_restart_seeded_pools
+                        .insert(counter_key);
+                    high_water.saturating_add(1)
+                }
+                Ok(None) => 1,
+                Err(e) => {
+                    warn!(
+                        error=?e,
+                        ?curve,
+                        ?signature_algorithm,
+                        "failed to read the persisted pool-slot high-water; seeding the \
+                         internal-presign ordinal stream from 1 (fast-forward will converge)",
+                    );
+                    1
+                }
+            };
+            self.next_internal_presign_sequence_number
+                .insert(counter_key, seed);
+        }
 
-        // `consensus_round` is logged for traceability but is
-        // deliberately NOT part of the request/session identifier:
-        // validators reach this point at different rounds (the network
-        // key installs asynchronously), and the identifier must come out
-        // identical on every committee member.
-        let request = DWalletSessionRequest::new_internal_presign(
-            self.epoch_id,
-            session_sequence_number,
-            curve,
-            signature_algorithm,
-            dwallet_network_encryption_key_id,
-            &network_key_id.0,
-        );
+        // Bound on ordinals skipped per mint. The seed lands at-or-behind the
+        // replay frontier, so the residue (fills whose replay landed after the
+        // first mint's seed read) is a handful of ordinals; hundreds of
+        // consecutive already-terminal ordinals past the seed means the seed
+        // source is stale relative to the session map, which should never
+        // happen.
+        const MAX_ORDINAL_FAST_FORWARD_PER_MINT: u64 = 512;
+        let mut fast_forwarded: u64 = 0;
+        loop {
+            let sequence_entry = self
+                .next_internal_presign_sequence_number
+                .get_mut(&counter_key)
+                .expect("seeded above");
+            let session_sequence_number = *sequence_entry;
+            *sequence_entry += 1;
 
-        if let Err(request) = self.try_activate_internal_presign_request(consensus_round, request) {
-            // The key's data isn't locally available yet (typically the VSS
-            // pools at epoch entry, before the frozen off-chain validator
-            // key set has been ingested; or a key installed on peers but not
-            // here). Park the request and retry once per service iteration;
-            // peers that already have the data run the session meanwhile,
-            // and any of their messages buffer in a
-            // `WaitingForSessionRequest` entry until activation.
-            info!(
-                consensus_round,
-                ?curve,
-                ?signature_algorithm,
-                ?session_sequence_number,
-                session_identifier=?request.session_identifier,
-                "network key data not ready for internal presign session; parking it for retry",
+            // `consensus_round` is logged for traceability but is
+            // deliberately NOT part of the request/session identifier:
+            // validators reach this point at different rounds (the network
+            // key installs asynchronously), and the identifier must come out
+            // identical on every committee member.
+            let request = DWalletSessionRequest::new_internal_presign(
+                self.epoch_id,
+                session_sequence_number,
+                curve,
+                signature_algorithm,
+                dwallet_network_encryption_key_id,
+                &network_key_id.0,
             );
-            self.internal_presign_requests_pending_for_network_key_data
-                .push(ParkedInternalPresignRequest(request));
+
+            match self
+                .sessions
+                .get(&request.session_identifier)
+                .map(|s| &s.status)
+            {
+                // The committee already finished this ordinal (a restart
+                // replay reconstructed it terminal). Minting it again can
+                // never produce live work — skip ahead so the stream
+                // converges on the live window instead of trailing it by a
+                // constant offset (#1952).
+                Some(
+                    SessionStatus::Completed
+                    | SessionStatus::ComputationCompleted
+                    | SessionStatus::Failed,
+                ) => {
+                    fast_forwarded += 1;
+                    if fast_forwarded >= MAX_ORDINAL_FAST_FORWARD_PER_MINT {
+                        ika_types::report_invariant_violation!(
+                            "internal_presign_ordinal_fast_forward_exhausted",
+                            consensus_round,
+                            ?curve,
+                            ?signature_algorithm,
+                            last_skipped_sequence_number = session_sequence_number,
+                            fast_forwarded,
+                            "internal-presign ordinal stream is still inside \
+                             already-completed history after the per-mint fast-forward \
+                             budget; the persisted seed disagrees with the session map — \
+                             continuing from here next tick",
+                        );
+                        return false;
+                    }
+                    continue;
+                }
+                // Already instantiated by this process — a mint here would
+                // double-count the batch guard.
+                Some(SessionStatus::Active { .. }) => return false,
+                Some(SessionStatus::WaitingForSessionRequest) | None => {}
+            }
+
+            if fast_forwarded > 0 {
+                info!(
+                    consensus_round,
+                    ?curve,
+                    ?signature_algorithm,
+                    fast_forwarded,
+                    resumed_at_sequence_number = session_sequence_number,
+                    "internal-presign ordinal stream fast-forwarded past \
+                     already-completed sessions and resumed at the live window",
+                );
+            }
+
+            if let Err(request) =
+                self.try_activate_internal_presign_request(consensus_round, request)
+            {
+                // The key's data isn't locally available yet (typically the VSS
+                // pools at epoch entry, before the frozen off-chain validator
+                // key set has been ingested; or a key installed on peers but not
+                // here). Park the request and retry once per service iteration;
+                // peers that already have the data run the session meanwhile,
+                // and any of their messages buffer in a
+                // `WaitingForSessionRequest` entry until activation.
+                info!(
+                    consensus_round,
+                    ?curve,
+                    ?signature_algorithm,
+                    ?session_sequence_number,
+                    session_identifier=?request.session_identifier,
+                    "network key data not ready for internal presign session; parking it for retry",
+                );
+                self.internal_presign_requests_pending_for_network_key_data
+                    .push(ParkedInternalPresignRequest(request));
+            }
+            // One-shot per pool after a seeded (re)join: the unambiguous
+            // "this validator is participating in live registry-driven
+            // instantiation again" marker — the #1952 regression scenario
+            // gates on this line on the restarted validator.
+            if self
+                .internal_presign_restart_seeded_pools
+                .remove(&counter_key)
+            {
+                info!(
+                    consensus_round,
+                    ?curve,
+                    ?signature_algorithm,
+                    live_sequence_number = session_sequence_number,
+                    "internal presign top-up resumed live instantiation after a \
+                     mid-epoch restart",
+                );
+            }
+            return true;
         }
     }
 

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -1214,6 +1214,48 @@ where
                     HashMap::new()
                 });
 
+            // Silence-proofing (#1952): an empty registry read while the
+            // coordinator itself reports existing keys is indistinguishable
+            // from the healthy "no keys yet" state at every layer above this
+            // one — empty-success is legal everywhere downstream, so without
+            // this marker the condition is invisible until sessions stop.
+            // The loop keeps retrying on its own cadence either way.
+            {
+                let DWalletCoordinatorInner::V1(coordinator_inner_v1) = &dwallet_coordinator_inner;
+                let on_chain_registry_size =
+                    coordinator_inner_v1.dwallet_network_encryption_keys.size;
+                if network_encryption_keys.is_empty() && on_chain_registry_size > 0 {
+                    ika_types::report_invariant_violation!(
+                        "network_key_registry_read_empty",
+                        on_chain_registry_size,
+                        current_epoch,
+                        "network-key registry read returned an empty map while the \
+                         coordinator reports existing keys — retrying next tick",
+                    );
+                }
+            }
+
+            // Recovery widening (#1952/#1852): the stranded-key chain-read
+            // recovery below can only run for keys PRESENT in the fetched
+            // registry map. A stranded key the registry read failed to return
+            // means the audited recovery is silently pinned — surface it
+            // instead of falling through to the healthy-looking
+            // "No new network keys to fetch" line.
+            {
+                let stranded_snapshot = stranded_network_keys.load();
+                for stranded_id in stranded_snapshot.iter() {
+                    if !network_encryption_keys.contains_key(stranded_id) {
+                        ika_types::report_invariant_violation!(
+                            "stranded_network_key_missing_from_registry_read",
+                            key_id = ?stranded_id,
+                            current_epoch,
+                            "a network key flagged for chain-sourced recovery is absent \
+                             from the registry read — recovery cannot run this tick",
+                        );
+                    }
+                }
+            }
+
             let keys_to_fetch: HashMap<ObjectID, DWalletNetworkEncryptionKey> =
                 network_encryption_keys
                     .into_iter()

--- a/crates/ika-upgrade-test/src/scenario.rs
+++ b/crates/ika-upgrade-test/src/scenario.rs
@@ -142,6 +142,15 @@ pub enum Step {
         index: usize,
         needle: String,
     },
+    /// Poll ONE validator's `node.log` until `needle` appears (or the
+    /// epoch timeout elapses). The immediate [`Step::ExpectLogLineOnValidator`]
+    /// asserts a decision that already happened; this is the variant for a
+    /// condition the scenario is WAITING to happen (e.g. a restarted
+    /// validator resuming a background loop).
+    WaitForLogLineOnValidator {
+        index: usize,
+        needle: String,
+    },
 }
 
 impl std::fmt::Display for Step {
@@ -225,6 +234,9 @@ impl std::fmt::Display for Step {
                     f,
                     "expect_log_line_present_on_validator({index}, {needle:?})"
                 )
+            }
+            Step::WaitForLogLineOnValidator { index, needle } => {
+                write!(f, "wait_for_log_line_on_validator({index}, {needle:?})")
             }
         }
     }
@@ -556,6 +568,21 @@ impl Scenario {
         needle: impl Into<String>,
     ) -> Self {
         self.steps.push(Step::ExpectLogLineOnValidator {
+            index,
+            needle: needle.into(),
+        });
+        self
+    }
+
+    /// Poll the validator at `index`'s `node.log` until `needle` appears,
+    /// failing after the scenario's epoch timeout. See
+    /// [`Step::WaitForLogLineOnValidator`].
+    pub fn wait_for_log_line_on_validator(
+        mut self,
+        index: usize,
+        needle: impl Into<String>,
+    ) -> Self {
+        self.steps.push(Step::WaitForLogLineOnValidator {
             index,
             needle: needle.into(),
         });
@@ -978,6 +1005,35 @@ impl Scenario {
                         needle = needle.as_str(),
                         "per-validator log-line assertion passed"
                     );
+                }
+                Step::WaitForLogLineOnValidator { index, needle } => {
+                    let c = cluster
+                        .as_ref()
+                        .context("WaitForLogLineOnValidator before StartAll")?;
+                    let proc = c
+                        .validators
+                        .get(*index)
+                        .with_context(|| format!("validator index {index} out of range"))?;
+                    let deadline = std::time::Instant::now() + self.epoch_timeout;
+                    loop {
+                        let log = std::fs::read_to_string(proc.log_path()).with_context(|| {
+                            format!("read validator log {}", proc.log_path().display())
+                        })?;
+                        if log.contains(needle.as_str()) {
+                            tracing::info!(
+                                index = *index,
+                                needle = needle.as_str(),
+                                "per-validator log line appeared"
+                            );
+                            break;
+                        }
+                        ensure!(
+                            std::time::Instant::now() < deadline,
+                            "timed out waiting for {needle:?} in {}",
+                            proc.log_path().display(),
+                        );
+                        sleep(Duration::from_secs(2)).await;
+                    }
                 }
                 Step::RunWorkload { label } => {
                     let c = cluster.as_ref().context("RunWorkload before StartAll")?;

--- a/crates/ika-upgrade-test/tests/restart_spectator.rs
+++ b/crates/ika-upgrade-test/tests/restart_spectator.rs
@@ -20,13 +20,12 @@
 //! spectators for the rest of the epoch: `active: 0`, completions only via
 //! `reconstructed_from_consensus`, readiness never evaluated.
 //!
-//! The gate: after the restart, validator 0 must log
-//!   1. the ordinal-stream seed from the persisted pool-slot high-water, and
-//!   2. the one-shot "resumed live instantiation" marker,
-//! and the run must stay free of the #1952 silence-proofing invariant
-//! markers. The user workload must also still complete (event-driven
-//! activation was never the broken path — asserting it alone is exactly how
-//! the wedge stayed invisible).
+//! The gate: after the restart, validator 0 must log (1) the ordinal-stream
+//! seed from the persisted pool-slot high-water and (2) the one-shot
+//! "resumed live instantiation" marker, and the run must stay free of the
+//! #1952 silence-proofing invariant markers. The user workload must also
+//! still complete (event-driven activation was never the broken path —
+//! asserting it alone is exactly how the wedge stayed invisible).
 //!
 //! Fault-validation (test-testing playbook): revert the seed+fast-forward in
 //! `instantiate_internal_presign_session` (restore the bare `.or_insert(1)`)

--- a/crates/ika-upgrade-test/tests/restart_spectator.rs
+++ b/crates/ika-upgrade-test/tests/restart_spectator.rs
@@ -1,0 +1,168 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Mid-epoch restart spectator gate (#1952).
+//!
+//! A validator restarted mid-epoch, in an epoch with an established
+//! (prior-epoch-DKG'd) network key and ongoing internal-presign volume, must
+//! RESUME registry-driven internal-presign instantiation within a bounded
+//! window — not merely stay consensus-healthy while peers absorb every
+//! session.
+//!
+//! This is the ingredient `v125_rollout` lacks: its binary swaps land minutes
+//! from an epoch boundary and none of its gates assert per-validator top-up
+//! participation, so a restarted validator that silently re-mints
+//! already-completed internal-presign ordinals (the in-memory
+//! `next_internal_presign_sequence_number` restarting at 1) passes every
+//! convergence and workload gate — peers carry the sessions and the wedge
+//! self-heals at the next boundary. In production (24h epochs, sustained
+//! volume) that same state left all six dWallet Labs validators as pure MPC
+//! spectators for the rest of the epoch: `active: 0`, completions only via
+//! `reconstructed_from_consensus`, readiness never evaluated.
+//!
+//! The gate: after the restart, validator 0 must log
+//!   1. the ordinal-stream seed from the persisted pool-slot high-water, and
+//!   2. the one-shot "resumed live instantiation" marker,
+//! and the run must stay free of the #1952 silence-proofing invariant
+//! markers. The user workload must also still complete (event-driven
+//! activation was never the broken path — asserting it alone is exactly how
+//! the wedge stayed invisible).
+//!
+//! Fault-validation (test-testing playbook): revert the seed+fast-forward in
+//! `instantiate_internal_presign_session` (restore the bare `.or_insert(1)`)
+//! and this scenario must FAIL at step 1/2's timeout while
+//! `expect_all_validators_healthy` and the workload still pass — reproducing
+//! the production spectator signature.
+//!
+//! Opt-in (real binaries + long-running), via `RUN_RESTART_SPECTATOR=1`:
+//!
+//! ```bash
+//! RUN_RESTART_SPECTATOR=1 \
+//!   IKA_VALIDATOR_BIN=target/release/ika-validator \
+//!   IKA_NOTIFIER_BIN=target/release/ika-notifier \
+//!   IKA_BIN=target/release/ika \
+//!   SUI_BIN=$(which sui) \
+//!   cargo test --release -p ika-upgrade-test --test restart_spectator -- --nocapture
+//! ```
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ika_swarm_config::sui_client::GenesisGlobalPresignConfig;
+use ika_upgrade_test::binary::BinarySpec;
+use ika_upgrade_test::scenario::Scenario;
+
+fn bin_from_env(var: &str, default: &str) -> PathBuf {
+    PathBuf::from(std::env::var(var).unwrap_or_else(|_| default.to_string()))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restarted_validator_resumes_internal_presign_top_up_mid_epoch() {
+    if std::env::var("RUN_RESTART_SPECTATOR").is_err() {
+        eprintln!(
+            "skipping: set RUN_RESTART_SPECTATOR=1 \
+             (needs IKA_VALIDATOR_BIN/IKA_NOTIFIER_BIN/IKA_BIN/SUI_BIN)"
+        );
+        return;
+    }
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
+        .with_log_level("info")
+        .with_env()
+        .init();
+
+    let current = BinarySpec::Path(bin_from_env(
+        "IKA_VALIDATOR_BIN",
+        "target/release/ika-validator",
+    ));
+    let notifier = bin_from_env("IKA_NOTIFIER_BIN", "target/release/ika-notifier");
+    let ika_cli = bin_from_env("IKA_BIN", "target/release/ika");
+    let sui = bin_from_env("SUI_BIN", "sui");
+    let repo = std::env::current_dir()
+        .expect("cwd")
+        .ancestors()
+        .nth(2)
+        .expect("workspace root")
+        .to_path_buf();
+    let base = PathBuf::from(
+        std::env::var("UPGRADE_TEST_DIR")
+            .unwrap_or_else(|_| "/mnt/nvme0n1p1/tmp/ika-restart-spectator".to_string()),
+    );
+    let _ = std::fs::remove_dir_all(&base);
+    // Long enough that the restart (right after the epoch-2 mid-epoch
+    // reconfiguration completes) lands minutes from the next boundary — the
+    // resume must be proven WITHIN the epoch, not by the boundary reset that
+    // masked #1952 everywhere else.
+    let epoch_duration_ms = std::env::var("EPOCH_DURATION_MS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(600_000);
+    assert!(
+        epoch_duration_ms >= 480_000,
+        "restart_spectator requires an epoch of at least 480000ms so the restart lands \
+         far from the boundary and the resume gates complete inside the epoch"
+    );
+
+    Scenario::new(4, repo, sui, notifier)
+        .with_base_dir(base)
+        .with_epoch_duration_ms(epoch_duration_ms)
+        .with_epoch_timeout(Duration::from_secs(1200))
+        .with_genesis_global_presign_config(GenesisGlobalPresignConfig::Full)
+        .with_ika_cli(ika_cli)
+        .start_all(current.clone())
+        // Epoch 2: the network key was DKG'd in a prior epoch and has crossed
+        // a reconfiguration boundary — the "established key" ingredient.
+        .wait_for_epoch(2)
+        .wait_for_all_validators_local_epoch(2)
+        .expect_all_validators_healthy()
+        // Ride past the epoch-2 mid-epoch reconfiguration: by then this
+        // epoch's internal-presign pools hold minutes of fills (the persisted
+        // ordinal high-water the seed reads), and the restart still lands
+        // minutes from the boundary.
+        .wait_for_network_key_reconfiguration_started(2)
+        .wait_for_network_key_reconfiguration_completed(2)
+        .expect_all_validators_healthy()
+        // ── The event under test: a pure mid-epoch restart of one validator
+        //    (same binary — this is a restart gate, not an upgrade gate). ──
+        .stop_and_swap(&[0], current)
+        .expect_all_validators_healthy()
+        .wait_for_all_validators_local_epoch(2)
+        // THE GATE (both lines are post-restart by construction: node.log is
+        // truncated on restart): the ordinal stream must be seeded from the
+        // persisted pool-slot high-water, and the top-up loop must land a
+        // LIVE mint — the spectator state produces neither, ever.
+        .wait_for_log_line_on_validator(
+            0,
+            "seeded internal-presign ordinal stream from the persisted pool-slot high-water",
+        )
+        .wait_for_log_line_on_validator(
+            0,
+            "internal presign top-up resumed live instantiation after a mid-epoch restart",
+        )
+        // Silence-proofing markers must not fire in a healthy run: the seed
+        // disagreeing with the session map, or a registry read coming back
+        // empty against a non-empty coordinator registry, are #1952 invariant
+        // violations, not noise.
+        .expect_log_line_absent("internal_presign_ordinal_fast_forward_exhausted")
+        .expect_log_line_absent("network_key_registry_read_empty")
+        .expect_log_line_absent("stranded_network_key_missing_from_registry_read")
+        // The user path must ALSO still work — but it alone proving healthy
+        // is exactly how the spectator state stayed invisible, hence the
+        // top-up gates above come first.
+        .run_workload("post-restart-user-lifecycle")
+        // And the network still advances normally afterwards.
+        .wait_for_epoch(3)
+        .wait_for_all_validators_local_epoch(3)
+        .expect_all_validators_healthy()
+        .run()
+        .await
+        .expect(
+            "a validator restarted mid-epoch must resume live internal-presign top-up \
+             instantiation within the same epoch",
+        );
+
+    tracing::info!(
+        "restart_spectator PASSED: the restarted validator seeded its internal-presign \
+         ordinal stream from persisted state and resumed live registry-driven \
+         instantiation mid-epoch"
+    );
+}

--- a/dev-docs/reviews/issue1952-root-mechanism-and-fix.md
+++ b/dev-docs/reviews/issue1952-root-mechanism-and-fix.md
@@ -1,0 +1,128 @@
+# #1952 — root mechanism of the mid-epoch-restart MPC spectator, and the fix
+
+Forensic synthesis grounded in the live wedged fleet (6/6 dWallet Labs
+validators, epoch 363 mainnet / 366 testnet, `v1.2.6 74a44ed06deb`) and the
+source at that commit. This CORRECTS the issue's root-cause dossier: the
+mandated final reproduction step — reproduce
+`SuiClientInner::get_network_encryption_keys` returning an empty map per
+transport — came back **negative**, and the actual mechanism is one layer
+further down, in the internal-presign ordinal stream.
+
+## 1. What the reproduction disproved
+
+The dossier's chain ended at "the transport/OCS layer returns a
+silently-empty key-registry map." Measured against the live coordinator
+(`0x5ea59bce…`, registry table `0xd0e04ada…`, size 1):
+
+- The exact v1.2.6 read path (`GrpcSuiClient::get_network_encryption_keys` →
+  `for_each_dynamic_child` → `SuiGrpcClient::list_dynamic_fields` →
+  `sui.rpc.v2.StateService/ListDynamicFields`) returns the key, state
+  `NetworkReconfigurationCompleted`. JSON-RPC agrees. The `sui-rpc` proto pin
+  (`5b41bc7`) is identical v1.2.5↔v1.2.6 and field-number-identical to the
+  fullnode's reflected schema.
+- On the wedged pods: `ika_network_key_overlay_incomplete = 0` — and the
+  syncer memoizes a key in `last_fetched_network_keys` ONLY on a complete
+  merge (`sui_syncer.rs`, the `overlay_incomplete` branch), so the observed
+  5s `"No new network keys to fetch"` stream is the *healthy* post-memoization
+  shape, not an empty-read symptom.
+- `network_key_loaded_epoch = <current epoch>` is only settable through
+  `adopt_cert_verified_keys` → `instantiate_adopted_network_keys` →
+  `update_network_key` (there is no persisted-state bypass), so adoption ran
+  and the overlay was non-empty. Two dossier inferences were invalid:
+  a *successful* adoption pass logs nothing at any level (the success arm is
+  a bare map insert), and "zero adopt logs" therefore does not imply
+  "adoption never ran."
+
+## 2. The actual mechanism: an ordinal pursuit curve with zero closing speed
+
+`next_internal_presign_sequence_number` (`mpc_manager.rs`) — the per-pool
+counter that internal-presign `SessionIdentifier`s are derived from — is
+in-memory. Every validator mints the SAME deterministic ordinal stream, which
+is what lets the sessions reach quorum without any on-chain event. A
+mid-epoch restart resets one validator's stream to 1 while the committee's
+live window is (13h into a 24h epoch) tens of thousands of ordinals ahead:
+
+1. The post-restart consensus replay reconstructs the epoch's completed
+   internal-presign sessions as **terminal** entries in the session map
+   (`session_origin: reconstructed_from_consensus`).
+2. Every ordinal the restarted top-up loop mints is already terminal → the
+   silent "already resolved without us" early-return in
+   `try_activate_internal_presign_request`. No session is created; nothing
+   ever activates; `ready_to_advance` is never sampled (it samples per
+   *Active* session).
+3. The `instantiated != completed` batch guard reopens only when the
+   **pool-aggregated** `completed_internal_presign_sessions` counter advances
+   — which peers' *live* completions do (saturating, keyed per pool, not per
+   session). So the dead-mint rate tracks the live window's advance rate
+   exactly: constant offset, zero closing speed, for the rest of the epoch.
+
+Live signature (mainnet-1, ~3h wedged): 2,604/2,604 session-map additions
+`active: false` (reconstruction); 1,737 "Topping up internal presign pools"
+lines minting +1/+2 at the peer-completion ingest rate; `active = 0`;
+`completed = 39,350`; zero warns/errors in the retained log. Event-driven
+sessions (user Sign, NOA) still activate — their path checks
+`key_public_data_exists`, which is true — so ONLY registry-driven
+instantiation dies. Self-heal at the epoch boundary is structural: ordinals,
+counters, pools, and slot markers are all per-epoch and reset fleet-wide
+together.
+
+Window changes that shaped (not caused) the incident: #1934's
+slot-idempotent fills (`filled_presign_pool_slots`) correctly stopped
+replayed fills from double-counting, which converted the pre-existing
+post-restart collision from "inflated pool, quiet no-op" into "mints dead
+ordinals, silently discards its own colliding refills"; #1922/#1916
+downgraded every symptom log on the path; #1895 removed the syncer's
+boot-window chain-read fallback (lengthening the key-adoption detour after
+restart — the key still recovered via the stranded-key machinery).
+
+## 3. Why every gate was green
+
+`v125_rollout` performs exactly this restart — but its epochs are minutes
+long and none of its gates assert per-validator top-up participation. Peers
+absorb the sessions, `run_workload` passes on the event-driven path, and the
+near-by boundary resets the ordinals before anything can notice. The missing
+ingredient is **restart-to-boundary distance × a per-validator liveness
+assertion on registry-driven instantiation**.
+
+## 4. The fix
+
+- **Seed** (`max_filled_presign_pool_slot`, `authority_per_epoch_store.rs`;
+  consumed in `instantiate_internal_presign_session`): a pool's counter is
+  lazily seeded on first touch from the persisted
+  `filled_presign_pool_slots` high-water + 1. The markers are written on
+  every fill and re-confirmed by replay, so the seed lands at-or-behind the
+  replay frontier. No new table; write-discipline unchanged. Determinism:
+  identifiers stay content-derived, and `high_water + 1` is exactly where
+  the non-restarted majority's counters already are — this also heals the
+  previously-documented "very late install is permanently ordinal-offset"
+  mode.
+- **Fast-forward**: the mint path skips ordinals whose sessions are already
+  terminal (bounded, 512/mint, `internal_presign_ordinal_fast_forward_exhausted`
+  invariant marker past the budget) and rejoins an in-flight
+  `WaitingForSessionRequest` reconstruction in place (peers' buffered
+  messages preserved). Only live mints count against the batch guard.
+- **Silence-proofing**: `network_key_registry_read_empty` (registry read
+  empty while the coordinator reports keys — the dossier's hypothesized
+  state, previously legal-empty at every layer) and
+  `stranded_network_key_missing_from_registry_read` (audited recovery pinned)
+  in the syncer.
+- **Recovery widening**: `adopt_cert_verified_keys` no longer memoizes an
+  empty overlay (the syncer republishes only on a fetching pass, so an
+  empty first Arc would latch `Arc::ptr_eq` for the epoch).
+- **Gate**: `crates/ika-upgrade-test/tests/restart_spectator.rs` — restart
+  one validator mid-epoch, far from the boundary, with production pool
+  sizing, and require the restarted validator itself to log the seed and the
+  one-shot "resumed live instantiation" marker within the epoch.
+
+## 5. Diagnostics that would have caught this in minutes
+
+- `ika_dwallet_mpc_session_state_count{state="active"} == 0` while
+  `state="completed"` grows → spectator; check
+  `sessions_reconstructed_total` for the reconstruction-only shape.
+- `ready_to_advance_result_total` having NO series at all (vs `not_ready`
+  samples) means zero sessions ever activated — different failure class from
+  "sessions stuck not-ready".
+- "Topping up internal presign pools" present while `active = 0` →
+  ordinal-stream offset (pre-fix) — now the seed/fast-forward log lines and
+  the `internal_presign_ordinal_fast_forward_exhausted` marker name it
+  directly.


### PR DESCRIPTION
Fixes #1952.

## The mandated reproduction refuted the dossier's final step — and found the real bug

The dossier's six-layer elimination landed on "`SuiClientInner::get_network_encryption_keys` returns a silently-empty map on v1.2.6." Per the dossier, the one remaining step was to reproduce that read empty, per transport, against the live coordinator. **The reproduction came back negative on every layer:**

- A v1.2.6-built client (`GrpcSuiClient::get_network_encryption_keys`, exact validator code path, same `sui-rpc` pin `5b41bc7`) against the live mainnet fullnode returns the registry key correctly: `0x0a9c…` in `NetworkReconfigurationCompleted`, registry size 1. Raw `sui.rpc.v2.StateService/ListDynamicFields` and JSON-RPC `suix_getDynamicFields` both serve the entry; client/server proto field numbering is identical.
- On the wedged pods themselves: `ika_network_key_overlay_incomplete = 0` (the overlay memoizes only on a **complete** merge), `network_key_loaded_epoch = 363` (adoption ran and the key instantiated at boot — the instantiation sub-call histograms each show exactly one ~1.2s sample), zero `sui_rpc_errors`. The 5-second `"No new network keys to fetch"` line is the *healthy post-memoization stream*, not an empty-read symptom. Two dossier inferences don't hold: a successful adoption pass is completely silent (no log at any level), and `network_key_loaded_epoch = current` positively proves the overlay was non-empty.

## Actual root cause: the internal-presign ordinal stream resets to 1 on restart and can never catch the live window

`next_internal_presign_sequence_number` — the per-pool ordinal counter that internal-presign session identifiers are derived from — is in-memory. On a mid-epoch restart it restarts at 1 while the committee's live ordinal window is (in production, 13h into a 24h epoch) tens of thousands ahead:

1. The post-restart consensus replay reconstructs the epoch's completed internal-presign sessions as terminal entries in the session map.
2. Every ordinal the restarted validator's top-up loop mints is therefore already terminal → the silent "already resolved without us" early-return in `try_activate_internal_presign_request`. No session is ever created, nothing activates.
3. The `instantiated != completed` batch guard reopens only when the **pool-aggregated** completed counter advances — which peers' *live* completions do, at exactly the network's completion rate. The mint rate therefore tracks the live window's advance rate with **zero closing speed**: a pursuit curve with a constant offset, for the rest of the epoch.

Live confirmation on `ika-validator-mainnet-1-0` (~3h wedged): 2,604/2,604 "Adding a new MPC session" log lines are `active: false, reconstructed_from_consensus`; 1,737 "Topping up internal presign pools" lines minting +1/+2 at precisely the ingest rate of peer completions; `active = 0`; zero `ready_to_advance` samples (readiness samples only per *Active* session); **zero warnings or errors in the entire retained log**. Event-driven sessions (user Sign / NOA) still activate — only registry-driven instantiation dies — matching the issue's testnet observation exactly.

Contributing changes from the v1.2.5→v1.2.6 window (none individually the cause):
- **#1934** made pool fills slot-idempotent (correct), which turned the pre-existing post-restart ordinal collision from "double-counted pool, top-up quiesces" into "mints dead ordinals and silently discards its own refills" — and its `filled_presign_pool_slots` table is exactly the durable high-water this fix seeds from.
- **#1922/#1916** downgraded every symptom log on this path (terminal-session messages, completion classification), which is why the state was invisible at every layer.
- **#1895** removed the syncer's boot-window chain-read fallback, lengthening the key-adoption detour after restart (the key still recovered via the stranded-key machinery — `prior_cert_blobs_missing = 0` throughout).

Why every gate was green: `v125_rollout`'s epochs are minutes long and **nothing asserts per-validator top-up participation** — peers absorb the sessions, the user workload passes, and the epoch boundary (which resets ordinals and counters fleet-wide, and is minutes away in the harness vs hours in production) heals the wedge before any gate can notice. The missing ingredient is **restart-to-boundary distance combined with a per-validator liveness assertion on registry-driven instantiation** — now encoded in the `restart_spectator` scenario.

## The fix (three parts, per the issue)

**1. The fix proper — seed + fast-forward (`mpc_manager.rs`, `authority_per_epoch_store.rs`):**
- A pool's ordinal counter is now lazily seeded on first touch from the persisted `filled_presign_pool_slots` high-water (`max_filled_presign_pool_slot`, new trait method; **no new table, no schema change** — write-discipline check passes untouched). The slot markers are written on every fill and re-confirmed by the post-restart replay, so the seed lands at-or-behind the replay frontier; a fresh pool (no fills yet) still seeds 1, identical to fleet behavior. Fleet-determinism is preserved: identifiers stay content-derived, and a late joiner seeding `high_water+1` lands exactly where the non-restarted majority's counters already are — this also heals the previously-documented "very late install is permanently ordinal-offset" mode.
- The mint path fast-forwards (bounded, 512/mint) across ordinals whose sessions are already terminal, and rejoins an in-flight reconstructed session in place (the designed `WaitingForSessionRequest` upgrade path, with peers' buffered messages preserved). Only live mints count against the `instantiated/completed` batch guard.

**2. Silence-proofing (`report_invariant_violation!`, unique slugs):**
- `internal_presign_ordinal_fast_forward_exhausted` — the stream is still inside completed history after the per-mint budget (seed disagrees with the session map).
- `network_key_registry_read_empty` — the registry read returns an empty map while the coordinator reports existing keys (the dossier's hypothesized state; empty-success was previously legal and invisible at every layer).
- `stranded_network_key_missing_from_registry_read` — a key flagged for the audited chain-read recovery is absent from the registry read, so the recovery is pinned; previously this fell through to the healthy-looking "No new network keys to fetch" line.

**3. Recovery widening:**
- `adopt_cert_verified_keys` no longer memoizes an **empty** overlay in `last_adoption_input` — the syncer only republishes a new overlay Arc on a pass that fetched something, so a wholly-empty first publish would have latched `Arc::ptr_eq` for the rest of the epoch.
- Restart-resume observability: a one-shot "seeded internal-presign ordinal stream…" line at seed time and "internal presign top-up resumed live instantiation after a mid-epoch restart" on the pool's first live mint — the regression scenario's gates.

## Regression scenario — the gate ingredient `v125_rollout` lacks

`crates/ika-upgrade-test/tests/restart_spectator.rs` (+ `wait_for_log_line_on_validator` DSL step, + workflow registration with production presign-pool sizing): 4 validators, 10-minute epochs, `GenesisGlobalPresignConfig::Full`; ride into epoch 2 past the mid-epoch reconfiguration (established prior-epoch key + minutes of ordinal history, minutes from the boundary); restart validator 0 (same binary); **gate on the restarted validator itself resuming live registry-driven instantiation within the epoch** (both resume markers), with the silence-proofing invariants asserted absent and the user workload passing only *after* the top-up gates (asserting it alone is exactly how the wedge stayed invisible).

An in-process integration test (`test_mid_epoch_restart_resumes_internal_presign_ordinals_from_pool_high_water`) additionally proves, against the testing epoch-store mock with real class-groups crypto: the seed is lazy (a full consensus replay mints nothing), the restarted validator's first mint lands at **exactly H+1** with the pool counter identical committee-wide after every round, post-restart ordinals bind to identical identifiers on every peer and advance the persisted high-water, and the fast-forward skips terminal ordinals without counting them against the batch guard.

**Fault-validation** (per `dev-docs/playbooks/test-testing.md`): revert the seed+fast-forward hunk (restore the bare `.or_insert(1)`), rebuild, rerun `restart_spectator` → the scenario must FAIL at the resume-marker timeout while `expect_all_validators_healthy` and the workload still pass — the production spectator signature. Results recorded below.

## Validation

- [x] In-process regression test + full `internal_presign` (7/7), `validator_restart` (4/4), `mid_epoch_restart_keys` (5/5) suites — green locally (`--release`, real crypto)
- [x] `cargo fmt --check`, `cargo clippy` (incl. `--tests`), `check-epoch-table-write-discipline.sh`, `check-invariant-violation-markers.sh` — clean
- [x] Upgrade matrix (`test=all`) — [all 8 scenarios green](https://github.com/dwallet-labs/ika/actions/runs/30391037171), including **`restart_spectator`** (the new gate: the restarted validator seeded from the persisted high-water and resumed live instantiation mid-epoch) and **`v125_rollout`** (deployed-release compatibility)
- [x] Fault-validation — [run on the reverted-fix branch](https://github.com/dwallet-labs/ika/actions/runs/30391243183) **failed exactly as predicted**: seed observability fired, the "resumed live instantiation" gate timed out after the full window while every health/workload gate passed — the production spectator signature; the gate is not vacuous. Fault branch deleted after the run per the test-testing playbook.
- [x] Rust dwallet-MPC integration tests — [green](https://github.com/dwallet-labs/ika/actions/runs/30391048290)
- [x] Cluster tests — [green](https://github.com/dwallet-labs/ika/actions/runs/30391053823)
- [x] TS integration tests — [green](https://github.com/dwallet-labs/ika/actions/runs/30391065453)
- [x] Simtest — [green](https://github.com/dwallet-labs/ika/actions/runs/30391071921)
- [ ] PR-triggered `v125_rollout` rerun on the clippy-fix commit (delta vs the matrix-validated commit is one doc comment) — in flight

## Operational notes

- All six production validators remain wedged as of this PR (epoch 363 mainnet / 366 testnet); expected self-heal at their next epoch boundaries (mainnet boundary ≈ 2026-07-29 ~09:40 UTC). The fix requires only a binary swap — the seed reads state that is already being persisted.
- v1.2.6 stays unannounced; this ships as **v1.2.7** (version bump lands as the usual separate chore PR after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
