### PR TITLE
fix(ci): skip a missing branch in the nightly fan-out instead of failing

### DIFF
--- a/.github/workflows/scheduled-all-suites.yaml
+++ b/.github/workflows/scheduled-all-suites.yaml
@@ -74,6 +74,18 @@ jobs:
           SUITE: ${{ matrix.suite }}
         run: |
           set -euo pipefail
+          # A branch in the matrix may not exist right now — `dev` is created
+          # and deleted as release trains come and go, and from 2026-07-29 to
+          # 2026-08-03 its absence failed half the fan-out every single night,
+          # which is exactly how a nightly turns into noise nobody reads.
+          # Skip a missing ref with a notice instead: the dispatch matrix
+          # self-heals when the branch reappears, and a MAIN dispatch failure
+          # still fails the job loudly, which is the half that must never be
+          # silent.
+          if ! gh api "repos/$GH_REPO/branches/$BRANCH" --silent 2>/dev/null; then
+            echo "::notice::branch '$BRANCH' does not exist; skipping $SUITE dispatch"
+            exit 0
+          fi
           # Per-suite default inputs mirror each suite's own documented
           # defaults (see dev-docs/playbooks/ci-suites.md). Threads stay at
           # the validated 4-way for the memory-bound suites.


### PR DESCRIPTION
## What's red

The `Scheduled — All Heavy Suites` orchestrator has failed every night since 2026-07-29 (`30783815917` is the latest). The failing half is the four dispatches targeting `dev`:

```
could not create workflow dispatch event: HTTP 422: No ref found for: dev
```

There is no branch named `dev`. The live train branch is `dev-v1.2.x`. The matrix hard-codes `[main, dev]`, so every dev-side `gh workflow run --ref dev` 422s, and `fail-fast: false` keeps the main-side dispatches working — but the *job* goes red nightly.

## Why it matters beyond the annoyance

The main-side dispatches (Test Cluster / Integration / TS Integration / Simtest) **are** succeeding — I checked, they're green on main. So today this is only noise. But a nightly that is red every morning is a nightly nobody reads, and the day a real main-side dispatch fails, it looks identical to the dev-branch noise. This is the "boy who cried wolf" failure mode for scheduled CI.

## Fix

Guard each dispatch with a branch-existence check (`gh api repos/.../branches/$BRANCH`): skip a missing ref with a `::notice::` and exit 0, dispatch when it exists. Verified against the live repo — `dev` returns 404 (skip), `main` and `dev-v1.2.x` resolve (dispatch).

Deliberately minimal: I did **not** rename `dev` to `dev-v1.2.x` in the matrix. That's a real decision — train branches are renamed per release — and hard-coding today's name just moves the same breakage to the next rename. The existence guard is correct regardless of what the branch is called, and it self-heals when `dev` next exists.

A main dispatch failure still fails the job, which is the half that must stay loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)