### PR TITLE
feat: support authenticated Sui gRPC endpoints

### DIFF
--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -9,8 +9,10 @@ use consensus_config::Parameters as ConsensusParameters;
 use ika_types::committee::EpochId;
 use once_cell::sync::OnceCell;
 use rand::rngs::OsRng;
-use serde::{Deserialize, Serialize};
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::serde_as;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
@@ -353,6 +355,83 @@ pub struct IkaIdentityOverride {
     pub ika_dwallet_coordinator_object_id: ObjectID,
 }
 
+/// Source for one complete Sui gRPC metadata value.
+#[derive(Clone, Eq, PartialEq)]
+pub enum SuiGrpcHeaderValue {
+    /// Read the complete header value from this environment variable.
+    FromEnv(String),
+    /// Read the complete header value from this file at startup.
+    FromFile(PathBuf),
+    /// Embed a non-secret header value directly in the node config.
+    Literal(String),
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct SuiGrpcHeaderValueRepr {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    from_env: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    from_file: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    literal: Option<String>,
+}
+
+impl Serialize for SuiGrpcHeaderValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let repr = match self {
+            Self::FromEnv(from_env) => SuiGrpcHeaderValueRepr {
+                from_env: Some(from_env.clone()),
+                from_file: None,
+                literal: None,
+            },
+            Self::FromFile(from_file) => SuiGrpcHeaderValueRepr {
+                from_env: None,
+                from_file: Some(from_file.clone()),
+                literal: None,
+            },
+            Self::Literal(literal) => SuiGrpcHeaderValueRepr {
+                from_env: None,
+                from_file: None,
+                literal: Some(literal.clone()),
+            },
+        };
+        repr.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SuiGrpcHeaderValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let repr = SuiGrpcHeaderValueRepr::deserialize(deserializer)?;
+        match (repr.from_env, repr.from_file, repr.literal) {
+            (Some(variable), None, None) => Ok(Self::FromEnv(variable)),
+            (None, Some(path), None) => Ok(Self::FromFile(path)),
+            (None, None, Some(value)) => Ok(Self::Literal(value)),
+            _ => Err(D::Error::custom(
+                "exactly one of `from-env`, `from-file`, or `literal` must be set",
+            )),
+        }
+    }
+}
+
+impl fmt::Debug for SuiGrpcHeaderValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FromEnv(variable) => f.debug_tuple("FromEnv").field(variable).finish(),
+            Self::FromFile(path) => f.debug_tuple("FromFile").field(path).finish(),
+            Self::Literal(_) => f.debug_tuple("Literal").field(&"[REDACTED]").finish(),
+        }
+    }
+}
+
+pub type SuiGrpcHeaders = BTreeMap<String, SuiGrpcHeaderValue>;
+
 /// Where this validator gets Sui state from.
 ///
 /// `SuiStateDirect` runs against a Sui fullnode reachable over gRPC, and
