### PR TITLE
chore: operational hardening across logging, staging and CI guards

### DIFF
--- a/.github/workflows/system-tests-ci.yaml
+++ b/.github/workflows/system-tests-ci.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install Sui from Github
         run: |
-          curl -L https://github.com/MystenLabs/sui/releases/download/mainnet-v1.64.2/sui-mainnet-v1.64.2-ubuntu-x86_64.tgz > sui.tgz
+          curl -L https://github.com/MystenLabs/sui/releases/download/mainnet-v1.76.1/sui-mainnet-v1.76.1-ubuntu-x86_64.tgz > sui.tgz
           tar -xvzf sui.tgz
           sudo cp ./sui /usr/local/bin/sui
 

--- a/crates/ika-archival/src/writer.rs
+++ b/crates/ika-archival/src/writer.rs
@@ -91,10 +91,8 @@ impl DWalletCheckpointWriter {
         let epoch_num = manifest.epoch_num();
         let checkpoint_sequence_num = manifest.next_dwallet_checkpoint_seq_num();
         let epoch_dir = root_dir_path.join(format!("{EPOCH_DIR_PREFIX}{epoch_num}"));
-        if epoch_dir.exists() {
-            fs::remove_dir_all(&epoch_dir)?;
-        }
         fs::create_dir_all(&epoch_dir)?;
+        clear_staged_files(&epoch_dir, DWALLET_CHECKPOINT_FILE_SUFFIX)?;
         let checkpoint_file = Self::next_file(
             &epoch_dir,
             checkpoint_sequence_num,
@@ -142,10 +140,8 @@ impl DWalletCheckpointWriter {
         {
             self.cut()?;
             self.update_to_next_epoch();
-            if self.epoch_dir().exists() {
-                fs::remove_dir_all(self.epoch_dir())?;
-            }
             fs::create_dir_all(self.epoch_dir())?;
+            clear_staged_files(&self.epoch_dir(), DWALLET_CHECKPOINT_FILE_SUFFIX)?;
             self.reset()?;
         }
 
@@ -301,10 +297,8 @@ impl SystemCheckpointWriter {
         let epoch_num = manifest.epoch_num();
         let system_checkpoint_sequence_num = manifest.next_system_checkpoint_seq_num();
         let epoch_dir = root_dir_path.join(format!("{EPOCH_DIR_PREFIX}{epoch_num}"));
-        if epoch_dir.exists() {
-            fs::remove_dir_all(&epoch_dir)?;
-        }
         fs::create_dir_all(&epoch_dir)?;
+        clear_staged_files(&epoch_dir, SYSTEM_CHECKPOINT_FILE_SUFFIX)?;
         let system_checkpoint_file = Self::next_file(
             &epoch_dir,
             system_checkpoint_sequence_num,
@@ -355,10 +349,8 @@ impl SystemCheckpointWriter {
         {
             self.cut()?;
             self.update_to_next_epoch();
-            if self.epoch_dir().exists() {
-                fs::remove_dir_all(self.epoch_dir())?;
-            }
             fs::create_dir_all(self.epoch_dir())?;
+            clear_staged_files(&self.epoch_dir(), SYSTEM_CHECKPOINT_FILE_SUFFIX)?;
             self.reset()?;
         }
 
@@ -767,4 +759,26 @@ impl ArchiveWriter {
         fs::remove_file(path_to_filesystem(dir, &path)?)?;
         Ok(())
     }
+}
+
+/// Clears only this writer's own staged files under `epoch_dir`, leaving files
+/// belonging to the other writer untouched.
+///
+/// The dWallet and system checkpoint writers stage into the SAME epoch
+/// directory and are constructed one after the other, so removing the whole
+/// directory would delete the sibling's freshly created, still-open output file
+/// and its first `cut()` would then fail on a path that no longer exists. The
+/// two write disjoint file names, so clearing just this writer's suffix is
+/// enough to drop stale partial files from a previous run.
+fn clear_staged_files(epoch_dir: &Path, suffix: &str) -> Result<()> {
+    if !epoch_dir.exists() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(epoch_dir)? {
+        let path = entry?.path();
+        if path.extension().is_some_and(|ext| ext == suffix) {
+            fs::remove_file(path)?;
+        }
+    }
+    Ok(())
 }

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -296,8 +296,11 @@ async fn get_decryption_key_shares_from_public_output(
             }
         };
 
-        if let Err(err) = key_shares_sender.send(res) {
-            error!(error=?err, "failed to send key shares");
+        // `oneshot::Sender::send` hands the payload back inside `Err`, so the
+        // "error" here IS the value that was being sent. This payload must not
+        // reach the log; report only that the send failed.
+        if key_shares_sender.send(res).is_err() {
+            error!("failed to send key shares: the receiver is gone");
         }
     });
 
@@ -861,8 +864,10 @@ pub(crate) fn spawn_network_encryption_key_public_data_instantiation(
             )
         };
 
-        if let Err(err) = key_public_data_sender.send(res) {
-            error!(error=?err, "failed to send a network encryption key ");
+        // Same shape as above: the `Err` carries the payload back, so it is
+        // not formatted into the log.
+        if key_public_data_sender.send(res).is_err() {
+            error!("failed to send a network encryption key: the receiver is gone");
         }
     });
 

--- a/crates/ika-core/src/sui_connector/ocs_verifier.rs
+++ b/crates/ika-core/src/sui_connector/ocs_verifier.rs
@@ -360,6 +360,12 @@ impl OcsVerifyingClient {
         last_seq: Option<CheckpointSequenceNumber>,
         reason: &str,
     ) -> Result<(), OcsError> {
+        // Set when an archive call FAILED, as distinct from the archive
+        // cleanly reporting that it does not hold this epoch. Those are not the
+        // same verdict: a failed call means we do not know, and only a clean
+        // absence justifies the terminal `ProofChainBroken` below — which is
+        // not retryable and so fails node startup outright.
+        let mut archive_error: Option<String> = None;
         if let Some(archive) = &self.archive {
             let seq = match last_seq {
                 Some(seq) => Some(seq),
@@ -373,6 +379,7 @@ impl OcsVerifyingClient {
                             "ratchet: archive epochs.json enumeration failed while resolving a \
                              pruned epoch record; trying next fallback"
                         );
+                        archive_error = Some(e.to_string());
                         None
                     }
                 },
@@ -399,6 +406,7 @@ impl OcsVerifyingClient {
                             "ratchet: epoch boundary pruned upstream and the verified archive \
                              fallback also failed; trying next fallback"
                         );
+                        archive_error = Some(e.to_string());
                     }
                 },
                 None => {
@@ -410,6 +418,20 @@ impl OcsVerifyingClient {
                     );
                 }
             }
