### PR TITLE
fix(epoch-store): don't let a rejected relay consume a joiner's consensus key

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -129,6 +129,20 @@ pub enum CancelConsensusCertificateReason {
     DkgFailed,
 }
 
+/// Whether a relayed joiner announcement was kept or discarded.
+///
+/// The distinction decides whether its consensus key is recorded as
+/// processed. The key is `(joiner, epoch, timestamp)` — the joiner's identity,
+/// not the relayer's — so recording it consumes that identity's one slot for
+/// the epoch. Only a copy we actually kept has earned that.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RelayedAnnouncementDisposition {
+    /// Accepted, or buffered for re-evaluation when a provider installs.
+    Retained,
+    /// Rejected on a verdict that re-evaluation cannot change.
+    Discarded,
+}
+
 pub enum ConsensusCertificateResult {
     /// The consensus message was ignored (e.g. because it has already been processed).
     Ignored,
@@ -2929,11 +2943,11 @@ impl AuthorityPerEpochStore {
     /// for the payload, so the joiner's Ed25519 consensus-key
     /// signature is verified against its next-epoch consensus pubkey
     /// (via the installed `JoinerPubkeyProvider`) before storing.
-    pub fn record_relayed_validator_mpc_data_announcement(
+    pub(crate) fn record_relayed_validator_mpc_data_announcement(
         &self,
         signed: &SignedValidatorMpcDataAnnouncement,
         blob: &[u8],
-    ) -> IkaResult {
+    ) -> IkaResult<RelayedAnnouncementDisposition> {
         // The blob is stored on every path that RETAINS the announcement —
         // accepted, or buffered for re-evaluation — because those paths need
         // the bytes later and consensus won't redeliver them. It is
@@ -2949,7 +2963,7 @@ impl AuthorityPerEpochStore {
             // redeliver.
             self.store_announced_mpc_data_blob(signed.announcement.blob_hash, blob);
             self.buffer_relayed_joiner_announcement(signed);
-            return Ok(());
+            return Ok(RelayedAnnouncementDisposition::Retained);
         };
         match verify_joiner_announcement(signed, provider.as_ref().as_ref(), next_epoch) {
             JoinerAnnouncementVerdict::Accept => {
@@ -2962,7 +2976,7 @@ impl AuthorityPerEpochStore {
                 // re-evaluates it.
                 self.store_announced_mpc_data_blob(signed.announcement.blob_hash, blob);
                 self.buffer_relayed_joiner_announcement(signed);
-                return Ok(());
+                return Ok(RelayedAnnouncementDisposition::Retained);
             }
             verdict @ (JoinerAnnouncementVerdict::InvalidSignature
             | JoinerAnnouncementVerdict::InconsistentEnvelope) => {
@@ -2972,12 +2986,13 @@ impl AuthorityPerEpochStore {
                     ?verdict,
                     authority = ?signed.announcement.validator,
                     "joiner mpc data announcement rejected — dropping without \
-                     persisting its blob"
+                     persisting its blob or consuming its consensus key"
                 );
-                return Ok(());
+                return Ok(RelayedAnnouncementDisposition::Discarded);
             }
         }
-        self.insert_validator_mpc_data_announcement(&signed.announcement)
+        self.insert_validator_mpc_data_announcement(&signed.announcement)?;
+        Ok(RelayedAnnouncementDisposition::Retained)
     }
 
     /// Buffers a relayed joiner announcement whose signature can't be
@@ -5619,8 +5634,26 @@ impl AuthorityPerEpochStore {
                 kind: ConsensusTransactionKind::RelayedValidatorMpcDataAnnouncement(signed, blob),
                 ..
             }) => {
-                self.record_relayed_validator_mpc_data_announcement(signed, blob)?;
-                Ok(ConsensusCertificateResult::ConsensusMessage)
+                // A discarded copy must not consume the joiner's key. The key
+                // is `(joiner, epoch, timestamp)` and this message kind carries
+                // NO sender constraint — any committee member may relay for any
+                // joiner — while the joiner's signature can only be checked
+                // here, not at admission (the pubkey provider may not be
+                // installed yet). Recording a rejected copy as processed
+                // therefore let one member burn a joiner's slot with a
+                // corrupted duplicate: every honest relay of the genuine
+                // announcement shares that key and was dropped as already
+                // processed, and the joiner cannot detect it because its
+                // success signal is the relayer's accept, not consensus
+                // inclusion. `Ignored` leaves the key free for the real one.
+                match self.record_relayed_validator_mpc_data_announcement(signed, blob)? {
+                    RelayedAnnouncementDisposition::Retained => {
+                        Ok(ConsensusCertificateResult::ConsensusMessage)
+                    }
+                    RelayedAnnouncementDisposition::Discarded => {
+                        Ok(ConsensusCertificateResult::Ignored)
+                    }
+                }
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::EpochMpcDataReadySignal(signal),

--- a/crates/ika-core/src/epoch_tasks/announcement_relay.rs
+++ b/crates/ika-core/src/epoch_tasks/announcement_relay.rs
@@ -227,7 +227,7 @@ mod tests {
         StaticJoinerPubkeyProvider, derive_mpc_data_blob, sign_validator_mpc_data_announcement,
     };
     use dwallet_rng::RootSeed;
-    use fastcrypto::ed25519::{Ed25519KeyPair, Ed25519PrivateKey};
+    use fastcrypto::ed25519::{Ed25519KeyPair, Ed25519PrivateKey, Ed25519Signature};
     use fastcrypto::traits::{KeyPair as _, ToFromBytes};
     use ika_network::mpc_artifacts::{InMemoryBlobStore, mpc_data_blob_hash};
     use ika_types::committee::Committee;
@@ -352,6 +352,91 @@ mod tests {
             .expect("relay must resolve once the announcement is sequenced")
             .unwrap();
         assert_eq!(result, Ok(()));
+    }
+
+    /// A rejected relay must not consume the joiner's consensus key.
+    ///
+    /// The key is `(joiner, epoch, timestamp)` — the joiner's identity, not
+    /// the relayer's — and this message kind carries no sender constraint,
+    /// because any committee member may legitimately relay for any joiner.
+    /// The joiner's signature can only be checked when the record handler
+    /// runs, not at admission, since the pubkey provider may not be installed
+    /// yet. So if a rejected copy were recorded as processed, one member could
+    /// relay a corrupted duplicate first and every honest relay of the genuine
+    /// announcement — which shares that key — would be dropped as already
+    /// processed. The joiner cannot notice: its success signal is the
+    /// relayer's accept, not consensus inclusion.
+    #[tokio::test]
+    async fn a_rejected_relay_leaves_the_joiners_key_free_for_the_genuine_one() {
+        let (epoch_store, signed, blob, _relay) = relay_fixture();
+
+        // Same envelope — so the same consensus key — with a corrupted
+        // signature. This is what a censoring relayer would submit.
+        let mut corrupted = signed.clone();
+        let mut signature_bytes = corrupted.joiner_sig.as_ref().to_vec();
+        signature_bytes[0] ^= 0xFF;
+        corrupted.joiner_sig = Ed25519Signature::from_bytes(&signature_bytes)
+            .expect("a corrupted signature still decodes");
+
+        let key = ConsensusTransaction::new_relayed_validator_mpc_data_announcement(
+            signed.clone(),
+            blob.clone(),
+        )
+        .key();
+        let sequenced_key = SequencedConsensusTransactionKey::External(key);
+
+        drive_commit(&epoch_store, corrupted, blob.clone(), 1).await;
+        assert!(
+            !epoch_store
+                .is_consensus_message_processed(&sequenced_key)
+                .unwrap(),
+            "a rejected copy must not burn the joiner's key"
+        );
+
+        // The genuine announcement, relayed after, must still land.
+        drive_commit(&epoch_store, signed.clone(), blob, 2).await;
+        assert!(
+            epoch_store
+                .is_consensus_message_processed(&sequenced_key)
+                .unwrap(),
+            "the genuine announcement must be processed, not skipped as a duplicate"
+        );
+        assert!(
+            epoch_store
+                .get_validator_mpc_data_announcement(&signed.announcement.validator)
+                .unwrap()
+                .is_some(),
+            "the joiner's announcement must be recorded"
+        );
+    }
+
+    /// Drive one relayed announcement through the real commit boundary.
+    async fn drive_commit(
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+        signed: SignedValidatorMpcDataAnnouncement,
+        blob: Vec<u8>,
+        round: u64,
+    ) {
+        let tx = ConsensusTransaction::new_relayed_validator_mpc_data_announcement(signed, blob);
+        epoch_store
+            .process_consensus_transactions_and_commit_boundary(
+                vec![VerifiedSequencedConsensusTransaction::new_test(tx)],
+                &ExecutionIndicesWithStats {
+                    index: ExecutionIndices {
+                        last_committed_round: round,
+                        sub_dag_index: 0,
+                        transaction_index: 0,
+                    },
+                    hash: 0,
+                    stats: ConsensusStats::default(),
+                },
+                &None::<Arc<DWalletCheckpointService>>,
+                &None::<Arc<SystemCheckpointService>>,
+                &ConsensusCommitInfo::new_for_test(round, 1_000 * round, true),
+                &Arc::new(AuthorityMetrics::new(&Registry::new())),
+            )
+            .await
+            .unwrap();
     }
 
     /// If the announcement never lands, the relay must reject rather


### PR DESCRIPTION
A joining validator isn't in the consensus committee, so it announces its MPC data by asking current members to relay for it. One member could stop that permanently, silently, with a single message.

### Three correct decisions that combine badly

- The relay message carries **no sender constraint** — any member may legitimately relay for any joiner. The verification arm is literally `let _ = signed;`.
- The joiner's signature is checked **in the record handler, not at admission** — it has to be, because the joiner pubkey provider may not be installed yet and the announcement must be buffered until it is.
- The consensus key is **`(joiner, epoch, timestamp)`**, taken from the announcement rather than the relayer, so honest relays of the same announcement collapse into one transaction instead of one per relayer.

So the key commits to the joiner's identity, while nothing verifies the copy came from the joiner before that identity is consumed. And processing returned `ConsensusMessage` unconditionally — including when the handler dropped the announcement as `InvalidSignature` — so the key was recorded as processed either way.

### The attack

Copy a joiner's envelope, corrupt one signature byte, relay it first. It passes admission (nothing is checked), the handler rejects it, and the key is burned. Every honest relay of the genuine announcement shares that key and is dropped as already processed.

The joiner cannot detect it:

- it signs **once** and re-sends the same envelope on every retry, so all retries carry the already-burned key;
- its success signal is the **relayer's accept**, which happens when the relayer queues the transaction — before the dedup discards it. It sees its accept threshold met and stops.

Its mpc_data never lands, and it joins the committee unable to participate in MPC.

### The fix

The record handler now reports a disposition, and a final-verdict discard maps to `ConsensusCertificateResult::Ignored` — which already exists for exactly this, with the comment *"ignored external transactions must not be recorded as processed."*

Buffered announcements stay `Retained`: re-evaluation can still accept them, so their key legitimately belongs to them. Only verdicts that re-evaluation cannot change release the key.

### Why no protocol gate

I initially thought this needed one, and it doesn't.

`freeze_mpc_data_if_first` tallies **purely from consensus-ordered ready-signals** and deliberately does *not* read the local announcement table — with a comment saying why: a validator whose provider lagged would otherwise shrink the frozen set and diverge from peers. So a mixed fleet disagreeing about a locally-recorded announcement does **not** diverge the frozen set, which was my only argument for gating.

And in honest operation no announcement is ever discarded, so the change is a no-op there.

### Verification

`cargo check --workspace --all-targets`, `cargo clippy -p ika-core -- -D warnings`, `cargo fmt --all`, `announcement_relay` 3/3.

The new test stages the real attack — same envelope, one flipped signature byte, relayed first — and asserts both that the key is unburned and that the genuine announcement then lands. **Fault-validated:** recording the discarded copy again fails it on the key-not-burned assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rLdsjCfcsTMaiLd3TX8w
