### PR TITLE
fix(state-sync): verify against a window of recent committees, not just the current one

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -406,10 +406,22 @@ jobs:
           TEST_TESTING_FAULT: ${{ inputs.test_testing_fault }}
         run: |
           set -euo pipefail
-          if { [ "$TEST_NAME" = "v127_rollout" ] || [ "$TEST_NAME" = "v127_churn" ] || [ "$TEST_NAME" = "malicious_v127" ]; } && [ "$USE_MOCKS" = "true" ]; then
-            echo "$TEST_NAME is a rollout gate and must use real cryptography" >&2
-            exit 1
-          fi
+          # Every gate whose evidence is cross-binary agreement. Mocked
+          # cryptography is deterministic, so two binaries agree under it for
+          # reasons that say nothing about whether they agree in production —
+          # a green run on mocks is not merely weaker evidence, it is evidence
+          # of a different claim. v127_v7_upgrade belongs here for the same
+          # reason as the rollout gates and was missing: it is the PROTOCOL
+          # transition gate, so it is the one run standing behind a version
+          # flip on a live network.
+          case "$TEST_NAME" in
+            v127_rollout|v127_churn|malicious_v127|v127_v7_upgrade)
+              if [ "$USE_MOCKS" = "true" ]; then
+                echo "$TEST_NAME is a cross-binary gate and must use real cryptography" >&2
+                exit 1
+              fi
+              ;;
+          esac
           # ONE scenario, deliberately. The two rollout gates this condition
           # was originally written for are now a single one, and
           # malicious_v127 is NOT a third: it builds its own faulty validator

--- a/crates/ika-network/src/state_sync/mod.rs
+++ b/crates/ika-network/src/state_sync/mod.rs
@@ -62,7 +62,7 @@ use ika_types::{
 use rand::Rng;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, VecDeque},
     sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
@@ -96,23 +96,69 @@ pub struct OnChainCheckpointCursors {
 
 /// The committees pull-mode sync verifies peer-supplied certificates against.
 ///
-/// Carries the previous epoch's committee alongside the current one: a
-/// certificate signed just before an epoch boundary is still legitimate once
-/// this node has already entered the new epoch, and dropping it would stall
-/// sync across every boundary.
+/// A WINDOW of recent committees, not just the current one, because the
+/// epoch a certificate was signed in is set by where sync starts — and sync
+/// starts at the on-chain processed cursor, i.e. at whatever the notifier has
+/// last landed on Sui. Every epoch that cursor trails by is an epoch whose
+/// committee must still be held:
+///
+/// - Current only would stall sync across every boundary.
+/// - Current plus previous still strands a node that BOOTS while the cursor
+///   trails a boundary: the outgoing committee is only ever installed by
+///   `reconfigure`, so a fresh process holds nothing to verify the tail of
+///   the epoch it just missed, and sync cannot move until the next boundary
+///   happens to repopulate the window — a full epoch of stall on a node whose
+///   sync is the point of running it.
+///
+/// The window is therefore seeded from the committees the node already has on
+/// disk, and advanced (not replaced) at each boundary.
 #[derive(Clone, Debug)]
 pub struct SyncCommittees {
-    pub current: Arc<Committee>,
-    pub previous: Option<Arc<Committee>>,
+    by_epoch: BTreeMap<EpochId, Arc<Committee>>,
 }
 
 impl SyncCommittees {
+    /// How many recent committees the window keeps.
+    ///
+    /// Sized well past the case it exists for: at 24h epochs this tolerates a
+    /// week of cursor lag, and a `Committee` is a validator list, so the whole
+    /// window is negligible beside what sync already buffers per peer. Beyond
+    /// it, verification fails closed and sync defers rather than trusting an
+    /// unverifiable certificate.
+    pub const WINDOW: usize = 8;
+
+    /// Builds a window from `committees`, keeping the most recent [`Self::WINDOW`].
+    pub fn new(committees: impl IntoIterator<Item = Arc<Committee>>) -> Self {
+        let mut by_epoch: BTreeMap<EpochId, Arc<Committee>> = committees
+            .into_iter()
+            .map(|committee| (committee.epoch(), committee))
+            .collect();
+        while by_epoch.len() > Self::WINDOW {
+            by_epoch.pop_first();
+        }
+        Self { by_epoch }
+    }
+
+    /// The window advanced to a new epoch, RETAINING the outgoing committees —
+    /// certificates signed just before the boundary stay verifiable.
+    pub fn advanced_to(&self, current: Arc<Committee>) -> Self {
+        Self::new(
+            self.by_epoch
+                .values()
+                .cloned()
+                .chain(std::iter::once(current)),
+        )
+    }
+
     /// The committee that signed at `epoch`, if this node holds it.
     pub fn for_epoch(&self, epoch: EpochId) -> Option<&Committee> {
-        std::iter::once(&self.current)
-            .chain(self.previous.iter())
-            .map(Arc::as_ref)
-            .find(|committee| committee.epoch() == epoch)
+        self.by_epoch.get(&epoch).map(Arc::as_ref)
+    }
+
+    /// Epochs currently verifiable, oldest first — for diagnostics when a
+    /// certificate falls outside the window.
+    pub fn epochs(&self) -> impl Iterator<Item = EpochId> + '_ {
+        self.by_epoch.keys().copied()
     }
 }
 
