### PR TITLE
fix(ci): nightly branch guard must use the exact-ref endpoint

### DIFF
--- a/.github/workflows/scheduled-all-suites.yaml
+++ b/.github/workflows/scheduled-all-suites.yaml
@@ -82,7 +82,13 @@ jobs:
           # self-heals when the branch reappears, and a MAIN dispatch failure
           # still fails the job loudly, which is the half that must never be
           # silent.
-          if ! gh api "repos/$GH_REPO/branches/$BRANCH" --silent 2>/dev/null; then
+          #
+          # The check must use the exact-ref endpoint (`git/ref/heads/...`):
+          # the "get a branch" endpoint (`branches/...`) fuzzy-resolves the
+          # name, so with no `dev` branch it happily returns `dev-v1.2.x`
+          # and the guard waves through a dispatch that then 422s with
+          # "No ref found for: dev".
+          if ! gh api "repos/$GH_REPO/git/ref/heads/$BRANCH" --silent 2>/dev/null; then
             echo "::notice::branch '$BRANCH' does not exist; skipping $SUITE dispatch"
             exit 0
           fi


### PR DESCRIPTION
## What

The nightly [Scheduled — All Heavy Suites](https://github.com/dwallet-labs/ika/actions/workflows/scheduled-all-suites.yaml) fan-out is failing its four `dev`-branch dispatches again (e.g. [run 31237369558](https://github.com/dwallet-labs/ika/actions/runs/31237369558)) — the same noise the skip-missing-branch guard was added to stop.

## Why the guard doesn't work

The guard checks branch existence with the **"get a branch"** endpoint:

```
gh api repos/$GH_REPO/branches/dev   →  200, returns {"name": "dev-v1.2.x"}
```

That endpoint **fuzzy-resolves** the ref name. There is currently no `dev` branch, but `dev-v1.2.x` and `dev-ts` exist, so the lookup succeeds, the guard concludes `dev` exists, and the real dispatch then dies with:

```
could not create workflow dispatch event: HTTP 422: No ref found for: dev
```

## Fix

Use the **exact-ref** endpoint, which only matches the literal branch:

```
gh api repos/$GH_REPO/git/ref/heads/dev   →  404 (guard skips, notice emitted)
gh api repos/$GH_REPO/git/ref/heads/main  →  200 (guard passes, dispatch runs)
```

Both verified against the live repo. `main` dispatch failures still fail the job loudly — only the genuinely-missing-ref case is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)