### PR TITLE
chore: robustness pass across node subsystems

### DIFF
--- a/crates/ika-core/src/authority.rs
+++ b/crates/ika-core/src/authority.rs
@@ -537,12 +537,12 @@ impl AuthorityState {
     pub fn tally_protocol_upgrade_votes(
         proposed_protocol_version: ProtocolVersion,
         committee: &Committee,
-        capabilities: Vec<AuthorityCapabilitiesV1>,
+        capabilities: &[AuthorityCapabilitiesV1],
     ) -> Option<Vec<ProtocolUpgradeVoteGroup>> {
         // For each validator, gather the protocol version and system packages that it would like
         // to upgrade to in the next epoch.
         let mut desired_upgrades: Vec<_> = capabilities
-            .into_iter()
+            .iter()
             .filter_map(|cap| {
                 debug!(
                     "validator {:?} supports {:?} with move packages: {:?}",
@@ -556,7 +556,7 @@ impl AuthorityState {
                 // bump.
                 cap.supported_protocol_versions
                     .get_version_digest(proposed_protocol_version)
-                    .map(|digest| (digest, cap.move_contracts_to_upgrade, cap.authority))
+                    .map(|digest| (digest, cap.move_contracts_to_upgrade.clone(), cap.authority))
             })
             .collect();
 
@@ -591,44 +591,42 @@ impl AuthorityState {
         )
     }
 
+    /// `None` when no same-(digest, contracts) vote group for
+    /// `proposed_protocol_version` reaches the effective threshold — including
+    /// the case where nobody votes for the version at all.
     fn is_protocol_version_supported_v1(
         proposed_protocol_version: ProtocolVersion,
         committee: &Committee,
-        capabilities: Vec<AuthorityCapabilitiesV1>,
+        capabilities: &[AuthorityCapabilitiesV1],
         buffer_stake_bps: u64,
-    ) -> (Option<AuthorityCapabilitiesVotingResults>, bool) {
+    ) -> Option<AuthorityCapabilitiesVotingResults> {
         let effective_threshold =
             Self::protocol_upgrade_effective_threshold(committee, buffer_stake_bps);
 
-        let Some(vote_groups) =
-            Self::tally_protocol_upgrade_votes(proposed_protocol_version, committee, capabilities)
-        else {
-            return (None, true);
-        };
+        let vote_groups =
+            Self::tally_protocol_upgrade_votes(proposed_protocol_version, committee, capabilities)?;
 
-        let res =
-            vote_groups
-                .into_iter()
-                .find_map(|(digest, move_contracts_to_upgrade, total_votes)| {
-                    let has_support = total_votes >= effective_threshold;
+        vote_groups
+            .into_iter()
+            .find_map(|(digest, move_contracts_to_upgrade, total_votes)| {
+                let has_support = total_votes >= effective_threshold;
 
-                    info!(
-                        protocol_config_digest = ?digest,
-                        ?total_votes,
-                        ?buffer_stake_bps,
-                        ?effective_threshold,
-                        ?proposed_protocol_version,
-                        ?move_contracts_to_upgrade,
-                        has_support,
-                        "checking support for upgrade"
-                    );
+                info!(
+                    protocol_config_digest = ?digest,
+                    ?total_votes,
+                    ?buffer_stake_bps,
+                    ?effective_threshold,
+                    ?proposed_protocol_version,
+                    ?move_contracts_to_upgrade,
+                    has_support,
+                    "checking support for upgrade"
+                );
 
-                    has_support.then_some(AuthorityCapabilitiesVotingResults {
-                        protocol_version: proposed_protocol_version,
-                        move_contracts_to_upgrade,
-                    })
-                });
-        (res, false)
+                has_support.then_some(AuthorityCapabilitiesVotingResults {
+                    protocol_version: proposed_protocol_version,
+                    move_contracts_to_upgrade,
+                })
+            })
     }
 
     pub(crate) fn choose_highest_protocol_version_and_move_contracts_upgrades_v1(
@@ -637,33 +635,29 @@ impl AuthorityState {
         capabilities: Vec<AuthorityCapabilitiesV1>,
         buffer_stake_bps: u64,
     ) -> AuthorityCapabilitiesVotingResults {
+        // Walk upward from the current version and stop at the first version
+        // that fails the effective threshold, mirroring upstream. Capability
+        // messages describe a contiguous version range, so a version cannot
+        // regain quorum after a gap and the chosen version is unchanged, while
+        // the number of iterations now follows the committee's votes rather
+        // than the length of any one member's advertised list.
         let mut next_protocol_version = current_protocol_version;
-        let mut versions = vec![];
-        let mut completed = false;
+        let mut last_supported = None;
 
-        while !completed {
-            let (version, current_completed) = Self::is_protocol_version_supported_v1(
-                next_protocol_version,
-                committee,
-                capabilities.clone(),
-                buffer_stake_bps,
-            );
-            completed = current_completed;
-            versions.push(version);
+        while let Some(supported) = Self::is_protocol_version_supported_v1(
+            next_protocol_version,
+            committee,
+            &capabilities,
+            buffer_stake_bps,
+        ) {
+            last_supported = Some(supported);
             next_protocol_version = next_protocol_version + 1;
         }
 
-        let versions = versions.into_iter().flatten().collect_vec();
-        let last_version = versions.into_iter().last();
-
-        if let Some(version) = last_version {
-            version
-        } else {
-            AuthorityCapabilitiesVotingResults {
-                protocol_version: current_protocol_version,
-                move_contracts_to_upgrade: vec![],
-            }
-        }
+        last_supported.unwrap_or(AuthorityCapabilitiesVotingResults {
+            protocol_version: current_protocol_version,
+            move_contracts_to_upgrade: vec![],
+        })
     }
 
     pub fn unixtime_now_ms() -> u64 {

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -2778,7 +2778,7 @@ impl AuthorityPerEpochStore {
         let supporting = crate::authority::AuthorityState::tally_protocol_upgrade_votes(
             self.protocol_version() + 1,
             committee,
-            capabilities,
+            &capabilities,
         )
         .map(|groups| {
             groups
@@ -4474,7 +4474,7 @@ impl AuthorityPerEpochStore {
     /// Important: This function can potentially be called in parallel and you can not rely on order of transactions to perform verification
     /// If this function return an error, transaction is skipped and is not passed to handle_consensus_transaction
     /// This function returns unit error and is responsible for emitting log messages for internal errors
-    fn verify_consensus_transaction(
+    pub(crate) fn verify_consensus_transaction(
         &self,
         transaction: SequencedConsensusTransaction,
         skipped_consensus_txns: &IntCounter,
@@ -4764,7 +4764,7 @@ impl AuthorityPerEpochStore {
         C: DWalletCheckpointServiceNotify,
     >(
         &self,
-        transactions: Vec<SequencedConsensusTransaction>,
+        verified_transactions: Vec<VerifiedSequencedConsensusTransaction>,
         consensus_stats: &ExecutionIndicesWithStats,
         checkpoint_service: &Option<Arc<C>>,
         system_checkpoint_service: &Option<Arc<SystemCheckpointService>>,
@@ -4774,16 +4774,6 @@ impl AuthorityPerEpochStore {
         Vec<DWalletCheckpointMessageKind>,
         Vec<SystemCheckpointMessageKind>,
     )> {
-        let verified_transactions: Vec<_> = transactions
-            .into_iter()
-            .filter_map(|transaction| {
-                self.verify_consensus_transaction(
-                    transaction,
-                    &authority_metrics.skipped_consensus_txns,
-                )
-            })
-            .collect();
-
         let mut output = ConsensusCommitOutput::new(consensus_commit_info.round);
 
         // Epoch consensus clock: advance the in-memory running max of

--- a/crates/ika-core/src/consensus_handler.rs
+++ b/crates/ika-core/src/consensus_handler.rs
@@ -324,19 +324,27 @@ impl<C: DWalletCheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     transaction,
                 };
 
-                let key = sequenced_transaction.key();
-                let in_set = !processed_set.insert(key);
-                let in_cache = self
-                    .processed_cache
-                    .put(sequenced_transaction.key(), ())
-                    .is_some();
+                // Verify before keying the dedup structures, matching the
+                // ordering used upstream: only an authenticated transaction
+                // should occupy a dedup key, since the key is derived from
+                // fields the submitter controls.
+                let Some(verified_transaction) = self.epoch_store.verify_consensus_transaction(
+                    sequenced_transaction,
+                    &self.metrics.skipped_consensus_txns,
+                ) else {
+                    continue;
+                };
+
+                let key = verified_transaction.0.key();
+                let in_set = !processed_set.insert(key.clone());
+                let in_cache = self.processed_cache.put(key, ()).is_some();
 
                 if in_set || in_cache {
                     self.metrics.skipped_consensus_txns_cache_hit.inc();
                     continue;
                 }
 
-                all_transactions.push(sequenced_transaction);
+                all_transactions.push(verified_transaction);
             }
         }
 

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -398,9 +398,12 @@ pub(crate) struct DWalletMPCManager {
     /// to determine the network's idle status.
     pub(crate) idle_status_by_party: HashMap<PartyID, bool>,
 
-    /// Tracks which parties have seen each presign request, keyed by sequence number.
-    /// When a presign request reaches majority, it's moved to `completed_presign_sequence_numbers`.
-    presign_request_votes: HashMap<u64, HashSet<PartyID>>,
+    /// Tracks which parties have announced each presign request, keyed by the
+    /// full request body: the body is what gets served and checkpointed, so it
+    /// is what has to reach quorum. When a body reaches majority its sequence
+    /// number moves to `completed_presign_sequence_numbers` and any other body
+    /// recorded for that sequence number is dropped.
+    presign_request_votes: HashMap<GlobalPresignRequest, HashSet<PartyID>>,
 
     /// Sequence numbers of presign requests that have reached majority vote.
     /// Once completed, we don't record new votes for these requests.
@@ -1246,17 +1249,23 @@ impl DWalletMPCManager {
                 continue;
             }
 
-            // Add this party's vote for this presign request.
-            let parties = self
-                .presign_request_votes
-                .entry(sequence_number)
-                .or_default();
+            // Agreement is content-addressed: a party votes for a specific
+            // request body, not merely for its sequence number. Honest
+            // validators derive the body from the same Sui event, so they
+            // announce byte-identical requests and the agreed body is
+            // unchanged.
+            let parties = self.presign_request_votes.entry(request).or_default();
             parties.insert(sender_party_id);
 
-            // Check if the parties that voted form an authorized subset.
+            // Check if the parties that voted for THIS body form an authorized subset.
             if self.access_structure.is_authorized_subset(parties).is_ok() {
                 self.completed_presign_sequence_numbers
                     .insert(sequence_number);
+                // Any other body recorded for this sequence number can no
+                // longer be agreed, so drop its tally rather than holding it
+                // until the epoch ends.
+                self.presign_request_votes
+                    .retain(|voted, _| voted.session_sequence_number != sequence_number);
                 agreed_presign_requests.push(request);
                 debug!(
                     sequence_number,

--- a/crates/ika-core/src/epoch_tasks/announcement_relay.rs
+++ b/crates/ika-core/src/epoch_tasks/announcement_relay.rs
@@ -219,7 +219,7 @@ mod tests {
     };
     use crate::authority::authority_perpetual_tables::AuthorityPerpetualTables;
     use crate::authority::epoch_start_configuration::EpochStartConfiguration;
-    use crate::consensus_handler::{ConsensusCommitInfo, SequencedConsensusTransaction};
+    use crate::consensus_handler::{ConsensusCommitInfo, VerifiedSequencedConsensusTransaction};
     use crate::dwallet_checkpoints::DWalletCheckpointService;
     use crate::epoch::epoch_metrics::EpochMetrics;
     use crate::system_checkpoints::SystemCheckpointService;
@@ -329,7 +329,7 @@ mod tests {
         let tx = ConsensusTransaction::new_relayed_validator_mpc_data_announcement(signed, blob);
         epoch_store
             .process_consensus_transactions_and_commit_boundary(
-                vec![SequencedConsensusTransaction::new_test(tx)],
+                vec![VerifiedSequencedConsensusTransaction::new_test(tx)],
                 &ExecutionIndicesWithStats {
                     index: ExecutionIndices {
                         last_committed_round: 1,

--- a/crates/ika-core/src/epoch_tasks/mpc_data_announcement_sender.rs
+++ b/crates/ika-core/src/epoch_tasks/mpc_data_announcement_sender.rs
@@ -1279,7 +1279,10 @@ mod tests {
             ConsensusStats, ExecutionIndices, ExecutionIndicesWithStats,
         };
         use crate::authority::epoch_start_configuration::EpochStartConfiguration;
-        use crate::consensus_handler::{ConsensusCommitInfo, SequencedConsensusTransaction};
+        use crate::consensus_handler::{
+            ConsensusCommitInfo, SequencedConsensusTransaction,
+            VerifiedSequencedConsensusTransaction,
+        };
         use crate::dwallet_checkpoints::DWalletCheckpointService;
         use crate::epoch::epoch_metrics::EpochMetrics;
         use crate::system_checkpoints::SystemCheckpointService;
@@ -1334,7 +1337,7 @@ mod tests {
         };
         epoch_store
             .process_consensus_transactions_and_commit_boundary(
-                vec![stale_landing],
+                vec![VerifiedSequencedConsensusTransaction(stale_landing)],
                 &ExecutionIndicesWithStats {
                     index: ExecutionIndices {
                         last_committed_round: 1,

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -897,10 +897,23 @@ where
     ) -> Vec<u8> {
         let committee_size = active_committee.members.len();
         let mut signers_bitmap = vec![0u8; committee_size.div_ceil(8)];
-        for singer in signers_map.iter() {
+        for signer in signers_map.iter() {
+            // The buffer is sized from the on-chain committee while
+            // `signers_map` is deserialized from the certificate, so the two
+            // are bounded independently. Drop anything outside the committee
+            // rather than indexing on it; the submission then fails the
+            // on-chain quorum check, which is the correct outcome.
+            if signer as usize >= committee_size {
+                warn!(
+                    signer,
+                    committee_size,
+                    "checkpoint certificate names a signer outside the committee; dropping the bit"
+                );
+                continue;
+            }
             // Set the i-th bit to 1,
-            let byte_index = (singer / 8) as usize;
-            let bit_index = singer % 8;
+            let byte_index = (signer / 8) as usize;
+            let bit_index = signer % 8;
             signers_bitmap[byte_index] |= 1u8 << bit_index;
         }
         signers_bitmap

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -877,7 +877,12 @@ where
             sui_client.get_validators_info_by_ids(unknown_ids).await?
         };
         for validator in &validators {
-            let info = validator.verified_validator_info();
+            let info = validator.verified_validator_info().map_err(|code| {
+                IkaError::InvalidCommittee(format!(
+                    "validator {} has unparsable on-chain metadata (Move error code {code})",
+                    validator.id
+                ))
+            })?;
             consensus_key_cache.insert(validator.id, info.consensus_pubkey.clone());
         }
         members

--- a/crates/ika-network/src/state_sync/builder.rs
+++ b/crates/ika-network/src/state_sync/builder.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 use super::{
-    Handle, OnChainCheckpointCursors, PeerHeights, StateSync, StateSyncEventLoop, StateSyncMessage,
-    StateSyncServer,
+    CommitteeSource, Handle, OnChainCheckpointCursors, PeerHeights, StateSync, StateSyncEventLoop,
+    StateSyncMessage, StateSyncServer,
     metrics::Metrics,
     server::{CheckpointMessageDownloadLimitLayer, Server},
 };
@@ -22,7 +22,7 @@ use std::{
 };
 use tap::Pipe;
 use tokio::{
-    sync::{broadcast, mpsc},
+    sync::{broadcast, mpsc, watch},
     task::JoinSet,
 };
 
@@ -33,6 +33,7 @@ pub struct Builder<S> {
     archive_readers: Option<ArchiveReaderBalancer>,
     chain_identifier: Option<ChainIdentifier>,
     on_chain_cursors: Option<OnChainCheckpointCursors>,
+    committees: Option<CommitteeSource>,
 }
 
 impl Builder<()> {
@@ -45,6 +46,7 @@ impl Builder<()> {
             archive_readers: None,
             chain_identifier: None,
             on_chain_cursors: None,
+            committees: None,
         }
     }
 }
@@ -58,6 +60,7 @@ impl<S> Builder<S> {
             archive_readers: self.archive_readers,
             chain_identifier: self.chain_identifier,
             on_chain_cursors: self.on_chain_cursors,
+            committees: self.committees,
         }
     }
 
@@ -81,6 +84,14 @@ impl<S> Builder<S> {
     /// the cursor instead of chasing full history from sequence 1.
     pub fn with_on_chain_cursors(mut self, on_chain_cursors: OnChainCheckpointCursors) -> Self {
         self.on_chain_cursors = Some(on_chain_cursors);
+        self
+    }
+
+    /// Feed of the committees pull-mode sync verifies peer-supplied
+    /// certificates against (see [`CommitteeSource`]). Without it every sync
+    /// job defers, because there is nothing to check a certificate against.
+    pub fn with_committees(mut self, committees: CommitteeSource) -> Self {
+        self.committees = Some(committees);
         self
     }
 }
@@ -137,12 +148,16 @@ where
             archive_readers,
             chain_identifier,
             on_chain_cursors,
+            committees,
         } = self;
         let store = store.unwrap();
         let config = config.unwrap_or_default();
         let metrics = metrics.unwrap_or_else(Metrics::disabled);
         let archive_readers = archive_readers.unwrap_or_default();
         let chain_identifier = chain_identifier.unwrap_or_default();
+        // With no feed configured there is nothing to check against, so sync
+        // defers.
+        let committees = committees.unwrap_or_else(|| watch::channel(None).1);
 
         let (sender, mailbox) = mpsc::channel(config.mailbox_capacity());
         let (dwallet_checkpoint_event_sender, _receiver) =
@@ -189,6 +204,7 @@ where
                 chain_identifier,
                 system_checkpoint_download_limit_layer: None,
                 on_chain_cursors,
+                committees,
             },
             server,
         )
@@ -209,6 +225,7 @@ pub struct UnstartedStateSync<S> {
     pub(super) archive_readers: ArchiveReaderBalancer,
     pub(crate) chain_identifier: ChainIdentifier,
     pub(super) on_chain_cursors: Option<OnChainCheckpointCursors>,
+    pub(super) committees: CommitteeSource,
 }
 
 impl<S> UnstartedStateSync<S>
@@ -234,6 +251,7 @@ where
             archive_readers,
             chain_identifier,
             on_chain_cursors,
+            committees,
         } = self;
 
         (
@@ -258,6 +276,7 @@ where
                 chain_identifier,
                 sync_system_checkpoint_from_archive_task: None,
                 on_chain_cursors,
+                committees,
             },
             handle,
         )

--- a/crates/ika-network/src/state_sync/mod.rs
+++ b/crates/ika-network/src/state_sync/mod.rs
@@ -51,6 +51,7 @@ use anemo::{PeerId, Request, Response, Result, types::PeerEvent};
 use futures::{FutureExt, StreamExt};
 use ika_config::p2p::StateSyncConfig;
 use ika_types::{
+    committee::{Committee, EpochId},
     digests::DWalletCheckpointMessageDigest,
     messages_dwallet_checkpoint::{
         CertifiedDWalletCheckpointMessage, DWalletCheckpointSequenceNumber,
@@ -92,6 +93,38 @@ pub struct OnChainCheckpointCursors {
     pub dwallet: watch::Receiver<Option<DWalletCheckpointSequenceNumber>>,
     pub system: watch::Receiver<Option<SystemCheckpointSequenceNumber>>,
 }
+
+/// The committees pull-mode sync verifies peer-supplied certificates against.
+///
+/// Carries the previous epoch's committee alongside the current one: a
+/// certificate signed just before an epoch boundary is still legitimate once
+/// this node has already entered the new epoch, and dropping it would stall
+/// sync across every boundary.
+#[derive(Clone, Debug)]
+pub struct SyncCommittees {
+    pub current: Arc<Committee>,
+    pub previous: Option<Arc<Committee>>,
+}
+
+impl SyncCommittees {
+    /// The committee that signed at `epoch`, if this node holds it.
+    pub fn for_epoch(&self, epoch: EpochId) -> Option<&Committee> {
+        std::iter::once(&self.current)
+            .chain(self.previous.iter())
+            .map(Arc::as_ref)
+            .find(|committee| committee.epoch() == epoch)
+    }
+}
+
+/// Live feed of [`SyncCommittees`], fed by the node on boot and on every
+/// reconfiguration.
+///
+/// `None` until the node has read its first committee. That window is real
+/// rather than theoretical: a peer-only node builds the p2p stack *in order
+/// to* read the committee over the OCS relay, so it necessarily starts with
+/// nothing to check against. Sync defers while the feed is `None`; bootstrap
+/// itself does not depend on pull-mode sync, so deferring costs nothing.
+pub type CommitteeSource = watch::Receiver<Option<SyncCommittees>>;
 
 mod generated {
     include!(concat!(env!("OUT_DIR"), "/ika.StateSync.rs"));
@@ -537,6 +570,7 @@ struct StateSyncEventLoop<S> {
     system_checkpoint_download_limit_layer: Option<SystemCheckpointDownloadLimitLayer>,
     sync_system_checkpoint_from_archive_task: Option<AbortHandle>,
     on_chain_cursors: Option<OnChainCheckpointCursors>,
+    committees: CommitteeSource,
 }
 
 impl<S> StateSyncEventLoop<S>
@@ -902,6 +936,7 @@ where
                 self.config.dwallet_checkpoint_header_download_concurrency(),
                 self.config.timeout(),
                 on_chain_cursor,
+                self.committees.clone(),
                 // The if condition should ensure that this is Some
                 highest_known_checkpoint.unwrap(),
             )
@@ -968,6 +1003,7 @@ where
                 self.config.system_checkpoint_header_download_concurrency(),
                 self.config.timeout(),
                 on_chain_cursor,
+                self.committees.clone(),
                 // The if condition should ensure that this is Some
                 highest_known_system_checkpoint.unwrap(),
             )
@@ -1197,6 +1233,7 @@ async fn sync_to_checkpoint<S>(
     checkpoint_header_download_concurrency: usize,
     timeout: Duration,
     on_chain_processed_cursor: DWalletCheckpointSequenceNumber,
+    committees: CommitteeSource,
     checkpoint: CertifiedDWalletCheckpointMessage,
 ) -> Result<()>
 where
@@ -1313,14 +1350,25 @@ where
         .pipe(futures::stream::iter)
         .buffered(checkpoint_header_download_concurrency);
 
-    while let Some((maybe_checkpoint, next, _maybe_peer_id)) = request_stream.next().await {
+    while let Some((maybe_checkpoint, next, maybe_peer_id)) = request_stream.next().await {
         assert_eq!(expected_sequence_number, next);
         expected_sequence_number = next.checked_add(1).expect("exhausted u64");
 
-        // We can't verify the checkpoint
-        let checkpoint = maybe_checkpoint
-            .map(VerifiedDWalletCheckpointMessage::new_unchecked)
+        let certified = maybe_checkpoint
             .ok_or_else(|| anyhow::anyhow!("no peers were able to help sync checkpoint {next}"))?;
+
+        // Check the committee signature before the certificate reaches the
+        // store. Everything downstream treats a stored certificate as
+        // authoritative: it is persisted, it moves the highest-verified
+        // watermark, and those rows are read back to build on-chain
+        // submissions.
+        let checkpoint = verify_certified_dwallet_checkpoint(
+            certified,
+            &committees,
+            &peer_heights,
+            maybe_peer_id,
+            next,
+        )?;
 
         debug!(checkpoint_seq = ?checkpoint.sequence_number(), "verified checkpoint summary");
 
@@ -1337,6 +1385,78 @@ where
         .cleanup_old_checkpoints(*checkpoint.sequence_number());
 
     Ok(())
+}
+
+/// Verifies a peer-supplied dWallet checkpoint certificate against the
+/// committee that actually signed it.
+///
+/// On failure the row is dropped from `peer_heights` and the serving peer is
+/// marked as not on our chain, so the retry reaches for a different one — the
+/// same handling upstream Sui applies to a failed summary.
+fn verify_certified_dwallet_checkpoint(
+    certified: CertifiedDWalletCheckpointMessage,
+    committees: &CommitteeSource,
+    peer_heights: &Arc<RwLock<PeerHeights>>,
+    maybe_peer_id: Option<PeerId>,
+    sequence_number: DWalletCheckpointSequenceNumber,
+) -> Result<VerifiedDWalletCheckpointMessage> {
+    let signature_epoch = certified.auth_sig().epoch;
+    let Some(committees) = committees.borrow().clone() else {
+        return Err(anyhow::anyhow!(
+            "no committee known yet; deferring verification of checkpoint {sequence_number}"
+        ));
+    };
+    let Some(committee) = committees.for_epoch(signature_epoch) else {
+        return Err(anyhow::anyhow!(
+            "no committee for epoch {signature_epoch} available to verify checkpoint \
+             {sequence_number}"
+        ));
+    };
+    let digest = *certified.digest();
+    certified.try_into_verified(committee).map_err(|e| {
+        let mut peer_heights = peer_heights.write().unwrap();
+        peer_heights.remove_checkpoint(&digest);
+        if let Some(peer_id) = maybe_peer_id {
+            peer_heights.mark_peer_as_not_on_same_chain(peer_id);
+        }
+        anyhow::anyhow!(
+            "peer-supplied checkpoint {sequence_number} failed committee verification: {e}"
+        )
+    })
+}
+
+/// System-checkpoint twin of [`verify_certified_dwallet_checkpoint`].
+fn verify_certified_system_checkpoint(
+    certified: CertifiedSystemCheckpointMessage,
+    committees: &CommitteeSource,
+    peer_heights: &Arc<RwLock<PeerHeights>>,
+    maybe_peer_id: Option<PeerId>,
+    sequence_number: SystemCheckpointSequenceNumber,
+) -> Result<VerifiedSystemCheckpointMessage> {
+    let signature_epoch = certified.auth_sig().epoch;
+    let Some(committees) = committees.borrow().clone() else {
+        return Err(anyhow::anyhow!(
+            "no committee known yet; deferring verification of system_checkpoint \
+             {sequence_number}"
+        ));
+    };
+    let Some(committee) = committees.for_epoch(signature_epoch) else {
+        return Err(anyhow::anyhow!(
+            "no committee for epoch {signature_epoch} available to verify system_checkpoint \
+             {sequence_number}"
+        ));
+    };
+    let digest = *certified.digest();
+    certified.try_into_verified(committee).map_err(|e| {
+        let mut peer_heights = peer_heights.write().unwrap();
+        peer_heights.remove_system_checkpoint(&digest);
+        if let Some(peer_id) = maybe_peer_id {
+            peer_heights.mark_peer_as_not_on_same_chain(peer_id);
+        }
+        anyhow::anyhow!(
+            "peer-supplied system_checkpoint {sequence_number} failed committee verification: {e}"
+        )
+    })
 }
 
 async fn sync_checkpoint_messages_from_archive<S>(archive_readers: ArchiveReaderBalancer, store: S)
@@ -1670,6 +1790,7 @@ async fn sync_to_system_checkpoint<S>(
     system_checkpoint_header_download_concurrency: usize,
     timeout: Duration,
     on_chain_processed_cursor: SystemCheckpointSequenceNumber,
+    committees: CommitteeSource,
     system_checkpoint: CertifiedSystemCheckpointMessage,
 ) -> Result<()>
 where
@@ -1781,16 +1902,24 @@ where
         .pipe(futures::stream::iter)
         .buffered(system_checkpoint_header_download_concurrency);
 
-    while let Some((maybe_system_checkpoint, next, _maybe_peer_id)) = request_stream.next().await {
+    while let Some((maybe_system_checkpoint, next, maybe_peer_id)) = request_stream.next().await {
         assert_eq!(expected_sequence_number, next);
         expected_sequence_number = next.checked_add(1).expect("exhausted u64");
 
-        // We can't verify the system_checkpoint
-        let system_checkpoint = maybe_system_checkpoint
-            .map(VerifiedSystemCheckpointMessage::new_unchecked)
-            .ok_or_else(|| {
-                anyhow::anyhow!("no peers were able to help sync system_checkpoint {next}")
-            })?;
+        let certified = maybe_system_checkpoint.ok_or_else(|| {
+            anyhow::anyhow!("no peers were able to help sync system_checkpoint {next}")
+        })?;
+
+        // Same trust boundary as the dWallet path: check the committee
+        // signature before the certificate is persisted and allowed to move
+        // the highest-verified watermark.
+        let system_checkpoint = verify_certified_system_checkpoint(
+            certified,
+            &committees,
+            &peer_heights,
+            maybe_peer_id,
+            next,
+        )?;
 
         debug!(system_checkpoint_seq = ?system_checkpoint.sequence_number(), "verified system_checkpoint summary");
 

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -200,6 +200,12 @@ pub struct IkaNode {
     /// Broadcast channel to notify state-sync for new validator peers.
     trusted_peer_change_tx: watch::Sender<TrustedPeerChangeEvent>,
 
+    /// Committees state sync verifies peer-supplied checkpoint certificates
+    /// against. Refreshed on every reconfiguration, carrying the outgoing
+    /// committee forward so a certificate signed just before the boundary
+    /// still verifies.
+    state_sync_committee_tx: watch::Sender<Option<ika_network::state_sync::SyncCommittees>>,
+
     #[cfg(msim)]
     sim_state: SimState,
 
@@ -426,6 +432,13 @@ impl IkaNode {
         let archive_readers =
             ArchiveReaderBalancer::new(config.archive_reader_config(), &prometheus_registry)?;
         let (trusted_peer_change_tx, trusted_peer_change_rx) = watch::channel(Default::default());
+        // Committees pull-mode state sync verifies peer-supplied checkpoint
+        // certificates against. Seeded `None`: a peer-only node builds the p2p
+        // stack in order to READ the committee over the OCS relay, so there is
+        // a bootstrap window with nothing to verify against. Sync defers during
+        // that window; bootstrap itself runs over the relay, not state sync.
+        let (state_sync_committee_tx, state_sync_committee_rx) =
+            watch::channel::<Option<ika_network::state_sync::SyncCommittees>>(None);
         // On-chain processed checkpoint cursors: written by the Sui connector
         // service (built later), read by p2p state sync as its pull-mode sync
         // floor (`None` until the first successful chain read) — a notifier on
@@ -561,6 +574,7 @@ impl IkaNode {
                 &prometheus_registry,
                 mode.is_notifier(),
                 on_chain_checkpoint_cursors.clone(),
+                state_sync_committee_rx.clone(),
                 perpetual_tables.clone(),
                 None,
             )?;
@@ -690,6 +704,12 @@ impl IkaNode {
 
         let committee = epoch_start_system_state.get_ika_committee();
         let committee_arc = Arc::new(committee.clone());
+        // Unblocks state-sync verification (no-op for a peer-only node, whose
+        // p2p stack was already built above and is watching this channel).
+        let _ = state_sync_committee_tx.send(Some(ika_network::state_sync::SyncCommittees {
+            current: committee_arc.clone(),
+            previous: None,
+        }));
 
         let secret = Arc::pin(config.protocol_key_pair().copy());
 
@@ -884,6 +904,7 @@ impl IkaNode {
                 &prometheus_registry,
                 is_state_sync_notifier,
                 on_chain_checkpoint_cursors.clone(),
+                state_sync_committee_rx.clone(),
                 perpetual_tables.clone(),
                 sui_state_mirror_server,
             )?
@@ -1293,6 +1314,7 @@ impl IkaNode {
             end_of_epoch_channel,
             connection_monitor_status,
             trusted_peer_change_tx,
+            state_sync_committee_tx,
 
             #[cfg(msim)]
             sim_state: Default::default(),
@@ -1679,6 +1701,7 @@ impl IkaNode {
         prometheus_registry: &Registry,
         is_notifier: bool,
         on_chain_checkpoint_cursors: ika_network::state_sync::OnChainCheckpointCursors,
+        committees: ika_network::state_sync::CommitteeSource,
         perpetual_tables: Arc<AuthorityPerpetualTables>,
         sui_state_mirror_server: Option<
             ika_network::sui_state_mirror::SuiStateMirrorServer<
@@ -1692,6 +1715,7 @@ impl IkaNode {
             .archive_readers(archive_readers)
             .with_metrics(prometheus_registry)
             .with_on_chain_cursors(on_chain_checkpoint_cursors)
+            .with_committees(committees)
             .build();
 
         let (discovery, discovery_server) = discovery::Builder::new(trusted_peer_change_rx)
@@ -3138,6 +3162,20 @@ impl IkaNode {
             .expect("Reconfigure authority state cannot fail");
         info!(next_epoch, "Node State has been reconfigured");
         assert_eq!(next_epoch, new_epoch_store.epoch());
+
+        // Keep the outgoing committee as `previous`: a checkpoint certified in
+        // the epoch we just left is still legitimate and must stay verifiable.
+        let previous = self
+            .state_sync_committee_tx
+            .borrow()
+            .as_ref()
+            .map(|committees| committees.current.clone());
+        let _ = self
+            .state_sync_committee_tx
+            .send(Some(ika_network::state_sync::SyncCommittees {
+                current: new_epoch_store.committee().clone(),
+                previous,
+            }));
 
         new_epoch_store
     }

--- a/crates/ika-sui-client/src/grpc_backend.rs
+++ b/crates/ika-sui-client/src/grpc_backend.rs
@@ -316,7 +316,12 @@ impl SuiClientInner for GrpcSuiClient {
     ) -> Result<HashMap<ObjectID, VersionedMPCData>, Self::Error> {
         let mut mpc_data_from_all_validators: HashMap<ObjectID, VersionedMPCData> = HashMap::new();
         for validator in validators {
-            let info = validator.verified_validator_info();
+            let info = validator.verified_validator_info().map_err(|code| {
+                GrpcSuiClientError::decode(format!(
+                    "validator {} has unparsable on-chain metadata (Move error code {code})",
+                    validator.id
+                ))
+            })?;
             let mpc_data_id = if read_next_mpc_data
                 && let Some(next_epoch_mpc_data_bytes) = info.next_epoch_mpc_data_bytes.as_ref()
                 && info.previous_mpc_data_bytes.is_none()

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -530,7 +530,19 @@ where
                                     m.validator_id
                                 ))
                             })?;
-                        let info = validator.verified_validator_info();
+                        // The stored key bytes are only length-checked on
+                        // chain, so parsing them can fail. Fail the read and
+                        // let it be retried.
+                        let info = validator.verified_validator_info().map_err(|code| {
+                            self.sui_client_metrics
+                                .sui_rpc_errors
+                                .with_label_values(&["epoch_start_invalid_validator_info"])
+                                .inc();
+                            IkaError::InvalidCommittee(format!(
+                                "validator {} has unparsable on-chain metadata (Move error code {code})",
+                                validator.id
+                            ))
+                        })?;
                         // An active member's mpc_data record is written at candidate
                         // registration and never emptied on chain, so a gap here is
                         // always a read defect (fullnode lag, table-walk race, or a
@@ -559,10 +571,31 @@ where
                                 info.name, validator.id
                             )));
                         };
+                        // Take the BLS protocol key from the FROZEN committee
+                        // member rather than from the validator record. The
+                        // committee is snapshotted mid-epoch from the key that
+                        // was current then, while `rotate_next_epoch_info`
+                        // installs a staged rotation into the record at the
+                        // epoch boundary — so for a validator that rotated, the
+                        // record holds a different key than the committee this
+                        // epoch is actually verified against, and the node's
+                        // per-signature check would disagree with the on-chain
+                        // aggregate check for a full epoch.
+                        let protocol_pubkey = m.parsed_protocol_pubkey().map_err(|e| {
+                            self.sui_client_metrics
+                                .sui_rpc_errors
+                                .with_label_values(&["epoch_start_invalid_committee_pubkey"])
+                                .inc();
+                            IkaError::InvalidCommittee(format!(
+                                "active committee member {} has an unparsable BLS protocol \
+                                 public key: {e}",
+                                m.validator_id
+                            ))
+                        })?;
                         Ok(EpochStartValidatorInfoV1 {
                             name: info.name.clone(),
                             validator_id: validator.id,
-                            protocol_pubkey: info.protocol_pubkey.clone(),
+                            protocol_pubkey,
                             network_pubkey: info.network_pubkey.clone(),
                             consensus_pubkey: info.consensus_pubkey.clone(),
                             mpc_data: Some(mpc_data.clone()),
@@ -1294,7 +1327,12 @@ impl SuiClientInner for SuiSdkClient {
     ) -> Result<HashMap<ObjectID, VersionedMPCData>, Self::Error> {
         let mut mpc_data_from_all_validators: HashMap<ObjectID, VersionedMPCData> = HashMap::new();
         for validator in validators {
-            let info = validator.verified_validator_info();
+            let info = validator.verified_validator_info().map_err(|code| {
+                Error::DataError(format!(
+                    "validator {} has unparsable on-chain metadata (Move error code {code})",
+                    validator.id
+                ))
+            })?;
             let mpc_data_id = if read_next_mpc_data
                 && let Some(next_epoch_mpc_data_bytes) = info.next_epoch_mpc_data_bytes.as_ref()
                 && info.previous_mpc_data_bytes.is_none()

--- a/crates/ika-types/src/sui/staking.rs
+++ b/crates/ika-types/src/sui/staking.rs
@@ -234,9 +234,13 @@ pub enum PoolState {
 }
 
 impl StakingPool {
-    pub fn verified_validator_info(&self) -> &VerifiedValidatorInfo {
-        // Todo (#1298): Remove unwrap.
+    /// Parses and caches this pool's validator metadata.
+    ///
+    /// Fallible on purpose: the stored key bytes are only length-checked on
+    /// chain, so parsing them can fail. Returning the Move error code lets the
+    /// caller fail the chain read and retry.
+    pub fn verified_validator_info(&self) -> Result<&VerifiedValidatorInfo, u64> {
         self.verified_validator_info
-            .get_or_init(|| self.validator_info.verify().unwrap()) // Why unwrap? this could fail
+            .get_or_try_init(|| self.validator_info.verify())
     }
 }

--- a/crates/ika-types/src/sui/system_inner_v1.rs
+++ b/crates/ika-types/src/sui/system_inner_v1.rs
@@ -4,6 +4,7 @@
 use super::{Element, ExtendedField, SystemInnerTrait};
 use crate::committee::StakeUnit;
 use crate::crypto::{AuthorityPublicKey, AuthorityPublicKeyBytes};
+use fastcrypto::error::FastCryptoError;
 use fastcrypto::traits::ToFromBytes;
 use serde::{Deserialize, Serialize};
 use sui_types::balance::Balance;
@@ -15,6 +16,23 @@ use sui_types::collection_types::{Bag, Table, VecMap, VecSet};
 pub struct BlsCommitteeMember {
     pub validator_id: ObjectID,
     pub protocol_pubkey: Element,
+}
+
+impl BlsCommitteeMember {
+    /// Parses this member's BLS protocol public key as recorded in the frozen
+    /// on-chain committee.
+    ///
+    /// This — not the validator's `ValidatorInfo` record — is the key the
+    /// committee is verified against for the epoch it serves. The committee is
+    /// snapshotted mid-epoch from whatever key was current then, while
+    /// `rotate_next_epoch_info` installs a staged rotation into the validator
+    /// record at the epoch boundary, so for a validator that rotated its
+    /// protocol key the two disagree for that whole epoch. The chain's frozen
+    /// committee is the authority, so every reader must derive the verification
+    /// basis from here.
+    pub fn parsed_protocol_pubkey(&self) -> Result<AuthorityPublicKey, FastCryptoError> {
+        AuthorityPublicKey::from_bytes(self.protocol_pubkey.bytes.as_ref())
+    }
 }
 
 /// Represents the current committee in the system.


### PR DESCRIPTION
Routine robustness pass across a few node subsystems ahead of the next release. Mostly input-validation and error-handling tightening on paths that consume externally-supplied data, plus some alignment with the ordering upstream Sui uses.

### What's here

- **Consensus handler** — transactions are authenticated before they occupy a dedup key, matching upstream ordering. `process_consensus_transactions_and_commit_boundary` now takes already-verified transactions, which also removes a redundant filter pass.
- **Global presign agreement** — content-addressed: parties vote for a request body rather than for a sequence number alone. Honest validators derive the body from the same Sui event, so the agreed body is unchanged.
- **State sync** — pull mode checks the committee signature on peer-supplied checkpoint certificates before storing them. Committees arrive over a new watch feed from the node, seeded `None` and refreshed on reconfiguration, retaining the previous epoch so a certificate spanning a boundary still verifies. Sync defers while the feed is empty — a peer-only node needs that, since it builds p2p in order to read the committee over the relay.
- **Protocol-version walk** — stops at the first version that fails the effective threshold, mirroring upstream, and takes the capability set by reference rather than cloning it per iteration.
- **Validator metadata** — parsing is fallible instead of unwrapping; all four callers already returned `Result`.
- **Checkpoint signers bitmap** — signer indices are bounded against the committee.
- **Committee key basis** — the node derives a member's BLS protocol key from the frozen on-chain committee rather than from the validator record, so its verification basis matches the chain's across a protocol-key rotation.

### Compatibility

No wire formats, BCS layouts, or protocol-version gates are affected.

One behavioural note worth flagging for operators: a staged protocol-key rotation now takes effect one epoch later than the field name suggests, but consistently — the node and the chain agree on the basis at every point, which they previously did not for the epoch following a rotation.

### Verification

- `cargo check --workspace --all-targets`, `cargo fmt --all`
- Release tests: `presign_consensus` (4), `announcement_relay` (2), `mpc_data_announcement_sender` (9), `authority_per_epoch_store` (22)

**Still to run before merge:** the cluster and upgrade suites. The state-sync and consensus-handler changes want them, in particular the cold-start path now that pull-mode sync defers until the committee feed populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rLdsjCfcsTMaiLd3TX8w
