### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-classgroups-types"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "bcs",
  "class_groups",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-rng"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "commitment",
  "fastcrypto",
@@ -6552,7 +6552,7 @@ dependencies = [
 
 [[package]]
 name = "ika"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6598,7 +6598,7 @@ dependencies = [
 
 [[package]]
 name = "ika-archival"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6769,7 +6769,7 @@ dependencies = [
 
 [[package]]
 name = "ika-node"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6840,7 +6840,7 @@ dependencies = [
 
 [[package]]
 name = "ika-proxy"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -6988,7 +6988,7 @@ dependencies = [
 
 [[package]]
 name = "ika-test-cluster"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7072,7 +7072,7 @@ dependencies = [
 
 [[package]]
 name = "ika-upgrade-test"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 [workspace.package]
 # This version string will be inherited by ika-core, ika-node, ika-tools, ika-sdk, and ika crates.
-version = "1.2.8"
+version = "1.3.0"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/sdk/ika-wasm/Cargo.lock
+++ b/sdk/ika-wasm/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.2.8"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "bcs",


### PR DESCRIPTION
Supersedes #1987 (closed by a head-branch rename — same commit, same checks). Bumps the workspace version for the next release: **1.3.0**.

Minor rather than patch because the release carries:
- a breaking validator config change (#1969) — the 10 remaining legacy-config validators must migrate,
- the Sui `mainnet-v1.76.1` + Rust 1.97.1 platform bump (#1992),
- the operational-hardening series (#1995, #1996, #1997, #1998, #1999, #2000, #2001).

Footprint mirrors every prior bump: root `Cargo.toml` version, root `Cargo.lock`, and `sdk/ika-wasm/Cargo.lock` (workspace-member versions only — external deps untouched in both locks). Built on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)