### PR TITLE
fix(node): crash on panic by default; export MPC core-slot occupancy; persist self-malicious diagnostics

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
@@ -234,6 +234,13 @@ impl CryptographicComputationsOrchestrator {
             < self.available_cores_for_cryptographic_computations
     }
 
+    /// The core-slot budget concurrent computations are admitted against.
+    /// Exposed for the occupancy gauges: `currently_running == budget` is the
+    /// state in which the orchestrator refuses every new computation.
+    pub(crate) fn available_cores(&self) -> usize {
+        self.available_cores_for_cryptographic_computations
+    }
+
     pub(crate) fn running_computation_count_for_session(
         &self,
         session_identifier: &SessionIdentifier,

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -170,6 +170,20 @@ pub struct DWalletMPCMetrics {
     /// rayon pool.
     pub(crate) network_key_instantiations_in_flight: IntGauge,
 
+    /// Cryptographic computations currently holding an orchestrator core
+    /// slot (spawned on rayon, completion update not yet drained). Slots are
+    /// reclaimed ONLY when a completion arrives, so a computation that never
+    /// completes holds its slot for the rest of the epoch — and once
+    /// `running == core budget` the orchestrator silently stops scheduling
+    /// MPC. That state was previously visible only as a `debug!` field
+    /// (#1978 stall audit); this gauge plus the budget gauge below make
+    /// slot exhaustion and slow slot leaks scrapable.
+    pub(crate) cryptographic_computations_running: IntGauge,
+
+    /// The orchestrator's core-slot budget for concurrent cryptographic
+    /// computations (the admission ceiling `running` is compared against).
+    pub(crate) cryptographic_computation_core_budget: IntGauge,
+
     /// Version (2 or 3) of the canonical network DKG output this validator most
     /// recently mirrored into the off-chain handoff. Migrates 2 -> 3 once, when
     /// a deployed key's cert-pinned reconfiguration output becomes V3 (protocol
@@ -579,6 +593,18 @@ impl DWalletMPCMetrics {
             network_key_instantiations_in_flight: register_int_gauge_with_registry!(
                 "ika_dwallet_mpc_network_key_instantiations_in_flight",
                 "Network-key instantiations currently in flight on the rayon pool",
+                registry
+            )
+            .unwrap(),
+            cryptographic_computations_running: register_int_gauge_with_registry!(
+                "ika_dwallet_mpc_cryptographic_computations_running",
+                "Cryptographic computations currently holding an orchestrator core slot (spawned on rayon, completion not yet drained)",
+                registry
+            )
+            .unwrap(),
+            cryptographic_computation_core_budget: register_int_gauge_with_registry!(
+                "ika_dwallet_mpc_cryptographic_computation_core_budget",
+                "The orchestrator's core-slot budget for concurrent cryptographic computations",
                 registry
             )
             .unwrap(),

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -236,7 +236,7 @@ impl DWalletMPCService {
             Some(root_seed) => root_seed.root_seed().clone(),
         };
 
-        let dwallet_mpc_manager = DWalletMPCManager::new(
+        let mut dwallet_mpc_manager = DWalletMPCManager::new(
             validator_name,
             committee.clone(),
             epoch_id,
@@ -252,6 +252,12 @@ impl DWalletMPCService {
             max_mpc_computation_cores,
             stranded_network_keys,
         );
+        // Self-malicious diagnostic snapshots are mirrored to disk beside the
+        // databases (NOT under `db_path()`/live, which is RocksDB-managed):
+        // the convicted validator's service stops right after emitting them,
+        // and its log stream — the only other copy — rotates out within hours
+        // at validator log volumes (#1978).
+        dwallet_mpc_manager.set_diagnostics_dir(node_config.db_path.join("mpc_diagnostics"));
 
         Self {
             last_read_consensus_round: None,

--- a/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
@@ -431,6 +431,29 @@ impl MpcAnomalySnapshot {
     }
 }
 
+/// Persist a self-malicious diagnostic JSON to `dir` so it survives log
+/// rotation. A validator that recognizes itself as malicious stops its MPC
+/// service on the spot, and the diagnostic explaining WHY exists only in its
+/// own log stream — which at validator log volumes rotates out within hours
+/// (in the #1978 investigation the convicted node's window was gone before
+/// anyone asked for it). The write is bounded by construction: the emitting
+/// paths fire at most a handful of times per epoch (self-recognition breaks
+/// the service loop right after), and the filename is deterministic, so a
+/// re-emission — e.g. the post-restart replay re-convicting — overwrites
+/// idempotently rather than accumulating files.
+pub(crate) fn persist_malicious_diagnostic_file(
+    dir: &std::path::Path,
+    epoch: u64,
+    anomaly_kind_label: &str,
+    session_label: &str,
+    diagnostic_json: &str,
+) -> std::io::Result<std::path::PathBuf> {
+    std::fs::create_dir_all(dir)?;
+    let path = dir.join(format!("epoch_{epoch}__{anomaly_kind_label}__{session_label}.json"));
+    std::fs::write(&path, diagnostic_json)?;
+    Ok(path)
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct MpcErrorDiagnostic {
     pub(crate) error_code: &'static str,
@@ -713,5 +736,45 @@ mod tests {
 
         assert!(backtrace.is_none());
         assert!(!truncated);
+    }
+
+    /// The persisted file must land under a deterministic name carrying the
+    /// epoch, anomaly kind, and session — and a re-emission (the post-restart
+    /// replay re-convicting, #1978) must overwrite that same file rather than
+    /// accumulate, so the directory stays bounded across restarts.
+    #[test]
+    fn persist_malicious_diagnostic_writes_and_overwrites_a_stable_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("mpc_diagnostics");
+
+        let path =
+            persist_malicious_diagnostic_file(&dir, 373, "quorum_anomaly", "bfdbe149", r#"{"a":1}"#)
+                .unwrap();
+        assert_eq!(
+            path.file_name().unwrap().to_str().unwrap(),
+            "epoch_373__quorum_anomaly__bfdbe149.json"
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), r#"{"a":1}"#);
+
+        let replayed =
+            persist_malicious_diagnostic_file(&dir, 373, "quorum_anomaly", "bfdbe149", r#"{"a":2}"#)
+                .unwrap();
+        assert_eq!(replayed, path);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), r#"{"a":2}"#);
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 1);
+    }
+
+    /// An unwritable destination surfaces as `Err` for the caller to log —
+    /// never a panic, since this runs on the conviction path right before the
+    /// MPC service stops.
+    #[test]
+    fn persist_malicious_diagnostic_reports_io_failure_instead_of_panicking() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Occupy the diagnostics-dir path with a FILE so create_dir_all fails.
+        let blocked = tmp.path().join("mpc_diagnostics");
+        std::fs::write(&blocked, b"in the way").unwrap();
+
+        let result = persist_malicious_diagnostic_file(&blocked, 1, "kind", "session", "{}");
+        assert!(result.is_err());
     }
 }

--- a/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
@@ -449,7 +449,9 @@ pub(crate) fn persist_malicious_diagnostic_file(
     diagnostic_json: &str,
 ) -> std::io::Result<std::path::PathBuf> {
     std::fs::create_dir_all(dir)?;
-    let path = dir.join(format!("epoch_{epoch}__{anomaly_kind_label}__{session_label}.json"));
+    let path = dir.join(format!(
+        "epoch_{epoch}__{anomaly_kind_label}__{session_label}.json"
+    ));
     std::fs::write(&path, diagnostic_json)?;
     Ok(path)
 }
@@ -747,18 +749,28 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("mpc_diagnostics");
 
-        let path =
-            persist_malicious_diagnostic_file(&dir, 373, "quorum_anomaly", "bfdbe149", r#"{"a":1}"#)
-                .unwrap();
+        let path = persist_malicious_diagnostic_file(
+            &dir,
+            373,
+            "quorum_anomaly",
+            "bfdbe149",
+            r#"{"a":1}"#,
+        )
+        .unwrap();
         assert_eq!(
             path.file_name().unwrap().to_str().unwrap(),
             "epoch_373__quorum_anomaly__bfdbe149.json"
         );
         assert_eq!(std::fs::read_to_string(&path).unwrap(), r#"{"a":1}"#);
 
-        let replayed =
-            persist_malicious_diagnostic_file(&dir, 373, "quorum_anomaly", "bfdbe149", r#"{"a":2}"#)
-                .unwrap();
+        let replayed = persist_malicious_diagnostic_file(
+            &dir,
+            373,
+            "quorum_anomaly",
+            "bfdbe149",
+            r#"{"a":2}"#,
+        )
+        .unwrap();
         assert_eq!(replayed, path);
         assert_eq!(std::fs::read_to_string(&path).unwrap(), r#"{"a":2}"#);
         assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 1);

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -5179,7 +5179,8 @@ impl DWalletMPCManager {
                 .len() as i64,
         );
         metrics.cryptographic_computation_core_budget.set(
-            self.cryptographic_computations_orchestrator.available_cores() as i64,
+            self.cryptographic_computations_orchestrator
+                .available_cores() as i64,
         );
 
         // ----- session-state counts + Active-session age buckets -----

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -17,6 +17,7 @@ use crate::dwallet_mpc::mpc_diagnostics::{
     LocalAuthorityMaliciousReason, MPC_ANOMALY_SCHEMA_VERSION, MpcAnomalyContext, MpcAnomalyKind,
     OutputReportDiagnostic, OutputVoteDiagnostics, OutputVoteGroupDiagnostic, SessionOrigin,
     mpc_error_diagnostic, network_key_reconfiguration_raw_output_digest,
+    persist_malicious_diagnostic_file,
 };
 use crate::dwallet_mpc::mpc_session::{
     AddMessageResult, AddOutputResult, DWalletMPCSessionOutput, DWalletSession, PublicInput,
@@ -354,6 +355,12 @@ pub(crate) struct DWalletMPCManager {
     pub(crate) last_session_to_complete_in_current_epoch: u64,
     pub(crate) recognized_self_as_malicious: bool,
     recognized_self_as_malicious_session: Option<SessionIdentifier>,
+
+    /// Directory for persisting self-malicious diagnostic snapshots (see
+    /// [`persist_malicious_diagnostic_file`]). Set by the service at
+    /// construction (`<db_path>/mpc_diagnostics`); `None` — persistence off —
+    /// in tests that don't wire it.
+    diagnostics_dir: Option<std::path::PathBuf>,
     pub(crate) network_keys: Box<DwalletMPCNetworkKeys>,
     /// Requests parked until their network key's PUBLIC DATA is locally
     /// available. Drained LEVEL-triggered on every
@@ -810,6 +817,7 @@ impl DWalletMPCManager {
             last_session_to_complete_in_current_epoch: 0,
             recognized_self_as_malicious: false,
             recognized_self_as_malicious_session: None,
+            diagnostics_dir: None,
             network_keys: Box::new(dwallet_network_keys),
             sui_data_receivers,
             requests_pending_for_next_active_committee: Vec::new(),
@@ -4592,6 +4600,49 @@ impl DWalletMPCManager {
         }
     }
 
+    /// Wire the directory self-malicious diagnostic snapshots are persisted
+    /// to. Called once by the service at construction; unset (tests) means
+    /// persistence is off.
+    pub(crate) fn set_diagnostics_dir(&mut self, dir: std::path::PathBuf) {
+        self.diagnostics_dir = Some(dir);
+    }
+
+    /// Persist a diagnostic that identifies THIS validator as malicious (see
+    /// [`persist_malicious_diagnostic_file`] for why disk, not just logs).
+    /// Failure is logged, never propagated — this runs on the conviction
+    /// path, where the service is about to stop, and a failed write must not
+    /// change behavior.
+    fn persist_malicious_diagnostic(
+        &self,
+        anomaly_kind: MpcAnomalyKind,
+        session_label: &str,
+        diagnostic_json: &str,
+    ) {
+        let Some(dir) = &self.diagnostics_dir else {
+            return;
+        };
+        match persist_malicious_diagnostic_file(
+            dir,
+            self.epoch_id,
+            anomaly_kind.label(),
+            session_label,
+            diagnostic_json,
+        ) {
+            // Error level on purpose: this line belongs next to the other
+            // conviction-time errors so an operator filtering on ERROR finds
+            // the pointer to the preserved evidence.
+            Ok(path) => error!(
+                path = %path.display(),
+                "persisted self-malicious diagnostic snapshot to disk (survives log rotation); attach this file when reporting"
+            ),
+            Err(err) => warn!(
+                error = ?err,
+                dir = %dir.display(),
+                "failed to persist the self-malicious diagnostic snapshot"
+            ),
+        }
+    }
+
     pub(crate) fn emit_session_anomaly(
         &mut self,
         session_identifier: SessionIdentifier,
@@ -4674,6 +4725,13 @@ impl DWalletMPCManager {
                     "MPC anomaly occurred after session state was unavailable"
                 );
             }
+            if context.local_authority_malicious {
+                self.persist_malicious_diagnostic(
+                    anomaly_kind,
+                    &hex::encode(session_identifier.into_bytes()),
+                    &diagnostic_json,
+                );
+            }
             return;
         };
         let Some(snapshot) = session.anomaly_snapshot(anomaly_kind, self.epoch_id, context) else {
@@ -4742,6 +4800,16 @@ impl DWalletMPCManager {
                 "abnormal MPC session diagnostic snapshot"
             );
         }
+        // A snapshot that identifies THIS validator as malicious is the one
+        // diagnostic whose loss is unrecoverable (the service stops right
+        // after, and the emitting node's logs rotate) — mirror it to disk.
+        if snapshot.local_authority_malicious {
+            self.persist_malicious_diagnostic(
+                anomaly_kind,
+                &hex::encode(snapshot.session_id),
+                &diagnostic_json,
+            );
+        }
     }
 
     fn record_session_anomaly_metrics(
@@ -4807,6 +4875,7 @@ impl DWalletMPCManager {
                 service_loop_termination_reason = "local_validator_recognized_as_malicious",
                 "MPC service exited after local malicious recognition without a source session"
             );
+            self.persist_malicious_diagnostic(anomaly_kind, "no_session", &diagnostic_json);
             return;
         };
         self.emit_session_anomaly(
@@ -5096,6 +5165,22 @@ impl DWalletMPCManager {
         }
 
         let metrics = &self.dwallet_mpc_metrics;
+
+        // ----- orchestrator core-slot occupancy -----
+        // A slot is reserved at spawn and reclaimed only when the completion
+        // update is drained, so a computation that never completes holds its
+        // slot for the rest of the epoch — and at running == budget the
+        // orchestrator silently refuses all new MPC work. Exported so slot
+        // exhaustion (and a slow leak: a floor that survives idle periods)
+        // is scrapable instead of living in a `debug!` field.
+        metrics.cryptographic_computations_running.set(
+            self.cryptographic_computations_orchestrator
+                .currently_running_cryptographic_computations
+                .len() as i64,
+        );
+        metrics.cryptographic_computation_core_budget.set(
+            self.cryptographic_computations_orchestrator.available_cores() as i64,
+        );
 
         // ----- session-state counts + Active-session age buckets -----
         // Only Active sessions get an age: Completed/Failed entries stay in

--- a/crates/ika-node/src/node_runner.rs
+++ b/crates/ika-node/src/node_runner.rs
@@ -145,11 +145,25 @@ pub fn run_node_with_name(
     let prometheus_registry = registry_service.default_registry();
     ika_types::metrics::init_invariant_violation_metric(&prometheus_registry);
 
-    // Initialize logging
-    let (_guard, filter_handle) = telemetry_subscribers::TelemetryConfig::new()
+    // Initialize logging.
+    //
+    // Crash on panic BY DEFAULT. The codebase's fail-loud design — dozens of
+    // `panic!`/`expect` sites in the MPC service loop and the consensus
+    // handler's "Unrecoverable error in consensus handler" — assumes a panic
+    // kills the process so the supervisor restarts it. Without this flag a
+    // panic inside a spawned tokio task kills ONLY that task: the process
+    // stays up serving metrics with a silently dead subsystem (MPC frozen /
+    // checkpoints stopped) while consensus-core keeps running — a wedge that
+    // looks healthy from the outside (see the ika #1978 stall audit). The
+    // upstream default is off unless the `CRASH_ON_PANIC` env var is set,
+    // which deployments predictably don't set; make loud-death the default
+    // and keep an explicit escape hatch for debugging.
+    let mut telemetry_config = telemetry_subscribers::TelemetryConfig::new()
         .with_env()
-        .with_prom_registry(&prometheus_registry)
-        .init();
+        .with_prom_registry(&prometheus_registry);
+    telemetry_config.crash_on_panic =
+        crash_on_panic(std::env::var("IKA_NO_CRASH_ON_PANIC").ok().as_deref());
+    let (_guard, filter_handle) = telemetry_config.init();
 
     drop(metrics_rt);
 
@@ -297,5 +311,30 @@ async fn wait_termination(mut shutdown_rx: broadcast::Receiver<()>) {
         _ = sigint => {},
         _ = sigterm_recv => {},
         _ = shutdown_recv => {},
+    }
+}
+
+/// Whether a panic anywhere in the process kills it (default), given the
+/// value of the `IKA_NO_CRASH_ON_PANIC` opt-out env var. Only the explicit
+/// sentinel `=1` opts out — mere presence (an empty or typo'd value carried
+/// over from a launch script) must not silently disable loud death, matching
+/// the `IKA_ENABLE_SMALL_PRESIGN_POOLS` convention above.
+fn crash_on_panic(no_crash_env: Option<&str>) -> bool {
+    no_crash_env != Some("1")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Loud death is the default, and only the explicit `1` sentinel opts
+    /// out — an unset, empty, or typo'd variable keeps panics fatal.
+    #[test]
+    fn crash_on_panic_default_on_with_explicit_opt_out() {
+        assert!(crash_on_panic(None));
+        assert!(crash_on_panic(Some("")));
+        assert!(crash_on_panic(Some("true")));
+        assert!(crash_on_panic(Some("0")));
+        assert!(!crash_on_panic(Some("1")));
     }
 }


### PR DESCRIPTION
## Summary

Three fixes from the [#1978](https://github.com/dwallet-labs/ika/issues/1978) stall audit — all aimed at the same failure class: a subsystem dying or wedging **silently** while the process looks healthy.

### 1. Crash on panic by default (`ika-node`)
The codebase's fail-loud design — dozens of `panic!`/`expect` sites in the MPC service loop, the consensus handler's `expect("Unrecoverable error in consensus handler")` — assumes a panic kills the process so the supervisor restarts it. But `telemetry-subscribers` only crashes on panic when the `CRASH_ON_PANIC` env var is set, which deployments predictably don't set. Without it, a panic inside a spawned tokio task kills **only that task**: the process stays up serving metrics with a silently dead subsystem (MPC frozen, checkpoints stopped) while consensus-core keeps running. `ika-node` now enables crash-on-panic by default; `IKA_NO_CRASH_ON_PANIC=1` is the explicit debugging opt-out (sentinel-gated, matching the `IKA_ENABLE_SMALL_PRESIGN_POOLS` convention).

### 2. MPC core-slot occupancy gauges
The orchestrator admits computations against a fixed core-slot budget; a slot is reclaimed only when a completion update is drained, so a computation that never completes holds its slot for the rest of the epoch — and at `running == budget` MPC silently stops scheduling. That state was visible only as a `debug!` field. New gauges, refreshed with the existing observability pass:
- `ika_dwallet_mpc_cryptographic_computations_running`
- `ika_dwallet_mpc_cryptographic_computation_core_budget`

### 3. Persist self-malicious diagnostic snapshots to disk
A validator that recognizes itself as malicious emits one diagnostic snapshot (the WHY: `local_authority_malicious_reason`, vote diagnostics, session trace) and then stops its MPC service. That snapshot exists only in its own log stream, which at validator log volumes rotates out within hours — in the #1978 investigation the convicted validator's window was gone before anyone asked for it. Snapshots identifying the local validator as malicious are now also written to `<db_path>/mpc_diagnostics/` with deterministic names (re-emission — e.g. the post-restart replay re-convicting — overwrites idempotently), and the ERROR log line carries the file path. Bounded by construction: these paths fire at most a handful of times per epoch, then the service stops.

## Testing
- `cargo check -p ika-core -p ika-node` clean.
- New unit tests: crash-on-panic opt-out semantics; persistence writes a stable, idempotently-overwritten filename; io failure surfaces as `Err` (never a panic on the conviction path).
- Each test fault-validated per `dev-docs/playbooks/test-testing.md`: error-swallowing injection fails the io test, filename-format injection fails the naming test, logic inversion fails the opt-out test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)