### PR TITLE
fix(noa): bound chain-submitter calls with a timeout

### DIFF
--- a/crates/ika-core/src/noa_checkpoints/chain_submitter.rs
+++ b/crates/ika-core/src/noa_checkpoints/chain_submitter.rs
@@ -18,6 +18,32 @@ pub enum TxExecutionStatus {
     Failed(String),
 }
 
+/// Ceiling on any single chain-submitter RPC.
+///
+/// These calls run inline in the MPC service loop (`poll_chain_status` and
+/// the sign-output path are steps of `run_service_loop_iteration`), so a call
+/// that never returns freezes ALL MPC processing on this validator — the
+/// consensus-alive/MPC-dead silent-stall class from the #1978 audit. The
+/// placeholder `LogOnlyChainSubmitter` cannot hang; this bound is armor for
+/// the real chain submitter that replaces it (v8 NOA), where a black-holed
+/// connection would otherwise become a service-wide wedge. A timeout surfaces
+/// as an ordinary error, which every call site already handles by warning and
+/// retrying on a later tick.
+pub(crate) const CHAIN_SUBMITTER_CALL_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(15);
+
+/// Run one chain-submitter call under [`CHAIN_SUBMITTER_CALL_TIMEOUT`],
+/// converting a timeout into an ordinary error for the caller's existing
+/// warn-and-retry paths.
+pub(crate) async fn call_with_timeout<T>(
+    what: &'static str,
+    call: impl std::future::Future<Output = Result<T, anyhow::Error>>,
+) -> Result<T, anyhow::Error> {
+    tokio::time::timeout(CHAIN_SUBMITTER_CALL_TIMEOUT, call)
+        .await
+        .map_err(|_| anyhow::anyhow!("{what} timed out after {CHAIN_SUBMITTER_CALL_TIMEOUT:?}"))?
+}
+
 // === NOAChainSubmitter Trait ===
 
 /// Abstracts submitting signed transactions to a destination chain and checking execution.
