### PR TITLE
feat(metrics): let a validator tell, locally, that it has stopped contributing

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -102,6 +102,28 @@ const LAST_CONSENSUS_STATS_ADDR: u64 = 0;
 const OVERRIDE_PROTOCOL_UPGRADE_BUFFER_STAKE_INDEX: u64 = 0;
 pub const EPOCH_DB_PREFIX: &str = "epoch_";
 
+/// Consensus rounds the MPC service may trail the commit path by before the
+/// node reports itself as no longer contributing.
+///
+/// Sized to be unmistakable rather than sensitive. Observed testnet round
+/// production is ~46k rounds/hour, so this is roughly an hour of falling
+/// behind — comfortably past any restart catch-up, and far below the gaps the
+/// two production incidents this exists for reached (ika #1978 sat ~247k rounds
+/// behind after 3.5h and kept going; #1980 passed 335k). A validator legitimately
+/// catching up closes the gap; a stopped one only grows it.
+const MPC_LAG_ALARM_ROUNDS: u64 = 50_000;
+
+/// What a single MPC-lag sample changed, so the loud log fires on transition
+/// rather than on every consensus commit. Returned rather than kept private so
+/// the latching is directly testable — the state flag alone cannot distinguish
+/// "logged once" from "logged every commit".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MpcLagTransition {
+    Raised,
+    Cleared,
+    Unchanged,
+}
+
 pub enum CancelConsensusCertificateReason {
     CongestionOnObjects(Vec<ObjectID>),
     DkgFailed,
@@ -242,6 +264,17 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
     ) -> IkaResult<()>;
 
     fn last_dwallet_mpc_message_round(&self) -> IkaResult<Option<Round>>;