+        }
+        if let Some(error) = archive_error {
+            warn!(
+                head,
+                ?last_seq,
+                target,
+                reason,
+                %error,
+                "ratchet: epoch boundary pruned upstream and the archive could not be consulted; \
+                 reporting a retryable failure rather than a broken proof chain"
+            );
+            return Err(OcsError::Transport(TransportError::Network(format!(
+                "checkpoint archive fallback for epoch {head} failed: {error}"
+            ))));
         }
         error!(
             head,
@@ -1153,6 +1175,37 @@ mod tests {
         assert_eq!(store.head_epoch(), 2, "archive bridged the pruned records");
         assert_eq!(mock.get_committee_call_count(), 0);
         assert_eq!(metrics.ratchet_stalled.get(), 0);
+    }
+
+    /// An archive that is configured but cannot be CONSULTED is a different
+    /// verdict from an archive that cleanly does not hold the epoch. The first
+    /// means "unknown" and must stay retryable; only the second justifies the
+    /// terminal `ProofChainBroken`, which at boot fails startup outright. Here
+    /// every archive enumeration fails, so nothing is learned either way.
+    #[tokio::test]
+    async fn archive_that_cannot_be_consulted_is_retryable_not_terminal() {
+        let (committee, keys) = Committee::new_simple_test_committee();
+        let (_dir, store) = store_with_genesis(committee.clone());
+        let mut archive = archive_for_chain(&committee, &keys, 2);
+        // Never answers, so neither the cold-bootstrap backfill nor the
+        // per-boundary fallback can resolve a sequence number.
+        archive.fail_enumerations = StdMutex::new(u32::MAX);
+        let archive: Arc<dyn CheckpointArchive> = Arc::new(archive);
+
+        let mock = Arc::new(mock_with_history(&committee, &keys, 2, 2));
+        let metrics = OcsMetrics::new_for_testing();
+        let client = OcsVerifyingClient::new(mock.clone(), store.clone(), metrics.clone())
+            .with_archive(Some(archive));
+
+        let err = client.ratchet_to_current_epoch().await.unwrap_err();
+        assert!(
+            err.is_retryable(),
+            "an archive that could not be consulted must stay retryable, got {err:?}"
+        );
+        assert!(
+            !matches!(err, OcsError::ProofChainBroken { .. }),
+            "a failed archive call is not proof that the chain is broken: {err:?}"
+        );
     }
 
     /// Anchor-less cold start on a history-less source (fresh DB, genesis-only

--- a/crates/ika-core/src/sui_connector/ocs_verifier.rs
+++ b/crates/ika-core/src/sui_connector/ocs_verifier.rs
@@ -410,12 +410,19 @@ impl OcsVerifyingClient {
                     }
                 },
                 None => {
-                    warn!(
-                        head,
-                        target,
-                        "ratchet: epoch boundary pruned upstream and the archive does not \
-                         enumerate this epoch; trying next fallback"
-                    );
+                    // Only a SUCCESSFUL enumeration that lacks this epoch means
+                    // the archive does not hold it. If the call itself failed,
+                    // the arm above already reported that and we know nothing
+                    // about what the archive holds — saying otherwise here
+                    // would mislabel an outage as a determinate answer.
+                    if archive_error.is_none() {
+                        warn!(
+                            head,
+                            target,
+                            "ratchet: epoch boundary pruned upstream and the archive does not \
+                             enumerate this epoch; trying next fallback"
+                        );
+                    }
                 }
             }
         }

