### PR TITLE
chore: update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,11 +14,11 @@ Check each box that your changes affect. If none of the boxes relate to your cha
 
 For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.
 
-- [ ] Protocol:
-- [ ] Nodes (Validators and Full nodes):
-- [ ] Indexer:
-- [ ] JSON-RPC:
-- [ ] GraphQL:
+- [ ] Protocol and cryptography:
+- [ ] Move contracts:
+- [ ] Nodes (validators, fullnodes, and notifier):
 - [ ] CLI:
 - [ ] Rust SDK:
-- [ ] REST API:
+- [ ] TypeScript SDK:
+- [ ] WASM SDK:
+- [ ] Proxy and operator tooling:


### PR DESCRIPTION
## Description

Update the pull request template release-note categories to match the current Ika repository:

- Add protocol and cryptography, Move contracts, notifier, TypeScript SDK, WASM SDK, and proxy/operator tooling.
- Remove inherited Indexer, JSON-RPC, GraphQL, and REST API entries that are not Ika release surfaces.

## Test plan

- cargo fmt --all
- git diff --check

## Release notes

Not required; repository maintenance only.