### PR TITLE
chore: upgrade Sui to mainnet-v1.76.1 and Rust to 1.97.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin or `stable` for the latest stable version.
-  rust_stable: 1.94
+  rust_stable: 1.97.1
   CARGO_NET_GIT_FETCH_WITH_CLI: true
   GH_DEPLOY_KEY: ${{ secrets.GH_DEPLOY_KEY }}
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/integration-tests-ci.yaml
+++ b/.github/workflows/integration-tests-ci.yaml
@@ -43,7 +43,7 @@ concurrency:
 env:
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin or `stable` for the latest stable version.
-  rust_stable: 1.94
+  rust_stable: 1.97.1
   rust_nightly: nightly
   CARGO_NET_GIT_FETCH_WITH_CLI: true
   GH_DEPLOY_KEY: ${{ secrets.GH_DEPLOY_KEY }}

--- a/.github/workflows/publish-typescript-sdk.yml
+++ b/.github/workflows/publish-typescript-sdk.yml
@@ -18,7 +18,7 @@ permissions:
 env:
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  rust_stable: 1.94
+  rust_stable: 1.97.1
   SUI_VERSION: 'sui@mainnet'
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -230,7 +230,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.94"
+          toolchain: "1.97.1"
           targets: ${{ matrix.target }}
 
       - name: Install dependencies (macOS)

--- a/.github/workflows/simtest.yaml
+++ b/.github/workflows/simtest.yaml
@@ -64,7 +64,7 @@ env:
   # long sub-quorum windows and slow recovery tails; virtual seconds cost
   # ~nothing in wall time.
   SUI_SIM_TEST_TIMEOUT_SECS: "3600"
-  rust_stable: "1.94"
+  rust_stable: "1.97.1"
 
 jobs:
   simtest:

--- a/.github/workflows/simtest.yaml
+++ b/.github/workflows/simtest.yaml
@@ -126,6 +126,11 @@ jobs:
         env:
           MSIM_TEST_SEED: ${{ inputs.seed }}
           MSIM_TEST_NUM: ${{ inputs.test_num }}
+          # The fault-matrix sim tests run real class-groups crypto whose
+          # synchronous steps can exceed msim's 5s no-progress watchdog;
+          # 60s matches scripts/simtest/codecov.sh. Without it every test
+          # aborts with "deadlock detected" while progressing normally.
+          MSIM_WATCHDOG_TIMEOUT_MS: "60000"
         run: |
           # --no-tests=pass is a nextest option, so it must come BEFORE the
           # `--` separator: the workspace currently has zero #[sim_test]

--- a/.github/workflows/test-cluster.yaml
+++ b/.github/workflows/test-cluster.yaml
@@ -58,7 +58,7 @@ env:
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
   RUST_LOG: ${{ inputs.rust_log || 'error' }}
-  rust_stable: "1.94"
+  rust_stable: "1.97.1"
 
 jobs:
   test-cluster:

--- a/.github/workflows/ts-ci.yaml
+++ b/.github/workflows/ts-ci.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install Sui from Github
         run: |
-          curl -L https://github.com/MystenLabs/sui/releases/download/mainnet-v1.73.2/sui-mainnet-v1.73.2-ubuntu-x86_64.tgz > sui.tgz
+          curl -L https://github.com/MystenLabs/sui/releases/download/mainnet-v1.76.1/sui-mainnet-v1.76.1-ubuntu-x86_64.tgz > sui.tgz
           tar -xvzf sui.tgz
           sudo cp ./sui /usr/local/bin/sui
 

--- a/.github/workflows/ts-integration-tests.yaml
+++ b/.github/workflows/ts-integration-tests.yaml
@@ -122,11 +122,11 @@ jobs:
         with:
           version: "latest"
 
-      # The Cargo workspace pins Sui to mainnet-v1.73.2; a mismatched local
+      # The Cargo workspace pins Sui to mainnet-v1.76.1; a mismatched local
       # sui completes DKG but stalls reconfiguration, so pin the binary too.
-      - name: Install Sui mainnet-v1.73.2
+      - name: Install Sui mainnet-v1.76.1
         run: |
-          curl -L https://github.com/MystenLabs/sui/releases/download/mainnet-v1.73.2/sui-mainnet-v1.73.2-ubuntu-x86_64.tgz > sui.tgz
+          curl -L https://github.com/MystenLabs/sui/releases/download/mainnet-v1.76.1/sui-mainnet-v1.76.1-ubuntu-x86_64.tgz > sui.tgz
           tar -xzf sui.tgz
           mkdir -p "$HOME/.local/bin"
           cp ./sui "$HOME/.local/bin/sui"

--- a/.github/workflows/ts-integration-tests.yaml
+++ b/.github/workflows/ts-integration-tests.yaml
@@ -48,7 +48,7 @@ env:
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
-  rust_stable: "1.94"
+  rust_stable: "1.97.1"
   # ika-wasm's prepare script builds wasm-pack with `--${PROFILE}`; the
   # integration tests run real client-side crypto through that WASM, so it
   # must be a release build (debug crypto is far too slow).

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -221,7 +221,7 @@ env:
   RUST_BACKTRACE: 1
   RUST_LOG: ${{ inputs.rust_log || 'info' }}
   CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
-  rust_stable: "1.94"
+  rust_stable: "1.97.1"
 
 jobs:
   # Resolve `inputs.test` into the matrix of scenarios to run: 'all' fans every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ already validated, branch names, and in-flight CI run IDs/URLs.
   at its root) and browsable at github.com/MystenLabs/sui at the pinned
   tag. How to locate it + what to read for what:
   `dev-docs/reference/sui-upstream.md`.
