### PR TITLE
fix(net,sui-client): bound outbound calls that could hang indefinitely

### DIFF
--- a/crates/ika-core/src/sui_connector/mod.rs
+++ b/crates/ika-core/src/sui_connector/mod.rs
@@ -542,9 +542,15 @@ async fn sweep_gas_coins_into_address_balance<C: SuiClientInner>(
     if gas_coins.is_empty() {
         anyhow::bail!("coin balance is {coin_total} MIST but no gas-coin objects were listed");
     }
-    if gas_coins.len() > SWEEP_MAX_GAS_COINS {
+    if gas_coins.len() >= SWEEP_MAX_GAS_COINS {
         // The subset's value is unknown, so a correct split amount can't be
         // computed. This does not happen to a writer address in practice.
+        //
+        // `>=`, not `>`: the lister truncates at the same cap, so a returned
+        // set of exactly this length may be a truncation of a larger holding.
+        // `coin_total` still counts every coin, so proceeding would smash a
+        // 256-coin payment while splitting the full balance, and the
+        // SplitCoins would abort on chain instead of bailing here.
         anyhow::bail!(
             "{} gas coins exceed the {SWEEP_MAX_GAS_COINS}-object gas payment cap;              consolidate them manually",
             gas_coins.len()

--- a/crates/ika-network/src/mpc_artifacts.rs
+++ b/crates/ika-network/src/mpc_artifacts.rs
@@ -22,6 +22,16 @@ mod generated {
     include!(concat!(env!("OUT_DIR"), "/ika.ValidatorMetadata.rs"));
 }
 
+/// Bound on an outbound `ValidatorMetadata` RPC.
+///
+/// Every call in this module is issued with one. Two of them —
+/// the handoff-certificate fetch and the blob fetch — are awaited inside the
+/// deliberately unbounded prepare-then-start barrier a validator crosses when
+/// entering an epoch, so a peer that accepts the stream and never answers
+/// would otherwise hold the validator out of the epoch indefinitely. anemo
+/// applies no default request timeout and ika configures none.
+pub const ARTIFACT_RPC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 pub mod announcement_relay;
 pub mod blob_store;
 pub mod handoff_cert;

--- a/crates/ika-network/src/mpc_artifacts.rs
+++ b/crates/ika-network/src/mpc_artifacts.rs
@@ -32,6 +32,13 @@ mod generated {
 /// applies no default request timeout and ika configures none.
 pub const ARTIFACT_RPC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// Bound on a blob fetch specifically, which moves real data rather than a
+/// small message: the blob cache is sized in hundreds of megabytes, so a
+/// single MPC-data blob can be tens of MB and 30s would systematically fail
+/// the slowest-but-honest peers on an inter-region link. Callers fall through
+/// to the next peer on timeout, so a generous bound costs a retry at worst.
+pub const BLOB_RPC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 pub mod announcement_relay;
 pub mod blob_store;
 pub mod handoff_cert;

--- a/crates/ika-network/src/mpc_artifacts/announcement_relay.rs
+++ b/crates/ika-network/src/mpc_artifacts/announcement_relay.rs
@@ -110,8 +110,10 @@ pub async fn submit_announcement_to_peer(
         .peer(peer_id)
         .ok_or_else(|| anyhow::anyhow!("peer not connected: {peer_id}"))?;
     let mut client = ValidatorMetadataClient::new(peer);
+    let request = anemo::Request::new(SubmitMpcDataAnnouncementRequest { announcement, blob })
+        .with_timeout(super::ARTIFACT_RPC_TIMEOUT);
     let response = client
-        .submit_mpc_data_announcement(SubmitMpcDataAnnouncementRequest { announcement, blob })
+        .submit_mpc_data_announcement(request)
         .await
         .map_err(|status| anyhow::anyhow!("submit_mpc_data_announcement failed: {status:?}"))?;
     Ok(response.into_inner())

--- a/crates/ika-network/src/mpc_artifacts/blob_store.rs
+++ b/crates/ika-network/src/mpc_artifacts/blob_store.rs
@@ -223,8 +223,10 @@ pub async fn fetch_blob(
         .peer(peer_id)
         .ok_or_else(|| anyhow::anyhow!("peer not connected: {peer_id}"))?;
     let mut client = ValidatorMetadataClient::new(peer);
+    let request = anemo::Request::new(GetMpcDataBlobRequest { blob_hash })
+        .with_timeout(super::ARTIFACT_RPC_TIMEOUT);
     let response = client
-        .get_mpc_data_blob(GetMpcDataBlobRequest { blob_hash })
+        .get_mpc_data_blob(request)
         .await
         .map_err(|status| anyhow::anyhow!("get_mpc_data_blob failed: {status:?}"))?;
     Ok(response.into_inner().map(|b| b.bytes))

--- a/crates/ika-network/src/mpc_artifacts/blob_store.rs
+++ b/crates/ika-network/src/mpc_artifacts/blob_store.rs
@@ -224,7 +224,7 @@ pub async fn fetch_blob(
         .ok_or_else(|| anyhow::anyhow!("peer not connected: {peer_id}"))?;
     let mut client = ValidatorMetadataClient::new(peer);
     let request = anemo::Request::new(GetMpcDataBlobRequest { blob_hash })
-        .with_timeout(super::ARTIFACT_RPC_TIMEOUT);
+        .with_timeout(super::BLOB_RPC_TIMEOUT);
     let response = client
         .get_mpc_data_blob(request)
         .await

--- a/crates/ika-network/src/mpc_artifacts/handoff_cert.rs
+++ b/crates/ika-network/src/mpc_artifacts/handoff_cert.rs
@@ -45,8 +45,10 @@ pub async fn fetch_certified_handoff_attestation(
         .peer(peer_id)
         .ok_or_else(|| anyhow::anyhow!("peer not connected: {peer_id}"))?;
     let mut client = ValidatorMetadataClient::new(peer);
+    let request = anemo::Request::new(GetCertifiedHandoffAttestationRequest { epoch })
+        .with_timeout(super::ARTIFACT_RPC_TIMEOUT);
     let response = client
-        .get_certified_handoff_attestation(GetCertifiedHandoffAttestationRequest { epoch })
+        .get_certified_handoff_attestation(request)
         .await
         .map_err(|status| {
             anyhow::anyhow!("get_certified_handoff_attestation failed: {status:?}")

--- a/crates/ika-sui-client/src/grpc.rs
+++ b/crates/ika-sui-client/src/grpc.rs
@@ -34,6 +34,16 @@ use crate::transport::{
     SuiFundsBreakdown, SuiTransport, SuiWriter, TransportError,
 };
 
+/// Sui rejects a transaction whose gas payment names more than
+/// `max_gas_payment_objects` objects — 256 on every live network. Selecting
+/// every coin the address owns therefore stops working, for every submission,
+/// as soon as it accumulates more than that; and the whole set is not needed
+/// in the first place. Stop paging at the cap.
+const MAX_GAS_PAYMENT_OBJECTS: usize = 256;
+
+/// Deadline for a transaction submission.
+const SUBMIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 pub struct SuiGrpcClient {
     rpc: SuiRpcClient,
     endpoint: String,
@@ -430,6 +440,10 @@ impl SuiWriter for SuiGrpcClient {
         let mut refs = Vec::new();
         let mut page_token = None;
         loop {
+            if refs.len() >= MAX_GAS_PAYMENT_OBJECTS {
+                refs.truncate(MAX_GAS_PAYMENT_OBJECTS);
+                break;
+            }
             let page = rpc
                 .get_owned_objects(address, Some(GasCoin::type_()), None, page_token)
                 .await
@@ -444,6 +458,7 @@ impl SuiWriter for SuiGrpcClient {
                 None => break,
             }
         }
+        refs.truncate(MAX_GAS_PAYMENT_OBJECTS);
         Ok(refs)
     }
 
@@ -479,7 +494,19 @@ impl SuiWriter for SuiGrpcClient {
         tx: &Transaction,
     ) -> Result<SubmittedTransaction, TransportError> {
         let mut rpc = self.rpc.clone();
-        let executed = rpc.execute_transaction(tx).await.map_err(Self::rpc_err)?;
+        // Bounded because the notifier holds its serial submission lock across
+        // this call: the underlying client configures a connect timeout and
+        // keepalives but no per-request deadline, so an upstream that accepts
+        // the request and never answers would stall every notifier write
+        // behind it, with no watchdog able to fire.
+        let executed = tokio::time::timeout(SUBMIT_TIMEOUT, rpc.execute_transaction(tx))
+            .await
+            .map_err(|_| {
+                TransportError::Network(format!(
+                    "execute_transaction exceeded {SUBMIT_TIMEOUT:?} with no response"
+                ))
+            })?
+            .map_err(Self::rpc_err)?;
         Ok(SubmittedTransaction {
             digest: *tx.digest(),
             effects: executed.effects,

--- a/crates/ika-sui-client/src/grpc.rs
+++ b/crates/ika-sui-client/src/grpc.rs
@@ -441,7 +441,6 @@ impl SuiWriter for SuiGrpcClient {
         let mut page_token = None;
         loop {
             if refs.len() >= MAX_GAS_PAYMENT_OBJECTS {
-                refs.truncate(MAX_GAS_PAYMENT_OBJECTS);
                 break;
             }
             let page = rpc


### PR DESCRIPTION
Three unbounded waits, none of which any existing watchdog could interrupt. Stacked on #1995 — both touch node-side code paths; review that one first.

### What's here

- **Every `ValidatorMetadata` RPC now carries a request timeout.** anemo applies no default, and ika configures neither `outbound_request_timeout_ms` nor `inbound_request_timeout_ms`, so all three calls in the module waited forever on a peer that accepted the stream and never answered. Two of them — the handoff-certificate fetch and the blob fetch — are awaited inside the deliberately unbounded prepare-then-start barrier a validator crosses when entering an epoch, so one unresponsive peer could hold it out of the epoch with nothing able to time it out.

- **`execute_transaction` is bounded.** The underlying client sets a connect timeout and keepalives but no per-request deadline, and the notifier holds its serial submission lock across this call — so an upstream that accepted the request and never answered stalled every notifier write behind it, in a way the existing retry watchdog cannot fire on, because the call never returns.

- **Gas-coin selection stops at Sui's `max_gas_payment_objects` limit (256).** It paged through every `Coin<SUI>` the address owns and returned all of them, so once the notifier address accumulated more than the cap, Sui rejected every transaction it built, before execution. The full set was never needed.

### Notes for review

- The 30s / 60s values are starting points, not measurements. If either is wrong for your topology, say so — they're single constants.
- The timeout on the announcement relay is deliberate even though that path is best-effort and documented as never blocking reconfiguration: best-effort still pins a task, and the fan-out already tolerates per-peer failure.
- `execute_transaction` is bounded at the call rather than at client construction. A client-wide deadline would be broader, but the submission path is where the lock is held and where a hang actually wedges something.

### Verification

`cargo check --workspace --all-targets`, `cargo clippy --all-targets -- -D warnings` on both touched crates, `cargo fmt --all`.

No new tests: all three changes are bounds on external I/O, which the existing suites don't exercise for the timeout case. The cluster and upgrade suites are the meaningful signal here and will run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rLdsjCfcsTMaiLd3TX8w
