### PR TITLE
fix(net,core): bound three structures a peer can grow without limit

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -98,6 +98,15 @@ on:
       # reason authority.rs once was.
       - "crates/ika-core/src/consensus_handler.rs"
       - "crates/ika-types/src/messages_consensus.rs"
+      # The whole p2p crate, not just state_sync and mpc_artifacts. This
+      # suite spawns REAL validator processes that reach each other over
+      # anemo: checkpoint sync, handoff-certificate and blob fetch at epoch
+      # entry, and peer discovery are all load-bearing for a cross-binary
+      # run. A per-subdirectory list would re-open this same gap the next
+      # time someone adds a module, which is how consensus_handler.rs and
+      # authority.rs both came to be missing. The cost is that unrelated p2p
+      # churn also triggers the suite; that is the cheaper mistake.
+      - "crates/ika-network/**"
       - "crates/ika-core/src/dwallet_mpc/**"
       - "crates/ika-core/src/dwallet_session_request.rs"
       - "crates/ika-core/src/request_protocol_data.rs"

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -89,6 +89,15 @@ on:
       # ever running had it not been dispatched by hand.
       - "crates/ika-core/src/authority.rs"
       - "crates/ika-core/src/authority/**"
+      # consensus_handler.rs decides which sequenced transactions are
+      # processed at all (verification order, dedup admission) and
+      # messages_consensus.rs defines the consensus transaction/key types —
+      # whose BCS encoding is persisted and append-only. Both change what a
+      # mixed-binary committee agrees on, which is precisely what the
+      # rollout scenarios assert, and both were missing here for the same
+      # reason authority.rs once was.
+      - "crates/ika-core/src/consensus_handler.rs"
+      - "crates/ika-types/src/messages_consensus.rs"
       - "crates/ika-core/src/dwallet_mpc/**"
       - "crates/ika-core/src/dwallet_session_request.rs"
       - "crates/ika-core/src/request_protocol_data.rs"

--- a/crates/ika-core/src/consensus_handler.rs
+++ b/crates/ika-core/src/consensus_handler.rs
@@ -337,7 +337,18 @@ impl<C: DWalletCheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
                 let key = verified_transaction.0.key();
                 let in_set = !processed_set.insert(key.clone());