@@ -55,5 +81,42 @@ impl<K: NOACheckpointKind> NOAChainSubmitter<K> for LogOnlyChainSubmitter {
         _tx_identifier: &[u8],
     ) -> Result<TxExecutionStatus, anyhow::Error> {
         Ok(TxExecutionStatus::Executed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A submitter call that never resolves must surface as a timeout error
+    /// instead of hanging — these calls run inline in the MPC service loop,
+    /// so "hangs forever" means "all MPC on this validator stops forever".
+    /// (`start_paused` auto-advances tokio's clock once every future is
+    /// pending, so the 15s ceiling elapses instantly in the test.)
+    #[tokio::test(start_paused = true)]
+    async fn hung_chain_submitter_call_times_out_instead_of_wedging() {
+        let hung = std::future::pending::<Result<(), anyhow::Error>>();
+        let err = call_with_timeout("test call", hung)
+            .await
+            .expect_err("a never-resolving call must become a timeout error");
+        assert!(
+            err.to_string().contains("timed out"),
+            "error should name the timeout: {err}"
+        );
+    }
+
+    /// Fast calls pass through untouched — successes and the callee's own
+    /// errors are not rewrapped.
+    #[tokio::test]
+    async fn fast_chain_submitter_calls_pass_through() {
+        let ok = call_with_timeout("ok call", async { Ok(7u32) }).await.unwrap();
+        assert_eq!(ok, 7);
+
+        let err = call_with_timeout("failing call", async {
+            Err::<(), _>(anyhow::anyhow!("boom"))
+        })
+        .await
+        .expect_err("the callee's error must pass through");
+        assert!(err.to_string().contains("boom"), "{err}");
     }
 }

--- a/crates/ika-core/src/noa_checkpoints/chain_submitter.rs
+++ b/crates/ika-core/src/noa_checkpoints/chain_submitter.rs
@@ -109,7 +109,9 @@ mod tests {
     /// errors are not rewrapped.
     #[tokio::test]
     async fn fast_chain_submitter_calls_pass_through() {
-        let ok = call_with_timeout("ok call", async { Ok(7u32) }).await.unwrap();
+        let ok = call_with_timeout("ok call", async { Ok(7u32) })
+            .await
+            .unwrap();
         assert_eq!(ok, 7);
 
         let err = call_with_timeout("failing call", async {

--- a/crates/ika-core/src/noa_checkpoints/handler.rs
+++ b/crates/ika-core/src/noa_checkpoints/handler.rs
@@ -12,7 +12,9 @@ use sui_types::base_types::EpochId;
 use tracing::{error, info, warn};
 
 use crate::dwallet_mpc::{NetworkOwnedAddressSignOutput, NetworkOwnedAddressSignRequest};
-use crate::noa_checkpoints::chain_submitter::{NOAChainSubmitter, TxExecutionStatus};
+use crate::noa_checkpoints::chain_submitter::{
+    NOAChainSubmitter, TxExecutionStatus, call_with_timeout,
+};
 use crate::noa_checkpoints::local_store::NOACheckpointLocalStore;
 
 // === NOACheckpointHandler ===
@@ -184,7 +186,12 @@ impl<K: NOACheckpointKind> NOACheckpointHandler<K> {
             match status {
                 NOACheckpointTxStatus::Pending => {
                     if let Some(chain_tx_id) = self.store.get_chain_tx_id(&tx_ref) {
-                        match self.chain_submitter.check_tx_status(&chain_tx_id).await {
+                        match call_with_timeout(
+                            "NOA check_tx_status",
+                            self.chain_submitter.check_tx_status(&chain_tx_id),
+                        )
+                        .await
+                        {
                             Ok(TxExecutionStatus::Executed) => {
                                 info!(
                                     kind = %K::KIND_NAME,
@@ -232,7 +239,12 @@ impl<K: NOACheckpointKind> NOACheckpointHandler<K> {
                 NOACheckpointTxStatus::SubmitFailed => {
                     // Re-attempt submission with existing tx_bytes + signature.
                     if let Some((tx_bytes, signature)) = self.store.get_tx_for_submission(&tx_ref) {
-                        match self.chain_submitter.submit_tx(&tx_bytes, &signature).await {
+                        match call_with_timeout(
+            "NOA submit_tx",
+            self.chain_submitter.submit_tx(&tx_bytes, &signature),
+        )
+        .await
+        {
                             Ok(chain_tx_id) => {
                                 info!(
                                     kind = %K::KIND_NAME,
@@ -306,7 +318,12 @@ impl<K: NOACheckpointKind> NOACheckpointHandler<K> {
                 epoch: self.epoch,
             };
 
-            match self.chain_submitter.submit_tx(tx_bytes, signature).await {
+            match call_with_timeout(
+                "NOA submit_tx",
+                self.chain_submitter.submit_tx(tx_bytes, signature),
+            )
+            .await
+            {
                 Ok(chain_tx_id) => {
                     info!(
                         kind = %K::KIND_NAME,
@@ -370,7 +387,12 @@ impl<K: NOACheckpointKind> NOACheckpointHandler<K> {
             None => return,
         };
 
-        match self.chain_submitter.submit_tx(&tx_bytes, &signature).await {
+        match call_with_timeout(
+            "NOA submit_tx",
+            self.chain_submitter.submit_tx(&tx_bytes, &signature),
+        )
+        .await
+        {
             Ok(chain_tx_id) => {
                 info!(
                     kind = %K::KIND_NAME,

--- a/crates/ika-core/src/noa_checkpoints/handler.rs
+++ b/crates/ika-core/src/noa_checkpoints/handler.rs
@@ -240,11 +240,11 @@ impl<K: NOACheckpointKind> NOACheckpointHandler<K> {
                     // Re-attempt submission with existing tx_bytes + signature.
                     if let Some((tx_bytes, signature)) = self.store.get_tx_for_submission(&tx_ref) {
                         match call_with_timeout(
-            "NOA submit_tx",
-            self.chain_submitter.submit_tx(&tx_bytes, &signature),
-        )
-        .await
-        {
+                            "NOA submit_tx",
+                            self.chain_submitter.submit_tx(&tx_bytes, &signature),
+                        )
+                        .await
+                        {
                             Ok(chain_tx_id) => {
                                 info!(
                                     kind = %K::KIND_NAME,


### PR DESCRIPTION
## Summary

From the [#1978](https://github.com/dwallet-labs/ika/issues/1978) stall audit. The NOA chain-submitter calls (`submit_tx` / `check_tx_status`) run **inline in the MPC service loop** — `poll_chain_status` and the sign-output path are steps of `run_service_loop_iteration` — so a call that never returns freezes all MPC processing on the validator: the consensus-alive/MPC-dead silent-stall shape.

Today this is latent: the only submitter is `LogOnlyChainSubmitter`, which cannot hang. This PR is armor for the real chain submitter that replaces it when v8 enables NOA checkpoints, where a black-holed connection would otherwise become a service-wide wedge that no reviewer of the future submitter would think to prevent (the trait signature gives no hint its callers can't tolerate an unbounded await).

All four call sites now go through `call_with_timeout` (15s ceiling). A timeout surfaces as an ordinary `anyhow` error, which every call site already handles by warning and keeping the item for retry on a later tick — so the failure mode degrades from "validator MPC wedged" to "one NOA item retried".

## Testing
- New unit tests: a never-resolving call becomes a timeout error (under `start_paused` so the 15s ceiling elapses instantly); fast successes and callee errors pass through unrewrapped.
- Fault-validated per `dev-docs/playbooks/test-testing.md`: bypassing the timeout inside `call_with_timeout` makes the hung-call test hang (detected; killed by the harness bound), restoring it goes green.
- `cargo test -p ika-core --lib chain_submitter` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)