### PR TITLE
fix(dwallet-mpc,epoch-store): stop paying worst case per session, and per dropped relay

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -2934,27 +2934,33 @@ impl AuthorityPerEpochStore {
         signed: &SignedValidatorMpcDataAnnouncement,
         blob: &[u8],
     ) -> IkaResult {
-        // Persist the joiner's blob immediately (hash-verified,
-        // content-addressed) even if the announcement itself must be
-        // buffered until the joiner pubkey provider installs: bytes
-        // keyed by their own digest are inert unless a frozen digest
-        // matches them, so storage needn't wait on the signature check.
-        self.store_announced_mpc_data_blob(signed.announcement.blob_hash, blob);
+        // The blob is stored on every path that RETAINS the announcement —
+        // accepted, or buffered for re-evaluation — because those paths need
+        // the bytes later and consensus won't redeliver them. It is
+        // deliberately NOT stored on the drop path below: that verdict is
+        // final, and `mpc_artifact_blobs` is perpetual with no pruning, so
+        // persisting there left permanent bytes behind an announcement we had
+        // just decided to discard. Storage is still hash-verified and
+        // content-addressed, so ordering it after the verdict costs nothing.
         let next_epoch = self.epoch().saturating_add(1);
         let Some(provider) = self.joiner_pubkey_provider.load_full() else {
             // Provider not installed yet — buffer and re-evaluate on
             // install, rather than drop a relay consensus won't
             // redeliver.
+            self.store_announced_mpc_data_blob(signed.announcement.blob_hash, blob);
             self.buffer_relayed_joiner_announcement(signed);
             return Ok(());
         };
         match verify_joiner_announcement(signed, provider.as_ref().as_ref(), next_epoch) {
-            JoinerAnnouncementVerdict::Accept => {}
+            JoinerAnnouncementVerdict::Accept => {
+                self.store_announced_mpc_data_blob(signed.announcement.blob_hash, blob);
+            }
             JoinerAnnouncementVerdict::UnregisteredJoiner => {
                 // The installed provider predates this joiner's
                 // registration (a next-epoch committee snapshot that
                 // hasn't caught up). Buffer; the next provider install
                 // re-evaluates it.
+                self.store_announced_mpc_data_blob(signed.announcement.blob_hash, blob);
                 self.buffer_relayed_joiner_announcement(signed);
                 return Ok(());
             }
@@ -2965,7 +2971,8 @@ impl AuthorityPerEpochStore {
                 warn!(
                     ?verdict,
                     authority = ?signed.announcement.validator,
-                    "joiner mpc data announcement rejected — dropping"
+                    "joiner mpc data announcement rejected — dropping without \
+                     persisting its blob"
                 );
                 return Ok(());
             }

--- a/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_diagnostics.rs
@@ -548,8 +548,16 @@ pub(crate) struct BoundedSessionDiagnostics {
 
 impl BoundedSessionDiagnostics {
     pub(crate) fn new(initial_status: String) -> Self {
+        // Grow on demand rather than reserving the full ring up front. A
+        // session is created for any session identifier named by a message
+        // arriving through consensus, and the vast majority record a handful
+        // of events, so pre-reserving `MAX_SESSION_DIAGNOSTIC_EVENTS` slots
+        // paid the worst-case footprint for every session in the epoch —
+        // several kilobytes each, against a map that is not pruned until the
+        // epoch advances. `record` still caps the length, so the ceiling is
+        // unchanged; only the up-front reservation goes away.
         let mut diagnostics = Self {
-            events: VecDeque::with_capacity(MAX_SESSION_DIAGNOSTIC_EVENTS),
+            events: VecDeque::new(),
             dropped_events: 0,
             emitted_anomalies: HashSet::new(),
         };

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -146,8 +146,13 @@ pub enum JoinerAnnouncementVerdict {
     /// All checks passed; caller may proceed to apply the
     /// latest-by-timestamp insert rule.
     Accept,
-    /// The provider doesn't know about this authority. Drop the
-    /// announcement; it's either spam or the provider is stale.
+    /// The provider doesn't know about this authority — either spam, or
+    /// the provider predates the joiner's registration.
+    ///
+    /// NOT necessarily a drop: because a stale provider is indistinguishable
+    /// from spam here, the per-epoch store buffers this verdict and
+    /// re-evaluates it when the next provider installs. Only the signature
+    /// and envelope verdicts are final.
     UnregisteredJoiner,
     /// The joiner's Ed25519 signature didn't verify against its
     /// consensus pubkey.
@@ -161,9 +166,11 @@ pub enum JoinerAnnouncementVerdict {
 /// Pure verification of a next-epoch joiner announcement. Intended
 /// for both unit tests and for `AuthorityPerEpochStore`'s next-epoch
 /// branch — the per-epoch-store method calls this and only inserts
-/// on `Accept`. Returning anything other than `Accept` is non-fatal
-/// (callers should `drop and log`); these are protocol-level
-/// outcomes, not unexpected errors.
+/// on `Accept`. Returning anything other than `Accept` is non-fatal;
+/// these are protocol-level outcomes, not unexpected errors. What a
+/// caller does with a non-`Accept` verdict is its own decision — the
+/// per-epoch store drops the final ones and buffers `UnregisteredJoiner`
+/// for re-evaluation.
 pub fn verify_joiner_announcement(
     signed: &SignedValidatorMpcDataAnnouncement,
     provider: &dyn JoinerPubkeyProvider,


### PR DESCRIPTION
Two independent reductions in what peer-driven input leaves behind. Follow-up to #1997, which deferred both of these as needing design rather than a constant.

### Session diagnostics: grow on demand

`BoundedSessionDiagnostics::new` reserved all `MAX_SESSION_DIAGNOSTIC_EVENTS` ring slots up front. A session is created for any session identifier named by a message arriving through consensus, and the session map isn't pruned until the epoch advances — so every session in an epoch paid the worst-case footprint (several KB) no matter how few events it ever recorded.

`record` still enforces the same ceiling, so the bound is unchanged; only the reservation goes away.

**Deliberately not an admission cap.** Creating a session requires a committee member to push the message through consensus, so the rate is already bounded and attributable, and the map clears at the epoch boundary. Refusing to create a session, by contrast, is consensus-observable — validators disagreeing about which sessions exist is a worse failure than the growth it would prevent. The cost per entry was the real problem, and that's what's fixed.

### Relayed announcements: don't keep the blob of a dropped relay

`record_relayed_validator_mpc_data_announcement` persisted the blob before verifying anything. The `InvalidSignature` / `InconsistentEnvelope` arm then logs *"dropping"* — but `mpc_artifact_blobs` is perpetual with no pruning anywhere, so the bytes outlived the announcement we'd just decided to discard.

The blob is now stored on the paths that **retain** the announcement — accepted, or buffered for re-evaluation, both of which need it later and can't get it again because consensus won't redeliver — and not on the drop path. Storage is hash-verified and content-addressed either way, so ordering it after the verdict costs nothing.

**This narrows the exposure; it does not close it.** A validly-signed joiner, or a spammer arriving while the pubkey provider is absent, still writes blobs that nothing prunes. `mpc_artifact_blobs` has no retention policy at all — grep finds no remove/prune/delete against it. Giving it one (drop blobs never claimed by a frozen digest at epoch end) is a separate design and isn't in here.

### Verification

`cargo check --workspace --all-targets`, `cargo clippy -p ika-core -- -D warnings`, `cargo fmt --all`, `mpc_diagnostics` 10/10 — including the existing test that asserts the event ceiling still holds after the allocation change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rLdsjCfcsTMaiLd3TX8w