--- a/crates/ika-core/src/sui_connector/ocs_verifier.rs
+++ b/crates/ika-core/src/sui_connector/ocs_verifier.rs
@@ -55,6 +55,14 @@ pub enum OcsError {
          when epoch {requested} was expected; refusing to install it"
     )]
     RatchetEpochMismatch { requested: u64, returned: u64 },
+    #[error(
+        "the checkpoint archive could not be consulted for epoch {epoch}: {reason}. The epoch \
+         record is pruned upstream, so whether the proof chain can still be rebuilt is UNKNOWN \
+         until the archive answers — this is not a verdict that the chain is broken. \
+         Remediation: check the reachability and retention of the configured \
+         `sui_checkpoint_archive`. Retried."
+    )]
+    ArchiveUnavailable { epoch: u64, reason: String },
     #[error("ika error: {0}")]
     Ika(String),
 }
@@ -79,13 +87,17 @@ impl OcsError {
     /// ratchet) MUST stop and surface a fatal error on a non-retryable result
     /// rather than spin forever against an unhealable condition.
     pub fn is_retryable(&self) -> bool {
-        matches!(self, OcsError::Transport(_))
+        matches!(
+            self,
+            OcsError::Transport(_) | OcsError::ArchiveUnavailable { .. }
+        )
     }
 
     /// Bounded label for `OcsMetrics::ratchet_failures_total`.
     pub fn metric_reason(&self) -> &'static str {
         match self {
             OcsError::Transport(_) => "transport",
+            OcsError::ArchiveUnavailable { .. } => "archive_unavailable",
             OcsError::MissingCommittee(_) => "missing_committee",
             OcsError::BadCheckpointSig(..) => "bad_checkpoint_sig",
             OcsError::NotEndOfEpoch(_) => "not_end_of_epoch",
@@ -436,9 +448,10 @@ impl OcsVerifyingClient {
                 "ratchet: epoch boundary pruned upstream and the archive could not be consulted; \
                  reporting a retryable failure rather than a broken proof chain"
             );
-            return Err(OcsError::Transport(TransportError::Network(format!(
-                "checkpoint archive fallback for epoch {head} failed: {error}"
-            ))));
+            return Err(OcsError::ArchiveUnavailable {
+                epoch: head,
+                reason: error,
+            });
         }
         error!(
             head,
@@ -1212,6 +1225,14 @@ mod tests {
         assert!(
             !matches!(err, OcsError::ProofChainBroken { .. }),
             "a failed archive call is not proof that the chain is broken: {err:?}"
+        );
+        // Its own reason label: on call, an unreachable or misconfigured
+        // archive must be distinguishable from an ordinary Sui RPC blip,
+        // because only the former needs an operator to touch configuration.
+        assert_eq!(
+            err.metric_reason(),
+            "archive_unavailable",
+            "the retry loop must be attributable to the archive, got {err:?}"
         );
     }
 

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -1054,30 +1054,47 @@ impl IkaNode {
                 .clone();
             tokio::spawn(async move {
                 use ika_core::sui_connector::push_worker::IkaCheckpointPusher;
-                match IkaCheckpointPusher::new(
-                    raw_transport,
-                    perpetual_for_push,
-                    metrics_for_push,
-                    &packages,
-                    // The scan must outrun the fullnode's checkpoint pruning
-                    // watermark, which can trail the executed head by as
-                    // little as ~2 seconds: at a 2s cadence the pusher lost
-                    // the 2-3 newest checkpoints of every pruner tick —
-                    // permanently, since a pruned full checkpoint never
-                    // materializes again. 250ms keeps the pusher within a
-                    // checkpoint or two of the head (a get_latest + at most
-                    // a few full-checkpoint fetches per tick — negligible
-                    // load); the pusher's pending-gap retries backstop
-                    // whatever still slips through.
-                    std::time::Duration::from_millis(250),
-                    cache_for_push,
-                    committees_for_push,
-                )
-                .await
-                {
-                    Ok(pusher) => pusher.run().await,
-                    Err(e) => warn!(error = ?e, "checkpoint folder failed to start"),
-                }
+                // Retry construction instead of giving up for the lifetime of
+                // the process. The constructor talks to the fullnode, so a
+                // transient failure at boot used to disable the pusher
+                // permanently — leaving this node's shared verified-state cache
+                // unfed and its mirrored peers unserved, with no further
+                // attempt and nothing but one warning to say so.
+                const PUSHER_START_RETRY: std::time::Duration = std::time::Duration::from_secs(5);
+                let pusher = loop {
+                    match IkaCheckpointPusher::new(
+                        raw_transport.clone(),
+                        perpetual_for_push.clone(),
+                        metrics_for_push.clone(),
+                        &packages,
+                        // The scan must outrun the fullnode's checkpoint pruning
+                        // watermark, which can trail the executed head by as
+                        // little as ~2 seconds: at a 2s cadence the pusher lost
+                        // the 2-3 newest checkpoints of every pruner tick —
+                        // permanently, since a pruned full checkpoint never
+                        // materializes again. 250ms keeps the pusher within a
+                        // checkpoint or two of the head (a get_latest + at most
+                        // a few full-checkpoint fetches per tick — negligible
+                        // load); the pusher's pending-gap retries backstop
+                        // whatever still slips through.
+                        std::time::Duration::from_millis(250),
+                        cache_for_push.clone(),
+                        committees_for_push.clone(),
+                    )
+                    .await
+                    {
+                        Ok(pusher) => break pusher,
+                        Err(e) => {
+                            warn!(
+                                error = ?e,
+                                retry_in = ?PUSHER_START_RETRY,
+                                "checkpoint pusher failed to start; retrying"
+                            );
+                            tokio::time::sleep(PUSHER_START_RETRY).await;
+                        }
+                    }
+                };
+                pusher.run().await;
             });
         }
 

--- a/crates/ika-upgrade-test/src/process.rs
+++ b/crates/ika-upgrade-test/src/process.rs
@@ -9,7 +9,7 @@
 //! is persistent and survives `swap_binary`, which is what makes the on-disk
 //! compatibility assertion real.
 
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -116,8 +116,15 @@ impl ValidatorProcess {
         if self.child.is_some() {
             bail!("validator {} already running", self.index);
         }
-        let log = File::create(&self.log_path)
-            .with_context(|| format!("create log file {}", self.log_path.display()))?;
+        // Append rather than truncate. Scenarios restart validators mid-run,
+        // and whole-run log assertions are evaluated at the end — truncating
+        // here would delete the earlier window those assertions exist to
+        // inspect, so they would pass by having nothing left to read.
+        let log = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.log_path)
+            .with_context(|| format!("open log file {}", self.log_path.display()))?;
         let stderr = log.try_clone()?;
         tracing::info!(
             index = self.index,

--- a/crates/ika-upgrade-test/src/process.rs
+++ b/crates/ika-upgrade-test/src/process.rs
@@ -9,7 +9,7 @@
 //! is persistent and survives `swap_binary`, which is what makes the on-disk
 //! compatibility assertion real.
 
-use std::fs::{File, OpenOptions};
+use std::fs::OpenOptions;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;

--- a/crates/ika-upgrade-test/src/process.rs
+++ b/crates/ika-upgrade-test/src/process.rs
@@ -120,6 +120,10 @@ impl ValidatorProcess {
         // and whole-run log assertions are evaluated at the end — truncating
         // here would delete the earlier window those assertions exist to
         // inspect, so they would pass by having nothing left to read.
+        //
+        // The corollary for scenario authors: a POSITIVE log assertion can now
+        // match an occurrence from before a restart. Assert on something the
+        // phase under test emits uniquely, or capture a line offset first.
         let log = OpenOptions::new()
             .create(true)
             .append(true)

--- a/crates/ika/src/validator_commands.rs
+++ b/crates/ika/src/validator_commands.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
@@ -1186,17 +1186,25 @@ fn read_or_generate_root_seed(
     ValidatorMPCSecrets,
     ika_types::committee::ValidatorEncryptionKeysAndProofs,
 )> {
-    let seed = match RootSeed::from_file(seed_path.clone()) {
-        Ok(seed) => {
-            println!("Use existing seed: {seed_path:?}.",);
-            seed
-        }
-        Err(_) => {
-            let seed = RootSeed::random_seed();
-            seed.save_to_file(seed_path.clone())?;
-            println!("Generated root seed () file: {seed_path:?}.",);
-            seed
-        }
+    // Decide on the file's EXISTENCE, not on whether it parsed. `from_file`
+    // reports an absent file and an unreadable or corrupt one as the same
+    // error, and generating a fresh seed overwrites the path — so treating any
+    // failure as "no seed" would destroy a validator's only copy of a seed
+    // that is merely unreadable right now.
+    let seed = if seed_path.exists() {
+        let seed = RootSeed::from_file(seed_path.clone()).with_context(|| {
+            format!(
+                "root seed file {seed_path:?} exists but could not be read; refusing to \
+                 overwrite it with a freshly generated seed"
+            )
+        })?;
+        println!("Use existing seed: {seed_path:?}.",);
+        seed
+    } else {
+        let seed = RootSeed::random_seed();
+        seed.save_to_file(seed_path.clone())?;
+        println!("Generated root seed () file: {seed_path:?}.",);
+        seed
     };
 
     Ok(ValidatorMPCSecrets::from_seed(&seed))

--- a/scripts/check-sui-version-consistency.sh
+++ b/scripts/check-sui-version-consistency.sh
@@ -22,12 +22,9 @@ tag=$(echo "$tags" | head -1)
 echo "root Cargo.toml Sui pin: $tag"
 
 # Every other location must carry the same tag (same flavor, same version).
-check_file() {
-    local file="$1"
-    [ -f "$file" ] || return 0
-    local found
-    found=$(grep -oE "$TAG_RE" "$file" | sort -u || true)
-    [ -n "$found" ] || return 0
+# Compare whatever tags a file carries against the root pin.
+compare_tags() {
+    local file="$1" found="$2"
     local mismatched
     mismatched=$(echo "$found" | grep -v -x "$tag" || true)
     if [ -n "$mismatched" ]; then
@@ -39,12 +36,55 @@ check_file() {
     fi
 }
 
+# A location that MUST exist and MUST carry the pin. A missing file or a file
+# that has lost its tag used to return success silently, so a rename or a
+# refactor that dropped the pin read as green.
+check_file() {
+    local file="$1"
+    if [ ! -f "$file" ]; then
+        echo "ERROR: $file is checked for the Sui pin but does not exist" >&2
+        echo "       Update the list in $0 if the file moved." >&2
+        fail=1
+        return 0
+    fi
+    local found
+    found=$(grep -oE "$TAG_RE" "$file" | sort -u || true)
+    if [ -z "$found" ]; then
+        echo "ERROR: $file is checked for the Sui pin but carries no release tag" >&2
+        echo "       Update the list in $0 if the pin legitimately moved out." >&2
+        fail=1
+        return 0
+    fi
+    compare_tags "$file" "$found"
+}
+
+# A location that legitimately carries no tag today because it resolves Sui
+# deps against the root workspace, but must not drift if a direct pin is added
+# later. The FILE must still exist: if it does not, this list is stale and the
+# guard has quietly stopped watching something.
+check_optional_pin() {
+    local file="$1"
+    if [ ! -f "$file" ]; then
+        echo "ERROR: $file is listed for the Sui pin check but does not exist" >&2
+        echo "       Update the list in $0 if the file moved or was removed." >&2
+        fail=1
+        return 0
+    fi
+    local found
+    found=$(grep -oE "$TAG_RE" "$file" | sort -u || true)
+    if [ -z "$found" ]; then
+        echo "$file: OK (no direct pin)"
+        return 0
+    fi
+    compare_tags "$file" "$found"
+}
+
 check_file .github/workflows/ts-integration-tests.yaml
 check_file .github/workflows/ts-ci.yaml
+check_file .github/workflows/system-tests-ci.yaml
 check_file CLAUDE.md
 # Excluded workspaces: manifests resolve workspace deps against the root,
 # but any direct tag pin added later must stay in lockstep.
-check_file sdk/ika-wasm/Cargo.toml
-check_file sdk/dwallet-mpc-wasm/Cargo.toml
+check_optional_pin sdk/ika-wasm/Cargo.toml
 
 exit "$fail"


### PR DESCRIPTION
Seven small, independent fixes across logging, local staging and CI guards. None touch consensus, wire formats, BCS layouts or protocol-version gates, so they should be reviewable individually and quickly.

### What's here

- **Failed `oneshot` sends no longer log their payload.** `oneshot::Sender::send` returns the value it failed to send inside `Err`, so formatting that error writes the payload itself into the log. Two sites in the network-DKG path did; both now report only that the send failed. A third site in the same file already had it right, which is the pattern the other two now follow.

- **Upgrade-test logs append instead of truncating.** The harness reopened each validator's log with `File::create` on every start. Scenarios restart validators mid-run and whole-run log assertions run at the end, so the earlier window those assertions exist to inspect was being deleted before they read it — they were passing by having nothing left to read.

- **A checkpoint-archive call that FAILS is no longer reported as a broken proof chain.** `pruned_boundary_fallback` returned the terminal, non-retryable `ProofChainBroken` for any archive error, which is not the same verdict as the archive cleanly not holding the epoch. Only the latter is determinate; the former means "unknown" and now returns a retryable transport error. A non-retryable error here fails node startup outright.

- **The two archive writers no longer delete each other's output.** The dWallet and system checkpoint writers stage into the same epoch directory and each removed the whole directory before creating its own file, so the second one constructed deleted the first's freshly created, still-open file. They write disjoint file names, so each now clears only its own.

- **A root seed that exists but cannot be read is no longer overwritten.** `read_or_generate_root_seed` treated any read failure as "no seed" and generated a fresh one over the top, and `RootSeed::from_file` reports an absent file and an unreadable one identically. It now branches on existence and fails loudly if a seed that IS there cannot be read.

- **`check-sui-version-consistency.sh` fails closed.** It returned success for a listed file that was missing, or that carried no tag — so a rename, or a refactor that dropped the pin, read as green. Both are errors now, with a separate `check_optional_pin` for locations that legitimately carry no direct pin today but must not drift if one is added.

- **The OCS checkpoint pusher retries construction.** It was started in a bare `tokio::spawn` with no retry, so a single error from its constructor disabled it for the process lifetime — leaving this node's shared verified-state cache unfed and its mirrored peers unserved, with one warning and no further attempt.

### Two things the guard fix immediately surfaced

Both are included here:

1. `sdk/dwallet-mpc-wasm/Cargo.toml` no longer exists. The guard had been "checking" it and passing.
2. `.github/workflows/system-tests-ci.yaml` was never in the list and pinned **`mainnet-v1.64.2`** against a root pin of **`mainnet-v1.76.1`**. It is now checked, and the pin corrected.

The second one is not hypothetical: the immediately preceding commit (#1992, *"upgrade Sui to mainnet-v1.76.1"*) bumped the root manifest, `CLAUDE.md` and both TS workflows, and left this file behind — because the guard was not watching it and reported green.

**Reviewers please note:** correcting that pin changes which Sui binary the system-tests suite runs, from v1.64.2 to v1.76.1 — twelve minor versions. That is the entire point of the guard, but it is a real behaviour change and worth watching on the first run after merge.

Worth knowing for anyone extending the guard: `release.yaml` and `upgrade-test.yaml` also match the tag regex, but those are *ika* release tags, not Sui pins. Adding them would produce false failures.

### Verification

- `cargo check --workspace --all-targets`, `cargo fmt --all`
- `ocs_verifier` 13/13, including a new test for the retryable-vs-terminal distinction. That path had no coverage before: the two existing tests that reach it either run with no archive configured, or succeed before the branch. **Fault-validated** — reverting the fix fails exactly the new test.
- The CI guard fault-validated against four failure modes (mismatched tag, listed file missing, listed file with no tag, optional-pin file missing). Each fails closed; baseline green.
- `ika-archival` has no test suite, so the writer change is covered by review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rLdsjCfcsTMaiLd3TX8w

