### PR TITLE
Export self-recognized malicious state as a fleet-visible counter (#1736 item 3)

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -219,6 +219,24 @@ pub struct DWalletMPCMetrics {
     /// so these are counted here — NOT in the anomaly taxonomy — to keep
     /// `anomaly_snapshots_total` meaningful. Labels: `race` (fixed condition
     /// strings), `session_type`.
+    /// This validator concluded that IT ITSELF is malicious for a session —
+    /// its own output diverged from the peers' quorum, or the majority output
+    /// reported it. Fleet-visible by design: until this counter existed the
+    /// conclusion lived only in one operator's `error!` log, so a validator
+    /// silently dropping out of MPC was invisible to everyone else on the
+    /// network.
+    ///
+    /// Not an invariant violation — this is a REAL condition a correct binary
+    /// can reach (a genuine divergence, a wire-format disagreement across an
+    /// upgrade), so it is deliberately kept out of
+    /// `ika_invariant_violations_total`, which means "should never happen".
+    ///
+    /// Labels are fixed enums: `reason` (the three
+    /// `LocalAuthorityMaliciousReason` variants, or `unspecified`) and
+    /// `session_type`. Never a session id, authority, or digest — those are
+    /// unbounded and identify operators.
+    pub(crate) self_malicious_total: IntCounterVec,
+
     pub(crate) completion_races_total: IntCounterVec,
 
     /// Consensus-delivered MPC messages ignored because the local session was
@@ -606,6 +624,13 @@ impl DWalletMPCMetrics {
                 "ika_dwallet_mpc_anomaly_triggers_total",
                 "Trigger conditions included in emitted privacy-safe MPC anomaly snapshots",
                 &["trigger", "session_type"],
+                registry,
+            )
+            .unwrap(),
+            self_malicious_total: register_int_counter_vec_with_registry!(
+                "ika_dwallet_mpc_self_malicious_total",
+                "Sessions for which this validator recognized ITSELF as malicious, by reason and session type",
+                &["reason", "session_type"],
                 registry,
             )
             .unwrap(),

--- a/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
@@ -196,6 +196,21 @@ pub(crate) enum LocalAuthorityMaliciousReason {
     MaliciousVoterAndReportedByMajorityOutput,
 }
 
+impl LocalAuthorityMaliciousReason {
+    /// A bounded, fixed label for `ika_dwallet_mpc_self_malicious_total`. The
+    /// variants are the whole label domain — never derive this from anything
+    /// operator- or session-specific.
+    pub(crate) fn metric_label(self) -> &'static str {
+        match self {
+            Self::MaliciousVoter => "malicious_voter",
+            Self::ReportedByMajorityOutput => "reported_by_majority_output",
+            Self::MaliciousVoterAndReportedByMajorityOutput => {
+                "malicious_voter_and_reported_by_majority_output"
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub(crate) enum SessionDiagnosticEvent {

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -4256,12 +4256,26 @@ impl DWalletMPCManager {
                 self.recognized_self_as_malicious = true;
                 self.recognized_self_as_malicious_session = Some(*session_identifier);
 
+                let reason = outputs_to_finalize
+                    .vote_diagnostics
+                    .local_authority_malicious_reason;
+                // Fleet-visible, not just local: this validator has concluded
+                // it diverged from its peers, and without a metric that fact
+                // reaches nobody but this operator. Labels are the two fixed
+                // enums only — a session id or authority here would be
+                // unbounded AND would identify the operator to every scraper.
+                self.dwallet_mpc_metrics
+                    .self_malicious_total
+                    .with_label_values(&[
+                        reason.map_or("unspecified", LocalAuthorityMaliciousReason::metric_label),
+                        session_type_label(session_identifier.session_type()),
+                    ])
+                    .inc();
+
                 error!(
                     ?session_identifier,
                     authority=?self.validator_name,
-                    local_authority_malicious_reason = ?outputs_to_finalize
-                        .vote_diagnostics
-                        .local_authority_malicious_reason,
+                    local_authority_malicious_reason = ?reason,
                     "node recognized itself as malicious"
                 );
             }

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -75,6 +75,23 @@ cross-binary malicious-detection test asserts exclusion programmatically
 instead of matching a log line. Log-level discipline itself lives in
 [`logging.md`](logging.md).
 
+`ika_dwallet_mpc_self_malicious_total{reason,session_type}` counts sessions for
+which a validator concluded that IT ITSELF is malicious — its output diverged
+from the peers' quorum, or the majority output named it. Before this counter the
+conclusion existed only as an `error!` in that one operator's logs, so a
+validator dropping itself out of MPC was invisible to the other ~93 on
+testnet+mainnet. It is deliberately NOT an invariant violation: a correct binary
+can reach this state (a genuine divergence, or a wire-format disagreement during
+a protocol upgrade), so it must not be routed through
+`report_invariant_violation!`, which means "should never happen" and would both
+mislabel the condition and pollute that counter during a rollout.
+
+Its labels are the whole reason it can be exported: `reason` is the fixed
+`LocalAuthorityMaliciousReason` set (plus `unspecified`) and `session_type` is
+the fixed session kind — at most a handful of series. Session ids, authority
+names and output digests are excluded on purpose. They are unbounded, and on a
+public metrics endpoint they identify which operator diverged and on what.
+
 `ika_invariant_violations_total{site}` shadows every structured
 `should_never_happen = true` error across the node. Call sites use
 `report_invariant_violation!` with a stable literal `site`; the macro emits the
@@ -263,6 +280,7 @@ ika_dwallet_mpc_received_requests_start_count
 ika_dwallet_mpc_requests_pending_for_frozen_mpc_data
 ika_dwallet_mpc_requests_pending_for_network_key
 ika_dwallet_mpc_requests_pending_for_next_active_committee
+ika_dwallet_mpc_self_malicious_total
 ika_dwallet_mpc_self_output_to_quorum_consensus_rounds
 ika_dwallet_mpc_service_end_of_publish_local
 ika_dwallet_mpc_session_late_output_info

--- a/dev-docs/playbooks/production-alerts.md
+++ b/dev-docs/playbooks/production-alerts.md
@@ -36,7 +36,41 @@ recovery. Transport errors preserve the last observed state and are counted by
 the Sui RPC/OCS transport metrics; an error is not evidence that an active
 condition recovered.
 
-## Alert 2: prepare-then-start barrier blocked
+## Alert 2: a validator recognized ITSELF as malicious
+
+```promql
+sum by (host, reason, session_type) (
+  increase(ika_dwallet_mpc_self_malicious_total[10m])
+) > 0
+# no for-duration: fire immediately
+```
+
+The validator concluded its own MPC output diverged from the peers' quorum, or
+the majority output named it. It has effectively dropped itself out of that
+session, and it will keep doing so for as long as the cause persists. There is
+no benign threshold: a correct, agreeing validator never increments this.
+
+Unlike Alert 1 this is NOT a broken invariant — a correct binary can reach it.
+The two causes that matter operationally:
+
+- **A genuine divergence** on this host (bad state, corrupted inputs, a real
+  fault). Confined to that validator; quorum absorbs it.
+- **A wire-format disagreement across a protocol upgrade** — the fleet-wide
+  case. During a rollout that changes serialization, validators emitting
+  different bytes compute different digests and reject each other while parsing
+  each other's messages perfectly. **This alert firing on multiple hosts at once
+  during an upgrade window is the signal that the rollout itself is splitting
+  the network**, not that those operators are individually broken.
+
+**Operator action**: check whether one host or many are firing, and whether the
+window coincides with a binary rollout or protocol-version activation. One host
+— investigate that node. Several, mid-upgrade — treat as a rollout-wide
+serialization split and stop the rollout before it crosses quorum. Correlate
+with `ika_dwallet_mpc_malicious_actors_count` on the *peers* (who they blame)
+and with the `node recognized itself as malicious` log on the affected host,
+which carries the session id the labels deliberately omit.
+
+## Alert 3: prepare-then-start barrier blocked
 
 ```promql
 ika_handoff_prepare_waiting == 1
@@ -52,7 +86,7 @@ missing input; `ika_handoff_prepare_retries_total` and the duration
 histogram quantify the wait. See `../specs/handoff.md`
 ("Prepare-then-start barrier").
 
-## Alert 3: off-chain assembly permanently wedged
+## Alert 4: off-chain assembly permanently wedged
 
 ```promql
 ika_off_chain_assembly_wedged != 0
@@ -68,7 +102,7 @@ announcement/ready-signal logs for why attestation coverage collapsed
 (propagation outage, mass restart inside the announcement window);
 recovery requires operator intervention, not waiting.
 
-## Alert 4 (log-based): joiner bootstrap fail-closed halt
+## Alert 5 (log-based): joiner bootstrap fail-closed halt
 
 There is no gauge for this one — the node **halts** when every
 current-committee peer served a handoff certificate and none verified


### PR DESCRIPTION
Item 3 of #1736.

When a validator concludes that **it itself** is malicious — its MPC output diverged from the peers' quorum, or the majority output named it — that conclusion has until now existed only as an `error!` in one operator's private logs. The other ~93 validators on testnet and mainnet cannot see it, so a node dropping itself out of MPC is invisible to everyone who would act on it.

Adds `ika_dwallet_mpc_self_malicious_total{reason, session_type}`, incremented beside the existing log line in `mpc_manager`.

## Why not `report_invariant_violation!`

Self-malicious is a **real condition a correct binary can reach** — a genuine divergence, or a wire-format disagreement during a protocol upgrade. That macro means "should never happen". Routing this through it would mislabel the condition *and* pollute `ika_invariant_violations_total` during exactly the rollout window this metric exists to illuminate.

## Bounded labels

This is what makes the condition safe to export at all:

- `reason` — the fixed `LocalAuthorityMaliciousReason` set (plus `unspecified`), via a new `metric_label()` on the enum
- `session_type` — reuses the existing `session_type_label`

At most a handful of series. Session ids, authority names and output digests stay in the log: they are unbounded, **and** on a public metrics endpoint they identify which operator diverged and on what.

## Why now

v1.2.8 ships protocol v7, which changes the `AuthorityName` wire encoding. Per #1959's own analysis, validators emitting different widths "compute different digests and reject each other's signatures while parsing each other's messages perfectly" — a validator on the wrong side of that would plausibly recognize itself as malicious, during precisely the window we most need fleet-wide visibility.

The `production-alerts.md` entry is built around that case rather than the single-node one: **one host firing** is a node to investigate; **several firing inside an upgrade window** means the rollout itself is splitting the network, and the operator action is to stop the rollout before it crosses quorum.

## Verification

- `cargo check --workspace --all-targets` clean; clippy clean
- `ika-core` non-integration 334/334
- `scripts/check-metric-names.sh` passes, with the new name present in its `--list` output

## Two notes for reviewers

1. **`check-metric-names.sh` does not enforce the metrics.md entry.** It enforces only the `ika_` prefix against an allowlist and merely references the doc in its error text. The doc entry here is added by hand and that list can still drift — worth a separate guard if we want it real.
2. **This is a follow-up to #1959, not a companion.** #1959 merged first, so the metric lands on a tree that already carries the v7 encoding change. That makes the alert's upgrade-split scenario concrete rather than hypothetical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
