### PR TITLE
fix: three self-contained correctness defects

### DIFF
--- a/crates/ika-core/src/epoch/committee_store.rs
+++ b/crates/ika-core/src/epoch/committee_store.rs
@@ -320,8 +320,13 @@ mod tests {
     /// `COMMITTEE_SCHEMA_VERSION_CURRENT`: gating on the current generation
     /// meant every bump re-armed the scan on every data directory the
     /// previous release had written, reopening the legacy view over
-    /// current-layout records — which `debug_fatal!`s under debug assertions,
-    /// so this test would panic rather than fail if the gate regressed.
+    /// current-layout records.
+    ///
+    /// A regressed gate fails THIS test on the assert: the scan would run and
+    /// rewrite the planted record, so the legacy view no longer finds it. The
+    /// `debug_fatal!` panic is the failure mode for a store holding
+    /// current-layout records, which `marker_skips_the_scan_on_reopen`
+    /// covers.
     #[tokio::test]
     async fn an_older_marker_generation_still_skips_the_scan() {
         let path = fresh_path();

--- a/crates/ika-core/src/epoch/committee_store.rs
+++ b/crates/ika-core/src/epoch/committee_store.rs
@@ -54,6 +54,23 @@ pub struct CommitteeStoreTables {
 /// decode errors instead of panicking, precisely for old-layout records.
 const COMMITTEE_SCHEMA_VERSION_CURRENT: u64 = 3;
 
+/// The marker generation at and above which the one-time 1.1.8 legacy scan is
+/// known to be unnecessary.
+///
+/// Deliberately NOT `COMMITTEE_SCHEMA_VERSION_CURRENT`. That constant answers
+/// "which layout does this binary write", and it moves whenever the record
+/// shape changes; this one answers "could this store still hold 1.1.8
+/// records", which stopped being true the moment any marker-writing binary
+/// opened it. Gating the scan on the current generation re-armed it on every
+/// data dir written by the previous release — the exact reopen-under-the-
+/// legacy-view pattern the marker was introduced to stop, which `debug_fatal!`s
+/// on a current-layout record in debug and msim builds.
+///
+/// The re-armed scan could not have helped either: a genuine 1.1.8 record
+/// carries 48-byte BLS-basis names in `voting_rights`, which the deserializer
+/// now rejects outright, so the loop can only produce decode failures.
+const COMMITTEE_SCHEMA_VERSION_MIGRATED: u64 = 2;
+
 // These functions are used to initialize the DB tables
 fn committee_table_default_config() -> DBOptions {
     default_db_options().optimize_for_point_lookup(64)
@@ -97,7 +114,7 @@ impl CommitteeStore {
         // #1836). Release builds log-and-skip instead, which is why the
         // real-binary upgrade rehearsal never saw it.
         match tables.committee_schema_version.get(&()) {
-            Ok(Some(version)) if version >= COMMITTEE_SCHEMA_VERSION_CURRENT => return,
+            Ok(Some(version)) if version >= COMMITTEE_SCHEMA_VERSION_MIGRATED => return,
             Ok(_) => {}
             Err(e) => {
                 // A marker read error must NOT skip the migration: a
@@ -293,6 +310,45 @@ mod tests {
                 .unwrap()
                 .is_some(),
             "the marker-guarded reopen must not have rewritten the record"
+        );
+    }
+
+    /// A store carrying an OLDER marker generation must still skip the scan.
+    ///
+    /// This is the regression that motivated splitting
+    /// `COMMITTEE_SCHEMA_VERSION_MIGRATED` out of
+    /// `COMMITTEE_SCHEMA_VERSION_CURRENT`: gating on the current generation
+    /// meant every bump re-armed the scan on every data directory the
+    /// previous release had written, reopening the legacy view over
+    /// current-layout records — which `debug_fatal!`s under debug assertions,
+    /// so this test would panic rather than fail if the gate regressed.
+    #[tokio::test]
+    async fn an_older_marker_generation_still_skips_the_scan() {
+        let path = fresh_path();
+        let (legacy_committee, _keys) = Committee::new_simple_test_committee_of_size(4);
+        {
+            let store = CommitteeStore::new(path.clone(), None);
+            // Pretend this directory was last opened by the previous release,
+            // which wrote generation 2.
+            store
+                .tables
+                .committee_schema_version
+                .insert(&(), &COMMITTEE_SCHEMA_VERSION_MIGRATED)
+                .unwrap();
+            legacy_view(&store)
+                .insert(
+                    &legacy_committee.epoch,
+                    &LegacyCommittee::mirror_of(&legacy_committee),
+                )
+                .unwrap();
+        }
+        let store = CommitteeStore::new(path.clone(), None);
+        assert!(
+            legacy_view(&store)
+                .get(&legacy_committee.epoch)
+                .unwrap()
+                .is_some(),
+            "a store marked as already migrated must not be re-scanned"
         );
     }
 

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -570,7 +570,24 @@ impl PartialOrd for SessionIdentifier {
 
 impl Ord for SessionIdentifier {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.session_identifier.cmp(&other.session_identifier)
+        // Every field, so `Ord` agrees with the derived `Eq`/`Hash`. Comparing
+        // the digest alone reported `Equal` for values that are `!=` — which
+        // breaks the total-order contract that `BTreeMap`, `sort` and `dedup`
+        // rely on, and is reachable because `Deserialize` is derived and so
+        // accepts any (type, digest, preimage) triple off the wire rather than
+        // only the ones `new` can produce.
+        //
+        // Digest first, so the order is unchanged wherever digests differ —
+        // which is every honestly-constructed pair, since the digest commits
+        // to the other two fields. The remaining fields only break ties that
+        // could not previously be broken at all.
+        self.session_identifier
+            .cmp(&other.session_identifier)
+            .then_with(|| self.session_type.cmp(&other.session_type))
+            .then_with(|| {
+                self.session_identifier_preimage
+                    .cmp(&other.session_identifier_preimage)
+            })
     }
 }
 

--- a/crates/ika/src/validator_commands.rs
+++ b/crates/ika/src/validator_commands.rs
@@ -1211,6 +1211,21 @@ fn read_or_generate_root_seed(
 }
 
 fn generate_new_root_seed(seed_path: PathBuf) -> Result<PathBuf> {
+    // Refuse to write over an existing file. A root seed is the only copy of
+    // a validator's MPC secrets — there is no derivation path back to it —
+    // and this command defaults its target to `root-seed.key` in the CURRENT
+    // WORKING DIRECTORY, so an operator running it from a node's data
+    // directory would otherwise destroy the live seed with no prompt and no
+    // backup. Refusing costs one manual `mv`; the alternative is
+    // unrecoverable.
+    if seed_path.exists() {
+        anyhow::bail!(
+            "refusing to overwrite an existing root seed at {}. A root seed cannot be \
+             recovered once replaced — move or delete this file deliberately if you really \
+             intend to generate a new one.",
+            seed_path.display()
+        );
+    }
     RootSeed::random_seed().save_to_file(seed_path.clone())?;
     Ok(seed_path)
 }
@@ -1265,18 +1280,23 @@ mod tests {
     }
 
     #[test]
-    fn generate_new_root_seed_overwrites_with_valid_seed() {
+    fn generate_new_root_seed_writes_once_and_then_refuses() {
         let temporary_directory = tempfile::tempdir().unwrap();
         let seed_path = temporary_directory.path().join("root-seed.key");
         let first_path = generate_new_root_seed(seed_path.clone()).unwrap();
         let first_bytes = fs::read(&first_path).unwrap();
-
-        let second_path = generate_new_root_seed(seed_path.clone()).unwrap();
-        let second_bytes = fs::read(&second_path).unwrap();
-
         assert_eq!(first_path, seed_path);
-        assert_eq!(second_path, seed_path);
-        assert_ne!(first_bytes, second_bytes);
-        RootSeed::from_file(seed_path).unwrap();
+        RootSeed::from_file(seed_path.clone()).unwrap();
+
+        // A root seed is unrecoverable once replaced, and this command
+        // defaults to the working directory — so a second run must not
+        // silently destroy the first seed.
+        let second = generate_new_root_seed(seed_path.clone());
+        assert!(second.is_err(), "a second run must refuse, not overwrite");
+        assert_eq!(
+            fs::read(&seed_path).unwrap(),
+            first_bytes,
+            "the existing seed must be left byte-identical"
+        );
     }
 }


### PR DESCRIPTION
Three independent defects, none of which touches a consensus decision rule. Grouped because each is small and they don't interact.

### `SessionIdentifier`: `Ord` disagreed with `Eq`

`Ord` compared only the digest while `Eq`/`Hash` derive over all three fields, so two values could compare `Equal` while being `!=` — breaking the total-order contract `BTreeMap`, `sort` and `dedup` rely on.

Reachable rather than theoretical: `Deserialize` is derived, so any `(type, digest, preimage)` triple arrives off the wire, not just the ones `new` can construct.

Now compares every field, **digest first** — so ordering is unchanged wherever digests differ, which is every honestly-constructed pair (the digest commits to the other two fields). The remaining fields only break ties that previously couldn't be broken at all. I checked before changing it: nothing keys an ordered container by this type and nothing sorts it, so no ordering anywhere moves.

### Committee-store schema marker re-armed a migration it can't perform

The one-time 1.1.8 legacy scan was gated on `COMMITTEE_SCHEMA_VERSION_CURRENT`. That constant answers *"which layout does this binary write"* and moves whenever the record shape changes — so bumping it to 3 re-armed the scan on **every data directory the previous release wrote**, reopening the legacy view over current-layout records. That's the exact pattern the marker was introduced to prevent, and it `debug_fatal!`s in debug and msim builds.

Split out `COMMITTEE_SCHEMA_VERSION_MIGRATED`, which answers *"could this store still hold 1.1.8 records"* — false the moment any marker-writing binary opens it.

The re-armed scan couldn't have helped anyway: a genuine 1.1.8 record carries 48-byte BLS-basis names that the deserializer now rejects outright, so the loop could only produce decode failures.

New test covers a store carrying the older marker generation. **Fault-validated** — restoring the gate to the current generation fails that test and nothing else. Note it would *panic* rather than fail under debug assertions if the gate regressed, which is the failure mode being prevented.

### `ika validator set-next-epoch-mpc-data` could destroy a live root seed

`generate_new_root_seed` overwrote unconditionally, and its only caller targets `root-seed.key` in the **current working directory**. An operator running the command from a node's data directory destroyed the live seed — no prompt, no backup, and a root seed has no recovery path.

It now refuses when the target exists. The existing test was named `..._overwrites_with_valid_seed` and asserted the destructive behaviour — it encoded the defect — so it's rewritten to assert the refusal and that the original bytes survive byte-for-byte.

**Correction to the report this came from:** it also claimed the command publishes the new class-groups key on chain before persisting the seed. It publishes nothing — it generates a file and prints its path. There's no ordering bug, only the destructive write.

### Verification

`cargo check --workspace --all-targets`, `cargo clippy -- -D warnings` on all three touched crates, `cargo fmt --all`, `committee_store` 10/10, CLI seed test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rLdsjCfcsTMaiLd3TX8w
