### PR TITLE
chore: bump version to v1.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-classgroups-types"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "bcs",
  "class_groups",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-rng"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "commitment",
  "fastcrypto",
@@ -6548,7 +6548,7 @@ dependencies = [
 
 [[package]]
 name = "ika"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6592,7 +6592,7 @@ dependencies = [
 
 [[package]]
 name = "ika-archival"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6765,7 +6765,7 @@ dependencies = [
 
 [[package]]
 name = "ika-node"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6836,7 +6836,7 @@ dependencies = [
 
 [[package]]
 name = "ika-proxy"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -6985,7 +6985,7 @@ dependencies = [
 
 [[package]]
 name = "ika-test-cluster"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "ika-upgrade-test"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 [workspace.package]
 # This version string will be inherited by ika-core, ika-node, ika-tools, ika-sdk, and ika crates.
-version = "1.2.6"
+version = "1.2.7"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/sdk/ika-wasm/Cargo.lock
+++ b/sdk/ika-wasm/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "bcs",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "bcs",


### PR DESCRIPTION
v1.2.7 carries the #1952 fix (https://github.com/dwallet-labs/ika/pull/1953): mid-epoch-restart internal-presign ordinal seeding + the restart_spectator gate. v1.2.6 stays published but unannounced per the release-blocker hold.

Release validation to record on the draft per the playbook: the fix branch's runs are linked in #1953's validation checklist (upgrade matrix 8/8 incl. restart_spectator + v125_rollout, Rust integration, cluster, TS, simtest, and the fault-validation red run); rerun v125_rollout + cluster + Rust integration against the tagged SHA at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)