@@ -392,6 +471,9 @@ pub enum SuiDataSource {
     SuiStateDirect {
         /// gRPC URL of a Sui fullnode this validator can reach directly.
         url: String,
+        /// Metadata attached to every request sent to the gRPC endpoint.
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        headers: SuiGrpcHeaders,
         /// If true, expose `SuiStateMirror` to Ika peers so other validators
         /// can read Sui state through us. Defaults to true.
         #[serde(default = "default_true")]
@@ -402,7 +484,21 @@ pub enum SuiDataSource {
         /// and `get_transaction`. Trust unaffected — OCS verifies regardless.
         #[serde(skip_serializing_if = "Option::is_none")]
         fallback_grpc_url: Option<String>,
+        /// Metadata attached to every request sent to the fallback endpoint.
+        /// Must be empty when no fallback endpoint is configured.
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        headers: SuiGrpcHeaders,
     },
+}
+
+impl SuiDataSource {
+    pub fn grpc_headers(&self) -> &SuiGrpcHeaders {
+        match self {
+            Self::SuiStateDirect { headers, .. } | Self::SuiStateMirrored { headers, .. } => {
+                headers
+            }
+        }
+    }
 }
 
 fn default_true() -> bool {
@@ -563,7 +659,8 @@ pub fn select_sui_transport(
                 && matches!(
                     source,
                     SuiDataSource::SuiStateMirrored {
-                        fallback_grpc_url: None
+                        fallback_grpc_url: None,
+                        ..
                     }
                 )
             {
@@ -575,9 +672,24 @@ pub fn select_sui_transport(
                         .to_string(),
                 );
             }
+            if matches!(
+                source,
+                SuiDataSource::SuiStateMirrored {
+                    fallback_grpc_url: None,
+                    headers,
+                } if !headers.is_empty()
+            ) {
+                return Err(
+                    "gRPC headers are configured on a peer-only `sui-state-mirrored` source, but \
+                     it has no direct endpoint to receive them; remove `headers` or configure \
+                     `fallback-grpc-url`"
+                        .to_string(),
+                );
+            }
             Ok(match source {
                 SuiDataSource::SuiStateMirrored {
                     fallback_grpc_url: None,
+                    ..
                 } => SuiTransportPlan::PeerOnlyRelay,
                 _ => SuiTransportPlan::Grpc,
             })
@@ -1451,17 +1563,20 @@ mod tests {
     fn direct() -> SuiDataSource {
         SuiDataSource::SuiStateDirect {
             url: "http://direct:9000".to_string(),
+            headers: BTreeMap::new(),
             serve_mirror: true,
         }
     }
     fn mirrored_with_fallback() -> SuiDataSource {
         SuiDataSource::SuiStateMirrored {
             fallback_grpc_url: Some("http://fallback:9000".to_string()),
+            headers: BTreeMap::new(),
         }
     }
     fn peer_only_source() -> SuiDataSource {
         SuiDataSource::SuiStateMirrored {
             fallback_grpc_url: None,
+            headers: BTreeMap::new(),
         }
     }
 
@@ -2007,6 +2122,20 @@ ika-system-object-id: "0x2222222222222222222222222222222222222222222222222222222
         );
     }
 
+    #[test]
+    fn peer_only_rejects_headers_without_an_endpoint() {
+        let source = SuiDataSource::SuiStateMirrored {
+            fallback_grpc_url: None,
+            headers: BTreeMap::from([(
+                "x-api-key".to_string(),
+                SuiGrpcHeaderValue::FromEnv("SUI_GRPC_API_KEY".to_string()),
+            )]),
+        };
+        let err = select_sui_transport(Some(&source), false, true, NodeMode::Validator)
+            .expect_err("headers without a direct endpoint must fail closed");
+        assert!(err.contains("no direct endpoint"), "{err}");
+    }
+
     /// A notifier submits transactions, which a peer-only node can't do safely
     /// (its relayed submission returns unverified effects) — so a notifier
     /// configured peer-only is rejected, while a notifier with a fallback (or
@@ -2097,6 +2226,7 @@ ika-system-object-id: "0x2222222222222222222222222222222222222222222222222222222
                 &mirrored,
                 SuiDataSource::SuiStateMirrored {
                     fallback_grpc_url: Some(url),
+                    ..
                 } if url == "http://fallback:9000"
             ),
             "expected SuiStateMirrored with the fallback set, got {mirrored:?}"
@@ -2114,6 +2244,7 @@ ika-system-object-id: "0x2222222222222222222222222222222222222222222222222222222
                 SuiDataSource::SuiStateDirect {
                     url,
                     serve_mirror: false,
+                    ..
                 } if url == "http://direct:9000"
             ),
             "expected SuiStateDirect {{ serve_mirror: false }}, got {direct_no_mirror:?}"
@@ -2154,6 +2285,7 @@ ika-system-object-id: "0x2222222222222222222222222222222222222222222222222222222
             mirrored_round,
             SuiDataSource::SuiStateMirrored {
                 fallback_grpc_url: Some(url),
+                ..
             } if url == "http://fallback:9000"
         ));
 