-- **Sui version is pinned in MULTIPLE places** (currently `mainnet-v1.73.2`;
+- **Sui version is pinned in MULTIPLE places** (currently `mainnet-v1.76.1`;
   sometimes a `testnet-v*` tag): when bumping it, bump EVERYWHERE in one
   PR — root `Cargo.toml` (~90 tag pins), excluded wasm workspace locks,
   the sui-binary downloads in the TS CI workflows, this file, and every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "anemo"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=487f8bc739e535391a56e1aa1193084da9d64ce8#487f8bc739e535391a56e1aa1193084da9d64ce8"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=68adc31d4ea1f4573f08c2c75317fcb205b823de#68adc31d4ea1f4573f08c2c75317fcb205b823de"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -944,7 +944,7 @@ dependencies = [
 [[package]]
 name = "anemo-build"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=487f8bc739e535391a56e1aa1193084da9d64ce8#487f8bc739e535391a56e1aa1193084da9d64ce8"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=68adc31d4ea1f4573f08c2c75317fcb205b823de#68adc31d4ea1f4573f08c2c75317fcb205b823de"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -955,7 +955,7 @@ dependencies = [
 [[package]]
 name = "anemo-tower"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=487f8bc739e535391a56e1aa1193084da9d64ce8#487f8bc739e535391a56e1aa1193084da9d64ce8"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=68adc31d4ea1f4573f08c2c75317fcb205b823de#68adc31d4ea1f4573f08c2c75317fcb205b823de"
 dependencies = [
  "anemo",
  "bytes",
@@ -2476,8 +2476,8 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "const-str 0.5.7",
  "git-version",
@@ -3404,7 +3404,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "fastcrypto",
  "mysten-network",
@@ -3416,7 +3416,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "base64 0.21.7",
  "consensus-config",
@@ -4242,7 +4242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 2.0.104",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4579,7 +4579,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4983,7 +4983,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -5095,9 +5095,9 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "euclid"
@@ -5177,8 +5177,8 @@ dependencies = [
 
 [[package]]
 name = "fastcrypto"
-version = "0.1.9"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3#0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3"
+version = "0.1.11"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3273734b9791df0c3d1655509476e10a49978528#3273734b9791df0c3d1655509476e10a49978528"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm 0.10.3",
@@ -5198,6 +5198,7 @@ dependencies = [
  "bs58 0.4.0",
  "bulletproofs",
  "cbc",
+ "ciborium",
  "ctr 0.9.2",
  "curve25519-dalek 4.2.0",
  "derive_more 0.99.18",
@@ -5216,10 +5217,12 @@ dependencies = [
  "num-bigint 0.4.6",
  "once_cell",
  "p256 0.13.2",
+ "p384",
  "rand 0.8.5",
  "readonly",
  "rfc6979 0.4.0",
  "rsa",
+ "rustls-pki-types",
  "schemars 0.8.21",
  "secp256k1 0.27.0",
  "serde",
@@ -5233,13 +5236,14 @@ dependencies = [
  "tokio",
  "tracing",
  "typenum",
+ "x509-parser",
  "zeroize",
 ]
 
 [[package]]
 name = "fastcrypto-derive"
-version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3#0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3"
+version = "0.1.4"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3273734b9791df0c3d1655509476e10a49978528#3273734b9791df0c3d1655509476e10a49978528"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -5248,7 +5252,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3#0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3273734b9791df0c3d1655509476e10a49978528#3273734b9791df0c3d1655509476e10a49978528"
 dependencies = [
  "bcs",
  "digest 0.10.7",
@@ -5256,8 +5260,8 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "rand 0.8.5",
+ "reed-solomon-erasure",
  "serde",
- "serde-big-array",
  "sha3 0.10.8",
  "tap",
  "tracing",
@@ -5268,7 +5272,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3#0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3273734b9791df0c3d1655509476e10a49978528#3273734b9791df0c3d1655509476e10a49978528"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -5284,8 +5288,8 @@ dependencies = [
 
 [[package]]
 name = "fastcrypto-zkp"
-version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3#0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3"
+version = "0.1.4"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3273734b9791df0c3d1655509476e10a49978528#3273734b9791df0c3d1655509476e10a49978528"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -5310,6 +5314,7 @@ dependencies = [
  "schemars 0.8.21",
  "serde",
  "serde_json",
+ "tracing",
  "typenum",
 ]
 
@@ -5924,9 +5929,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -6300,9 +6305,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -6315,7 +6320,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -7477,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "serde",
  "serde_json",
@@ -8622,12 +8626,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 
 [[package]]
 name = "move-abstract-interpreter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-binary-format",
 ]
@@ -8635,17 +8639,17 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 
 [[package]]
 name = "move-analyzer"
 version = "1.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "clap",
@@ -8677,7 +8681,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -8693,12 +8697,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8714,7 +8718,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -8727,7 +8731,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -8744,7 +8748,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -8754,7 +8758,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -8769,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -8784,7 +8788,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -8799,7 +8803,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -8816,7 +8820,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "clap",
@@ -8831,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "clap",
@@ -8876,7 +8880,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8896,7 +8900,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8932,7 +8936,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8954,7 +8958,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8980,7 +8984,7 @@ dependencies = [
 [[package]]
 name = "move-decompiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -9000,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "clap",
@@ -9020,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "clap",
@@ -9039,7 +9043,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -9057,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "hex",
@@ -9070,7 +9074,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -9082,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "codespan",
@@ -9104,7 +9108,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -9121,7 +9125,7 @@ dependencies = [
 [[package]]
 name = "move-package-alt"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -9162,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "move-package-alt-compilation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "clap",
@@ -9189,7 +9193,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "enum-compat-util",
  "quote",
@@ -9199,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "move-regex-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "indexmap 2.9.0",
  "move-binary-format",
@@ -9211,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -9232,7 +9236,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "move-abstract-interpreter",
@@ -9250,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "hex",
@@ -9266,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v0"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -9281,7 +9285,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v1"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -9296,7 +9300,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v2"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -9311,7 +9315,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v3"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -9326,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "phf",
  "serde",
@@ -9335,7 +9339,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -9347,7 +9351,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9371,7 +9375,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-binary-format",
 ]
@@ -9379,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-trace-format",
  "move-vm-config",
@@ -9391,7 +9395,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9421,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "better_any",
  "fail",
@@ -9439,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "better_any",
  "fail",
@@ -9457,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "better_any",
  "fail",
@@ -9475,7 +9479,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "better_any",
  "fail",
@@ -9493,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9505,7 +9509,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9517,7 +9521,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9529,7 +9533,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9715,7 +9719,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "mysten-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "antithesis_sdk",
  "either",
@@ -9736,7 +9740,7 @@ dependencies = [
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -9757,11 +9761,12 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anemo",
  "anemo-tower",
  "anyhow",
+ "base64 0.21.7",
  "bcs",
  "bytes",
  "dashmap 5.5.3",
@@ -9776,12 +9781,14 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "prometheus",
+ "prost-reflect",
  "quinn-proto",
  "rand 0.8.5",
  "rustls",
  "serde",
  "snap",
  "sui-http",
+ "sui-macros",
  "tokio",
  "tokio-rustls",
  "tonic 0.14.6",
@@ -9793,7 +9800,7 @@ dependencies = [
 [[package]]
 name = "mysten-service"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -9952,7 +9959,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10354,6 +10361,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-float"
@@ -11239,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -11346,8 +11362,6 @@ dependencies = [
  "prettyplease",
  "prost 0.14.3",
  "prost-types 0.14.3",
- "pulldown-cmark",
- "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.104",
  "tempfile",
@@ -11385,10 +11399,13 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
 dependencies = [
+ "base64 0.22.1",
  "logos 0.15.1",
  "miette",
  "prost 0.14.3",
  "prost-types 0.14.3",
+ "serde",
+ "serde-value",
 ]
 
 [[package]]
@@ -11464,26 +11481,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
-dependencies = [
- "bitflags 2.11.1",
- "memchr",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark-to-cmark"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
-dependencies = [
- "pulldown-cmark",
 ]
 
 [[package]]
@@ -11943,6 +11940,19 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "reed-solomon-erasure"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
+dependencies = [
+ "libm",
+ "lru 0.7.8",
+ "parking_lot 0.11.2",
+ "smallvec",
+ "spin",
 ]
 
 [[package]]
@@ -12753,15 +12763,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde-env"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12792,6 +12793,16 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -13066,7 +13077,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "eyre",
@@ -13242,7 +13253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13510,8 +13521,8 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sui"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anemo",
  "anyhow",
@@ -13585,6 +13596,7 @@ dependencies = [
  "sui-package-alt",
  "sui-package-management",
  "sui-pg-db",
+ "sui-prompt",
  "sui-protocol-config",
  "sui-replay-2",
  "sui-rpc",
@@ -13603,6 +13615,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tikv-jemalloc-ctl",
  "tokio",
+ "tokio-stream",
  "tracing",
  "url",
 ]
@@ -13610,7 +13623,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13645,7 +13658,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13673,7 +13686,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13700,7 +13713,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13727,7 +13740,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13762,7 +13775,7 @@ dependencies = [
 [[package]]
 name = "sui-authority-aggregation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "futures",
  "mysten-metrics",
@@ -13773,8 +13786,8 @@ dependencies = [
 
 [[package]]
 name = "sui-bridge"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "alloy",
  "alloy-multiprovider-strategy",
@@ -13830,7 +13843,7 @@ dependencies = [
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anemo",
  "anyhow",
@@ -13860,9 +13873,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-consistent-store"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backoff",
+ "bcs",
+ "bytes",
+ "clap",
+ "fastcrypto",
+ "futures",
+ "integer-encoding",
+ "object_store",
+ "parking_lot 0.12.5",
+ "prometheus",
+ "prost 0.14.3",
+ "reqwest",
+ "rocksdb",
+ "scoped-futures",
+ "serde",
+ "serde_json",
+ "sui-futures",
+ "sui-indexer-alt-framework",
+ "sui-indexer-alt-framework-store-traits",
+ "sui-storage",
+ "sui-types",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "zstd 0.12.4",
+]
+
+[[package]]
 name = "sui-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anemo",
  "antithesis_sdk",
@@ -13927,15 +13976,18 @@ dependencies = [
  "strum_macros 0.27.1",
  "sui-authority-aggregation",
  "sui-config",
+ "sui-consistent-store",
  "sui-execution",
  "sui-framework",
  "sui-genesis-builder",
+ "sui-indexer-alt-framework",
  "sui-inverted-index",
  "sui-json-rpc-types",
  "sui-macros",
  "sui-network",
  "sui-protocol-config",
  "sui-rpc",
+ "sui-rpc-store",
  "sui-simulator",
  "sui-storage",
  "sui-swarm-config",
@@ -13959,7 +14011,7 @@ dependencies = [
 [[package]]
 name = "sui-crypto"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5b41bc701525f1b94f1fe63008d4841bc6fb1065#5b41bc701525f1b94f1fe63008d4841bc6fb1065"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d8643443b523fb14873c3ea566a7b7f8146b34e8#d8643443b523fb14873c3ea566a7b7f8146b34e8"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",
@@ -13985,7 +14037,7 @@ dependencies = [
 [[package]]
 name = "sui-data-store"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14004,18 +14056,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sui-default-config"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "sui-display"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14038,7 +14081,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -14046,7 +14089,7 @@ dependencies = [
 [[package]]
 name = "sui-execution"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-interpreter-v2",
@@ -14093,11 +14136,12 @@ dependencies = [
 
 [[package]]
 name = "sui-faucet"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
+ "backoff",
  "bin-version",
  "clap",
  "http 1.4.0",
@@ -14119,16 +14163,16 @@ dependencies = [
 
 [[package]]
 name = "sui-field-count"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "sui-field-count-derive",
 ]
 
 [[package]]
 name = "sui-field-count-derive"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -14137,7 +14181,7 @@ dependencies = [
 [[package]]
 name = "sui-framework"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -14149,8 +14193,8 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14164,8 +14208,8 @@ dependencies = [
 
 [[package]]
 name = "sui-futures"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "futures",
@@ -14178,7 +14222,7 @@ dependencies = [
 [[package]]
 name = "sui-genesis-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14205,17 +14249,19 @@ dependencies = [
 
 [[package]]
 name = "sui-http"
-version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b46940575ea7ee7eaf2a7000da28d82a61b76f8d4160590674946263975782"
 dependencies = [
  "bytes",
+ "futures-core",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-util",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.6.4",
  "tokio",
  "tokio-rustls",
  "tokio-util 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -14225,8 +14271,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14240,7 +14286,6 @@ dependencies = [
  "itertools 0.13.0",
  "prometheus",
  "serde",
- "sui-default-config",
  "sui-indexer-alt-framework",
  "sui-indexer-alt-metrics",
  "sui-indexer-alt-schema",
@@ -14255,8 +14300,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-consistent-api"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
@@ -14266,8 +14311,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-consistent-store"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14296,8 +14341,8 @@ dependencies = [
  "scoped-futures",
  "serde",
  "serde_json",
- "sui-default-config",
  "sui-futures",
+ "sui-http",
  "sui-indexer-alt-consistent-api",
  "sui-indexer-alt-framework",
  "sui-indexer-alt-metrics",
@@ -14318,8 +14363,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14333,7 +14378,6 @@ dependencies = [
  "diesel_migrations",
  "futures",
  "http 1.4.0",
- "mysten-network",
  "num_cpus",
  "object_store",
  "prometheus",
@@ -14346,6 +14390,7 @@ dependencies = [
  "serde_json",
  "sui-field-count",
  "sui-futures",
+ "sui-http",
  "sui-indexer-alt-framework-store-traits",
  "sui-indexer-alt-metrics",
  "sui-pg-db",
@@ -14356,6 +14401,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.14.6",
+ "tower 0.5.3",
  "tracing",
  "url",
  "zstd 0.12.4",
@@ -14363,8 +14409,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework-store-traits"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14374,8 +14420,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-graphql"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -14388,6 +14434,7 @@ dependencies = [
  "backoff",
  "bcs",
  "bin-version",
+ "bytes",
  "chrono",
  "clap",
  "const-str 0.5.7",
@@ -14410,7 +14457,6 @@ dependencies = [
  "serde",
  "serde_json",
  "shared-crypto",
- "sui-default-config",
  "sui-display",
  "sui-futures",
  "sui-indexer-alt-metrics",
@@ -14421,6 +14467,7 @@ dependencies = [
  "sui-pg-db",
  "sui-protocol-config",
  "sui-rpc",
+ "sui-rpc-cursor",
  "sui-sdk-types",
  "sui-sql-macro",
  "sui-types",
@@ -14439,8 +14486,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-metrics"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -14455,13 +14502,14 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-reader"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-graphql",
  "async-trait",
  "bcs",
+ "bytes",
  "clap",
  "diesel",
  "diesel-async",
@@ -14492,8 +14540,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-schema"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14509,14 +14557,15 @@ dependencies = [
 
 [[package]]
 name = "sui-inverted-index"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-stream",
  "bcs",
  "futures",
  "move-core-types",
+ "mysten-common",
  "roaring",
  "sui-types",
  "thiserror 1.0.69",
@@ -14525,7 +14574,7 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14542,7 +14591,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -14597,7 +14646,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14617,7 +14666,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14652,7 +14701,7 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14679,8 +14728,8 @@ dependencies = [
 
 [[package]]
 name = "sui-kvstore"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -14707,7 +14756,6 @@ dependencies = [
  "rustls",
  "scoped-futures",
  "serde",
- "sui-default-config",
  "sui-futures",
  "sui-indexer-alt-framework",
  "sui-indexer-alt-framework-store-traits",
@@ -14725,8 +14773,8 @@ dependencies = [
 
 [[package]]
 name = "sui-light-client"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14767,7 +14815,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "futures",
  "once_cell",
@@ -14778,7 +14826,7 @@ dependencies = [
 [[package]]
 name = "sui-metrics-push-client"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14794,8 +14842,8 @@ dependencies = [
 
 [[package]]
 name = "sui-move"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -14835,8 +14883,8 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14862,7 +14910,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "better_any",
@@ -14883,7 +14931,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "better_any",
@@ -14904,7 +14952,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "better_any",
@@ -14925,7 +14973,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "better_any",
@@ -14946,7 +14994,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "better_any",
@@ -14968,8 +15016,8 @@ dependencies = [
 
 [[package]]
 name = "sui-name-service"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -14981,7 +15029,7 @@ dependencies = [
 [[package]]
 name = "sui-network"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -15034,8 +15082,8 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -15046,7 +15094,10 @@ dependencies = [
  "base64 0.21.7",
  "bcs",
  "bin-version",
+ "bytes",
  "clap",
+ "consensus-config",
+ "consensus-core",
  "fastcrypto",
  "fastcrypto-zkp",
  "futures",
@@ -15060,6 +15111,7 @@ dependencies = [
  "prometheus",
  "reqwest",
  "serde",
+ "serde_json",
  "sui-config",
  "sui-core",
  "sui-http",
@@ -15081,6 +15133,7 @@ dependencies = [
  "telemetry-subscribers",
  "tikv-jemallocator",
  "tokio",
+ "tonic-rustls",
  "tower 0.5.3",
  "tower-http 0.5.2",
  "tracing",
@@ -15090,8 +15143,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "schemars 0.8.21",
@@ -15103,7 +15156,7 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -15115,8 +15168,8 @@ dependencies = [
 
 [[package]]
 name = "sui-package-alt"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15134,8 +15187,8 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "sui-framework-snapshot",
@@ -15147,7 +15200,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "async-trait",
  "bcs",
@@ -15163,8 +15216,8 @@ dependencies = [
 
 [[package]]
 name = "sui-pg-db"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15193,7 +15246,7 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "msim-macros 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6)",
  "proc-macro2",
@@ -15203,9 +15256,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-prompt"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_yaml 0.8.26",
+]
+
+[[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "clap",
  "fastcrypto",
@@ -15226,7 +15290,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15236,7 +15300,7 @@ dependencies = [
 [[package]]
 name = "sui-replay-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -15275,7 +15339,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc"
 version = "0.3.1"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5b41bc701525f1b94f1fe63008d4841bc6fb1065#5b41bc701525f1b94f1fe63008d4841bc6fb1065"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d8643443b523fb14873c3ea566a7b7f8146b34e8#d8643443b523fb14873c3ea566a7b7f8146b34e8"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -15283,6 +15347,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "http-body 1.0.1",
+ "hyper",
  "prost 0.14.3",
  "prost-types 0.14.3",
  "serde",
@@ -15299,7 +15364,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -15318,7 +15383,6 @@ dependencies = [
  "prometheus",
  "prost 0.14.3",
  "prost-types 0.14.3",
- "protox",
  "rand 0.8.5",
  "roaring",
  "serde",
@@ -15326,12 +15390,14 @@ dependencies = [
  "sui-config",
  "sui-crypto",
  "sui-display",
+ "sui-http",
  "sui-inverted-index",
  "sui-macros",
  "sui-name-service",
  "sui-package-resolver",
  "sui-protocol-config",
  "sui-rpc",
+ "sui-rpc-cursor",
  "sui-sdk-types",
  "sui-transaction-builder",
  "sui-transaction-checks",
@@ -15342,18 +15408,57 @@ dependencies = [
  "tonic 0.14.6",
  "tonic-health",
  "tonic-prost",
- "tonic-prost-build",
  "tonic-reflection",
  "tonic-web",
  "tower 0.5.3",
  "tracing",
- "walkdir",
+]
+
+[[package]]
+name = "sui-rpc-cursor"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "prost 0.14.3",
+]
+
+[[package]]
+name = "sui-rpc-store"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bcs",
+ "bytes",
+ "fdlimit",
+ "lru 0.10.1",
+ "move-core-types",
+ "prometheus",
+ "prost 0.14.3",
+ "roaring",
+ "rocksdb",
+ "serde",
+ "sui-consistent-store",
+ "sui-execution",
+ "sui-futures",
+ "sui-indexer-alt-framework",
+ "sui-indexer-alt-framework-store-traits",
+ "sui-inverted-index",
+ "sui-protocol-config",
+ "sui-types",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "typed-store-error",
 ]
 
 [[package]]
 name = "sui-sdk"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15389,7 +15494,7 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.3.1"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5b41bc701525f1b94f1fe63008d4841bc6fb1065#5b41bc701525f1b94f1fe63008d4841bc6fb1065"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d8643443b523fb14873c3ea566a7b7f8146b34e8#d8643443b523fb14873c3ea566a7b7f8146b34e8"
 dependencies = [
  "base64ct",
  "bcs",
@@ -15410,7 +15515,7 @@ dependencies = [
 [[package]]
 name = "sui-simulator"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -15435,7 +15540,7 @@ dependencies = [
 [[package]]
 name = "sui-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -15462,8 +15567,8 @@ dependencies = [
 
 [[package]]
 name = "sui-source-validation"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "colored 2.2.0",
@@ -15496,8 +15601,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sql-macro"
-version = "1.73.2"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+version = "1.76.1"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -15507,7 +15612,7 @@ dependencies = [
 [[package]]
 name = "sui-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15560,7 +15665,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "futures",
@@ -15587,7 +15692,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anemo",
  "anyhow",
@@ -15613,7 +15718,7 @@ dependencies = [
 [[package]]
 name = "sui-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "reqwest",
  "serde",
@@ -15624,10 +15729,11 @@ dependencies = [
 [[package]]
 name = "sui-test-transaction-builder"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "bcs",
  "move-core-types",
+ "rand 0.8.5",
  "shared-crypto",
  "sui-genesis-builder",
  "sui-move-build",
@@ -15639,7 +15745,7 @@ dependencies = [
 [[package]]
 name = "sui-tls"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -15661,7 +15767,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15677,7 +15783,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-checks"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "fastcrypto-zkp",
  "sui-config",
@@ -15691,7 +15797,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anemo",
  "anyhow",
@@ -15766,7 +15872,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -15783,7 +15889,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -15799,7 +15905,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -15814,7 +15920,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -15830,7 +15936,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -15982,7 +16088,7 @@ dependencies = [
 [[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -16098,7 +16204,7 @@ dependencies = [
  "nix 0.28.0",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf",
@@ -16122,7 +16228,7 @@ dependencies = [
 [[package]]
 name = "test-cluster"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -16727,22 +16833,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-prost-build"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "prost-types 0.14.3",
- "quote",
- "syn 2.0.104",
- "tempfile",
- "tonic-build",
-]
-
-[[package]]
 name = "tonic-reflection"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17160,7 +17250,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "anyhow",
  "backoff",
@@ -17189,7 +17279,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -17200,7 +17290,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.73.2#1f6e1e6dd72dc75ac4037b3d4e38e73b133c5ef6"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -17780,7 +17870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim 0.11.1",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6575,7 +6575,7 @@ dependencies = [
  "ika-swarm-config",
  "ika-types",
  "move-core-types",
- "msim 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=53016c1a9038154b1e47b96f0a314efa7e7d809b)",
+ "msim",
  "rand 0.9.0",
  "reqwest",
  "serde",
@@ -9588,36 +9588,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "libc",
- "msim-macros 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6)",
- "naive-timer",
- "pin-project-lite",
- "rand 0.8.5",
- "real_tokio",
- "serde",
- "socket2 0.4.10",
- "tap",
- "tokio-util 0.7.18 (git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=e8ce7593bfbfbbd7c7ee8671faecb062a8966b2d)",
- "toml 0.5.11",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "msim"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=53016c1a9038154b1e47b96f0a314efa7e7d809b#53016c1a9038154b1e47b96f0a314efa7e7d809b"
-dependencies = [
- "ahash 0.7.8",
- "async-task",
- "bincode 1.3.3",
- "bytes",
- "cc",
- "downcast-rs 1.2.1",
- "erasable",
- "futures",
- "lazy_static",
- "libc",
- "msim-macros 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=53016c1a9038154b1e47b96f0a314efa7e7d809b)",
+ "msim-macros",
  "naive-timer",
  "pin-project-lite",
  "rand 0.8.5",
@@ -9635,17 +9606,6 @@ dependencies = [
 name = "msim-macros"
 version = "0.1.0"
 source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6#2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "msim-macros"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=53016c1a9038154b1e47b96f0a314efa7e7d809b#53016c1a9038154b1e47b96f0a314efa7e7d809b"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -13562,7 +13522,7 @@ dependencies = [
  "move-symbol-pool",
  "move-trace-format",
  "move-vm-profiler",
- "msim 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6)",
+ "msim",
  "mysten-common",
  "normalize-line-endings",
  "num-bigint 0.4.6",
@@ -15248,7 +15208,7 @@ name = "sui-proc-macros"
 version = "0.7.0"
 source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
 dependencies = [
- "msim-macros 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6)",
+ "msim-macros",
  "proc-macro2",
  "quote",
  "sui-enum-compat-util",
@@ -15524,7 +15484,7 @@ dependencies = [
  "lru 0.10.1",
  "move-package-alt",
  "move-package-alt-compilation",
- "msim 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6)",
+ "msim",
  "mysten-network",
  "rand 0.8.5",
  "serde",
@@ -15582,7 +15542,7 @@ dependencies = [
  "move-package-alt",
  "move-package-alt-compilation",
  "move-symbol-pool",
- "msim 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6)",
+ "msim",
  "mysten-common",
  "serde",
  "sui-move-build",
@@ -17260,7 +17220,7 @@ dependencies = [
  "fastcrypto",
  "fdlimit",
  "hdrhistogram",
- "msim 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6)",
+ "msim",
  "mysten-common",
  "mysten-metrics",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,70 +283,70 @@ shlex = "1.3.0"
 lazy_static = "1.5.0"
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-move-bytecode-utils = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-move-compiler = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-move-package = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-move-package-alt-compilation = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-move-symbol-pool = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
+move-binary-format = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+move-bytecode-utils = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+move-compiler = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+move-package = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+move-package-alt-compilation = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+move-symbol-pool = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
 
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3" }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3", package = "fastcrypto-zkp" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "3273734b9791df0c3d1655509476e10a49978528" }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "3273734b9791df0c3d1655509476e10a49978528" }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "3273734b9791df0c3d1655509476e10a49978528", package = "fastcrypto-zkp" }
 
 # anemo dependencies
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "487f8bc739e535391a56e1aa1193084da9d64ce8" }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "487f8bc739e535391a56e1aa1193084da9d64ce8" }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "487f8bc739e535391a56e1aa1193084da9d64ce8" }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "68adc31d4ea1f4573f08c2c75317fcb205b823de" }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "68adc31d4ea1f4573f08c2c75317fcb205b823de" }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "68adc31d4ea1f4573f08c2c75317fcb205b823de" }
 
 ### Sui Members ###
-bin-version =  { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-mysten-common = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-mysten-network = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-mysten-service = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-shared-crypto = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-faucet = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-graphql-rpc = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-indexer = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-json = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-light-client = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-metrics-push-client = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-move = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-protocol-config-macros = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
+bin-version =  { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+mysten-common = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+mysten-network = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+mysten-service = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+shared-crypto = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-faucet = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-graphql-rpc = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-indexer = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-json = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-light-client = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-metrics-push-client = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-move = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-protocol-config-macros = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
 # Proto/BCS type conversions (e.g. ValidatorAggregatedSignature) used by the
-# OCS gRPC read layer. Pinned to the sui-rust-sdk rev that sui@mainnet-v1.73.2
+# OCS gRPC read layer. Pinned to the sui-rust-sdk rev that sui@mainnet-v1.76.1
 # itself depends on, so there's exactly one sui-sdk-types in the tree.
-sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "5b41bc701525f1b94f1fe63008d4841bc6fb1065" }
-sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-swarm = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-swarm-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-test-transaction-builder = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-tls = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-transaction-checks = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-typed-store = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-typed-store-error = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
+sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "d8643443b523fb14873c3ea566a7b7f8146b34e8" }
+sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-swarm = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-swarm-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-test-transaction-builder = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-tls = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-transaction-checks = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+typed-store = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+typed-store-error = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
 
-sui-execution = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
+sui-execution = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
 
-consensus-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-consensus-core = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
-consensus-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.73.2" }
+consensus-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+consensus-core = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+consensus-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
 
 ### Workspace Members ###
 dwallet-rng = { path = "crates/dwallet-rng" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ moka = { version = "0.12", default-features = false, features = [
     "atomic64",
 ] }
 more-asserts = "0.3.1"
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "53016c1a9038154b1e47b96f0a314efa7e7d809b", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6", package = "msim" }
 multiaddr = "0.18.2"
 nonempty = "0.12.0"
 num-bigint = "0.4.6"

--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -1402,9 +1402,9 @@ impl AuthorityKeyPairWithPath {
 /// Read from file as Base64 encoded `privkey` and return a AuthorityKeyPair.
 pub fn read_authority_keypair_from_file(path: &PathBuf) -> AuthorityKeyPair {
     let contents = std::fs::read_to_string(path)
-        .unwrap_or_else(|_| panic!("Invalid authority keypair file at path {:?}", &path));
+        .unwrap_or_else(|_| panic!("Invalid authority keypair file at path {:?}", path));
     AuthorityKeyPair::decode_base64(contents.as_str().trim())
-        .unwrap_or_else(|_| panic!("Invalid authority keypair file at path {:?}", &path))
+        .unwrap_or_else(|_| panic!("Invalid authority keypair file at path {:?}", path))
 }
 
 /// Wrapper struct for RootSeed that can be deserialized from a file path.

--- a/crates/ika-core/src/consensus_manager/mod.rs
+++ b/crates/ika-core/src/consensus_manager/mod.rs
@@ -60,25 +60,18 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
         config.consensus_max_transactions_in_block_bytes(),
         config.consensus_max_num_transactions_in_block(),
         config.gc_depth(),
-        // `transaction_voting_enabled`: ika runs this OFF, unlike Sui (which
-        // hardcodes `true`). The slot is fed by `mysticeti_fastpath()`, an
-        // ika feature flag that is false at every supported protocol version
-        // — Sui renamed this constructor parameter out from under that call
-        // some tags before mainnet-v1.73.2, so what reads like a fastpath
-        // toggle has in fact been ika's transaction-voting switch for as long
-        // as both networks have been live.
-        //
-        // Keep it flag-sourced rather than hardcoding upstream's `true`:
+        // `transaction_voting_enabled`: ika runs this OFF (false at every
+        // supported protocol version), unlike Sui, which hardcodes `true`.
+        // Keep it flag-sourced rather than adopting upstream's constant:
         // flipping it on changes the DAG that consensus builds, and a node
         // replaying a backlog of certified commits then panics in
         // consensus-core's `linearizer::calculate_commit_timestamp` ("We
         // should have all blocks in dag state") — the commit-sync path does
-        // not accept a leader's uncommitted round-1 ancestors, which the new
+        // not accept a leader's uncommitted round-1 ancestors, which the
         // median-timestamp computation `expect`s. Reproduced 2/2 in the
-        // upgrade test on the sui-1.76.1 bump. Turning voting on is therefore
-        // a deliberate, version-gated protocol change (add an ika feature
-        // flag), never a side effect of a Sui bump.
-        config.mysticeti_fastpath(),
+        // upgrade test. Enabling voting is a deliberate, version-gated
+        // protocol change, never a side effect of a Sui bump.
+        config.transaction_voting_enabled(),
         config.mysticeti_num_leaders_per_round(),
         config.consensus_bad_nodes_stake_threshold(),
         // `enable_v3`: hardcoded `false` to match upstream exactly. At the

--- a/crates/ika-core/src/consensus_manager/mod.rs
+++ b/crates/ika-core/src/consensus_manager/mod.rs
@@ -60,17 +60,25 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
         config.consensus_max_transactions_in_block_bytes(),
         config.consensus_max_num_transactions_in_block(),
         config.gc_depth(),
-        // `transaction_voting_enabled`: hardcoded `true`, mirroring Sui's own
-        // `to_consensus_protocol_config` at the pinned mainnet-v1.76.1. This
-        // parameter REPLACED `mysticeti_fastpath` at this position in the
-        // constructor between 1.73.2 and 1.76.1 — two adjacent bools, so the
-        // old `config.mysticeti_fastpath()` argument (an always-false,
-        // now-vestigial ika flag) kept compiling while silently disabling
-        // transaction voting. Mirror upstream's exact value: their rolling
-        // binary upgrades shipped this transition on live networks, so the
-        // mixed-committee behavior is the upstream-tested path.
-        /* transaction_voting_enabled */
-        true,
+        // `transaction_voting_enabled`: ika runs this OFF, unlike Sui (which
+        // hardcodes `true`). The slot is fed by `mysticeti_fastpath()`, an
+        // ika feature flag that is false at every supported protocol version
+        // — Sui renamed this constructor parameter out from under that call
+        // some tags before mainnet-v1.73.2, so what reads like a fastpath
+        // toggle has in fact been ika's transaction-voting switch for as long
+        // as both networks have been live.
+        //
+        // Keep it flag-sourced rather than hardcoding upstream's `true`:
+        // flipping it on changes the DAG that consensus builds, and a node
+        // replaying a backlog of certified commits then panics in
+        // consensus-core's `linearizer::calculate_commit_timestamp` ("We
+        // should have all blocks in dag state") — the commit-sync path does
+        // not accept a leader's uncommitted round-1 ancestors, which the new
+        // median-timestamp computation `expect`s. Reproduced 2/2 in the
+        // upgrade test on the sui-1.76.1 bump. Turning voting on is therefore
+        // a deliberate, version-gated protocol change (add an ika feature
+        // flag), never a side effect of a Sui bump.
+        config.mysticeti_fastpath(),
         config.mysticeti_num_leaders_per_round(),
         config.consensus_bad_nodes_stake_threshold(),
         // `enable_v3`: hardcoded `false` to match upstream exactly. At the

--- a/crates/ika-core/src/consensus_manager/mod.rs
+++ b/crates/ika-core/src/consensus_manager/mod.rs
@@ -249,6 +249,9 @@ impl ConsensusManager {
             commit_consumer,
             registry.clone(),
             *boot_counter,
+            // Sui's randomness-beacon signature handler; ika runs no
+            // randomness protocol, so there is nothing to sign.
+            None,
         )
         .await;
         let client = authority.transaction_client();

--- a/crates/ika-core/src/consensus_manager/mod.rs
+++ b/crates/ika-core/src/consensus_manager/mod.rs
@@ -60,11 +60,21 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
         config.consensus_max_transactions_in_block_bytes(),
         config.consensus_max_num_transactions_in_block(),
         config.gc_depth(),
-        config.mysticeti_fastpath(),
+        // `transaction_voting_enabled`: hardcoded `true`, mirroring Sui's own
+        // `to_consensus_protocol_config` at the pinned mainnet-v1.76.1. This
+        // parameter REPLACED `mysticeti_fastpath` at this position in the
+        // constructor between 1.73.2 and 1.76.1 — two adjacent bools, so the
+        // old `config.mysticeti_fastpath()` argument (an always-false,
+        // now-vestigial ika flag) kept compiling while silently disabling
+        // transaction voting. Mirror upstream's exact value: their rolling
+        // binary upgrades shipped this transition on live networks, so the
+        // mixed-committee behavior is the upstream-tested path.
+        /* transaction_voting_enabled */
+        true,
         config.mysticeti_num_leaders_per_round(),
         config.consensus_bad_nodes_stake_threshold(),
         // `enable_v3`: hardcoded `false` to match upstream exactly. At the
-        // pinned mainnet-v1.73.2, Sui's own `to_consensus_protocol_config` also
+        // pinned mainnet-v1.76.1, Sui's own `to_consensus_protocol_config` also
         // hardcodes `/* enable_v3 */ false` — it is NOT yet exposed by
         // `sui_protocol_config::ProtocolConfig`, so there is no version-gated
         // getter to source it from. When Sui gates it behind the protocol config
@@ -75,7 +85,7 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
         false,
         // `leader_schedule_window_size` / `leader_schedule_update_interval`:
         // hardcoded to match upstream's `to_consensus_protocol_config` at the
-        // pinned mainnet-v1.73.2 (300 / 12). These only take effect under the
+        // pinned mainnet-v1.76.1 (300 / 12). These only take effect under the
         // Mysticeti v3 leader schedule, which is gated off above (`enable_v3 =
         // false`), so they are inert today; mirror upstream exactly so enabling
         // v3 later (via a version-gated getter) does not silently fork.

--- a/crates/ika-core/src/consensus_throughput_calculator.rs
+++ b/crates/ika-core/src/consensus_throughput_calculator.rs
@@ -410,9 +410,7 @@ impl ConsensusThroughputCalculator {
 
             let period = first_element_ts.saturating_sub(last_element_ts);
 
-            if period > 0 {
-                let current_throughput = inner.total_transactions / period;
-
+            if let Some(current_throughput) = inner.total_transactions.checked_div(period) {
                 self.metrics
                     .consensus_calculated_throughput
                     .set(current_throughput as i64);

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -838,8 +838,7 @@ async fn test_internal_presign_continues_when_idle() {
     // multiple presigns, pushing the pool past max by up to
     // sessions_to_instantiate * (n - threshold).
     let max_overshoot = TEST_NETWORK_OWNED_ADDRESS_SIGN_PRESIGN_SESSIONS_TO_INSTANTIATE
-        * (test_state.dwallet_mpc_services.len() as u64
-            - test_state.committee.quorum_threshold() as u64);
+        * (test_state.dwallet_mpc_services.len() as u64 - test_state.committee.quorum_threshold());
     assert!(
         pool_size_final >= max_pool_size,
         "pool should reach at least max_pool_size (max={}, got={})",

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -3487,8 +3487,8 @@ impl DWalletMPCManager {
     ) {
         let mut ready_to_advance_sessions: Vec<_> = self
             .sessions
-            .iter()
-            .filter_map(|(_, session)| {
+            .values()
+            .filter_map(|session| {
                 let SessionStatus::Active { request, .. } = &session.status else {
                     return None;
                 };
@@ -3543,8 +3543,7 @@ impl DWalletMPCManager {
             })
             .collect();
 
-        ready_to_advance_sessions
-            .sort_by(|(_, request), (_, other_request)| request.cmp(other_request));
+        ready_to_advance_sessions.sort_by_key(|&(_, request)| request);
 
         let number_of_ready_to_advance_sessions = ready_to_advance_sessions.len();
 

--- a/crates/ika-core/src/mysticeti_adapter.rs
+++ b/crates/ika-core/src/mysticeti_adapter.rs
@@ -92,7 +92,13 @@ impl ConsensusClient for LazyMysticetiClient {
         let (block_ref, tx_indices, status_waiter) = client
             .as_ref()
             .expect("Client should always be returned")
-            .submit(transactions_bytes)
+            // Normal keeps the pre-1.76 single-lane behavior for ALL ika
+            // traffic. High is a 128-slot reserved lane for low-volume
+            // critical submissions; ika's dominant traffic here is MPC
+            // messages (bulk), which would overflow it — routing select
+            // kinds (EndOfPublish, checkpoint signatures) as High is a
+            // possible follow-up tune, not a drop-in.
+            .submit(transactions_bytes, consensus_core::Priority::Normal)
             .await
             .tap_err(|err| {
                 // Will be logged by caller as well.

--- a/crates/ika-core/src/sui_connector/bag_event_pump.rs
+++ b/crates/ika-core/src/sui_connector/bag_event_pump.rs
@@ -378,12 +378,9 @@ fn decode_session_event(verified: &VerifiedObject) -> Option<DBSuiEvent> {
         o.data.try_as_move()
     }
     let move_obj = move_obj(&verified.object)?;
-    let event_tag = match move_obj.type_().type_params().get(1) {
-        Some(cow) => match cow.as_ref() {
-            TypeTag::Struct(s) => (**s).clone(),
-            _ => return None,
-        },
-        None => return None,
+    let event_tag = match move_obj.type_().type_params().get(1)?.as_ref() {
+        TypeTag::Struct(s) => (**s).clone(),
+        _ => return None,
     };
     Some(DBSuiEvent {
         type_: event_tag,

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -745,7 +745,7 @@ pub fn build_epoch_mpc_data_ready_signal_transaction(
     // Sort + dedup by authority so the BCS bytes are canonical — one
     // `(peer, hash)` pair per peer (a validator validates a single
     // blob per peer).
-    validated_peers.sort_by(|left, right| left.0.cmp(&right.0));
+    validated_peers.sort_by_key(|entry| entry.0);
     validated_peers.dedup_by(|left, right| left.0 == right.0);
     let signal = EpochMpcDataReadySignal {
         authority,

--- a/crates/ika-network/src/state_sync/mod.rs
+++ b/crates/ika-network/src/state_sync/mod.rs
@@ -526,7 +526,7 @@ impl PeerBalancer {
                     .map(|peer| (peer.connection_rtt(), peer, *info))
             })
             .collect();
-        peers.sort_by(|(rtt_a, _, _), (rtt_b, _, _)| rtt_a.cmp(rtt_b));
+        peers.sort_by_key(|(rtt_a, _, _)| *rtt_a);
         Self {
             peers: peers
                 .into_iter()

--- a/crates/ika-protocol-config/Cargo.toml
+++ b/crates/ika-protocol-config/Cargo.toml
@@ -15,7 +15,7 @@ tracing.workspace = true
 serde_with.workspace = true
 sui-protocol-config-macros.workspace = true
 # The ProtocolConfigAccessors/Override derive macros expand to
-# `::mysten_common::rpc_format::*` paths (since mainnet-v1.73.2), so every
+# `::mysten_common::rpc_format::*` paths (since mainnet-v1.76.1), so every
 # crate deriving them must depend on mysten-common (mirrors upstream
 # sui-protocol-config).
 mysten-common.workspace = true

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -168,11 +168,6 @@ struct FeatureFlags {
     consensus_round_prober: bool,
 
     // Enables Mysticeti fastpath.
-    // The manual `ProtocolConfig::mysticeti_fastpath` getter consults an
-    // env override before the flag; suppress the macro's plain-forward getter
-    // so the override keeps winning. The generated setter is still emitted
-    // (and is the one tests use).
-    #[skip_protocol_config_accessor]
     #[serde(skip_serializing_if = "is_false")]
     mysticeti_fastpath: bool,
 
@@ -543,13 +538,6 @@ impl ProtocolConfig {
         } else {
             self.consensus_gc_depth.unwrap_or(0)
         }
-    }
-
-    pub fn mysticeti_fastpath(&self) -> bool {
-        if let Some(enabled) = is_mysticeti_fpc_enabled_in_env() {
-            return enabled;
-        }
-        self.feature_flags.mysticeti_fastpath
     }
 }
 
@@ -1300,17 +1288,6 @@ macro_rules! check_limit_by_meter {
         };
         result
     }};
-}
-
-pub fn is_mysticeti_fpc_enabled_in_env() -> Option<bool> {
-    if let Ok(v) = std::env::var("CONSENSUS") {
-        if v == "mysticeti_fpc" {
-            return Some(true);
-        } else if v == "mysticeti" {
-            return Some(false);
-        }
-    }
-    None
 }
 
 #[cfg(all(test, not(msim)))]

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -168,6 +168,11 @@ struct FeatureFlags {
     consensus_round_prober: bool,
 
     // Enables Mysticeti fastpath.
+    // The manual `ProtocolConfig::mysticeti_fastpath` getter consults an
+    // env override before the flag; suppress the macro's plain-forward getter
+    // so the override keeps winning. The generated setter is still emitted
+    // (and is the one tests use).
+    #[skip_protocol_config_accessor]
     #[serde(skip_serializing_if = "is_false")]
     mysticeti_fastpath: bool,
 
@@ -527,25 +532,6 @@ impl ProtocolConfig {
         self.feature_flags.internal_presign_sessions
     }
 
-    /// True iff Fast Schnorr (VSS) signature algorithms are enabled at this
-    /// protocol version (>= 4). Gates the internal NOA-VSS presign pool and
-    /// the Rust-side defense-in-depth VSS request guard.
-    pub fn fast_schnorr_supported(&self) -> bool {
-        self.feature_flags.fast_schnorr_supported
-    }
-
-    pub fn bls_checkpoints(&self) -> bool {
-        self.feature_flags.bls_checkpoints
-    }
-
-    pub fn noa_checkpoints(&self) -> bool {
-        self.feature_flags.noa_checkpoints
-    }
-
-    pub fn consensus_round_prober(&self) -> bool {
-        self.feature_flags.consensus_round_prober
-    }
-
     pub fn mysticeti_num_leaders_per_round(&self) -> Option<usize> {
         self.feature_flags.mysticeti_num_leaders_per_round
     }
@@ -564,23 +550,6 @@ impl ProtocolConfig {
             return enabled;
         }
         self.feature_flags.mysticeti_fastpath
-    }
-
-    pub fn consensus_batched_block_sync(&self) -> bool {
-        self.feature_flags.consensus_batched_block_sync
-    }
-
-    pub fn consensus_skip_gced_blocks_in_direct_finalization(&self) -> bool {
-        self.feature_flags
-            .consensus_skip_gced_blocks_in_direct_finalization
-    }
-
-    pub fn enforce_checkpoint_timestamp_monotonicity(&self) -> bool {
-        self.feature_flags.enforce_checkpoint_timestamp_monotonicity
-    }
-
-    pub fn consensus_zstd_compression(&self) -> bool {
-        self.feature_flags.consensus_zstd_compression
     }
 }
 
@@ -1239,33 +1208,9 @@ impl ProtocolConfig {
         self.feature_flags.mysticeti_num_leaders_per_round = val;
     }
 
-    pub fn set_consensus_round_prober_for_testing(&mut self, val: bool) {
-        self.feature_flags.consensus_round_prober = val;
-    }
-
-    pub fn set_mysticeti_fastpath_for_testing(&mut self, val: bool) {
-        self.feature_flags.mysticeti_fastpath = val;
-    }
-
-    pub fn set_consensus_batched_block_sync_for_testing(&mut self, val: bool) {
-        self.feature_flags.consensus_batched_block_sync = val;
-    }
-
     pub fn set_consensus_skip_gced_blocks_in_direct_finalization(&mut self, val: bool) {
         self.feature_flags
             .consensus_skip_gced_blocks_in_direct_finalization = val;
-    }
-
-    pub fn set_enforce_checkpoint_timestamp_monotonicity_for_testing(&mut self, val: bool) {
-        self.feature_flags.enforce_checkpoint_timestamp_monotonicity = val;
-    }
-
-    pub fn set_internal_presign_sessions_for_testing(&mut self, val: bool) {
-        self.feature_flags.internal_presign_sessions = val;
-    }
-
-    pub fn set_noa_checkpoints_for_testing(&mut self, val: bool) {
-        self.feature_flags.noa_checkpoints = val;
     }
 }
 

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -167,9 +167,22 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     consensus_round_prober: bool,
 
-    // Enables Mysticeti fastpath.
+    // Enables consensus transaction voting. Named `mysticeti_fastpath` until
+    // 2026-08: Sui renamed the `ConsensusProtocolConfig::new` parameter this
+    // flag feeds (`mysticeti_fastpath` -> `transaction_voting_enabled`) at a
+    // tag before mainnet-v1.73.2, and ika's caller kept the old name — so the
+    // flag has in fact been ika's transaction-voting switch, off, for as long
+    // as both networks have been live. Renaming is digest-safe: BCS does not
+    // encode field names, and a false flag is skipped entirely.
+    //
+    // Turning it on changes the DAG consensus builds and requires a
+    // version-gated rollout, not a flip: with voting on, a node replaying a
+    // backlog of certified commits panics in consensus-core's
+    // `linearizer::calculate_commit_timestamp` (the commit-sync path does not
+    // accept a leader's uncommitted round-1 ancestors that the
+    // median-timestamp computation expects).
     #[serde(skip_serializing_if = "is_false")]
-    mysticeti_fastpath: bool,
+    transaction_voting_enabled: bool,
 
     // Set number of leaders per round for Mysticeti commits.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/ika-sui-client/src/archive.rs
+++ b/crates/ika-sui-client/src/archive.rs
@@ -90,7 +90,7 @@ impl SuiCheckpointArchive {
     /// or `no-sign-request`).
     pub fn new(url: impl Into<String>, options: Vec<(String, String)>) -> Self {
         let url = url.into();
-        let store = build_object_store(&url, options.clone());
+        let store = build_object_store(&url, options.clone(), vec![]);
         Self {
             url,
             options,

--- a/crates/ika-swarm-config/src/sui_client.rs
+++ b/crates/ika-swarm-config/src/sui_client.rs
@@ -1898,11 +1898,20 @@ pub(crate) async fn execute_sui_transaction(
     gas_payment: Vec<ObjectRef>,
 ) -> Result<ExecutedTransaction, anyhow::Error> {
     let gas_payment = if gas_payment.is_empty() {
-        let Some(gas_ref) = context.get_one_gas_object_owned_by_address(signer).await? else {
+        // Pay with ALL of the signer's gas coins, not an arbitrary one:
+        // `get_one_gas_object_owned_by_address` returns whatever the read
+        // api lists first, with no balance check, so a long scenario that
+        // funds every step from one address eventually picks a coin worth
+        // less than DEFAULT_GAS_BUDGET and dies with "Balance of gas object
+        // ... is lower than the needed amount". Multi-coin payment funds
+        // the budget from the total and gas-smashes the dust into one coin
+        // as a side effect. Capped at Sui's max_gas_payment_objects (256).
+        let mut gas_refs = context.get_all_gas_objects_owned_by_address(signer).await?;
+        if gas_refs.is_empty() {
             panic!("No gas object found in the wallet context.");
-        };
-
-        vec![gas_ref]
+        }
+        gas_refs.truncate(256);
+        gas_refs
     } else {
         gas_payment
     };

--- a/crates/ika-swarm-config/src/sui_client.rs
+++ b/crates/ika-swarm-config/src/sui_client.rs
@@ -142,6 +142,55 @@ pub async fn fund_address_from_faucet(
         })
 }
 
+/// Faucet-fund `address` until its total SUI gas balance is at least
+/// `min_total_mist`, waiting for each grant to actually land.
+///
+/// Two failure modes make the plain fire-and-forget
+/// [`fund_address_from_faucet`] insufficient for gas-critical steps:
+/// the faucet executes its transfer asynchronously ("It can take up to 1
+/// minute to get the coin"), and a long-lived payer can arrive at a step
+/// with its earlier grants already burned down to dust (seen live in
+/// v128_churn: the publisher entered the join step with 0.199 SUI total
+/// against a 5 SUI budget). Polling the summed gas-coin balance covers
+/// both.
+pub async fn ensure_sui_balance_from_faucet(
+    context: &WalletContext,
+    address: SuiAddress,
+    sui_faucet_url: String,
+    min_total_mist: u64,
+) -> Result<(), anyhow::Error> {
+    const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+    const MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(90);
+
+    async fn total_gas(context: &WalletContext, address: SuiAddress) -> Result<u64, anyhow::Error> {
+        Ok(context
+            .gas_objects(address)
+            .await?
+            .iter()
+            .map(|(value, _)| *value)
+            .sum())
+    }
+
+    if total_gas(context, address).await? >= min_total_mist {
+        return Ok(());
+    }
+    fund_address_from_faucet(address, sui_faucet_url).await?;
+
+    let deadline = tokio::time::Instant::now() + MAX_WAIT;
+    loop {
+        if total_gas(context, address).await? >= min_total_mist {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            bail!(
+                "faucet grant for {address} did not raise the SUI balance to \
+                 {min_total_mist} MIST within {MAX_WAIT:?}"
+            );
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
 pub fn setup_contract_paths(chain: Chain) -> Result<ContractPaths, anyhow::Error> {
     let current_working_dir = std::env::current_dir()?;
 
@@ -235,7 +284,12 @@ pub async fn init_ika_on_sui(
 
     let client = context.grpc_client()?;
 
+    // The publisher pays for the whole bootstrap (4 package publishes, system
+    // init, genesis staking) and observed runs have ended bootstrap with only
+    // dust left of two grants — give it four for margin.
     let mut request_tokens_from_faucet_futures = vec![
+        request_tokens_from_faucet(publisher_address, sui_faucet_url.clone()),
+        request_tokens_from_faucet(publisher_address, sui_faucet_url.clone()),
         request_tokens_from_faucet(publisher_address, sui_faucet_url.clone()),
         request_tokens_from_faucet(publisher_address, sui_faucet_url.clone()),
     ];

--- a/crates/ika-swarm-config/src/sui_client.rs
+++ b/crates/ika-swarm-config/src/sui_client.rs
@@ -825,9 +825,7 @@ pub async fn ika_system_initialize(
         .collect();
 
     // Insert pricing for all curves for protocols without signature algorithms
-    for (curve, _signature_algorithms_to_hash_schemes) in
-        SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES.iter()
-    {
+    for curve in SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES.keys() {
         let curve_arg = ptb.input(CallArg::Pure(bcs::to_bytes(curve)?))?;
         let none_option = ptb.input(CallArg::Pure(bcs::to_bytes(&None::<u32>)?))?;
 

--- a/crates/ika-types/src/crypto.rs
+++ b/crates/ika-types/src/crypto.rs
@@ -1142,13 +1142,12 @@ impl<'a> VerificationObligation<'a> {
         .map_err(|e| {
             let message = format!(
                 "pks: {:?}, messages: {:?}, sigs: {:?}",
-                &self.public_keys,
+                self.public_keys,
                 self.messages
                     .iter()
                     .map(Base64::encode)
                     .collect::<Vec<String>>(),
-                &self
-                    .signatures
+                self.signatures
                     .iter()
                     .map(|s| Base64::encode(s.as_ref()))
                     .collect::<Vec<String>>()

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -27,7 +27,7 @@ use ika_sui_client::metrics::SuiClientMetrics;
 use ika_swarm_config::node_config_builder::{FullnodeConfigBuilder, ValidatorConfigBuilder};
 use ika_swarm_config::sui_client::{
     GenesisGlobalPresignConfig, InitializedIkaSystem, PublishedIkaPackages,
-    fund_address_from_faucet, init_ika_on_sui, request_add_validator,
+    ensure_sui_balance_from_faucet, init_ika_on_sui, request_add_validator,
     request_add_validator_candidate, request_remove_validator, set_global_presign_config,
     stake_ika,
 };
@@ -1872,9 +1872,29 @@ impl ClusterOfProcesses {
         self.wallet
             .add_account(init.name.clone(), init.account_key_pair.copy())
             .await;
-        fund_address_from_faucet(joiner_address, self.sui.faucet_url().to_string())
-            .await
-            .context("faucet-fund joiner")?;
+        // 6 SUI: enough for the joiner's candidate + activation txs at the
+        // flat 5 SUI budget, and far below a single faucet grant.
+        ensure_sui_balance_from_faucet(
+            &self.wallet,
+            joiner_address,
+            self.sui.faucet_url().to_string(),
+            6_000_000_000,
+        )
+        .await
+        .context("faucet-fund joiner")?;
+
+        // The publisher signs `stake_ika` below, and by this point in a long
+        // scenario its bootstrap grants can be burned down to dust (v128_churn
+        // reached this step with 0.199 SUI total against the 5 SUI budget).
+        // Top it up and wait for the grant to land before signing.
+        ensure_sui_balance_from_faucet(
+            &self.wallet,
+            self.publisher_address,
+            self.sui.faucet_url().to_string(),
+            15_000_000_000,
+        )
+        .await
+        .context("faucet-fund publisher before stake_ika")?;
 
         let metadata = init.to_validator_info();
         let (validator_id, validator_cap_id) = retry_on_object_contention!(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94"
+channel = "1.97.1"
 components = ["clippy", "rustfmt"]

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -55,7 +55,7 @@ else
   # mysten-sim rev — MUST match the msim/sui-simulator rev the pinned Sui
   # version uses (see Sui's own scripts/simtest/cargo-simtest at the tag),
   # else simtest links two mysten-sim copies and panics "no reactor running".
-  # Bump together with the Sui tag in root Cargo.toml. (mainnet-v1.73.2 -> 2c2ec3ff)
+  # Bump together with the Sui tag in root Cargo.toml. (mainnet-v1.76.1 -> 2c2ec3ff)
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
     --config 'patch.crates-io.tokio.rev = "2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6"'

--- a/scripts/simtest/config-patch
+++ b/scripts/simtest/config-patch
@@ -18,5 +18,5 @@ index c0829bc1b6..4007f97d66 100644
  include_dir = "0.7.3"
 
  [patch.crates-io]
-+tokio = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "9c6636c399d5c60a1759f1670b1c07b3d408799a" }
-+futures-timer = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "9c6636c399d5c60a1759f1670b1c07b3d408799a" }
++tokio = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6" }
++futures-timer = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6" }


### PR DESCRIPTION
## Summary

Dependency + toolchain refresh ahead of the next release.

- **Sui: `mainnet-v1.73.2` → `mainnet-v1.76.1`** (all 47 git-dep pins), with the coupled Mysten git pins aligned to what sui itself uses at that tag: fastcrypto `3273734`, anemo `68adc31`, sui-rust-sdk `d8643443` — the last one fixes a latent wrong pin (the manifest comment already claimed the 1.76.1 rev while pinning `5b41bc70`).
- **Rust: 1.94 → 1.97.1** — `rust-toolchain.toml` plus all 8 CI workflow pins, matching (slightly ahead of) sui 1.76.1's own 1.96.1.

## Lockfile strategy — why not a blanket `cargo update`

A full `cargo update` breaks the build twice over: it moves `allocative` past what `starlark_map` supports, and — worse — it splits the inkrypto **RustCrypto release-candidate family** (`ecdsa 0.17.0-rc.7`, `elliptic-curve 0.14.0-rc.14`, `sec1 0.8.0-rc.9`, `signature 3.0.0-rc.4`): some members have since graduated to real releases, and cargo mixes graduated + RC members into an uncompilable set. Those crates only move in matched sets and belong to an **inkrypto** upgrade, not this one.

Instead: re-resolve only the Sui dependency cone on top of the known-good lock. Shared deps still came forward to sui's own picks (tokio 1.52, serde 1.0.228, http 1.4, prost 0.14.3, hyper 1.11 — a new `sui-http` minimum), plus targeted bumps: `allocative` 0.3.4 (sui's pin), `ethnum` (pre-1.97 versions fail const-eval on the new rustc). Net lock churn: +586/−353 instead of ±3,700.

## Code adaptations (4)

1. **`sui-protocol-config-macros` now generates `ProtocolConfig` accessors** for every bool feature flag: deleted our 14 now-duplicate trivial getters/setters. One exception kept manual: `mysticeti_fastpath()` consults an env override before the flag, so the field carries `#[skip_protocol_config_accessor]` and the generated plain-forward getter is suppressed (the generated setter replaces our manual one).
2. **`TransactionClient::submit` gained a `Priority` lane** — `Normal` everywhere, preserving pre-1.76 single-lane behavior. `High` is a 128-slot reserved lane for low-volume critical submissions; ika's dominant traffic on this path is bulk MPC messages. Routing select kinds (EndOfPublish, checkpoint signatures) as `High` is a possible follow-up tune.
3. **`ConsensusAuthority::start` gained an optional randomness-signature handler** — `None`; ika runs no randomness protocol.
4. **`build_object_store` gained a headers argument** — empty, matching sui's own call sites.

## Testing

Local (macOS): full `cargo check --workspace --all-targets` clean on 1.97.1; suites green: `ika-protocol-config` 6/6 (the riskiest crate — macro change), `ika-config` 26/26, `ika-sui-client` 19/19, `ika-types` 28/28. The long `ika-core` suite is deferred to CI per its runtime (and the 5 pre-existing macOS-broken NOA tests, #1989). CI is the adjudicator here — simtest + the dispatched Upgrade Test matter more than usual since the consensus runtime, transport stack, and toolchain all changed underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)