### PR TITLE
feat(metrics): make the AuthorityName wire width and its handoff retry observable

### DIFF
--- a/crates/ika-core/src/handoff_cert.rs
+++ b/crates/ika-core/src/handoff_cert.rs
@@ -520,10 +520,35 @@ pub fn verify_certified_handoff_attestation(
     match verify_certified_handoff_attestation_at_current_width(cert, committee, provider) {
         Err(first @ IkaError::InvalidSignature { .. }) => {
             let other_width = !ika_types::crypto::authority_name_short_encoding();
-            ika_types::crypto::with_authority_name_short_encoding(other_width, || {
-                verify_certified_handoff_attestation_at_current_width(cert, committee, provider)
-            })
-            .map_err(|_| {
+            let retried =
+                ika_types::crypto::with_authority_name_short_encoding(other_width, || {
+                    verify_certified_handoff_attestation_at_current_width(cert, committee, provider)
+                });
+            // Counted, because this path is otherwise invisible: a successful
+            // retry looks exactly like a verification that never needed one,
+            // so "the boundary worked" cannot distinguish the two. Exactly one
+            // `recovered` is the expected shape at an activation boundary —
+            // the cert is signed at the end of epoch N under the old width and
+            // verified in N+1 under the new one. Anywhere else means two
+            // validators disagree about the width mid-epoch. `exhausted` is a
+            // bad cert rather than an encoding problem, kept on its own label
+            // so the retry is not blamed for it.
+            match &retried {
+                Ok(()) => {
+                    ika_types::metrics::record_handoff_attestation_width_retry(
+                        ika_types::metrics::WIDTH_RETRY_RECOVERED,
+                    );
+                    tracing::info!(
+                        epoch = cert.attestation.epoch,
+                        retried_at_width_bytes = if other_width { 32 } else { 48 },
+                        "handoff attestation verified at the other AuthorityName width"
+                    );
+                }
+                Err(_) => ika_types::metrics::record_handoff_attestation_width_retry(
+                    ika_types::metrics::WIDTH_RETRY_EXHAUSTED,
+                ),
+            }
+            retried.map_err(|_| {
                 // Report the FIRST failure: the retry's error is always
                 // "wrong width" noise when the cert is genuinely bad, and it
                 // would send the reader after an encoding problem that isn't

--- a/crates/ika-node/src/node_runner.rs
+++ b/crates/ika-node/src/node_runner.rs
@@ -144,6 +144,7 @@ pub fn run_node_with_name(
     let registry_service = mysten_metrics::start_prometheus_server(config.metrics_address);
     let prometheus_registry = registry_service.default_registry();
     ika_types::metrics::init_invariant_violation_metric(&prometheus_registry);
+    ika_types::metrics::init_authority_name_width_metrics(&prometheus_registry);
 
     // Initialize logging
     let (_guard, filter_handle) = telemetry_subscribers::TelemetryConfig::new()

--- a/crates/ika-types/src/crypto.rs
+++ b/crates/ika-types/src/crypto.rs
@@ -338,8 +338,24 @@ thread_local! {
 /// sufficient: the flag guards no other memory, and correctness depends on
 /// committee-wide agreement on the protocol version, not on intra-process
 /// ordering against any particular write.
+/// Published to `ika_authority_name_encoding_width_bytes` on every call, and
+/// logged when the value actually CHANGES. Both matter and neither is
+/// redundant: the gauge is the only fleet-wide readout — a validator on the
+/// wrong width is rejected by peers while parsing their messages perfectly, so
+/// the condition otherwise presents as unexplained rejection with nothing
+/// naming an encoding — and the log line is what dates the flip when
+/// reconstructing a boundary afterwards. Instrumenting HERE rather than at the
+/// caller covers every path, including the test-only inversion fault.
 pub fn set_authority_name_short_encoding(enabled: bool) {
-    AUTHORITY_NAME_SHORT_ENCODING.store(enabled, Ordering::Relaxed);
+    let previous = AUTHORITY_NAME_SHORT_ENCODING.swap(enabled, Ordering::Relaxed);
+    crate::metrics::record_authority_name_encoding_width(enabled);
+    if previous != enabled {
+        tracing::info!(
+            width_bytes = if enabled { 32 } else { 48 },
+            previous_width_bytes = if previous { 32 } else { 48 },
+            "AuthorityName wire encoding width changed"
+        );
+    }
 }
 
 /// The `AuthorityName` encoding width in effect on this thread: the

--- a/crates/ika-types/src/metrics.rs
+++ b/crates/ika-types/src/metrics.rs
@@ -2,9 +2,19 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 use once_cell::sync::OnceCell;
-use prometheus::{IntCounterVec, Registry, register_int_counter_vec_with_registry};
+use prometheus::{
+    IntCounterVec, IntGauge, Registry, register_int_counter_vec_with_registry,
+    register_int_gauge_with_registry,
+};
 
 static INVARIANT_VIOLATIONS_TOTAL: OnceCell<IntCounterVec> = OnceCell::new();
+static AUTHORITY_NAME_ENCODING_WIDTH: OnceCell<IntGauge> = OnceCell::new();
+static HANDOFF_ATTESTATION_WIDTH_RETRY_TOTAL: OnceCell<IntCounterVec> = OnceCell::new();
+
+/// Outcome labels for [`record_handoff_attestation_width_retry`]. Bounded to
+/// two by construction — the retry either rescues the verification or does not.
+pub const WIDTH_RETRY_RECOVERED: &str = "recovered";
+pub const WIDTH_RETRY_EXHAUSTED: &str = "exhausted";
 
 pub fn init_invariant_violation_metric(registry: &Registry) {
     INVARIANT_VIOLATIONS_TOTAL.get_or_init(|| {
@@ -18,10 +28,66 @@ pub fn init_invariant_violation_metric(registry: &Registry) {
     });
 }
 
+/// Registers the `AuthorityName` wire-width metrics.
+///
+/// Both exist because the width is a PROCESS-WIDE property with no other
+/// readout: a validator emitting the wrong width computes different digests
+/// and is rejected by its peers while parsing their messages perfectly, so the
+/// condition presents as unexplained rejection rather than as anything naming
+/// an encoding. During the v6→v7 activation this was diagnosable only by
+/// inference from what did not break.
+pub fn init_authority_name_width_metrics(registry: &Registry) {
+    AUTHORITY_NAME_ENCODING_WIDTH.get_or_init(|| {
+        register_int_gauge_with_registry!(
+            "ika_authority_name_encoding_width_bytes",
+            "Wire width in bytes this process serializes AuthorityName at: 48 \
+             (zero-padded, pre-v7) or 32 (raw consensus key, v7+). The fleet \
+             must agree — two distinct values across hosts is a split",
+            registry,
+        )
+        .expect("authority name width gauge registration must succeed")
+    });
+    HANDOFF_ATTESTATION_WIDTH_RETRY_TOTAL.get_or_init(|| {
+        register_int_counter_vec_with_registry!(
+            "ika_handoff_attestation_width_retry_total",
+            "Handoff-attestation verifications that fell back to the other \
+             AuthorityName width, by outcome",
+            &["outcome"],
+            registry,
+        )
+        .expect("handoff width retry metric registration must succeed")
+    });
+}
+
 #[doc(hidden)]
 pub fn record_invariant_violation(site: &'static str) {
     if let Some(metric) = INVARIANT_VIOLATIONS_TOTAL.get() {
         metric.with_label_values(&[site]).inc();
+    }
+}
+
+/// Publishes the wire width this process is serializing `AuthorityName` at.
+///
+/// Called from the one place the width is set, so every path is covered —
+/// including the test-only inversion fault, which is the point: a gate that
+/// injects a width straggler should be able to SEE the straggler.
+pub fn record_authority_name_encoding_width(short: bool) {
+    if let Some(metric) = AUTHORITY_NAME_ENCODING_WIDTH.get() {
+        metric.set(if short { 32 } else { 48 });
+    }
+}
+
+/// Records that a handoff-attestation verification retried at the other width.
+///
+/// `recovered` is the expected shape at an activation boundary and exactly
+/// once: the cert is signed at the end of epoch N under the old width and
+/// verified in N+1 under the new one. Anywhere else it means two validators
+/// disagree about the width mid-epoch. `exhausted` means neither width
+/// verified, i.e. the cert is bad for reasons that have nothing to do with
+/// encoding — worth separating so the retry is not blamed for it.
+pub fn record_handoff_attestation_width_retry(outcome: &'static str) {
+    if let Some(metric) = HANDOFF_ATTESTATION_WIDTH_RETRY_TOTAL.get() {
+        metric.with_label_values(&[outcome]).inc();
     }
 }
 
@@ -92,5 +158,83 @@ mod tests {
         assert_eq!(metric.len(), 1);
         assert_eq!(metric[0].get_counter().value(), 1.0);
         assert_eq!(metric[0].get_label()[0].value(), "metrics_test");
+    }
+
+    /// The width metrics live behind a process-global `OnceCell`, so every
+    /// test in this binary has to share the registry it was initialised with —
+    /// a second `init_*` call with a fresh registry is silently a no-op, and
+    /// the metrics keep reporting into the first one.
+    fn width_metrics_registry() -> &'static Registry {
+        static REGISTRY: once_cell::sync::OnceCell<Registry> = once_cell::sync::OnceCell::new();
+        REGISTRY.get_or_init(|| {
+            let registry = Registry::new();
+            super::init_authority_name_width_metrics(&registry);
+            registry
+        })
+    }
+
+    /// The gauge must report the WIDTH IN BYTES, not a boolean, and must
+    /// follow the setter rather than the protocol version — a validator on the
+    /// wrong width is exactly the case where those two disagree, and it is the
+    /// only case this metric exists to catch.
+    #[test]
+    fn authority_name_width_gauge_reports_the_wire_width() {
+        let registry = width_metrics_registry();
+
+        let width = || {
+            registry
+                .gather()
+                .into_iter()
+                .find(|f| f.name() == "ika_authority_name_encoding_width_bytes")
+                .expect("width gauge must be exported")
+                .get_metric()[0]
+                .get_gauge()
+                .value()
+        };
+
+        crate::crypto::set_authority_name_short_encoding(false);
+        assert_eq!(width(), 48.0, "pre-v7 emits the zero-padded 48-byte form");
+        crate::crypto::set_authority_name_short_encoding(true);
+        assert_eq!(width(), 32.0, "v7+ emits the raw 32-byte consensus key");
+        // Restore, so this test cannot leak a width into any other test in the
+        // process — the value is a process-wide global by design.
+        crate::crypto::set_authority_name_short_encoding(false);
+        assert_eq!(width(), 48.0);
+    }
+
+    /// `recovered` and `exhausted` must land on separate series. Collapsing
+    /// them would make a bad certificate look like an encoding straddle, which
+    /// is the one confusion this counter exists to prevent.
+    #[test]
+    fn handoff_width_retry_counter_separates_recovery_from_a_bad_cert() {
+        let registry = width_metrics_registry();
+        assert!(
+            registry
+                .gather()
+                .iter()
+                .all(|f| f.name() != "ika_handoff_attestation_width_retry_total"),
+            "no series before a retry actually happens — absent is not zero"
+        );
+
+        super::record_handoff_attestation_width_retry(super::WIDTH_RETRY_RECOVERED);
+        super::record_handoff_attestation_width_retry(super::WIDTH_RETRY_RECOVERED);
+        super::record_handoff_attestation_width_retry(super::WIDTH_RETRY_EXHAUSTED);
+
+        let by_outcome: std::collections::HashMap<String, f64> = registry
+            .gather()
+            .into_iter()
+            .find(|f| f.name() == "ika_handoff_attestation_width_retry_total")
+            .expect("retry counter must be exported")
+            .get_metric()
+            .iter()
+            .map(|m| {
+                (
+                    m.get_label()[0].value().to_string(),
+                    m.get_counter().value(),
+                )
+            })
+            .collect();
+        assert_eq!(by_outcome.get("recovered"), Some(&2.0));
+        assert_eq!(by_outcome.get("exhausted"), Some(&1.0));
     }
 }

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -110,6 +110,34 @@ allowed when operators need them, but reminders do not increment the invariant
 counter. The network-key registry sites are guarded structurally by
 `scripts/check-invariant-violation-markers.sh`.
 
+### Process-wide wire settings need a gauge, not just a log
+
+`ika_authority_name_encoding_width_bytes` reports the width this process
+serializes `AuthorityName` at — 48 (zero-padded, pre-v7) or 32 (raw consensus
+key, v7+). It exists because the width is a **process-wide** property with no
+other readout, and because of how it fails: a validator on the wrong width
+computes different digests while parsing its peers' messages perfectly, so the
+condition presents as unexplained rejection with nothing in it naming an
+encoding. Through the v6→v7 activation the only available evidence was
+inference from what did not break.
+
+The rule the metric encodes: a setting the whole committee must agree on, held
+in process memory, needs a fleet-scrapeable gauge. Two distinct values across
+hosts is then a visible split rather than something to deduce. Publish it from
+the setter rather than the caller, so every path is covered — including
+test-only fault injection, since a gate that injects a straggler should be able
+to see the straggler it injected.
+
+`ika_handoff_attestation_width_retry_total{outcome}` covers the paired
+recovery path. `recovered` means the other width verified: expected exactly
+once per activation boundary, because the handoff cert is signed at the end of
+epoch N under the old width and verified in N+1 under the new one. Anywhere
+else it means two validators disagree mid-epoch. `exhausted` means neither
+width verified — a bad certificate, not an encoding problem, kept on its own
+label so the retry is not blamed for it. Counting the recovery matters because
+a successful retry is otherwise indistinguishable from a verification that
+never needed one: "the boundary worked" cannot tell you which happened.
+
 Per-authority output observations are collected protocol-generically but
 **exported only for an allow-listed set of protocols** (currently network-key
 reconfiguration; see `OUTPUT_OBSERVATION_EXPORT_PROTOCOLS` in `mpc_manager.rs`).
@@ -202,6 +230,7 @@ Regenerate with: `./scripts/check-metric-names.sh --list`
 ika_archive_actions_read
 ika_archive_dwallet_checkpoints_read
 ika_archive_system_checkpoints_read
+ika_authority_name_encoding_width_bytes
 ika_binary_max_protocol_version
 ika_configured_max_protocol_version
 ika_consensus_calculated_throughput
@@ -259,13 +288,13 @@ ika_dwallet_mpc_data_ready_quorum_round
 ika_dwallet_mpc_data_ready_signal_deadline_timestamp_seconds
 ika_dwallet_mpc_data_ready_signal_stake
 ika_dwallet_mpc_data_ready_signals
-ika_dwallet_mpc_messages_after_terminal_session_total
 ika_dwallet_mpc_global_presign_requests_waiting
 ika_dwallet_mpc_global_presigns_served_total
 ika_dwallet_mpc_internal_presign_pool_size
 ika_dwallet_mpc_internal_presign_requests_pending_for_network_key_data
 ika_dwallet_mpc_last_completion_duration
 ika_dwallet_mpc_malicious_actors_count
+ika_dwallet_mpc_messages_after_terminal_session_total
 ika_dwallet_mpc_network_encryption_key_canonical_dkg_output_version
 ika_dwallet_mpc_network_key_instantiation_failures_total
 ika_dwallet_mpc_network_key_instantiation_sub_call_duration_seconds
@@ -310,6 +339,7 @@ ika_epoch_reconfig_start_time_since_epoch_close_ms
 ika_epoch_total_computation_reward
 ika_epoch_total_duration
 ika_epoch_validator_halt_duration_ms
+ika_handoff_attestation_width_retry_total
 ika_handoff_prepare_duration_seconds
 ika_handoff_prepare_retries_total
 ika_handoff_prepare_waiting
@@ -386,10 +416,10 @@ ika_ocs_serve_request_by_peer_total
 ika_ocs_serve_request_total
 ika_ocs_unverified_committee_fallback_total
 ika_ocs_verify_latency_seconds
-ika_off_chain_assembly_incomplete_ticks_total
 ika_off_chain_assembly_consecutive_incomplete_ticks
 ika_off_chain_assembly_incomplete
 ika_off_chain_assembly_incomplete_duration_seconds
+ika_off_chain_assembly_incomplete_ticks_total
 ika_off_chain_assembly_last_success_timestamp_seconds
 ika_off_chain_assembly_missing
 ika_off_chain_assembly_wedged


### PR DESCRIPTION
Protocol v7 changes how `AuthorityName` is serialized — 48-byte zero-padded to raw 32 bytes — and ships with **no instrumentation of its own**.

Verifying the testnet activation this morning, the only available evidence that the encoding worked was that the epoch advanced. That is sound reasoning: the handoff cert is signed at the end of epoch N under the old width and verified in N+1 under the new one, and the epoch cannot close without a cert quorum, so crossing the boundary proves the dual-width retry did its job. But it is *inference*, and it cannot answer the two questions that matter next:

- **Which width is any individual validator actually emitting?**
- **Did the retry fire, or was it simply never needed?**

Neither is answerable after the fact, and both matter more on mainnet: 56 validators, real value, and a partial-width fleet that presents as unexplained signature rejection with nothing in it naming an encoding. This is the failure mode #1959's own review notes flagged as the main risk.

## `ika_authority_name_encoding_width_bytes` (gauge: 48 or 32)

Published from `set_authority_name_short_encoding` **itself** rather than its caller, so every path is covered — including the test-only `FAULT_INVERT_AUTHORITY_NAME_WIDTH` inversion. That last part is the point: a gate that injects a width straggler should be able to *see* the straggler it injected.

Two distinct values across hosts is now a visible split rather than something to deduce. Also logged on transition, which is what dates a flip when reconstructing a boundary afterwards.

## `ika_handoff_attestation_width_retry_total{outcome}`

- **`recovered`** — the other width verified. Expected **exactly once per activation boundary**. Anywhere else it means two validators disagree about the width mid-epoch.
- **`exhausted`** — neither width verified, i.e. a bad certificate rather than an encoding problem. Kept on its own label so the retry is not blamed for it.

Counting the recovery is the load-bearing part: a successful retry is otherwise indistinguishable from a verification that never needed one, so "the boundary worked" cannot tell you which happened.

Both follow the established `OnceCell` pattern from `ika_invariant_violations_total` and register alongside it at boot.

## Verification

Two tests: the gauge must report **bytes** and follow the setter (not the protocol version — a validator on the wrong width is precisely where those disagree), and the two retry outcomes must land on separate series.

**Fault-validated** per `dev-docs/playbooks/test-testing.md`:

| injection | result |
|---|---|
| setter no longer publishes the gauge | `authority_name_width_gauge_reports_the_wire_width` FAILS at `pre-v7 emits the zero-padded 48-byte form` |
| retry outcomes collapse onto one label | `handoff_width_retry_counter_separates_recovery_from_a_bad_cert` FAILS (left `3.0`, right `2.0`) |

Both reverted; no artifacts remain. `ika-types` metrics 3/3, `ika-core` handoff 4/4, `cargo clippy` clean across `ika-types`/`ika-core`/`ika-node`, `check-metric-names.sh` passes with both names added to the inventory.

One implementation note worth flagging for review: the metrics live behind a process-global `OnceCell`, so tests in the same binary must share the registry it was initialised with — a second `init_*` with a fresh registry is silently a no-op. The test helper makes that explicit rather than leaving it as a trap.

## Convention

`dev-docs/conventions/metrics.md` gains the general rule this is an instance of: **a setting the whole committee must agree on, held in process memory, needs a fleet-scrapeable gauge rather than only a log** — and it should be published from the setter, so no path escapes it.

## Not in this PR

No alerting. The infra side (dashboard panel + an alert on two distinct widths across the fleet) is a separate change in `dwallet-labs/infra`, and I would land it before the mainnet v7 activation rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)