-                let in_cache = self.processed_cache.put(key, ()).is_some();
+                // The LRU is a local fast path in front of the durable
+                // `is_consensus_message_processed` check, so declining to cache
+                // a key costs one DB read and nothing else. Two key variants
+                // embed their whole MPC payload, so admitting them budgets
+                // `PROCESSED_CACHE_CAP` entries times an unbounded per-entry
+                // size — a cap in name only. They are the ones least worth
+                // caching anyway: an MPC message or output is submitted once.
+                let in_cache = if key.embeds_payload() {
+                    false
+                } else {
+                    self.processed_cache.put(key, ()).is_some()
+                };
 
                 if in_set || in_cache {
                     self.metrics.skipped_consensus_txns_cache_hit.inc();
@@ -515,6 +526,15 @@ impl From<SerializableSequencedConsensusTransactionKind> for SequencedConsensusT
 #[derive(Serialize, Deserialize, Clone, Hash, PartialEq, Eq, Debug, Ord, PartialOrd)]
 pub enum SequencedConsensusTransactionKey {
     External(ConsensusTransactionKey),
+}
+
+impl SequencedConsensusTransactionKey {
+    /// See [`ConsensusTransactionKey::embeds_payload`].
+    pub fn embeds_payload(&self) -> bool {
+        match self {
+            Self::External(key) => key.embeds_payload(),
+        }
+    }
 }
 
 impl SequencedConsensusTransactionKind {

--- a/crates/ika-network/src/mpc_artifacts.rs
+++ b/crates/ika-network/src/mpc_artifacts.rs
@@ -16,6 +16,8 @@
 //! The [`server::Server`] type implements the Anemo service and
 //! routes each method to the relevant submodule's storage/handle.
 
+use anemo::codegen::InboundRequestLayer;
+use anemo_tower::inflight_limit;
 use std::sync::Arc;
 
 mod generated {
@@ -68,10 +70,42 @@ pub use handoff_cert::{
 /// relay handle starts empty; the node installs a relay impl into
 /// it once per-epoch state is up. The cert store is wired directly
 /// to perpetual storage at construction time.
+/// Concurrent `GetMpcDataBlob` reads. A blob is multi-megabyte MPC data
+/// served out of storage, so this is the heaviest of the three — calibrated
+/// alongside `sui_state_mirror`'s heaviest read (`changeset_page`, 16).
+const INFLIGHT_GET_BLOB: usize = 16;
+
+/// Concurrent `SubmitMpcDataAnnouncement` relays. The handler holds while the
+/// announcement is sequenced through consensus rather than returning
+/// immediately, so a held slot is expensive in wall-clock, not just memory.
+const INFLIGHT_SUBMIT_ANNOUNCEMENT: usize = 16;
+
+/// Concurrent `GetCertifiedHandoffAttestation` reads — a single certificate,
+/// cheap, matching `sui_state_mirror`'s checkpoint-read tier.
+const INFLIGHT_GET_HANDOFF_CERT: usize = 64;
+
 pub fn build_server<S: MpcDataBlobStorage, C: HandoffCertStorage>(
     storage: Arc<S>,
     relay: Arc<AnnouncementRelayHandle>,
     cert_storage: Arc<C>,
 ) -> ValidatorMetadataServer<Server<S, C>> {
+    // Every served RPC gets an inflight ceiling. This service had none at all,
+    // so any host able to open an anemo connection could hold unlimited
+    // concurrent multi-megabyte blob reads, or unlimited relay calls that each
+    // occupy the handler until consensus sequences them. The sibling
+    // `SuiStateMirror` service in this crate caps all ten of its methods; this
+    // one capped none. (`add_layer_for_*` is generic over its own request
+    // type, so the layers are built inline rather than via a shared helper.)
+    macro_rules! inflight {
+        ($n:expr) => {
+            InboundRequestLayer::new(inflight_limit::InflightLimitLayer::new(
+                $n,
+                inflight_limit::WaitMode::ReturnError,
+            ))
+        };
+    }
     ValidatorMetadataServer::new(Server::new(storage, relay, cert_storage))
+        .add_layer_for_get_mpc_data_blob(inflight!(INFLIGHT_GET_BLOB))
+        .add_layer_for_submit_mpc_data_announcement(inflight!(INFLIGHT_SUBMIT_ANNOUNCEMENT))
+        .add_layer_for_get_certified_handoff_attestation(inflight!(INFLIGHT_GET_HANDOFF_CERT))
 }

--- a/crates/ika-network/src/state_sync/mod.rs
+++ b/crates/ika-network/src/state_sync/mod.rs
@@ -429,12 +429,45 @@ impl PeerHeights {
         let digest = *checkpoint.digest();
         let sequence_number = *checkpoint.sequence_number();
         self.unprocessed_checkpoints.insert(digest, checkpoint);
-        self.sequence_number_to_digest
-            .insert(sequence_number, digest);
+        Self::displace_previous_body(
+            &mut self.unprocessed_checkpoints,
+            &mut self.sequence_number_to_digest,
+            sequence_number,
+            digest,
+        );
         Self::evict_beyond(
             &mut self.unprocessed_checkpoints,
             &mut self.sequence_number_to_digest,
         );
+    }
+
+    /// Points `sequence_number` at `digest`, dropping the body it displaces.
+    ///
+    /// Without this the two maps drift apart and the ceiling below counts the
+    /// wrong thing. Bodies are keyed by DIGEST and the index by SEQUENCE, and
+    /// the push RPC verifies no signature — the only gate is that the sender
+    /// is a registered same-chain peer. So one peer can push many bodies that
+    /// all claim a single far-ahead sequence number with distinct digests:
+    /// each adds a body while merely overwriting the same index key, leaving
+    /// the counted map at one entry while the bodies grow without limit.
+    ///
+    /// Keeping only the newest body per sequence is safe: two valid
+    /// certificates for one sequence would mean the committee equivocated,
+    /// and the fetch path re-checks against pinned digests regardless.
+    fn displace_previous_body<D, S, T>(
+        bodies: &mut HashMap<D, T>,
+        by_sequence: &mut HashMap<S, D>,
+        sequence_number: S,
+        digest: D,
+    ) where
+        D: Copy + Eq + std::hash::Hash,
+        S: Copy + Eq + std::hash::Hash,
+    {
+        if let Some(previous) = by_sequence.insert(sequence_number, digest)
+            && previous != digest
+        {
+            bodies.remove(&previous);
+        }
     }
 
     /// Bounds the stored bodies by dropping the FURTHEST-ahead entries.
@@ -511,8 +544,12 @@ impl PeerHeights {
         let sequence_number = *system_checkpoint.sequence_number();
         self.unprocessed_system_checkpoint
             .insert(digest, system_checkpoint);
-        self.sequence_number_to_digest_system_checkpoint
-            .insert(sequence_number, digest);
+        Self::displace_previous_body(
+            &mut self.unprocessed_system_checkpoint,
+            &mut self.sequence_number_to_digest_system_checkpoint,
+            sequence_number,
+            digest,
+        );
         Self::evict_beyond(
             &mut self.unprocessed_system_checkpoint,
             &mut self.sequence_number_to_digest_system_checkpoint,
@@ -2137,6 +2174,59 @@ where
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod peer_heights_bounds_tests {
+    use super::*;
+
+    /// The bound counts the SEQUENCE index, but bodies are keyed by digest.
+    /// The push RPC verifies no signature, so one peer can push many crafted
+    /// bodies that all claim a single far-ahead sequence number with distinct
+    /// digests — each adding a body while merely overwriting one index entry.
+    /// Displacing the previous body is what keeps the two in step.
+    #[test]
+    fn same_sequence_distinct_digests_cannot_grow_the_body_map() {
+        let mut bodies: HashMap<u64, ()> = HashMap::new();
+        let mut by_sequence: HashMap<u64, u64> = HashMap::new();
+        const FAR_AHEAD: u64 = 9_999_999;
+
+        for digest in 0..50_000u64 {
+            bodies.insert(digest, ());
+            PeerHeights::displace_previous_body(&mut bodies, &mut by_sequence, FAR_AHEAD, digest);
+            PeerHeights::evict_beyond(&mut bodies, &mut by_sequence);
+        }
+
+        assert_eq!(by_sequence.len(), 1, "one sequence was ever claimed");
+        assert_eq!(
+            bodies.len(),
+            1,
+            "bodies must not outgrow the index they are counted by"
+        );
+    }
+
+    /// Across distinct sequences the ceiling applies, and it discards the
+    /// furthest-ahead — sync advances upward, so the entries nearest our
+    /// position are the ones worth keeping.
+    #[test]
+    fn distinct_sequences_are_capped_and_evict_from_the_top() {
+        let mut bodies: HashMap<u64, ()> = HashMap::new();
+        let mut by_sequence: HashMap<u64, u64> = HashMap::new();
+
+        for sequence in 0..(MAX_UNPROCESSED_CHECKPOINTS as u64 + 5_000) {
+            bodies.insert(sequence, ());
+            PeerHeights::displace_previous_body(&mut bodies, &mut by_sequence, sequence, sequence);
+            PeerHeights::evict_beyond(&mut bodies, &mut by_sequence);
+        }
+
+        assert_eq!(by_sequence.len(), MAX_UNPROCESSED_CHECKPOINTS);
+        assert_eq!(bodies.len(), MAX_UNPROCESSED_CHECKPOINTS);
+        assert!(by_sequence.contains_key(&0), "the nearest entry is kept");
+        assert!(
+            !by_sequence.contains_key(&(MAX_UNPROCESSED_CHECKPOINTS as u64 + 4_999)),
+            "the furthest-ahead entry is the one dropped"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/ika-network/src/state_sync/mod.rs
+++ b/crates/ika-network/src/state_sync/mod.rs
@@ -88,6 +88,13 @@ use tracing::{debug, error, info, instrument, trace, warn};
 /// deployed on a fresh database chases checkpoint 1 forever ("no peers were
 /// able to help sync checkpoint 1"), synced pinned at 0 while known grows —
 /// the 2026-07 epoch-close outage shape (issue #1892).
+/// Ceiling on peer-pushed checkpoint bodies held per stream.
+///
+/// Generous relative to any legitimate backlog — sync advances sequentially,
+/// so the useful entries are the ones near our current position — while
+/// bounding what an unauthenticated push can pin in memory.
+const MAX_UNPROCESSED_CHECKPOINTS: usize = 10_000;
+
 #[derive(Clone)]
 pub struct OnChainCheckpointCursors {
     pub dwallet: watch::Receiver<Option<DWalletCheckpointSequenceNumber>>,
@@ -424,6 +431,39 @@ impl PeerHeights {
         self.unprocessed_checkpoints.insert(digest, checkpoint);
         self.sequence_number_to_digest
             .insert(sequence_number, digest);
+        Self::evict_beyond(
+            &mut self.unprocessed_checkpoints,
+            &mut self.sequence_number_to_digest,
+        );
+    }
+
+    /// Bounds the stored bodies by dropping the FURTHEST-ahead entries.
+    ///
+    /// These maps are fed directly by an unauthenticated push RPC whose rate
+    /// limit defaults to `None`, and are pruned only by
+    /// `cleanup_old_checkpoints`, which removes entries at or below a synced
+    /// target — so entries far ahead of us are never reached by that pruning
+    /// and accumulate without limit.
+    ///
+    /// Evicting from the top is deliberate: sync advances upward from where we
+    /// are, so the entries closest to our position are the useful ones, and a
+    /// peer pushing an implausibly high sequence number is exactly the case
+    /// worth discarding. A peer's reported HEIGHT is kept regardless — that is
+    /// one `u64`, it is what tells us how far behind we are, and bounding it
+    /// would blind the sync target.
+    fn evict_beyond<D, S, T>(bodies: &mut HashMap<D, T>, by_sequence: &mut HashMap<S, D>)
+    where
+        D: Copy + Eq + std::hash::Hash,
+        S: Copy + Ord + std::hash::Hash,
+    {
+        while by_sequence.len() > MAX_UNPROCESSED_CHECKPOINTS {
+            let Some(highest) = by_sequence.keys().copied().max() else {
+                break;
+            };
+            if let Some(digest) = by_sequence.remove(&highest) {
+                bodies.remove(&digest);
+            }
+        }
     }
 
     #[allow(unused)]
@@ -473,6 +513,10 @@ impl PeerHeights {
             .insert(digest, system_checkpoint);
         self.sequence_number_to_digest_system_checkpoint
             .insert(sequence_number, digest);
+        Self::evict_beyond(
+            &mut self.unprocessed_system_checkpoint,
+            &mut self.sequence_number_to_digest_system_checkpoint,
+        );
     }
 
     #[allow(unused)]

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -139,6 +139,22 @@ pub enum ConsensusTransactionKey {
     NOAPresignDemand([u8; 32]),
 }
 
+impl ConsensusTransactionKey {
+    /// Whether this key embeds an unbounded payload rather than being a
+    /// digest or a small tuple.
+    ///
+    /// Most variants are a digest or an `(authority, u64)`-shaped tuple —
+    /// tens of bytes. Two carry their whole MPC payload, so anything that
+    /// budgets by ENTRY COUNT rather than by bytes is really budgeting
+    /// `count * unbounded`.
+    pub fn embeds_payload(&self) -> bool {
+        matches!(
+            self,
+            Self::DWalletMPCMessage(..) | Self::DWalletMPCOutput(..)
+        )
+    }
+}
+
 impl Debug for ConsensusTransactionKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
Three structures fed by peer-supplied input that had no ceiling of any kind. Independent of each other; each is a bound, none changes a decision rule.

### What's here

- **`ValidatorMetadata` anemo service gets per-method inflight limits.** It had none, so any host able to open a connection could hold unlimited concurrent multi-megabyte blob reads, or unlimited relay calls that each occupy the handler until consensus sequences the announcement. The sibling `SuiStateMirror` service in the same crate caps all ten of its methods — the values here are calibrated against its tiers rather than picked fresh: 16 for blob reads (matching its heaviest read, `changeset_page`), 16 for the relay, 64 for the small certificate read.

- **Peer-pushed checkpoint bodies are bounded**, evicting the furthest-ahead first. `unprocessed_checkpoints` / `sequence_number_to_digest` are fed by a push RPC whose rate limit defaults to `None`, and pruned only by `cleanup_old_checkpoints` — which removes entries *at or below* a synced target, so entries far ahead were never reached by it at all. Evicting from the top is deliberate: sync advances upward from where we are, so entries nearest our position are the useful ones.

  A peer's reported **height** is deliberately left unbounded. It's a single `u64` per peer, and it's what tells us how far behind we are — capping it would blind the sync target. Only the bodies grow.

- **The two `ConsensusTransactionKey` variants that embed an MPC payload no longer enter the dedup LRU.** `PROCESSED_CACHE_CAP` budgets by entry *count*, which for those variants means `1M × unbounded` — a cap in name only.

### Why not just shrink the key

The obvious fix — hash or shrink the key — isn't available. `ConsensusTransactionKey` is BCS-serialized into the persisted `consensus_message_processed` DBMap and carries an explicit append-only discipline comment, so changing its shape is a stored-format change.

The LRU is a local fast path in front of that durable check, so declining to cache a key costs exactly one DB read and cannot affect correctness. And these are the least valuable entries to cache anyway: an MPC message or output is submitted once. `PROCESSED_CACHE_CAP` stays at 1M, which is now an honest number.

### Verification

`cargo check --workspace --all-targets`, `cargo clippy --all-targets -- -D warnings` on all three touched crates, `cargo fmt --all`.

No new tests: all three are ceilings on externally-driven growth, which the existing suites don't exercise. Cluster and upgrade suites are the meaningful signal and will run here.

### Follow-up

Two related findings are deliberately **not** in this PR, because they need design rather than a constant:
- the relayed-blob perpetual store has no pruning at all, and no signature check before persisting;
- bounding MPC session entries is consensus-observable — rejecting session creation has to distinguish peer-created from chain-event-created sessions, or the bound becomes a worse bug than the growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rLdsjCfcsTMaiLd3TX8w
