### PR TITLE
fix(sui-connector): bind a summary to its sequence, and bootstrap currency where a peer can serve it

### DIFF
--- a/crates/ika-core/src/authority/authority_perpetual_tables.rs
+++ b/crates/ika-core/src/authority/authority_perpetual_tables.rs
@@ -479,6 +479,19 @@ impl AuthorityPerpetualTables {
         Ok(())
     }
 
+    /// The highest-epoch retained end-of-epoch summary, if any.
+    ///
+    /// The counterpart to [`Self::oldest_sui_committee_summary`]. The oldest is
+    /// the deepest checkpoint this node can committee-verify; the newest is the
+    /// most RECENT one it can, which is what a backfill that has to be served
+    /// by a peer needs — a peer only retains recent history.
+    pub fn newest_sui_committee_summary(&self) -> IkaResult<Option<SuiCertifiedCheckpointSummary>> {
+        let Some(head_epoch) = self.highest_sui_committee_epoch()? else {
+            return Ok(None);
+        };
+        self.get_sui_committee_summary(head_epoch)
+    }
+
     pub fn get_sui_committee_summary(
         &self,
         sui_epoch: u64,

--- a/crates/ika-core/src/sui_connector/setup.rs
+++ b/crates/ika-core/src/sui_connector/setup.rs
@@ -383,10 +383,22 @@ pub async fn build_sui_connector_stack(
     // Mirrored / peer-only currency: a changeset index the reader consults,
     // folded by a background `ChangesetReceiver` that pulls committee-signed
     // changesets from the relay. Direct nodes leave it `None` (their pusher-fed
-    // cache is already a complete, contiguous fold). The receiver backfills from
-    // the oldest committee-verifiable checkpoint — the anchor summary's seq + 1
-    // (it can't verify earlier); if the serving peer has pruned below that,
-    // currency stays dormant on those objects, a safe `Unknown` fallback.
+    // cache is already a complete, contiguous fold). The receiver backfills
+    // from the NEWEST committee-verifiable checkpoint — the highest retained
+    // transition summary's seq + 1.
+    //
+    // Newest, not oldest. The oldest retained summary is the epoch-0
+    // transition and that table is never pruned, so an oldest-anchored
+    // bootstrap asks a peer for history it pruned long ago. Nothing absorbs,
+    // the index stays empty, and because the cursor falls back to
+    // `bootstrap_from` precisely WHEN the index is empty, the next poll asks
+    // for the same unavailable checkpoint — forever. Currency never engages at
+    // all, rather than being dormant on some objects, and `check_currency`
+    // answers `Unknown` (accept) for everything.
+    //
+    // Anchoring recent also matches what the index keeps: entries below
+    // `CHANGESET_RETAIN_WINDOW` of the head are dropped, so a genesis-anchored
+    // fold would discard its own output as it produced it.
     const CHANGESET_PAGE_LIMIT: u32 = 64;
     const CHANGESET_POLL_INTERVAL: Duration = Duration::from_secs(2);
     // Keep currency for objects modified within this many checkpoints of the
@@ -405,8 +417,8 @@ pub async fn build_sui_connector_stack(
     let changeset_receiver = match (changeset_source, &changeset_index) {
         (Some(source), Some(index)) => {
             let bootstrap_from = perpetual
-                .oldest_sui_committee_summary()
-                .map_err(|e| SetupError::Transport(format!("oldest committee summary: {e}")))?
+                .newest_sui_committee_summary()
+                .map_err(|e| SetupError::Transport(format!("newest committee summary: {e}")))?
                 .map(|summary| (*summary.sequence_number()).saturating_add(1))
                 .unwrap_or(0);
             Some(ChangesetReceiver::new(

--- a/crates/ika-core/src/sui_connector/verified_reader.rs
+++ b/crates/ika-core/src/sui_connector/verified_reader.rs
@@ -572,6 +572,27 @@ impl OcsVerifiedReader {
                     let verified_summary = self
                         .verify_summary(summary)
                         .map_err(|e| self.record_fail("batch_objects", e))?;
+                    // The map key is the RELAY'S claim about which
+                    // checkpoint this entry came from; `verify_summary` only
+                    // proves the summary is genuine, not that it is the
+                    // summary for THAT sequence. Without this, a relay could
+                    // file a genuine committee-signed summary for an old
+                    // checkpoint under an arbitrary current-looking key and
+                    // serve a validly-proven stale object against it —
+                    // passing the freshness check on the claimed number while
+                    // the proof binds to the old one. The single-object path
+                    // avoids this by taking the sequence FROM the summary
+                    // (`*resp.summary.sequence_number()`); these paths need
+                    // the key to find the summary, so they assert instead.
+                    if *verified_summary.sequence_number() != seq {
+                        return Err(self.record_fail(
+                            "batch_objects",
+                            ReaderError::InvalidProof(format!(
+                                "summary served for checkpoint {seq} is actually checkpoint {}",
+                                verified_summary.sequence_number()
+                            )),
+                        ));
+                    }
                     e.insert(verified_summary)
                 }
             };
@@ -777,6 +798,27 @@ impl OcsVerifiedReader {
                     let verified_summary = self
                         .verify_summary(summary)
                         .map_err(|e| self.record_fail("dynamic_field_entry", e))?;
+                    // The map key is the RELAY'S claim about which
+                    // checkpoint this entry came from; `verify_summary` only
+                    // proves the summary is genuine, not that it is the
+                    // summary for THAT sequence. Without this, a relay could
+                    // file a genuine committee-signed summary for an old
+                    // checkpoint under an arbitrary current-looking key and
+                    // serve a validly-proven stale object against it —
+                    // passing the freshness check on the claimed number while
+                    // the proof binds to the old one. The single-object path
+                    // avoids this by taking the sequence FROM the summary
+                    // (`*resp.summary.sequence_number()`); these paths need
+                    // the key to find the summary, so they assert instead.
+                    if *verified_summary.sequence_number() != seq {
+                        return Err(self.record_fail(
+                            "dynamic_field_entry",
+                            ReaderError::InvalidProof(format!(
+                                "summary served for checkpoint {seq} is actually checkpoint {}",
+                                verified_summary.sequence_number()
+                            )),
+                        ));
+                    }
                     e.insert(verified_summary)
                 }
             };
@@ -2567,6 +2609,43 @@ mod tests {
         assert!(
             matches!(err, ReaderError::Transport(TransportError::NotFound(_))),
             "expected NotFound for the slot/id count mismatch, got {err:?}",
+        );
+    }
+
+    /// A relay may file a GENUINE committee-signed summary under a sequence
+    /// number that summary did not come from.
+    ///
+    /// Everything else in the path still passes: the summary verifies (it is
+    /// real), the inclusion proof verifies against it (it was built for that
+    /// checkpoint), and the freshness check sees only the fabricated,
+    /// current-looking number. So the anchor a stale object is judged by
+    /// becomes the relay's choice — which is what the currency gate exists to
+    /// deny. The single-object path is immune because it reads the sequence
+    /// off the summary; these paths need the key to FIND the summary, so they
+    /// have to assert the two agree.
+    #[tokio::test]
+    async fn batch_read_rejects_a_summary_filed_under_the_wrong_sequence() {
+        let (committee, keypairs) = SuiCommittee::new_simple_test_committee();
+        let id = ObjectID::from_single_byte(0x31);
+        let object = test_object(id, 3, address_owner(0xAB));
+        // A real summary and a real proof, both for checkpoint 100 ...
+        let (summary_for_100, proof) =
+            sign_inclusion(&committee, &keypairs, 100, &[&object], &object);
+        // ... served as though they were checkpoint 900's.
+        let entry = field_entry(object, proof, 900, "", Vec::new());
+        let resp = BatchVerifiedObjectsResponse {
+            summaries: BTreeMap::from([(900, summary_for_100)]),
+            results: vec![Some(entry)],
+            claimed_latest_checkpoint_seq: 900,
+        };
+        let (_dir, reader, _metrics) = reader_with(StagedProvider::batch(resp), committee, None);
+        let err = reader
+            .verified_objects(&[id])
+            .await
+            .expect_err("a summary filed under a sequence it did not come from must be rejected");
+        assert!(
+            matches!(err, ReaderError::InvalidProof(_)),
+            "expected InvalidProof for the summary/sequence mismatch, got {err:?}",
         );
     }
 

--- a/crates/ika-core/src/sui_connector/verified_reader.rs
+++ b/crates/ika-core/src/sui_connector/verified_reader.rs
@@ -2612,6 +2612,36 @@ mod tests {
         );
     }
 
+    /// The dynamic-field twin of
+    /// `batch_read_rejects_a_summary_filed_under_the_wrong_sequence`. The
+    /// assertion is duplicated in both paths, so the coverage has to be too —
+    /// otherwise removing one of them stays green.
+    #[tokio::test]
+    async fn field_page_rejects_a_summary_filed_under_the_wrong_sequence() {
+        let (committee, keypairs) = SuiCommittee::new_simple_test_committee();
+        let parent_id = ObjectID::from_single_byte(0x57);
+        let entry_id = ObjectID::from_single_byte(0x58);
+        let object = test_object(entry_id, 1, Owner::ObjectOwner(parent_id.into()));
+        // Genuine summary and proof for checkpoint 100, served as 900.
+        let (summary_for_100, proof) =
+            sign_inclusion(&committee, &keypairs, 100, &[&object], &object);
+        let provider = StagedProvider::bag(field_page_response(
+            summary_for_100,
+            field_entry(object, proof, 900, "", vec![]),
+            900,
+        ));
+        let (_dir, reader, _metrics) = reader_with(provider, committee, None);
+
+        let err = reader
+            .verified_dynamic_fields_page(parent_id, None, None)
+            .await
+            .expect_err("a summary filed under a sequence it did not come from must be rejected");
+        assert!(
+            matches!(err, ReaderError::InvalidProof(_)),
+            "expected InvalidProof for the summary/sequence mismatch, got {err:?}",
+        );
+    }
+
     /// A relay may file a GENUINE committee-signed summary under a sequence
     /// number that summary did not come from.
     ///


### PR DESCRIPTION
Two defects in the verified-read currency gate. One lets a relay choose the anchor a read is judged against; the other means the gate never engages at all.

### A summary was never bound to the sequence it was served under

The batch and dynamic-field paths took the checkpoint sequence from the wire (`entry.checkpoint_seq`) and looked the summary up under that same relay-chosen key.

`verify_summary` proves a summary is **genuine** — not that it's the summary **for that sequence**. So a relay could file a real, committee-signed summary for an old checkpoint under a current-looking key and serve a validly-proven stale object against it. Everything else still passes: the summary verifies, the inclusion proof verifies against it (it was built for that checkpoint), and the freshness check sees only the fabricated number.

Both paths now assert the verified summary's own sequence equals the key.

The single-object path was already immune — it reads the sequence off the summary (`*resp.summary.sequence_number()`). These two need the key to *find* the summary in the response map, so they can't derive it and assert instead. That asymmetry is now in a comment so nobody "simplifies" the assertion away.

New test stages a genuine checkpoint-100 summary and proof filed as checkpoint 900. **Fault-validated:** disabling the batch-path assertion fails exactly that test.

### Currency bootstrapped from history no peer retains

The changeset receiver anchored at `oldest_sui_committee_summary`. That table is never pruned, so the anchor is the epoch-0 transition — history a peer pruned long ago.

The consequence is worse than a slow start. The cursor is `highest_contiguous_seq().map(|s| s + 1).unwrap_or(bootstrap_from)`, and the fallback fires **precisely when the index is empty**. So: nothing absorbs, the index stays empty, the next poll requests the same unavailable checkpoint, forever. The gate never engages, and `check_currency` answers `Unknown` (accept) for every object rather than being dormant for some.

Now anchors at the **newest** committee-verifiable summary — at most one epoch old, so a peer still retains it. That also matches what the index keeps: entries below `CHANGESET_RETAIN_WINDOW` (432k) of the head are dropped, so a genesis-anchored fold would have been discarding its own output as it produced it, even against a peer with full history.

Adds `newest_sui_committee_summary`, mirroring the existing `oldest_`. The old comment documented the previous intent, so it is rewritten to say what the code does now and why newest rather than oldest — otherwise the next reader restores the old behaviour.

### Trade-off worth reviewing

A recent anchor means objects not modified since it have **no** index entry, so currency returns `Unknown` (accept) for them — a narrower gate than a complete fold would give. That is strictly better than today's "never engages for anything," but it is a real ceiling: currency covers objects modified since the last epoch transition, not all objects. If you want deeper coverage, the lever is a backfill that walks *down* from the anchor as far as the peer will serve, which is a bigger change than this.

### Verification

`cargo check --workspace --all-targets`, `cargo clippy -p ika-core -- -D warnings`, `cargo fmt --all`, `verified_reader` 43/43, `changeset_receiver` 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rLdsjCfcsTMaiLd3TX8w