@@ -2178,6 +2310,57 @@ ika-system-object-id: "0x2222222222222222222222222222222222222222222222222222222
             typo.is_err(),
             "a misspelled key must fail the parse (fail-closed), not flip the node to peer-only"
         );
+    }
+
+    #[test]
+    fn sui_grpc_headers_round_trip_and_debug_redacts_literals() {
+        let source: SuiDataSource = serde_yaml::from_str(
+            r#"kind: sui-state-direct
+url: https://provider.example.com:443
+headers:
+  authorization:
+    from-env: SUI_GRPC_AUTHORIZATION
+  x-api-key:
+    from-file: /run/secrets/sui-grpc-api-key
+  x-client-name:
+    literal: private-literal
+"#,
+        )
+        .expect("all supported header sources must deserialize");
+        let headers = source.grpc_headers();
+        assert_eq!(
+            headers.get("authorization"),
+            Some(&SuiGrpcHeaderValue::FromEnv(
+                "SUI_GRPC_AUTHORIZATION".to_string()
+            ))
+        );
+        assert_eq!(
+            headers.get("x-api-key"),
+            Some(&SuiGrpcHeaderValue::FromFile(
+                "/run/secrets/sui-grpc-api-key".into()
+            ))
+        );
+        assert_eq!(
+            headers.get("x-client-name"),
+            Some(&SuiGrpcHeaderValue::Literal("private-literal".to_string()))
+        );
+        assert!(!format!("{source:?}").contains("private-literal"));
+
+        let yaml = serde_yaml::to_string(&source).expect("headers must serialize");
+        let round_trip: SuiDataSource =
+            serde_yaml::from_str(&yaml).expect("serialized headers must deserialize");
+        assert_eq!(round_trip.grpc_headers(), headers);
+
+        for invalid in [
+            "kind: sui-state-direct\nurl: http://unused\nheaders:\n  x-api-key: {}\n",
+            "kind: sui-state-direct\nurl: http://unused\nheaders:\n  x-api-key:\n    from-env: KEY\n    from-file: /secret\n",
+            "kind: sui-state-direct\nurl: http://unused\nheaders:\n  x-api-key:\n    from-environment: KEY\n",
+        ] {
+            assert!(
+                serde_yaml::from_str::<SuiDataSource>(invalid).is_err(),
+                "a header value must have exactly one recognized source: {invalid}"
+            );
+        }
     }
 
     /// An old-style config (no `sui-data-source`) that nonetheless carries a Sui

