### PR TITLE
fix(sui): recover pruned network-key registry reads

### DIFF
--- a/crates/ika-core/src/sui_connector/metrics.rs
+++ b/crates/ika-core/src/sui_connector/metrics.rs
@@ -51,6 +51,14 @@ pub struct SuiConnectorMetrics {
     /// committee validator stuck non-zero.
     pub(crate) network_key_overlay_incomplete: IntGauge,
 
+    /// 1 while a successful network-key registry read is empty even though the
+    /// coordinator reports existing entries; 0 after an observed recovery.
+    pub(crate) network_key_registry_read_empty_condition_active: IntGauge,
+
+    /// 1 while at least one key awaiting chain-sourced recovery is absent from
+    /// a successful registry read; 0 after an observed recovery.
+    pub(crate) stranded_network_key_missing_from_registry_read_condition_active: IntGauge,
+
     /// Total sync ticks on which the off-chain next-committee
     /// validator-mpc_data assembly was incomplete (benign retry while
     /// announcements/blobs converge; a stall shows as sustained growth).
@@ -224,6 +232,20 @@ impl SuiConnectorMetrics {
                 registry,
             )
             .unwrap(),
+            network_key_registry_read_empty_condition_active:
+                register_int_gauge_with_registry!(
+                    "ika_network_key_registry_read_empty_condition_active",
+                    "1 while a successful network-key registry read is empty despite a non-empty on-chain registry; 0 after recovery",
+                    registry,
+                )
+                .unwrap(),
+            stranded_network_key_missing_from_registry_read_condition_active:
+                register_int_gauge_with_registry!(
+                    "ika_stranded_network_key_missing_from_registry_read_condition_active",
+                    "1 while a stranded network key is absent from a successful registry read; 0 after recovery",
+                    registry,
+                )
+                .unwrap(),
             off_chain_assembly_incomplete_ticks_total: register_int_counter_with_registry!(
                 "ika_off_chain_assembly_incomplete_ticks_total",
                 "Total sync ticks on which the off-chain validator-mpc_data assembly was incomplete",
@@ -362,6 +384,18 @@ mod tests {
         let _mpc_metrics = DWalletMPCMetrics::new(&registry);
 
         assert_eq!(metrics.off_chain_assembly_incomplete.get(), 0);
+        assert_eq!(
+            metrics
+                .network_key_registry_read_empty_condition_active
+                .get(),
+            0
+        );
+        assert_eq!(
+            metrics
+                .stranded_network_key_missing_from_registry_read_condition_active
+                .get(),
+            0
+        );
         assert_eq!(
             metrics
                 .off_chain_assembly_consecutive_incomplete_ticks

--- a/crates/ika-core/src/sui_connector/setup.rs
+++ b/crates/ika-core/src/sui_connector/setup.rs
@@ -195,6 +195,15 @@ pub async fn build_sui_connector_stack(
     metrics: Arc<OcsMetrics>,
     provider_metrics: Arc<ProofProviderMetrics>,
 ) -> Result<SuiConnectorStack, SetupError> {
+    // Durable cache: rehydrates from the perpetual `verified_object_cache`
+    // column on boot and writes through every absorb. The direct proof
+    // provider also reuses a snapshot when Sui still returns the exact same
+    // object but has pruned the checkpoint needed to rebuild its proof.
+    let state_cache: SharedVerifiedStateCache = Arc::new(
+        VerifiedStateCache::open(perpetual.clone())?
+            .with_retain_window(Some(cfg.verified_cache_retention_checkpoints())),
+    );
+
     // 1. Build the *raw* transport used by the committee ratchet (and,
     //    on sui-state-direct nodes, by the LocalProofProvider
     //    underneath). Direct-gRPC for sui-state-direct;
@@ -215,11 +224,14 @@ pub async fn build_sui_connector_stack(
             );
             // Same provider instance used by the local reader and (via
             // the mirror server) by remote sui-state-mirrored peers.
-            let provider: Arc<dyn ProofProvider> = Arc::new(LocalProofProvider::new(
-                grpc.clone(),
-                &proof_cache_cfg,
-                provider_metrics.clone(),
-            ));
+            let provider: Arc<dyn ProofProvider> = Arc::new(
+                LocalProofProvider::new(
+                    grpc.clone(),
+                    &proof_cache_cfg,
+                    provider_metrics.clone(),
+                )
+                .with_proof_snapshot_cache(state_cache.clone()),
+            );
             provider_metrics
                 .role_info
                 .with_label_values(&["sui_state_direct"])
@@ -414,15 +426,6 @@ pub async fn build_sui_connector_stack(
         }
         _ => None,
     };
-
-    // Durable cache: rehydrates from the perpetual `verified_object_cache`
-    // column on boot and writes through every absorb, so a restart resumes
-    // serving from DB instead of re-fetching from the (possibly pruned) Sui
-    // fullnode.
-    let state_cache: SharedVerifiedStateCache = Arc::new(
-        VerifiedStateCache::open(perpetual.clone())?
-            .with_retain_window(Some(cfg.verified_cache_retention_checkpoints())),
-    );
 
     // 4. Verified-read surface for consumers. Freshness defense is
     //    version-monotonicity (per-object high-water mark in the

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -146,6 +146,36 @@ impl AssemblyHealthState {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ConditionTransition {
+    Unchanged,
+    Entered,
+    Recovered,
+}
+
+#[derive(Default)]
+struct PersistentConditionState {
+    active: bool,
+}
+
+impl PersistentConditionState {
+    fn observe(&mut self, active: bool) -> ConditionTransition {
+        let transition = match (self.active, active) {
+            (false, true) => ConditionTransition::Entered,
+            (true, false) => ConditionTransition::Recovered,
+            _ => ConditionTransition::Unchanged,
+        };
+        self.active = active;
+        transition
+    }
+}
+
+#[derive(Default)]
+struct NetworkKeyRegistryHealthState {
+    registry_read_empty: PersistentConditionState,
+    stranded_key_missing: PersistentConditionState,
+}
+
 fn set_assembly_missing_metrics(
     metrics: &SuiConnectorMetrics,
     current: Option<(OffChainAssemblyMissingReason, usize)>,
@@ -1175,6 +1205,7 @@ where
         // validator stuck incomplete escalates to warn every 60th
         // consecutive tick (~5 min).
         let mut consecutive_overlay_incomplete_ticks: HashMap<ObjectID, u64> = HashMap::new();
+        let mut registry_health = NetworkKeyRegistryHealthState::default();
         loop {
             time::sleep(Duration::from_secs(5)).await;
 
@@ -1206,13 +1237,19 @@ where
             };
             let current_epoch = system_inner.epoch();
 
-            let network_encryption_keys = sui_client
+            let network_encryption_keys = match sui_client
                 .get_dwallet_mpc_network_keys(&dwallet_coordinator_inner)
                 .await
-                .unwrap_or_else(|e| {
-                    warn!("failed to fetch dwallet MPC network keys: {e}");
-                    HashMap::new()
-                });
+            {
+                Ok(network_encryption_keys) => network_encryption_keys,
+                Err(error) => {
+                    // A transport failure is not proof that the registry is
+                    // empty and must not start or recover an invariant episode.
+                    // Preserve the last observed condition state and retry.
+                    warn!(?error, "failed to fetch dwallet MPC network keys");
+                    continue;
+                }
+            };
 
             // Silence-proofing (#1952): an empty registry read while the
             // coordinator itself reports existing keys is indistinguishable
@@ -1224,14 +1261,32 @@ where
                 let DWalletCoordinatorInner::V1(coordinator_inner_v1) = &dwallet_coordinator_inner;
                 let on_chain_registry_size =
                     coordinator_inner_v1.dwallet_network_encryption_keys.size;
-                if network_encryption_keys.is_empty() && on_chain_registry_size > 0 {
-                    ika_types::report_invariant_violation!(
-                        "network_key_registry_read_empty",
-                        on_chain_registry_size,
-                        current_epoch,
-                        "network-key registry read returned an empty map while the \
-                         coordinator reports existing keys — retrying next tick",
-                    );
+                let condition_active =
+                    network_encryption_keys.is_empty() && on_chain_registry_size > 0;
+                metrics
+                    .network_key_registry_read_empty_condition_active
+                    .set(i64::from(condition_active));
+                match registry_health
+                    .registry_read_empty
+                    .observe(condition_active)
+                {
+                    ConditionTransition::Entered => {
+                        ika_types::report_invariant_violation!(
+                            "network_key_registry_read_empty",
+                            on_chain_registry_size,
+                            current_epoch,
+                            "network-key registry read returned an empty map while the \
+                             coordinator reports existing keys — retrying next tick",
+                        );
+                    }
+                    ConditionTransition::Recovered => {
+                        info!(
+                            on_chain_registry_size,
+                            current_epoch,
+                            "network-key registry read recovered after returning an empty map"
+                        );
+                    }
+                    ConditionTransition::Unchanged => {}
                 }
             }
 
@@ -1243,16 +1298,37 @@ where
             // "No new network keys to fetch" line.
             {
                 let stranded_snapshot = stranded_network_keys.load();
-                for stranded_id in stranded_snapshot.iter() {
-                    if !network_encryption_keys.contains_key(stranded_id) {
+                let mut missing_stranded_keys: Vec<ObjectID> = stranded_snapshot
+                    .iter()
+                    .filter(|stranded_id| !network_encryption_keys.contains_key(stranded_id))
+                    .copied()
+                    .collect();
+                missing_stranded_keys.sort_unstable();
+                let condition_active = !missing_stranded_keys.is_empty();
+                metrics
+                    .stranded_network_key_missing_from_registry_read_condition_active
+                    .set(i64::from(condition_active));
+                match registry_health
+                    .stranded_key_missing
+                    .observe(condition_active)
+                {
+                    ConditionTransition::Entered => {
                         ika_types::report_invariant_violation!(
                             "stranded_network_key_missing_from_registry_read",
-                            key_id = ?stranded_id,
+                            missing_key_ids = ?missing_stranded_keys,
+                            missing_key_count = missing_stranded_keys.len(),
                             current_epoch,
-                            "a network key flagged for chain-sourced recovery is absent \
+                            "network keys flagged for chain-sourced recovery are absent \
                              from the registry read — recovery cannot run this tick",
                         );
                     }
+                    ConditionTransition::Recovered => {
+                        info!(
+                            current_epoch,
+                            "all stranded network keys are present in the registry read again"
+                        );
+                    }
+                    ConditionTransition::Unchanged => {}
                 }
             }
 
@@ -1903,6 +1979,18 @@ fn overlay_network_key_data(
 mod tests {
     use super::*;
     use crate::validator_metadata::StaticNetworkKeyBlobSource;
+
+    #[test]
+    fn persistent_condition_reports_once_per_episode_and_recovers_once() {
+        let mut state = PersistentConditionState::default();
+        assert_eq!(state.observe(false), ConditionTransition::Unchanged);
+        assert_eq!(state.observe(true), ConditionTransition::Entered);
+        assert_eq!(state.observe(true), ConditionTransition::Unchanged);
+        assert_eq!(state.observe(true), ConditionTransition::Unchanged);
+        assert_eq!(state.observe(false), ConditionTransition::Recovered);
+        assert_eq!(state.observe(false), ConditionTransition::Unchanged);
+        assert_eq!(state.observe(true), ConditionTransition::Entered);
+    }
 
     #[test]
     fn assembly_health_warns_on_sustained_incompleteness_and_recovers_once() {

--- a/crates/ika-core/src/sui_connector/verified_state_cache.rs
+++ b/crates/ika-core/src/sui_connector/verified_state_cache.rs
@@ -18,8 +18,9 @@
 //! Bounded by a retain window ([`VerifiedStateCache::with_retain_window`]):
 //! object snapshots more than `window` checkpoints behind the head are pruned
 //! from both the in-memory maps and the persisted column. The window prunes
-//! freely — this is the direct node's *own* cache-first read path, not the
-//! mirrored-serving surface, so a pruned snapshot just re-fetches from gRPC. The
+//! freely. The direct proof provider can also reuse an exact-current snapshot
+//! when the source checkpoint has been pruned; if the snapshot has aged out,
+//! that fallback is unavailable and the provider retries its normal source. The
 //! *served* end-of-epoch checkpoint summaries are retained deeper — back to the
 //! oldest committee-verifiable anchor — because a mirrored peer's committee
 //! ratchet can't re-derive a pruned one. Tombstone eviction on on-chain
@@ -30,7 +31,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use ika_network::proof_provider::VerifiedObjectEntry;
+use ika_network::proof_provider::{ProofSnapshotCache, VerifiedObjectEntry};
 use ika_types::error::IkaResult;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
@@ -283,11 +284,11 @@ impl VerifiedStateCache {
     /// source checkpoint is older than this are dropped. `None` when pruning is
     /// disabled.
     ///
-    /// Deliberately **not** clamped to the bootstrap anchor. This cache is the
-    /// *direct node's own* cache-first read path — mirrored peers are served
-    /// fresh proofs by `LocalProofProvider`, which never reads it — so a pruned
-    /// snapshot is a pure cache miss that re-fetches + re-verifies from gRPC,
-    /// which is harmless. Clamping the floor down to the (slow-moving) anchor
+    /// Deliberately **not** clamped to the bootstrap anchor. This cache backs
+    /// both the direct node's cache-first reads and the proof provider's
+    /// exact-current fallback after upstream pruning. A snapshot older than the
+    /// window intentionally loses that fallback and returns to the normal
+    /// gRPC proof path. Clamping the floor down to the (slow-moving) anchor
     /// would pin it below `head - window` forever, so the window would never
     /// prune and the cache would leak one entry per distinct object id. The
     /// anchor clamp belongs only on [`Self::eop_retention_floor`], whose
@@ -500,6 +501,24 @@ impl VerifiedStateCache {
 impl Default for VerifiedStateCache {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl ProofSnapshotCache for VerifiedStateCache {
+    fn get_proof_snapshot(
+        &self,
+        id: ObjectID,
+    ) -> Option<(VerifiedObjectEntry, CertifiedCheckpointSummary)> {
+        self.get(id).map(|snapshot| {
+            let entry = VerifiedObjectEntry {
+                object: snapshot.object,
+                checkpoint_seq: snapshot.source_checkpoint_seq,
+                proof: snapshot.proof,
+                dynamic_field_name_type: String::new(),
+                dynamic_field_name_bcs: Vec::new(),
+            };
+            (entry, snapshot.summary)
+        })
     }
 }
 

--- a/crates/ika-network/src/proof_provider.rs
+++ b/crates/ika-network/src/proof_provider.rs
@@ -31,7 +31,7 @@ use prometheus::{
 };
 use serde::{Deserialize, Serialize};
 use sui_light_client::proof::ocs::{ModifiedObjectTree, OCSInclusionProof};
-use sui_types::base_types::ObjectID;
+use sui_types::base_types::{ObjectID, ObjectRef};
 use sui_types::digests::TransactionDigest;
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointArtifacts, CheckpointSequenceNumber,
@@ -71,6 +71,9 @@ pub struct ProofProviderMetrics {
     pub proof_tree_cache_hits_total: IntCounter,
     /// Cache miss → had to fetch the full checkpoint and build the tree.
     pub proof_tree_cache_misses_total: IntCounter,
+    /// Proofs reused from the durable verified-state snapshot cache after the
+    /// current object's last-modifying checkpoint was pruned upstream.
+    pub proof_snapshot_cache_hits_total: IntCounter,
 
     // -- SuiMirrorProofProvider (sui-state-mirrored) --
     /// Relay calls initiated by a sui-state-mirrored provider, by op label.
@@ -150,6 +153,12 @@ impl ProofProviderMetrics {
             proof_tree_cache_misses_total: register_int_counter_with_registry!(
                 "ika_ocs_proof_tree_cache_misses_total",
                 "Per-checkpoint ModifiedObjectTree not in cache; refetched and rebuilt",
+                registry,
+            )
+            .unwrap(),
+            proof_snapshot_cache_hits_total: register_int_counter_with_registry!(
+                "ika_ocs_proof_snapshot_cache_hits_total",
+                "OCS proofs reused from the durable verified-state snapshot cache after upstream pruning",
                 registry,
             )
             .unwrap(),
@@ -361,6 +370,44 @@ pub trait ProofProvider: Send + Sync {
     ) -> Result<VerifiedDynamicFieldsPageResponse, TransportError>;
 }
 
+/// Read-only bridge to the durable, already-verified object snapshots owned by
+/// the connector. The producer consults it only after fetching the current Sui
+/// object and requiring an exact object-reference match, so a stale snapshot
+/// can never be served as current.
+pub trait ProofSnapshotCache: Send + Sync {
+    fn get_proof_snapshot(
+        &self,
+        id: ObjectID,
+    ) -> Option<(VerifiedObjectEntry, CertifiedCheckpointSummary)>;
+}
+
+type ProofBuildResult = Result<
+    (
+        CheckpointSequenceNumber,
+        VerifiedObjectEntry,
+        CertifiedCheckpointSummary,
+    ),
+    TransportError,
+>;
+
+fn recover_pruned_proof(
+    result: ProofBuildResult,
+    proof_snapshot_cache: Option<&dyn ProofSnapshotCache>,
+    current_object_ref: ObjectRef,
+) -> (ProofBuildResult, bool) {
+    let Err(TransportError::NotFound(reason)) = result else {
+        return (result, false);
+    };
+    let recovered = proof_snapshot_cache
+        .and_then(|cache| cache.get_proof_snapshot(current_object_ref.0))
+        .filter(|(entry, _)| entry.object.compute_object_reference() == current_object_ref)
+        .map(|(entry, summary)| (entry.checkpoint_seq, entry, summary));
+    match recovered {
+        Some(recovered) => (Ok(recovered), true),
+        None => (Err(TransportError::NotFound(reason)), false),
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ProofCacheConfig {
     /// Entry-count capacity for the per-checkpoint tree cache. Sized by
@@ -427,6 +474,7 @@ pub struct LocalProofProvider {
     /// sui-state-direct node over its own fullnode, so the concrete type fits.
     raw: Arc<SuiGrpcClient>,
     cache: ProofCache,
+    proof_snapshot_cache: Option<Arc<dyn ProofSnapshotCache>>,
     metrics: Arc<ProofProviderMetrics>,
 }
 
@@ -439,8 +487,14 @@ impl LocalProofProvider {
         Self {
             raw,
             cache: ProofCache::new(cfg),
+            proof_snapshot_cache: None,
             metrics,
         }
+    }
+
+    pub fn with_proof_snapshot_cache(mut self, cache: Arc<dyn ProofSnapshotCache>) -> Self {
+        self.proof_snapshot_cache = Some(cache);
+        self
     }
 
     async fn cached_checkpoint(
@@ -476,25 +530,35 @@ impl LocalProofProvider {
         ),
         TransportError,
     > {
-        let cp_seq = self.tx_checkpoint(object.previous_transaction).await?;
-        let cached = self.cached_checkpoint(cp_seq).await?;
         let object_ref = object.compute_object_reference();
-        let proof = cached.tree.get_inclusion_proof(object_ref).map_err(|e| {
-            TransportError::NotFound(format!("inclusion proof for {object_ref:?}: {e}"))
-        })?;
-        Ok((
-            cp_seq,
-            VerifiedObjectEntry {
-                object,
-                checkpoint_seq: cp_seq,
-                proof,
-                // Populated by the dynamic-fields-page walk (which has the field key);
-                // empty for direct/batch object reads.
-                dynamic_field_name_type: String::new(),
-                dynamic_field_name_bcs: Vec::new(),
-            },
-            cached.summary.clone(),
-        ))
+        let result = async {
+            let cp_seq = self.tx_checkpoint(object.previous_transaction).await?;
+            let cached = self.cached_checkpoint(cp_seq).await?;
+            let proof = cached.tree.get_inclusion_proof(object_ref).map_err(|e| {
+                TransportError::NotFound(format!("inclusion proof for {object_ref:?}: {e}"))
+            })?;
+            Ok((
+                cp_seq,
+                VerifiedObjectEntry {
+                    object,
+                    checkpoint_seq: cp_seq,
+                    proof,
+                    // Populated by the dynamic-fields-page walk (which has the field key);
+                    // empty for direct/batch object reads.
+                    dynamic_field_name_type: String::new(),
+                    dynamic_field_name_bcs: Vec::new(),
+                },
+                cached.summary.clone(),
+            ))
+        }
+        .await;
+
+        let (result, recovered) =
+            recover_pruned_proof(result, self.proof_snapshot_cache.as_deref(), object_ref);
+        if recovered {
+            self.metrics.proof_snapshot_cache_hits_total.inc();
+        }
+        result
     }
 
     /// `tx_digest → checkpoint_seq`, memoized. The mapping is immutable once
@@ -709,5 +773,116 @@ impl ProofProvider for LocalProofProvider {
             claimed_latest_checkpoint_seq: head,
             skipped_entry_ids,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use sui_light_client::proof::ocs::ModifiedObjectTree;
+    use sui_types::base_types::SequenceNumber;
+    use sui_types::committee::Committee as SuiCommittee;
+    use sui_types::crypto::AuthorityKeyPair;
+    use sui_types::digests::CheckpointContentsDigest;
+    use sui_types::gas::GasCostSummary;
+    use sui_types::messages_checkpoint::{
+        CheckpointArtifacts, CheckpointCommitment, CheckpointSummary,
+    };
+    use sui_types::object::Owner;
+
+    struct StaticSnapshotCache {
+        entry: VerifiedObjectEntry,
+        summary: CertifiedCheckpointSummary,
+    }
+
+    impl ProofSnapshotCache for StaticSnapshotCache {
+        fn get_proof_snapshot(
+            &self,
+            id: ObjectID,
+        ) -> Option<(VerifiedObjectEntry, CertifiedCheckpointSummary)> {
+            (id == self.entry.object.id()).then(|| {
+                let entry = bcs::from_bytes(
+                    &bcs::to_bytes(&self.entry).expect("verified entry must serialize"),
+                )
+                .expect("verified entry must deserialize");
+                (entry, self.summary.clone())
+            })
+        }
+    }
+
+    fn snapshot_cache(
+        committee: &SuiCommittee,
+        keys: &[AuthorityKeyPair],
+        seq: CheckpointSequenceNumber,
+        object: &Object,
+    ) -> StaticSnapshotCache {
+        let (id, version, digest) = object.compute_object_reference();
+        let artifacts =
+            CheckpointArtifacts::from_object_states(BTreeMap::from([(id, (version, digest))]));
+        let artifacts_digest = artifacts.digest().expect("artifacts digest");
+        let summary = CheckpointSummary {
+            epoch: committee.epoch(),
+            sequence_number: seq,
+            network_total_transactions: 0,
+            content_digest: CheckpointContentsDigest::new([0; 32]),
+            previous_digest: None,
+            epoch_rolling_gas_cost_summary: GasCostSummary::default(),
+            timestamp_ms: 0,
+            checkpoint_commitments: vec![CheckpointCommitment::from(artifacts_digest)],
+            end_of_epoch_data: None,
+            version_specific_data: Vec::new(),
+        };
+        let summary =
+            CertifiedCheckpointSummary::new_from_keypairs_for_testing(summary, keys, committee);
+        let proof = ModifiedObjectTree::new(&artifacts)
+            .expect("modified object tree")
+            .get_inclusion_proof(object.compute_object_reference())
+            .expect("inclusion proof");
+        StaticSnapshotCache {
+            entry: VerifiedObjectEntry {
+                object: object.clone(),
+                checkpoint_seq: seq,
+                proof,
+                dynamic_field_name_type: String::new(),
+                dynamic_field_name_bcs: Vec::new(),
+            },
+            summary,
+        }
+    }
+
+    #[test]
+    fn pruned_proof_reuses_only_an_exact_current_snapshot() {
+        let (committee, keys) = SuiCommittee::new_simple_test_committee();
+        let id = ObjectID::from_single_byte(0xA1);
+        let owner = Owner::ObjectOwner(ObjectID::from_single_byte(0xB2).into());
+        let cached_object = Object::with_id_owner_version_for_testing(
+            id,
+            SequenceNumber::from(7u64),
+            owner.clone(),
+        );
+        let cache = snapshot_cache(&committee, &keys, 42, &cached_object);
+
+        let (recovered, cache_hit) = recover_pruned_proof(
+            Err(TransportError::NotFound("checkpoint pruned".into())),
+            Some(&cache),
+            cached_object.compute_object_reference(),
+        );
+        assert!(cache_hit);
+        let (_, entry, _) = recovered.expect("exact-current snapshot must recover the proof");
+        assert_eq!(
+            entry.object.compute_object_reference(),
+            cached_object.compute_object_reference()
+        );
+
+        let newer_object =
+            Object::with_id_owner_version_for_testing(id, SequenceNumber::from(8u64), owner);
+        let (rejected, cache_hit) = recover_pruned_proof(
+            Err(TransportError::NotFound("checkpoint pruned".into())),
+            Some(&cache),
+            newer_object.compute_object_reference(),
+        );
+        assert!(!cache_hit);
+        assert!(matches!(rejected, Err(TransportError::NotFound(_))));
     }
 }

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -83,6 +83,16 @@ fields, never label values. The counter vector does not create a series until a
 site fires, so an absent series means zero violations. CI rejects bare
 `should_never_happen = true` markers outside the macro.
 
+An invariant counter records an **occurrence**, not an ongoing state. A
+condition inside a retry or service loop that can persist across ticks must fire
+the macro only on transition into the condition, log recovery once, and expose
+a paired `*_condition_active` gauge for the current state. Repeating the macro
+on every retry destroys incident boundaries and makes `increase(...) > 0`
+indistinguishable from a previously-known condition. Bounded reminder logs are
+allowed when operators need them, but reminders do not increment the invariant
+counter. The network-key registry sites are guarded structurally by
+`scripts/check-invariant-violation-markers.sh`.
+
 Per-authority output observations are collected protocol-generically but
 **exported only for an allow-listed set of protocols** (currently network-key
 reconfiguration; see `OUTPUT_OBSERVATION_EXPORT_PROTOCOLS` in `mpc_manager.rs`).
@@ -321,6 +331,7 @@ ika_mpc_blob_store_evictions_total
 ika_mpc_blob_store_size_bytes
 ika_mpc_data_announcement_blob_bytes
 ika_network_key_overlay_incomplete
+ika_network_key_registry_read_empty_condition_active
 ika_num_peers_with_external_address
 ika_ocs_anchor_info
 ika_ocs_bag_omission_suspected_total
@@ -336,6 +347,7 @@ ika_ocs_last_successful_relay_timestamp_seconds
 ika_ocs_proof_build_failures_total
 ika_ocs_proof_build_latency_seconds
 ika_ocs_proof_built_total
+ika_ocs_proof_snapshot_cache_hits_total
 ika_ocs_proof_tree_cache_hits_total
 ika_ocs_proof_tree_cache_misses_total
 ika_ocs_proof_verify_failures_total
@@ -383,6 +395,7 @@ ika_skipped_consensus_txns
 ika_skipped_consensus_txns_cache_hit
 ika_split_brain_dwallet_checkpoint_forks
 ika_split_brain_system_checkpoint_forks
+ika_stranded_network_key_missing_from_registry_read_condition_active
 ika_sui_client_chain_blob_reads
 ika_sui_client_sui_rpc_errors
 ika_sui_connector_chain_active_system_sessions_count

--- a/dev-docs/playbooks/production-alerts.md
+++ b/dev-docs/playbooks/production-alerts.md
@@ -19,6 +19,23 @@ so an absent series means that site has recorded zero violations. **Operator
 action**: inspect the matching `should_never_happen = true` log on the affected
 host and correlate it with subsystem metrics around the event timestamp.
 
+Invariant sites report incidents on **entry**, not on every retry tick. For a
+persistent condition, alert its paired state gauge separately; the counter says
+"a new episode began" while the gauge says "the episode is still active." The
+network-key registry conditions use:
+
+```promql
+ika_network_key_registry_read_empty_condition_active == 1
+or
+ika_stranded_network_key_missing_from_registry_read_condition_active == 1
+# for: 1m (filters a single read/convergence tick without delaying a real stall)
+```
+
+Both gauges clear on the first successful registry read that demonstrates
+recovery. Transport errors preserve the last observed state and are counted by
+the Sui RPC/OCS transport metrics; an error is not evidence that an active
+condition recovered.
+
 ## Alert 2: prepare-then-start barrier blocked
 
 ```promql

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -480,6 +480,14 @@ dropping entries are layered:
   readers to receive a proof after the source checkpoint is pruned. Hits are
   counted by `ika_ocs_proof_snapshot_cache_hits_total`.
 
+  A malicious or lagging Sui source can replay an older, once-current object
+  reference and thereby make an exact cached snapshot appear current. This
+  grants no capability beyond withholding: control of that source already lets
+  it freeze the validator on an old view by withholding newer state. The cached
+  object remains bound to a committee-certified inclusion proof, so the source
+  cannot fabricate state, and the consumer's version high-water still rejects
+  a rollback below any version the process has already accepted.
+
   If no exact cached snapshot exists, the provider reports the ids it listed
   but could not prove (`skipped_entry_ids`). A direct reader can still resolve
   each through its trusted listing plus `verified_object` cache fallback.

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -465,24 +465,31 @@ dropping entries are layered:
   *persistent* suspicion is actionable. It is count-only (cannot tell
   *which* entries are missing) and is disabled on direct nodes (where the
   bag is trusted-local but `Bag.size` lags cache-first).
-- **Pruned-defining-checkpoint resolution (direct nodes only)**: the
+- **Pruned-defining-checkpoint resolution**: the
   page builder needs each entry's defining checkpoint to construct its
   inclusion proof, and once the fullnode prunes that checkpoint the
   proof can never be built again — a skip there is permanent, not
   transient (this silently hid `session_events` entries of sessions
-  re-pulled across epoch boundaries and pinned epoch closes). The
-  provider therefore reports the ids it listed but could not prove
-  (`skipped_entry_ids`), and the reader resolves each through
-  `verified_object` — its own proof verification, currency check, and
-  committee-verified cache fallback included. Being live-listed proves
-  the entry still exists on-chain, so resolution cannot resurrect a
-  completed session's entry. Trusted listings only: on a mirrored node
-  a relay's skipped ids carry no membership binding (no proof), so they
-  stay omitted and the count-based policing covers them. Residual: if
-  the local cache also lacks the entry (e.g. the node was down when it
-  was folded and the upstream has pruned it), the reader warns per walk
-  until the session completes network-wide and the entry leaves the
-  bag.
+  re-pulled across epoch boundaries and pinned epoch closes). The direct
+  proof provider shares the durable verified-state snapshot cache populated
+  by the checkpoint pusher. If rebuilding a proof returns `NotFound`, it may
+  reuse a cached `(object, proof, summary)` only after fetching the current
+  object from Sui and requiring its complete object reference (id, version,
+  digest) to equal the cached object reference. That makes a stale snapshot
+  unusable while allowing both the local direct reader and remote mirrored
+  readers to receive a proof after the source checkpoint is pruned. Hits are
+  counted by `ika_ocs_proof_snapshot_cache_hits_total`.
+
+  If no exact cached snapshot exists, the provider reports the ids it listed
+  but could not prove (`skipped_entry_ids`). A direct reader can still resolve
+  each through its trusted listing plus `verified_object` cache fallback.
+  Being live-listed by its own Sui source proves the entry still exists, so
+  resolution cannot resurrect a completed session's entry. On a mirrored node
+  a relay's remaining skipped ids carry no membership binding (no proof), so
+  they stay omitted and the count-based policing covers them. Residual: if the
+  direct cache lacks the current version (for example, the node was down when
+  it was folded and the upstream pruned it), the entry remains unavailable
+  until a source capable of proving that version is used.
 - **Downstream session-id dedup**: the MPC engine keys sessions by
   `SessionIdentifier`, skips already-completed sessions via the
   perpetual store, and treats re-delivery of an in-flight session as a

--- a/scripts/check-invariant-violation-markers.sh
+++ b/scripts/check-invariant-violation-markers.sh
@@ -21,4 +21,22 @@ if ! grep -Eq 'tracing::error!\(should_never_happen[[:space:]]*=[[:space:]]*true
     exit 1
 fi
 
+# These sites live in the five-second network-key sync loop. They must remain
+# transition-gated: putting either marker back on the raw condition turns one
+# incident into hundreds of invariant events per host per hour.
+syncer=crates/ika-core/src/sui_connector/sui_syncer.rs
+for site in \
+    network_key_registry_read_empty \
+    stranded_network_key_missing_from_registry_read
+do
+    count="$(grep -Fc "\"$site\"" "$syncer")"
+    if [[ "$count" -ne 1 ]] || \
+        ! grep -B 3 "\"$site\"" "$syncer" | grep -q 'ConditionTransition::Entered'
+    then
+        echo "ERROR: hot-loop invariant site '$site' must have exactly one transition-gated call:"
+        grep -n "\"$site\"" "$syncer" || true
+        exit 1
+    fi
+done
+
 echo "invariant violation markers OK"


### PR DESCRIPTION
Fixes #1957.

## Root cause

The OCS dynamic-field proof provider drops a live-listed child when the child's last-modifying checkpoint has been pruned. The durable verified-state cache already retains the exact object, proof, and certified summary, but only the local reader used it; mirrored registry walks therefore observed a successful empty page indefinitely. Different upstream pruning/configuration explains the per-host split on the same binary and epoch.

## Fix

- Share the durable verified snapshot cache with the direct proof provider. After a normal proof build returns `NotFound`, reuse a cached proof only when the current object fetched from Sui has the exact same `(id, version, digest)` as the cached object. Direct and mirrored consumers still verify the proof normally.
- Make the two registry invariant sites episode-shaped: one counter increment on entry, one recovery log, and paired active-condition gauges. Transport failures no longer masquerade as successful empty reads.
- Add a CI structural guard preventing those hot-loop invariant sites from losing their transition gate.
- Update the metrics convention, production alert playbook, and OCS verified-read spec.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --release -p ika-network pruned_proof_reuses_only_an_exact_current_snapshot --lib`
- focused release-mode `ika-core` transition, metric-registration, and durable-cache tests
- `./scripts/check-invariant-violation-markers.sh`
- `./scripts/check-metric-names.sh`
- `git diff --check`

Test-testing: temporarily disabled the exact-match recovery predicate; the pruning regression failed at `assert!(cache_hit)` as predicted. The mutation was removed and the clean test passed.