@@ -1407,9 +1453,13 @@ fn verify_certified_dwallet_checkpoint(
         ));
     };
     let Some(committee) = committees.for_epoch(signature_epoch) else {
+        // Naming the window matters: this is the one verification failure the
+        // peer is not at fault for, and it says sync cannot advance until the
+        // node holds that epoch's committee.
         return Err(anyhow::anyhow!(
             "no committee for epoch {signature_epoch} available to verify checkpoint \
-             {sequence_number}"
+             {sequence_number}; verifiable epochs are {:?}",
+            committees.epochs().collect::<Vec<_>>()
         ));
     };
     let digest = *certified.digest();
@@ -1443,7 +1493,8 @@ fn verify_certified_system_checkpoint(
     let Some(committee) = committees.for_epoch(signature_epoch) else {
         return Err(anyhow::anyhow!(
             "no committee for epoch {signature_epoch} available to verify system_checkpoint \
-             {sequence_number}"
+             {sequence_number}; verifiable epochs are {:?}",
+            committees.epochs().collect::<Vec<_>>()
         ));
     };
     let digest = *certified.digest();
@@ -2149,6 +2200,91 @@ mod tests {
         assert_eq!(
             tracker.observe(Some(100), Some(90), at(start, 245)),
             (120, true)
+        );
+    }
+
+    /// A committee at `epoch`, membership irrelevant — these tests are about
+    /// which epochs the window answers for, not signature checking.
+    fn committee_at(epoch: EpochId) -> Arc<Committee> {
+        let (base, _keys) = Committee::new_simple_test_committee_of_size(4);
+        Arc::new(Committee::new(
+            epoch,
+            base.voting_rights.clone(),
+            std::collections::HashMap::new(),
+            std::collections::HashMap::new(),
+            base.quorum_threshold,
+            base.validity_threshold,
+        ))
+    }
+
+    /// The boot case: a node restarting while the on-chain cursor still trails
+    /// an epoch boundary must be able to verify certificates signed BEFORE the
+    /// boundary, from committees it already holds on disk.
+    ///
+    /// Seeding the window with the current committee alone (the pre-fix
+    /// behaviour, and what `previous: None` amounted to at boot) leaves those
+    /// certificates unverifiable until the NEXT boundary repopulates the
+    /// window — a full epoch of stalled sync.
+    #[test]
+    fn committee_window_verifies_epochs_the_cursor_still_trails() {
+        let booted_at = 10;
+        let seeded = SyncCommittees::new((5..=booted_at).map(committee_at));
+
+        assert!(
+            seeded.for_epoch(booted_at).is_some(),
+            "the current epoch must verify"
+        );
+        for trailing in 5..booted_at {
+            assert!(
+                seeded.for_epoch(trailing).is_some(),
+                "epoch {trailing} is inside the window and must verify: a cursor that trails \
+                 the boundary makes its certificates the ones sync actually walks"
+            );
+        }
+        assert!(
+            seeded.for_epoch(booted_at + 1).is_none(),
+            "a future epoch must NOT verify"
+        );
+        assert!(
+            SyncCommittees::new([committee_at(booted_at)])
+                .for_epoch(booted_at - 1)
+                .is_none(),
+            "control: with only the current committee the trailing epoch is unverifiable — \
+             the stall this window exists to prevent"
+        );
+    }
+
+    /// Crossing a boundary must ADVANCE the window, not replace it: the epoch
+    /// just left stays verifiable, and the window stays bounded.
+    #[test]
+    fn committee_window_advances_without_dropping_the_outgoing_epoch() {
+        let mut committees = SyncCommittees::new([committee_at(1)]);
+        for epoch in 2..=(SyncCommittees::WINDOW as u64 + 3) {
+            committees = committees.advanced_to(committee_at(epoch));
+            assert!(
+                committees.for_epoch(epoch).is_some(),
+                "the new current epoch must verify"
+            );
+            assert!(
+                committees.for_epoch(epoch - 1).is_some(),
+                "the epoch just left must stay verifiable across the boundary"
+            );
+        }
+
+        let held: Vec<_> = committees.epochs().collect();
+        assert_eq!(
+            held.len(),
+            SyncCommittees::WINDOW,
+            "the window must stay bounded as epochs advance"
+        );
+        assert_eq!(
+            *held.last().unwrap(),
+            SyncCommittees::WINDOW as u64 + 3,
+            "the newest committee is retained"
+        );
+        assert!(
+            committees.for_epoch(1).is_none(),
+            "committees older than the window are evicted"
         );
     }
 }

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -706,10 +706,36 @@ impl IkaNode {
         let committee_arc = Arc::new(committee.clone());
         // Unblocks state-sync verification (no-op for a peer-only node, whose
         // p2p stack was already built above and is watching this channel).
-        let _ = state_sync_committee_tx.send(Some(ika_network::state_sync::SyncCommittees {
-            current: committee_arc.clone(),
-            previous: None,
-        }));
+        //
+        // Seeded with the recent committees this node already has on disk, not
+        // the current one alone. Pull-mode sync starts at the on-chain
+        // processed cursor, so a node restarting while that cursor still
+        // trails an epoch boundary has to verify certificates signed BEFORE
+        // the boundary. The outgoing committee is otherwise only ever
+        // installed by `reconfigure`, so a fresh process would hold nothing
+        // for those epochs and sync would stay stuck until the next boundary
+        // — a full epoch, on a node whose sync is the reason it is running.
+        // A never-seen epoch simply is not in the store; sync then defers on
+        // it rather than trusting it.
+        let sync_committees = {
+            let current_epoch = committee_arc.epoch();
+            let window = ika_network::state_sync::SyncCommittees::WINDOW as u64;
+            let mut recent = vec![committee_arc.clone()];
+            for epoch in current_epoch.saturating_sub(window - 1)..current_epoch {
+                match committee_store.get_committee(&epoch) {
+                    Ok(Some(committee)) => recent.push(committee),
+                    Ok(None) => {}
+                    Err(e) => warn!(
+                        epoch,
+                        error = ?e,
+                        "failed to read a past committee while seeding state-sync verification; \
+                         certificates signed in that epoch will defer until it is available",
+                    ),
+                }
+            }
+            ika_network::state_sync::SyncCommittees::new(recent)
+        };
+        let _ = state_sync_committee_tx.send(Some(sync_committees));
 
         let secret = Arc::pin(config.protocol_key_pair().copy());
 
@@ -3163,19 +3189,16 @@ impl IkaNode {
         info!(next_epoch, "Node State has been reconfigured");
         assert_eq!(next_epoch, new_epoch_store.epoch());
 
-        // Keep the outgoing committee as `previous`: a checkpoint certified in
-        // the epoch we just left is still legitimate and must stay verifiable.
-        let previous = self
-            .state_sync_committee_tx
-            .borrow()
-            .as_ref()
-            .map(|committees| committees.current.clone());
-        let _ = self
-            .state_sync_committee_tx
-            .send(Some(ika_network::state_sync::SyncCommittees {
-                current: new_epoch_store.committee().clone(),
-                previous,
-            }));
+        // Advance the verification window rather than replacing it: a
+        // checkpoint certified in the epoch we just left — or in any epoch the
+        // on-chain cursor still trails — is legitimate and must stay
+        // verifiable.
+        let current = new_epoch_store.committee().clone();
+        let advanced = match self.state_sync_committee_tx.borrow().as_ref() {
+            Some(committees) => committees.advanced_to(current),
+            None => ika_network::state_sync::SyncCommittees::new([current]),
+        };
+        let _ = self.state_sync_committee_tx.send(Some(advanced));
 
         new_epoch_store
     }

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -112,6 +112,18 @@ so both silently stopped covering the PR-default gate. A name that stays
 superficially correct while the thing it tests changes underneath is
 worse than one that visibly goes stale.
 
+**Which gates must refuse mocks.** Every gate whose evidence is
+cross-binary agreement: `v127_rollout`, `v127_churn`, `malicious_v127`
+and `v127_v7_upgrade`. Mocked cryptography is deterministic, so two
+binaries agree under it for reasons that say nothing about whether they
+agree in production — a green run on mocks is not weaker evidence of the
+same claim, it is evidence of a different one. Retarget this list with
+the family: when the `v128_*` set lands, so do its guard entries. Add a
+gate here the moment it starts standing behind a rollout or a protocol
+flip. `v127_v7_upgrade` was omitted when it was added and was, for that
+window, the one run backing a version flip on a live network while still
+accepting mocks.
+
 ```bash
 # `test` selects scenarios: 'all' (the default) fans EVERY scenario out as its
 # own matrix job on its own runner, in parallel (fail-fast off). Pass a


### PR DESCRIPTION
Follow-up to #1967. Also widens the real-crypto CI guard restored by #1966.

## The stall

#1967 correctly closed the trust boundary — peer-supplied certificates are now verified before they reach the store. It carried `current` + `previous` committees, and seeded `previous: None` at boot. That seeding leaves a reachable stall.

Pull-mode sync starts at `max(local_next, on_chain_processed_cursor + 1)` — the cursor being whatever the notifier last landed on Sui. So **the epochs sync walks are exactly the epochs that cursor trails by.** A node restarting while the cursor still trails an epoch boundary has to verify certificates signed *before* the boundary. `previous` is only ever installed by `reconfigure`, so a fresh process holds nothing for those epochs:

- every fetch fails `no committee for epoch {e}`,
- the failure correctly does **not** blame the peer, so retries reach for other peers and fail identically,
- and nothing repopulates the window until the **next** boundary.

At 24h epochs (measured on both networks) that is up to a full day of stalled sync. The node it strands is typically the notifier — the sole dwallet-checkpoint writer, with the fallback-writer ask deliberately rejected in #1892 — and a lagging cursor is itself the notifier-stall shape we have hit twice on testnet and once near-missed on mainnet.

## The fix

`SyncCommittees` becomes a bounded window keyed by epoch (`WINDOW = 8`):

- **seeded at boot** from the committees already in `CommitteeStore`, so a restart keeps whatever history that node has. An epoch it never saw simply is not there, and sync defers on it rather than trusting it — fail-closed is preserved end to end.
- **advanced** at each boundary rather than replaced, so the outgoing committee survives instead of being the only thing carried forward.
- **bounded**, so it cannot grow with uptime. A `Committee` is a validator list; eight is negligible beside what sync already buffers per peer.

`for_epoch` keeps its signature, so both verification call sites are untouched. The out-of-window error now names the epochs actually held — it is the one verification failure the peer is not at fault for, and it should say what sync is waiting for.

Why 8 rather than 2: the window has to cover cursor lag, which is unbounded in principle and driven by notifier health, not by anything sync controls. Eight epochs is a week of tolerance at current epoch length, for a few KB.

## Also: `v127_v7_upgrade` was not in the real-crypto guard

#1966 restored that guard for the rollout gates. The protocol-transition gate was never in it — so the single run standing behind a **version flip on a live network** would have accepted `use_mocks=true`. Mocked cryptography is deterministic: two binaries agree under it for reasons that say nothing about whether they agree in production, so a green mocked run is not weaker evidence of the same claim, it is evidence of a different one.

Rewritten as a `case`, with the list and its retarget rule recorded in `dev-docs/playbooks/ci-suites.md` next to #1966's incident note.

## Verification

- `committee_window_verifies_epochs_the_cursor_still_trails` — the boot case, including a control asserting that a current-committee-only window (the pre-fix behaviour) leaves the trailing epoch unverifiable.
- `committee_window_advances_without_dropping_the_outgoing_epoch` — the epoch just left stays verifiable across every boundary, and the window stays bounded as epochs advance.
- **Fault-validated** per `dev-docs/playbooks/test-testing.md`: shrinking the window to 1 fails both tests at the predicted assertions (`epoch 5 is inside the window and must verify`). Injection reverted; no artifacts remain.
- `ika-network` state_sync suite 8/8; `cargo clippy` clean on `ika-network` and `ika-node`; workflow YAML parses and the guard was exercised across all eight scenario names (four reject mocks, four unaffected).

Heavy suites dispatched separately — this touches node boot and reconfiguration, so Test Cluster and the upgrade matrix should be green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)