+
+    /// Publishes the consensus round the MPC service has finished consuming.
+    ///
+    /// The MPC service cannot report its own stall: every path that stops it
+    /// also stops the code that would notice — most starkly the deliberate
+    /// `break` on self-recognised maliciousness, which ends the service loop
+    /// for the life of the process while consensus keeps running normally.
+    /// So the MPC side only publishes its progress here, and the CONSENSUS
+    /// commit path — which is still alive in exactly the cases that matter —
+    /// does the comparing.
+    fn record_mpc_consumed_consensus_round(&self, round: Round);
 
     fn next_dwallet_mpc_message(
         &self,
@@ -511,6 +544,11 @@ impl AuthorityPerEpochStoreTrait for AuthorityPerEpochStore {
         Ok(tables
             .pending_dwallet_checkpoints
             .insert(&checkpoint.height(), &checkpoint)?)
+    }
+
+    fn record_mpc_consumed_consensus_round(&self, round: Round) {
+        self.mpc_consumed_consensus_round
+            .store(round, std::sync::atomic::Ordering::Relaxed);
     }
 
     fn last_dwallet_mpc_message_round(&self) -> IkaResult<Option<Round>> {
@@ -1011,6 +1049,17 @@ pub struct AuthorityPerEpochStore {
     /// (each validator emits one V2 per epoch).
     pending_handoff_signatures:
         parking_lot::Mutex<Vec<ika_types::handoff::HandoffSignatureMessage>>,
+
+    /// Consensus round the MPC service last finished consuming, published by
+    /// the service itself. Compared against the commit round on the consensus
+    /// path to detect an MPC subsystem that has stopped while consensus keeps
+    /// running — see `record_mpc_consumed_consensus_round`. `0` until the
+    /// service reports its first round.
+    mpc_consumed_consensus_round: std::sync::atomic::AtomicU64,
+
+    /// Whether the MPC-lag alarm is currently raised, so the loud log fires on
+    /// transition instead of on every consensus commit.
+    mpc_lag_alarm_active: std::sync::atomic::AtomicBool,
 
     /// Pending `handoff_signatures` row mutations, waiting to be folded into
     /// the next `ConsensusCommitOutput`. `Some(signature)` is an upsert,
@@ -2502,6 +2551,8 @@ impl AuthorityPerEpochStore {
             end_of_publish: Mutex::new(end_of_publish),
             joiner_pubkey_provider: ArcSwapOption::empty(),
             expected_handoff_attestation: ArcSwapOption::empty(),
+            mpc_consumed_consensus_round: std::sync::atomic::AtomicU64::new(0),
+            mpc_lag_alarm_active: std::sync::atomic::AtomicBool::new(false),
             pending_handoff_signatures: parking_lot::Mutex::new(Vec::new()),
             staged_handoff_signature_rows: parking_lot::Mutex::new(BTreeMap::new()),
             pending_relayed_joiner_announcements: parking_lot::Mutex::new(Vec::new()),
@@ -3532,6 +3583,67 @@ impl AuthorityPerEpochStore {
             self.name,
             consensus_keypair,
         ))
+    }
+
+    /// Publishes how far the MPC service trails the consensus commit path, and
+    /// escalates to a loud log once the gap is unambiguous.
+    ///
+    /// A healthy validator sits a small, roughly constant distance behind: the
+    /// MPC service consumes rounds slightly after the commit boundary produces
+    /// them. A gap that grows without bound means MPC has stopped while
+    /// consensus continues — the node follows consensus, serves requests,
+    /// exports metrics, and contributes nothing.
+    ///
+    /// The threshold is deliberately generous. Genuine catch-up after a restart
+    /// transiently produces a large gap and then closes it, and we would rather
+    /// miss the first minutes of a real stall than teach operators to ignore
+    /// this line. `MPC_LAG_ALARM_ROUNDS` is roughly an hour of production round
+    /// production at observed testnet rates; the two production incidents this
+    /// exists for sat far past it for many hours.
+    ///
+    /// Logged on TRANSITION only, not per commit: this runs on every consensus
+    /// commit, so an unconditional log would emit thousands of lines an hour
+    /// and bury itself. The gauge carries the continuous signal.
+    fn report_mpc_consensus_round_lag(&self, commit_round: Round) -> MpcLagTransition {
+        let consumed = self
+            .mpc_consumed_consensus_round
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if consumed == 0 {
+            // The MPC service has not reported a round yet (fresh epoch store,
+            // still replaying). Round 0 is legitimate, so the gauge carries a
+            // sentinel rather than a plausible-looking 0.
+            self.metrics.mpc_consensus_round_lag.set(-1);
+            return MpcLagTransition::Unchanged;
+        }
+        let lag = commit_round.saturating_sub(consumed);
+        self.metrics.mpc_consensus_round_lag.set(lag as i64);
+
+        let alarming = lag >= MPC_LAG_ALARM_ROUNDS;
+        let was_alarming = self
+            .mpc_lag_alarm_active
+            .swap(alarming, std::sync::atomic::Ordering::Relaxed);
+        let transition = match (was_alarming, alarming) {
+            (false, true) => MpcLagTransition::Raised,
+            (true, false) => MpcLagTransition::Cleared,
+            _ => MpcLagTransition::Unchanged,
+        };
+        match transition {
+            MpcLagTransition::Raised => error!(
+                lag_rounds = lag,
+                commit_round,
+                mpc_consumed_round = consumed,
+                "MPC subsystem has stopped keeping up with consensus: this validator is \
+                 following consensus normally but is no longer contributing MPC work. It will \
+                 not recover on its own in every known case — check for an earlier fatal in \
+                 the dWallet MPC service, and restart the node if none explains it"
+            ),
+            MpcLagTransition::Cleared => info!(
+                lag_rounds = lag,
+                "MPC subsystem has caught back up with consensus"
+            ),
+            MpcLagTransition::Unchanged => {}
+        }
+        transition
     }
 
     /// Queues `handoff_signatures` row mutations for the next commit's batch.
@@ -4959,6 +5071,13 @@ impl AuthorityPerEpochStore {
         self.metrics
             .consensus_last_committed_timestamp_seconds
             .set((consensus_commit_info.timestamp / 1000) as i64);
+        // Self-health: is the MPC subsystem keeping up with consensus? Sampled
+        // HERE, on the commit path, because that path is still running in every
+        // case where MPC is not — including the deliberate service-loop `break`
+        // on self-recognised maliciousness, which stops MPC for the life of the
+        // process while the node keeps serving consensus and looking healthy
+        // from outside (ika #1978, #1980).
+        let _ = self.report_mpc_consensus_round_lag(consensus_commit_info.round);
 
         let mut verified_dwallet_checkpoint_certificates =
             VecDeque::with_capacity(transactions.len() + 1);
@@ -6475,6 +6594,127 @@ mod tests {
     /// `all_voted || grace_elapsed` with no handoff-cert gate, so it would close
     /// at STEP 1 (reconfig flips to `RejectAllTx`, an `EndOfPublish` close
     /// message is emitted) and FAIL the STEP 1 assertions.
+    /// A validator must be able to tell, from purely local state, that its MPC
+    /// subsystem has stopped while consensus keeps running. Both production
+    /// incidents this exists for (#1978, #1980) were invisible to their
+    /// operators and diagnosable only from a fleet-wide view they do not have.
+    #[tokio::test]
+    async fn mpc_lag_is_reported_and_alarms_only_once_stopped() {
+        let (committee, _keys) = Committee::new_simple_test_committee_of_size(4);
+        let committee = Arc::new(committee);
+        let names: Vec<AuthorityName> = committee.names().copied().collect();
+        let dir = tempfile::tempdir().unwrap();
+        let epoch_store = AuthorityPerEpochStore::new(
+            names[0],
+            committee,
+            dir.path(),
+            None,
+            EpochMetrics::new(&Registry::new()),
+            EpochStartConfiguration::new(EpochStartSystem::new_for_testing_with_epoch(0)).unwrap(),
+            ChainIdentifier::default(),
+            IkaNetworkConfig::new_for_testing(),
+        )
+        .unwrap();
+        let lag = || epoch_store.metrics.mpc_consensus_round_lag.get();
+
+        // Before the MPC service reports anything the gauge must NOT read 0 —
+        // round 0 is a legitimate consumed round, so 0 would be a
+        // plausible-but-wrong "perfectly caught up".
+        epoch_store.report_mpc_consensus_round_lag(1_000);
+        assert_eq!(lag(), -1, "no MPC report yet must be a sentinel, not 0");
+
+        // Healthy: the service trails the commit path slightly.
+        epoch_store.record_mpc_consumed_consensus_round(990);
+        epoch_store.report_mpc_consensus_round_lag(1_000);
+        assert_eq!(lag(), 10);
+        assert!(
+            !epoch_store
+                .mpc_lag_alarm_active
+                .load(std::sync::atomic::Ordering::Relaxed),
+            "an ordinary trailing distance must not alarm"
+        );
+
+        // Stopped: consensus advances, MPC does not.
+        epoch_store.report_mpc_consensus_round_lag(990 + MPC_LAG_ALARM_ROUNDS);
+        assert_eq!(lag(), MPC_LAG_ALARM_ROUNDS as i64);
+        assert!(
+            epoch_store
+                .mpc_lag_alarm_active
+                .load(std::sync::atomic::Ordering::Relaxed),
+            "a stopped MPC subsystem must raise the alarm"
+        );
+
+        // Recovery clears it, so a restart that fixes the node is visible too.
+        epoch_store.record_mpc_consumed_consensus_round(990 + MPC_LAG_ALARM_ROUNDS);
+        epoch_store.report_mpc_consensus_round_lag(990 + MPC_LAG_ALARM_ROUNDS);
+        assert_eq!(lag(), 0);
+        assert!(
+            !epoch_store
+                .mpc_lag_alarm_active
+                .load(std::sync::atomic::Ordering::Relaxed),
+            "catching up must clear the alarm"
+        );
+    }
+
+    /// The alarm latches, so the loud line fires on transition rather than on
+    /// every consensus commit — this runs per commit, and an unconditional log
+    /// would emit thousands of lines an hour and bury itself.
+    #[tokio::test]
+    async fn mpc_lag_alarm_does_not_re_fire_while_it_stays_raised() {
+        let (committee, _keys) = Committee::new_simple_test_committee_of_size(4);
+        let committee = Arc::new(committee);
+        let names: Vec<AuthorityName> = committee.names().copied().collect();
+        let dir = tempfile::tempdir().unwrap();
+        let epoch_store = AuthorityPerEpochStore::new(
+            names[0],
+            committee,
+            dir.path(),
+            None,
+            EpochMetrics::new(&Registry::new()),
+            EpochStartConfiguration::new(EpochStartSystem::new_for_testing_with_epoch(0)).unwrap(),
+            ChainIdentifier::default(),
+            IkaNetworkConfig::new_for_testing(),
+        )
+        .unwrap();
+
+        epoch_store.record_mpc_consumed_consensus_round(1);
+        // A sustained stall across many commits must announce itself exactly
+        // once. This asserts the LOGGING decision, not the flag: the flag ends
+        // up `true` either way, so observing it cannot tell a latched alarm
+        // from one that re-fires on every commit.
+        let transitions: Vec<_> = (1..=5)
+            .map(|i| epoch_store.report_mpc_consensus_round_lag(MPC_LAG_ALARM_ROUNDS + i))
+            .collect();
+        assert_eq!(
+            transitions,
+            vec![
+                MpcLagTransition::Raised,
+                MpcLagTransition::Unchanged,
+                MpcLagTransition::Unchanged,
+                MpcLagTransition::Unchanged,
+                MpcLagTransition::Unchanged,
+            ],
+            "the alarm must latch — this runs on EVERY consensus commit"
+        );
+        // The gauge keeps tracking growth throughout, so the continuous signal
+        // is not lost to the latching.
+        assert_eq!(
+            epoch_store.metrics.mpc_consensus_round_lag.get(),
+            (MPC_LAG_ALARM_ROUNDS + 4) as i64
+        );
+
+        // Recovery announces itself once too, then goes quiet.
+        epoch_store.record_mpc_consumed_consensus_round(MPC_LAG_ALARM_ROUNDS + 5);
+        assert_eq!(
+            epoch_store.report_mpc_consensus_round_lag(MPC_LAG_ALARM_ROUNDS + 5),
+            MpcLagTransition::Cleared
+        );
+        assert_eq!(
+            epoch_store.report_mpc_consensus_round_lag(MPC_LAG_ALARM_ROUNDS + 5),
+            MpcLagTransition::Unchanged
+        );
+    }
+
     #[tokio::test]
     async fn epoch_close_wiring_defers_until_handoff_cert_quorum() {
         // Four equal-weight validators: quorum_threshold = 3, validity = 2.

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -1875,6 +1875,11 @@ impl DWalletMPCService {
             self.dwallet_mpc_metrics
                 .last_process_mpc_consensus_round
                 .set(consensus_round as i64);
+            // Publish progress for the consensus-path stall detector. It has to
+            // live over there: every way this service stops also stops any
+            // check placed inside it.
+            self.epoch_store
+                .record_mpc_consumed_consensus_round(consensus_round);
             tokio::task::yield_now().await;
         }
     }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -66,6 +66,9 @@ pub(crate) struct TestingAuthorityPerEpochStore {
             >,
         >,
     >,
+    /// Mirrors the real store's field so the MPC service's progress
+    /// publication is exercised by the integration tests rather than stubbed.
+    pub(crate) mpc_consumed_consensus_round: std::sync::atomic::AtomicU64,
     pub(crate) round_to_idle_status_updates: Arc<Mutex<HashMap<Round, Vec<IdleStatusUpdate>>>>,
     pub(crate) round_to_sui_chain_observation_updates:
         Arc<Mutex<HashMap<Round, Vec<SuiChainObservationUpdate>>>>,
@@ -162,6 +165,7 @@ impl TestingAuthorityPerEpochStore {
             round_to_internal_outputs: Arc::new(Mutex::new(HashMap::from([(0, vec![])]))),
             round_to_verified_checkpoint: Arc::new(Mutex::new(HashMap::from([(0, vec![])]))),
             round_to_verified_system_checkpoint: Arc::new(Mutex::new(HashMap::from([(0, vec![])]))),
+            mpc_consumed_consensus_round: std::sync::atomic::AtomicU64::new(0),
             round_to_idle_status_updates: Arc::new(Mutex::new(HashMap::from([(0, vec![])]))),
             round_to_sui_chain_observation_updates: Arc::new(Mutex::new(HashMap::from([(
                 0,
@@ -190,6 +194,11 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
     ) -> IkaResult<()> {
         self.pending_checkpoints.lock().unwrap().push(checkpoint);
         Ok(())
+    }
+
+    fn record_mpc_consumed_consensus_round(&self, round: Round) {
+        self.mpc_consumed_consensus_round
+            .store(round, std::sync::atomic::Ordering::Relaxed);
     }
 
     fn last_dwallet_mpc_message_round(&self) -> IkaResult<Option<Round>> {

--- a/crates/ika-core/src/epoch/epoch_metrics.rs
+++ b/crates/ika-core/src/epoch/epoch_metrics.rs
@@ -114,6 +114,24 @@ pub struct EpochMetrics {
     /// epoch-store open.
     pub consensus_last_committed_leader_round: IntGauge,
 
+    /// How many consensus rounds the MPC service trails the consensus commit
+    /// path by, sampled on every commit. Small and roughly constant in normal
+    /// operation (the MPC service consumes slightly behind the commit
+    /// boundary); UNBOUNDED GROWTH means the MPC subsystem has stopped while
+    /// consensus keeps running — the node serves consensus normally, looks
+    /// alive from every angle, and contributes nothing.
+    ///
+    /// This is the signal a validator operator needs and previously did not
+    /// have. Two validators went dark for hours in production this way (ika
+    /// #1978, #1980), both diagnosed only from a fleet-wide Grafana no
+    /// external operator can see, and both cleared by a restart nobody knew
+    /// to perform. Locally computable on purpose: it needs no peer data and no
+    /// fleet context, so it works for anyone running a validator.
+    ///
+    /// `-1` before the MPC service reports its first round, since round 0 is
+    /// a legitimate value.
+    pub mpc_consensus_round_lag: IntGauge,
+
     /// Consensus timestamp (unix seconds) of the latest commit processed at
     /// the Ika commit boundary. Zero until this process handles its first
     /// commit; metric collection never mutates it.
@@ -318,6 +336,12 @@ impl EpochMetrics {
                 "Leader round of the latest consensus commit processed at the commit boundary \
                  (the freeze-grace round domain); -1 before the epoch's first commit",
                 registry
+            )
+            .unwrap(),
+            mpc_consensus_round_lag: register_int_gauge_with_registry!(
+                "ika_mpc_consensus_round_lag",
+                "Consensus rounds the MPC service trails the consensus commit path by; unbounded growth means MPC has stopped while consensus keeps running (-1 before the MPC service reports its first round)",
+                registry,
             )
             .unwrap(),
             consensus_last_committed_timestamp_seconds: register_int_gauge_with_registry!(

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -110,6 +110,32 @@ allowed when operators need them, but reminders do not increment the invariant
 counter. The network-key registry sites are guarded structurally by
 `scripts/check-invariant-violation-markers.sh`.
 
+### A node must be able to tell it has stopped contributing
+
+`ika_mpc_consensus_round_lag` is how far the MPC service trails the consensus
+commit path, sampled on every commit. Small and roughly constant in normal
+operation; unbounded growth means MPC has stopped while consensus keeps
+running — the node follows consensus, serves requests, exports every other
+metric, and contributes nothing.
+
+The rule it encodes: **a subsystem cannot report its own stall.** Every path
+that stops the MPC service also stops any check placed inside it — most
+starkly the deliberate `break` on self-recognised maliciousness, which ends the
+service loop for the life of the process. So the stalled side only publishes
+its progress, and a path that is still running does the comparing.
+
+It is deliberately computable from local state alone, needing no peer data and
+no fleet context. Two validators went dark for hours in production this way
+(#1978, #1980); both were diagnosed from a fleet-wide Grafana no external
+operator can see, and both were cleared by a restart nobody knew to perform.
+A signal that only we can read is not a signal for the people running the
+network.
+
+Paired with a latched log: the sample runs on every consensus commit, so the
+loud line fires on transition into and out of the condition, and the gauge
+carries the continuous signal. `-1` before the MPC service reports its first
+round, since round 0 is a legitimate value.
+
 ### Process-wide wire settings need a gauge, not just a log
 
 `ika_authority_name_encoding_width_bytes` and
@@ -369,6 +395,7 @@ ika_messages_included_in_dwallet_checkpoint
 ika_messages_included_in_system_checkpoint
 ika_mpc_blob_store_evictions_total
 ika_mpc_blob_store_size_bytes
+ika_mpc_consensus_round_lag
 ika_mpc_data_announcement_blob_bytes
 ika_network_key_overlay_incomplete
 ika_network_key_registry_read_empty_condition_active


### PR DESCRIPTION
## Why

Two validators went dark in production this week and **neither operator had any way to know**:

| | dark for | consensus | how it was found | how it was cleared |
|---|---|---|---|---|
| `node_cr` (#1978) | **15h 37m** | perfectly healthy | our fleet Grafana | operator restart |
| `algo\|stake` (#1980) | ~6h | perfectly healthy | our fleet Grafana | operator restart |

In both cases the node followed consensus, served requests, exported every other metric, never crashed and never logged a fatal — and contributed nothing. We found them by comparing each node's MPC round against the *fleet maximum*, which no external operator can do. That is why they ran for hours.

This is not two bugs, it is one missing signal. The same shape covers #1864 (consensus-dead while alive) and the #1952 spectator wedge.

## What

`ika_mpc_consensus_round_lag` — how far the MPC service trails the consensus commit path, sampled every commit. Small and roughly constant in normal operation; **unbounded growth is the condition**. Deliberately computable from local state alone: no peer data, no fleet context, so it works for anyone running a validator.

## The placement is the design

It lives on the **consensus path**, not in the MPC service, because **a subsystem cannot report its own stall.** Every path that stops the MPC service also stops a check placed inside it — most starkly this, which is intentional and permanent:

```rust
if self.dwallet_mpc_manager.recognized_self_as_malicious {
    ...
    // This signifies a bug, we can't proceed before we fix it.
    break;
}
```

That ends the service loop for the life of the process while consensus keeps running normally — precisely the observed production shape. So the MPC side only *publishes* its progress (`record_mpc_consumed_consensus_round`), and the commit path — still alive in exactly the cases that matter — does the comparing.

## Tuning

- **Threshold 50k rounds** (~1h at observed testnet rates). Generous on purpose: restart catch-up transiently produces a large gap then closes it, and a signal operators learn to ignore is worse than no signal. The two incidents reached **247k** and **335k** and were still growing.
- **The log latches**, firing on transition into and out of the condition. This runs on *every consensus commit* — an unconditional log would emit thousands of lines an hour and bury itself. The gauge carries the continuous signal.
- **`-1` before the MPC service reports its first round**, since round 0 is a legitimate consumed round and 0 would read as "perfectly caught up".

## A note on the fault validation, because it caught a real problem in my own test

Per `dev-docs/playbooks/test-testing.md`, both tests were fault-validated. **The latch test failed that validation on its first version** — it asserted on the state flag, which ends up identical whether the alarm latches or re-fires every commit, so removing the latch did not fail it. It was a vacuous test that looked fine and passed.

Fixed by making the transition an explicit returned value (`MpcLagTransition`) and asserting the *sequence* across a sustained stall. The injection now fails it as it should. Both injections reverted; no artifacts remain.

## Verification

Workspace compiles, clippy clean, `check-metric-names.sh` passes with the metric added to the inventory. `dev-docs/conventions/metrics.md` gains the general rule — *a subsystem cannot report its own stall; the stalled side publishes, a live path compares* — since this will not be the last time it applies.

## Follow-up

An infra alert on this is straightforward once it ships, and it will catch the class within minutes rather than hours. But the point of this PR is the signal reaching **operators**, not us — we already had the fleet view that found both incidents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)