--- a/crates/ika-core/src/sui_connector/setup.rs
+++ b/crates/ika-core/src/sui_connector/setup.rs
@@ -213,12 +213,12 @@ pub async fn build_sui_connector_stack(
         .as_ref()
         .ok_or(SetupError::MissingDataSource)?
     {
-        SuiDataSource::SuiStateDirect { url, .. } => {
+        SuiDataSource::SuiStateDirect { url, headers, .. } => {
             // Concrete `SuiGrpcClient`: the proof builder needs
             // `get_transaction_checkpoint`, an inherent gRPC method (not part of
             // the relay-able `SuiTransport` surface).
             let grpc = Arc::new(
-                SuiGrpcClient::new(url)
+                SuiGrpcClient::new_with_headers(url, headers)
                     .await
                     .map_err(|e| SetupError::Transport(format!("connect {url}: {e}")))?,
             );
@@ -239,7 +239,10 @@ pub async fn build_sui_connector_stack(
             let grpc: Arc<dyn SuiTransport> = grpc;
             (grpc.clone(), provider, true, Some(grpc), None)
         }
-        SuiDataSource::SuiStateMirrored { fallback_grpc_url } => {
+        SuiDataSource::SuiStateMirrored {
+            fallback_grpc_url,
+            headers,
+        } => {
             let net = network.clone().ok_or(SetupError::MirroredWithoutNetwork)?;
             let mut peer_ids = Vec::with_capacity(cfg.sui_state_mirror_peers.len());
             for entry in &cfg.sui_state_mirror_peers {
@@ -283,7 +286,7 @@ pub async fn build_sui_connector_stack(
             let raw: Arc<dyn SuiTransport> = match fallback_grpc_url {
                 Some(url) => {
                     let fallback: Arc<dyn SuiTransport> =
-                        Arc::new(SuiGrpcClient::new(url).await.map_err(|e| {
+                        Arc::new(SuiGrpcClient::new_with_headers(url, headers).await.map_err(|e| {
                             SetupError::Transport(format!("connect fallback {url}: {e}"))
                         })?);
                     Arc::new(FallbackTransport::new(relay, fallback))
@@ -594,6 +597,7 @@ mod tests {
             sui_rpc_url: None,
             sui_data_source: Some(SuiDataSource::SuiStateDirect {
                 url: "http://unused".to_string(),
+                headers: Default::default(),
                 serve_mirror: false,
             }),
             sui_state_mirror_peers: vec![],

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -672,22 +672,35 @@ impl IkaNode {
             peer_only_stack = Some(stack);
             client
         } else {
-            let grpc_url =
-                match &config.sui_connector_config.sui_data_source {
-                    Some(SuiDataSource::SuiStateDirect { url, .. }) => url.clone(),
-                    Some(SuiDataSource::SuiStateMirrored {
-                        fallback_grpc_url: Some(url),
-                    }) => url.clone(),
-                    Some(SuiDataSource::SuiStateMirrored {
-                        fallback_grpc_url: None,
-                    }) => unreachable!("peer_only is handled in the branch above"),
-                    // Old-style config on a notifier/fullnode: Sui fullnodes
-                    // serve gRPC on the same endpoint as JSON-RPC.
-                    None => config.sui_connector_config.sui_rpc_url.clone().expect(
+            let empty_headers = Default::default();
+            let (grpc_url, grpc_headers) = match &config.sui_connector_config.sui_data_source {
+                Some(SuiDataSource::SuiStateDirect { url, headers, .. }) => (url.clone(), headers),
+                Some(SuiDataSource::SuiStateMirrored {
+                    fallback_grpc_url: Some(url),
+                    headers,
+                }) => (url.clone(), headers),
+                Some(SuiDataSource::SuiStateMirrored {
+                    fallback_grpc_url: None,
+                    ..
+                }) => unreachable!("peer_only is handled in the branch above"),
+                // Old-style config on a notifier/fullnode: Sui fullnodes
+                // serve gRPC on the same endpoint as JSON-RPC.
+                None => (
+                    config.sui_connector_config.sui_rpc_url.clone().expect(
                         "the no-endpoint guard above ensures sui_rpc_url on old-style configs",
                     ),
-                };
-            Arc::new(SuiClient::new_grpc(&grpc_url, sui_client_metrics, ika_network_config).await?)
+                    &empty_headers,
+                ),
+            };
+            Arc::new(
+                SuiClient::new_grpc_with_headers(
+                    &grpc_url,
+                    grpc_headers,
+                    sui_client_metrics,
+                    ika_network_config,
+                )
+                .await?,
+            )
         };
 
         let (_, latest_system_inner) = sui_client.must_get_system_inner_object().await;

--- a/crates/ika-sui-client/src/grpc.rs
+++ b/crates/ika-sui-client/src/grpc.rs
@@ -9,10 +9,17 @@
 //! Do NOT put the client behind a Mutex held across the call — that would
 //! serialize every Sui read/write on the node behind one in-flight RPC.
 
+use std::env::{self, VarError};
+use std::fmt::Display;
+use std::fs;
+use std::path::Path;
+
 use async_trait::async_trait;
 use futures::StreamExt;
+use ika_config::node::{SuiGrpcHeaderValue, SuiGrpcHeaders};
 use sui_rpc_api::Client as SuiRpcClient;
 use sui_rpc_api::client::ExecutedTransaction;
+use sui_rpc_api::client::HeadersInterceptor;
 use sui_rpc_api::proto::sui::rpc::v2 as proto;
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest};
 use sui_types::full_checkpoint_content::CheckpointData;
@@ -20,6 +27,7 @@ use sui_types::gas_coin::{GAS, GasCoin};
 use sui_types::messages_checkpoint::{CertifiedCheckpointSummary, CheckpointSequenceNumber};
 use sui_types::object::Object;
 use sui_types::transaction::Transaction;
+use tonic::metadata::{Ascii, MetadataKey, MetadataValue};
 
 use crate::transport::{
     CheckpointSummaryStream, DynamicFieldEntry, DynamicFieldPage, SubmittedTransaction,
@@ -34,9 +42,20 @@ pub struct SuiGrpcClient {
 impl SuiGrpcClient {
     /// Connects (lazily) and probes the endpoint by fetching the chain id.
     pub async fn new(endpoint: impl Into<String>) -> Result<Self, TransportError> {
+        Self::new_with_headers(endpoint, &SuiGrpcHeaders::new()).await
+    }
+
+    /// Connects with configured metadata attached to every request, then
+    /// probes the endpoint by fetching the chain id.
+    pub async fn new_with_headers(
+        endpoint: impl Into<String>,
+        headers: &SuiGrpcHeaders,
+    ) -> Result<Self, TransportError> {
         let endpoint = endpoint.into();
+        let headers = resolve_grpc_headers(headers)?;
         let rpc = SuiRpcClient::new(endpoint.as_str())
-            .map_err(|e| TransportError::Network(format!("connect {endpoint}: {e}")))?;
+            .map_err(|e| TransportError::Network(format!("connect {endpoint}: {e}")))?
+            .with_headers(headers);
         let client = Self { rpc, endpoint };
         let _ = client.get_chain_identifier().await?;
         Ok(client)
@@ -109,6 +128,66 @@ impl SuiGrpcClient {
             signature,
         ))
     }
+}
+
+fn resolve_grpc_headers(headers: &SuiGrpcHeaders) -> Result<HeadersInterceptor, TransportError> {
+    resolve_grpc_headers_with(
+        headers,
+        |variable| match env::var(variable) {
+            Ok(value) => Ok(value),
+            Err(VarError::NotPresent) => {
+                Err(format!("environment variable `{variable}` is not set"))
+            }
+            Err(VarError::NotUnicode(_)) => Err(format!(
+                "environment variable `{variable}` is not valid UTF-8"
+            )),
+        },
+        |path| {
+            fs::read_to_string(path).map_err(|e| format!("cannot read `{}`: {e}", path.display()))
+        },
+    )
+}
+
+fn resolve_grpc_headers_with(
+    headers: &SuiGrpcHeaders,
+    read_env: impl Fn(&str) -> Result<String, String>,
+    read_file: impl Fn(&Path) -> Result<String, String>,
+) -> Result<HeadersInterceptor, TransportError> {
+    let mut resolved = HeadersInterceptor::new();
+    for (name, source) in headers {
+        let value = match source {
+            SuiGrpcHeaderValue::FromEnv(variable) => read_env(variable),
+            SuiGrpcHeaderValue::FromFile(path) => read_file(path).map(strip_one_line_ending),
+            SuiGrpcHeaderValue::Literal(value) => Ok(value.clone()),
+        }
+        .map_err(|reason| grpc_header_config_error(name, reason))?;
+        if value.is_empty() {
+            return Err(grpc_header_config_error(name, "value is empty"));
+        }
+        let key = MetadataKey::<Ascii>::from_bytes(name.as_bytes())
+            .map_err(|_| grpc_header_config_error(name, "name is not valid ASCII metadata"))?;
+        let mut value = MetadataValue::<Ascii>::try_from(value.as_str()).map_err(|_| {
+            grpc_header_config_error(name, "value contains invalid ASCII metadata bytes")
+        })?;
+        value.set_sensitive(true);
+        resolved.headers_mut().insert(key, value);
+    }
+    Ok(resolved)
+}
+
+fn strip_one_line_ending(mut value: String) -> String {
+    if value.ends_with("\r\n") {
+        value.truncate(value.len() - 2);
+    } else if value.ends_with('\n') {
+        value.truncate(value.len() - 1);
+    }
+    value
+}
+
+fn grpc_header_config_error(name: &str, reason: impl Display) -> TransportError {
+    TransportError::Network(format!(
+        "invalid Sui gRPC header configuration for `{name}`: {reason}"
+    ))
 }
 
 fn parse_object_id(s: &str) -> Result<ObjectID, TransportError> {
@@ -412,6 +491,76 @@ impl SuiWriter for SuiGrpcClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn configured_headers_resolve_all_sources_and_are_sensitive() {
+        let headers = SuiGrpcHeaders::from([
+            (
+                "authorization".to_string(),
+                SuiGrpcHeaderValue::FromEnv("SUI_AUTH".to_string()),
+            ),
+            (
+                "x-api-key".to_string(),
+                SuiGrpcHeaderValue::FromFile("/run/secrets/sui-api-key".into()),
+            ),
+            (
+                "x-client-name".to_string(),
+                SuiGrpcHeaderValue::Literal("ika-validator".to_string()),
+            ),
+        ]);
+        let resolved = resolve_grpc_headers_with(
+            &headers,
+            |variable| {
+                assert_eq!(variable, "SUI_AUTH");
+                Ok("Bearer token".to_string())
+            },
+            |path| {
+                assert_eq!(path, Path::new("/run/secrets/sui-api-key"));
+                Ok("file-token\r\n".to_string())
+            },
+        )
+        .expect("valid headers must resolve");
+
+        for (name, expected) in [
+            ("authorization", "Bearer token"),
+            ("x-api-key", "file-token"),
+            ("x-client-name", "ika-validator"),
+        ] {
+            let value = resolved.headers().get(name).expect("header must exist");
+            assert_eq!(value.to_str().expect("ASCII value"), expected);
+            assert!(value.is_sensitive(), "{name} must be marked sensitive");
+        }
+    }
+
+    #[test]
+    fn configured_header_errors_never_expose_values() {
+        let invalid_value = "private-token\nsecond-line";
+        let headers = SuiGrpcHeaders::from([(
+            "authorization".to_string(),
+            SuiGrpcHeaderValue::Literal(invalid_value.to_string()),
+        )]);
+        let err = resolve_grpc_headers_with(
+            &headers,
+            |_| unreachable!("literal source must not read the environment"),
+            |_| unreachable!("literal source must not read a file"),
+        )
+        .expect_err("newline is not valid ASCII metadata");
+        let message = err.to_string();
+        assert!(message.contains("authorization"));
+        assert!(!message.contains("private-token"));
+
+        let missing_env = SuiGrpcHeaders::from([(
+            "x-api-key".to_string(),
+            SuiGrpcHeaderValue::FromEnv("MISSING_SUI_KEY".to_string()),
+        )]);
+        let err = resolve_grpc_headers_with(
+            &missing_env,
+            |variable| Err(format!("environment variable `{variable}` is not set")),
+            |_| unreachable!("environment source must not read a file"),
+        )
+        .expect_err("missing environment variable must fail");
+        assert!(err.to_string().contains("MISSING_SUI_KEY"));
+    }
 
     /// A gRPC `NotFound` must map to `TransportError::NotFound` (carrying the
     /// message), and every other status code to `TransportError::Network`. This

--- a/crates/ika-sui-client/src/grpc_backend.rs
+++ b/crates/ika-sui-client/src/grpc_backend.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use dwallet_mpc_types::dwallet_mpc::VersionedMPCData;
+use ika_config::node::SuiGrpcHeaders;
 use ika_types::error::IkaError;
 use ika_types::messages_consensus::MovePackageDigest;
 use ika_types::messages_dwallet_mpc::{
@@ -76,7 +77,14 @@ impl GrpcSuiClient {
     /// Connect to a Sui fullnode over gRPC at `grpc_url`. The same direct
     /// client backs both the read transport and the writer uplink.
     pub async fn new(grpc_url: &str) -> anyhow::Result<Self> {
-        let grpc = std::sync::Arc::new(SuiGrpcClient::new(grpc_url).await?);
+        Self::new_with_headers(grpc_url, &SuiGrpcHeaders::new()).await
+    }
+
+    pub async fn new_with_headers(
+        grpc_url: &str,
+        headers: &SuiGrpcHeaders,
+    ) -> anyhow::Result<Self> {
+        let grpc = std::sync::Arc::new(SuiGrpcClient::new_with_headers(grpc_url, headers).await?);
         Ok(Self {
             transport: grpc.clone(),
             writer: Some(grpc),

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -6,6 +6,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use core::panic;
 use dwallet_mpc_types::dwallet_mpc::VersionedMPCData;
+use ika_config::node::SuiGrpcHeaders;
 use ika_types::error::{IkaError, IkaResult};
 use ika_types::messages_consensus::MovePackageDigest;
 use ika_types::messages_dwallet_mpc::{
@@ -162,7 +163,22 @@ impl SuiConnectorClient {
         sui_client_metrics: Arc<SuiClientMetrics>,
         ika_network_config: IkaNetworkConfig,
     ) -> anyhow::Result<Self> {
-        let inner = grpc_backend::GrpcSuiClient::new(grpc_url).await?;
+        Self::new_grpc_with_headers(
+            grpc_url,
+            &SuiGrpcHeaders::new(),
+            sui_client_metrics,
+            ika_network_config,
+        )
+        .await
+    }
+
+    pub async fn new_grpc_with_headers(
+        grpc_url: &str,
+        headers: &SuiGrpcHeaders,
+        sui_client_metrics: Arc<SuiClientMetrics>,
+        ika_network_config: IkaNetworkConfig,
+    ) -> anyhow::Result<Self> {
+        let inner = grpc_backend::GrpcSuiClient::new_with_headers(grpc_url, headers).await?;
         let self_ = Self {
             inner: SuiBackend::Grpc(inner),
             sui_client_metrics,

--- a/crates/ika-swarm-config/src/node_config_builder.rs
+++ b/crates/ika-swarm-config/src/node_config_builder.rs
@@ -190,6 +190,7 @@ impl ValidatorConfigBuilder {
                     self.sui_data_source_override.clone().unwrap_or_else(|| {
                         SuiDataSource::SuiStateDirect {
                             url: sui_rpc_url.to_string(),
+                            headers: Default::default(),
                             serve_mirror: true,
                         }
                     })
@@ -475,6 +476,7 @@ impl FullnodeConfigBuilder {
                 sui_data_source: (!self.legacy_sui_rpc_only).then(|| {
                     SuiDataSource::SuiStateDirect {
                         url: sui_rpc_url.to_string(),
+                        headers: Default::default(),
                         serve_mirror: false,
                     }
                 }),

--- a/crates/ika-test-cluster/src/lib.rs
+++ b/crates/ika-test-cluster/src/lib.rs
@@ -1587,6 +1587,7 @@ impl IkaTestClusterBuilder {
                     };
                     builder = builder.with_sui_data_source(SuiDataSource::SuiStateMirrored {
                         fallback_grpc_url,
+                        headers: Default::default(),
                     });
                     // Automatic discovery mode leaves `sui_state_mirror_peers`
                     // empty: the mirrored validators must find the serving

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -1976,6 +1976,7 @@ impl ClusterOfProcesses {
             builder = builder
                 .with_sui_data_source(SuiDataSource::SuiStateMirrored {
                     fallback_grpc_url: None,
+                    headers: Default::default(),
                 })
                 .with_sui_state_mirror_peers(mirror_peers.clone());
         }

--- a/crates/ika-upgrade-test/src/process.rs
+++ b/crates/ika-upgrade-test/src/process.rs
@@ -31,6 +31,7 @@ fn rewrite_config_to_mirrored(config_path: &Path, mirror_peers: Vec<String>) -> 
     let mut config: NodeConfig = serde_yaml::from_str(&yaml).context("parse node config")?;
     config.sui_connector_config.sui_data_source = Some(SuiDataSource::SuiStateMirrored {
         fallback_grpc_url: None,
+        headers: Default::default(),
     });
     config.sui_connector_config.sui_state_mirror_peers =
         mirror_peers.into_iter().map(Into::into).collect();

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -231,6 +231,49 @@ the committee chain). `SuiDataSource` must carry `rename_all_fields =
 "kebab-case"` so `fallback-grpc-url` is not silently dropped (a dropped field
 flips a mirrored validator into peer-only).
 
+### Authenticated gRPC endpoints
+
+Both direct sources and mirrored sources with a fallback can attach arbitrary
+ASCII gRPC metadata to every request sent to their configured endpoint. This is
+the provider-neutral authentication surface: bearer authentication is an
+`authorization` header whose complete value is `Bearer …`; provider-specific
+schemes use names such as `x-api-key` or `x-auth-header`. There are no separate
+bearer- or provider-specific config branches.
+
+```yaml
+sui-data-source:
+  kind: sui-state-direct
+  url: https://provider.example.com:443
+  headers:
+    authorization:
+      from-file: /run/secrets/sui-grpc-authorization
+    x-client-name:
+      literal: ika-validator
+```
+
+A mirrored validator places the same `headers` map next to
+`fallback-grpc-url`; the headers apply only to that direct fallback, never to
+the Ika p2p relay. Configuring headers on a peer-only source (no fallback URL)
+is rejected at startup because there is no endpoint to receive them.
+
+Each header value has exactly one source:
+
+- `from-file`: recommended for credentials mounted by Kubernetes, Docker, or
+  systemd. The file is read once at startup. One terminal LF or CRLF is removed
+  to accommodate ordinary secret files; all other bytes are preserved and
+  validated. Rotation therefore requires a node restart.
+- `from-env`: reads the complete value from the named environment variable at
+  startup. A missing, non-UTF-8, or empty value fails startup.
+- `literal`: embeds the value in YAML and is intended only for non-secret
+  metadata.
+
+Header names and values are validated before the client connects. Every value
+is marked sensitive in tonic metadata, and config debug output redacts literal
+values. Errors may name the header and its environment variable or file path,
+but never include the resolved value or file contents. The same metadata covers
+unary calls, checkpoint subscriptions, and notifier transaction submission
+because it is installed on the shared upstream Sui RPC client.
+
 ## Bootstrap and the committee ratchet
 
 The trust root is the **Sui genesis blob** (`sui_genesis`). At boot the node


### PR DESCRIPTION
## Description

Add provider-neutral custom metadata support for authenticated Sui gRPC endpoints.

- Allow direct and mirrored-with-fallback data sources to configure arbitrary ASCII gRPC headers.
- Resolve complete header values from mounted files, environment variables, or non-secret YAML literals.
- Install the headers on both production Sui clients so they cover ordinary reads and writes, checkpoint subscriptions, OCS proof construction, and fallback requests.
- Validate all names and values before connecting, mark values sensitive in tonic, redact literal values from debug output, and never include resolved values in errors.
- Reject headers on peer-only configurations because they have no direct endpoint.
- Document the configuration contract and startup/rotation behavior in the OCS specification.

## Test plan

- `cargo test --release -p ika-config`
- `cargo test --release -p ika-sui-client configured_header`
- `cargo check --release -p ika-node -p ika-core -p ika-swarm-config -p ika-upgrade-test -p ika-test-cluster`
- `cargo clippy --release -p ika-config -p ika-sui-client -p ika-core -p ika-node -p ika-swarm-config -p ika-upgrade-test -p ika-test-cluster --all-targets --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

---

## Release notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Sui gRPC endpoints can now configure a `headers` map. Each complete header value may come from `from-file`, `from-env`, or `literal`; use files or environment variables for credentials. File and environment values are loaded at startup, so credential rotation requires a node restart.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
