### PR TITLE
fix(checkpoints): treat the previous epoch's last checkpoint as a floor, not a fallback

### DIFF
--- a/crates/ika-core/src/dwallet_checkpoints/mod.rs
+++ b/crates/ika-core/src/dwallet_checkpoints/mod.rs
@@ -921,21 +921,61 @@ impl DWalletCheckpointAggregator {
         Ok(result)
     }
 
+    /// The next sequence to certify: this validator's own local progress,
+    /// floored at the previous epoch's last checkpoint.
+    ///
+    /// That floor is a lower BOUND, not merely a fallback for an empty store.
+    /// A validator that stops certifying before an epoch flips — a restart,
+    /// crash or partition straddling the boundary, or simply lagging in
+    /// consensus when the epoch's checkpoint tasks are aborted — enters the new
+    /// epoch with a local head below the floor. The new epoch's builder table
+    /// starts AT the floor, so asking for the stale local head requests a
+    /// sequence that table will never hold, and the aggregator returns empty on
+    /// every tick, for this epoch and every later one.
+    ///
+    /// Skipping the gap is correct rather than merely expedient: the floor is
+    /// set on chain from `last_processed_checkpoint_sequence_number`, so every
+    /// sequence at or below it has already landed on Sui and is submit-useless.
+    /// This is the same rationale as the pull-mode sync floor, which likewise
+    /// leaves a legitimate gap below its first post-floor sequence.
+    fn next_checkpoint_to_certify_from(
+        local_last_certified: Option<DWalletCheckpointSequenceNumber>,
+        previous_epoch_last_checkpoint_sequence_number: DWalletCheckpointSequenceNumber,
+    ) -> DWalletCheckpointSequenceNumber {
+        let floor = previous_epoch_last_checkpoint_sequence_number + 1;
+        local_last_certified.map_or(floor, |sequence_number| (sequence_number + 1).max(floor))
+    }
+
     fn next_checkpoint_to_certify(&self) -> IkaResult<DWalletCheckpointSequenceNumber> {
-        let default_next_checkpoint_to_certify =
-            self.previous_epoch_last_checkpoint_sequence_number + 1;
-        debug!(
-            default_next_checkpoint_to_certify,
-            "Getting next dwallet checkpoint to certify",
-        );
-        Ok(self
+        let local_last_certified = self
             .tables
             .certified_checkpoints
             .reversed_safe_iter_with_bounds(None, None)?
             .next()
             .transpose()?
-            .map(|(seq, _)| seq + 1)
-            .unwrap_or(default_next_checkpoint_to_certify))
+            .map(|(seq, _)| seq);
+        let next_checkpoint_to_certify = Self::next_checkpoint_to_certify_from(
+            local_last_certified,
+            self.previous_epoch_last_checkpoint_sequence_number,
+        );
+        if local_last_certified
+            .is_some_and(|sequence_number| sequence_number + 1 < next_checkpoint_to_certify)
+        {
+            info!(
+                ?local_last_certified,
+                next_checkpoint_to_certify,
+                previous_epoch_last_checkpoint_sequence_number =
+                    self.previous_epoch_last_checkpoint_sequence_number,
+                "local certified dwallet checkpoint store trails the previous epoch's last \
+                 checkpoint; resuming at that floor and leaving the gap uncertified",
+            );
+        } else {
+            debug!(
+                next_checkpoint_to_certify,
+                "Getting next dwallet checkpoint to certify",
+            );
+        }
+        Ok(next_checkpoint_to_certify)
     }
 }
 
@@ -1178,5 +1218,60 @@ impl DWalletCheckpointServiceNotify for DWalletCheckpointService {
     fn notify_checkpoint(&self) -> IkaResult {
         self.notify_builder.notify_one();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A validator whose certified store is BELOW the previous epoch's last
+    /// checkpoint must resume at that floor. Before, the floor applied only
+    /// when the store was empty, so such a validator asked for a sequence the
+    /// new epoch's builder table never holds and certified nothing again.
+    #[test]
+    fn a_certified_store_behind_the_previous_epoch_resumes_at_the_floor() {
+        assert_eq!(
+            DWalletCheckpointAggregator::next_checkpoint_to_certify_from(Some(470), 500),
+            501
+        );
+    }
+
+    #[test]
+    fn a_certified_store_ahead_of_the_floor_keeps_its_own_progress() {
+        assert_eq!(
+            DWalletCheckpointAggregator::next_checkpoint_to_certify_from(Some(512), 500),
+            513
+        );
+    }
+
+    #[test]
+    fn a_certified_store_exactly_at_the_floor_moves_one_past_it() {
+        assert_eq!(
+            DWalletCheckpointAggregator::next_checkpoint_to_certify_from(Some(500), 500),
+            501
+        );
+    }
+
+    #[test]
+    fn an_empty_certified_store_starts_at_the_floor() {
+        assert_eq!(
+            DWalletCheckpointAggregator::next_checkpoint_to_certify_from(None, 500),
+            501
+        );
+    }
+
+    /// In the first epoch the chain's floor is still 0, so the local head
+    /// governs — flooring must not drag a validator backwards there.
+    #[test]
+    fn the_first_epoch_floor_of_zero_never_overrides_local_progress() {
+        assert_eq!(
+            DWalletCheckpointAggregator::next_checkpoint_to_certify_from(Some(7), 0),
+            8
+        );
+        assert_eq!(
+            DWalletCheckpointAggregator::next_checkpoint_to_certify_from(None, 0),
+            1
+        );
     }
 }

--- a/crates/ika-core/src/system_checkpoints/mod.rs
+++ b/crates/ika-core/src/system_checkpoints/mod.rs
@@ -850,21 +850,61 @@ impl SystemCheckpointAggregator {
         Ok(result)
     }
 
+    /// The next sequence to certify: this validator's own local progress,
+    /// floored at the previous epoch's last checkpoint.
+    ///
+    /// That floor is a lower BOUND, not merely a fallback for an empty store.
+    /// A validator that stops certifying before an epoch flips — a restart,
+    /// crash or partition straddling the boundary, or simply lagging in
+    /// consensus when the epoch's checkpoint tasks are aborted — enters the new
+    /// epoch with a local head below the floor. The new epoch's builder table
+    /// starts AT the floor, so asking for the stale local head requests a
+    /// sequence that table will never hold, and the aggregator returns empty on
+    /// every tick, for this epoch and every later one.
+    ///
+    /// Skipping the gap is correct rather than merely expedient: the floor is
+    /// set on chain from `last_processed_checkpoint_sequence_number`, so every
+    /// sequence at or below it has already landed on Sui and is submit-useless.
+    /// This is the same rationale as the pull-mode sync floor, which likewise
+    /// leaves a legitimate gap below its first post-floor sequence.
+    fn next_checkpoint_to_certify_from(
+        local_last_certified: Option<SystemCheckpointSequenceNumber>,
+        previous_epoch_last_checkpoint_sequence_number: SystemCheckpointSequenceNumber,
+    ) -> SystemCheckpointSequenceNumber {
+        let floor = previous_epoch_last_checkpoint_sequence_number + 1;
+        local_last_certified.map_or(floor, |sequence_number| (sequence_number + 1).max(floor))
+    }
+
     fn next_checkpoint_to_certify(&self) -> IkaResult<SystemCheckpointSequenceNumber> {
-        let default_next_checkpoint_to_certify =
-            self.previous_epoch_last_checkpoint_sequence_number + 1;
-        debug!(
-            default_next_checkpoint_to_certify,
-            "Getting next system checkpoint to certify",
-        );
-        Ok(self
+        let local_last_certified = self
             .tables
             .certified_checkpoints
             .reversed_safe_iter_with_bounds(None, None)?
             .next()
             .transpose()?
-            .map(|(seq, _)| seq + 1)
-            .unwrap_or(default_next_checkpoint_to_certify))
+            .map(|(seq, _)| seq);
+        let next_checkpoint_to_certify = Self::next_checkpoint_to_certify_from(
+            local_last_certified,
+            self.previous_epoch_last_checkpoint_sequence_number,
+        );
+        if local_last_certified
+            .is_some_and(|sequence_number| sequence_number + 1 < next_checkpoint_to_certify)
+        {
+            info!(
+                ?local_last_certified,
+                next_checkpoint_to_certify,
+                previous_epoch_last_checkpoint_sequence_number =
+                    self.previous_epoch_last_checkpoint_sequence_number,
+                "local certified system checkpoint store trails the previous epoch's last \
+                 checkpoint; resuming at that floor and leaving the gap uncertified",
+            );
+        } else {
+            debug!(
+                next_checkpoint_to_certify,
+                "Getting next system checkpoint to certify",
+            );
+        }
+        Ok(next_checkpoint_to_certify)
     }
 }
 
@@ -1106,5 +1146,60 @@ impl SystemCheckpointServiceNotify for SystemCheckpointService {
     fn notify_checkpoint(&self) -> IkaResult {
         self.notify_builder.notify_one();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A validator whose certified store is BELOW the previous epoch's last
+    /// checkpoint must resume at that floor. Before, the floor applied only
+    /// when the store was empty, so such a validator asked for a sequence the
+    /// new epoch's builder table never holds and certified nothing again.
+    #[test]
+    fn a_certified_store_behind_the_previous_epoch_resumes_at_the_floor() {
+        assert_eq!(
+            SystemCheckpointAggregator::next_checkpoint_to_certify_from(Some(470), 500),
+            501
+        );
+    }
+
+    #[test]
+    fn a_certified_store_ahead_of_the_floor_keeps_its_own_progress() {
+        assert_eq!(
+            SystemCheckpointAggregator::next_checkpoint_to_certify_from(Some(512), 500),
+            513
+        );
+    }
+
+    #[test]
+    fn a_certified_store_exactly_at_the_floor_moves_one_past_it() {
+        assert_eq!(
+            SystemCheckpointAggregator::next_checkpoint_to_certify_from(Some(500), 500),
+            501
+        );
+    }
+
+    #[test]
+    fn an_empty_certified_store_starts_at_the_floor() {
+        assert_eq!(
+            SystemCheckpointAggregator::next_checkpoint_to_certify_from(None, 500),
+            501
+        );
+    }
+
+    /// In the first epoch the chain's floor is still 0, so the local head
+    /// governs — flooring must not drag a validator backwards there.
+    #[test]
+    fn the_first_epoch_floor_of_zero_never_overrides_local_progress() {
+        assert_eq!(
+            SystemCheckpointAggregator::next_checkpoint_to_certify_from(Some(7), 0),
+            8
+        );
+        assert_eq!(
+            SystemCheckpointAggregator::next_checkpoint_to_certify_from(None, 0),
+            1
+        );
     }
 }

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -39,7 +39,8 @@ them has a bug — determine which before changing either.
 - [`specs/checkpoint-sync-floor.md`](specs/checkpoint-sync-floor.md)
   — why pull-mode checkpoint sync starts from the on-chain processed
   cursor (a fresh-DB notifier can never fetch deep history from peers),
-  the cold-start deferral, and the gap-tolerant store invariants.
+  the cold-start deferral, why a validator's aggregator floors at the
+  previous epoch's last checkpoint, and the gap-tolerant store invariants.
 - [`specs/checkpoint-writer-observability.md`](specs/checkpoint-writer-observability.md)
   — the deliberate single-notifier write path, why a stalled writer
   blocks the epoch close, and the two stall signals (the notifier's

--- a/dev-docs/specs/checkpoint-sync-floor.md
+++ b/dev-docs/specs/checkpoint-sync-floor.md
@@ -1,9 +1,11 @@
-# Pull-mode checkpoint sync floor (notifier cold start on a history-less network)
+# On-chain checkpoint sequence floors (pull-mode cold start, and the validator aggregator)
 
-Why a notifier (or any non-committee node) deployed with a fresh database
-could never sync on a long-lived network, and the on-chain floor that fixes
-it. Actors: `ika-network` state sync (pull mode), the node's Sui connector
-(cursor feed), every validator (as a serving peer).
+Why a node whose checkpoint store sits far below the chain can never catch
+up on its own, and the on-chain floor that fixes it — first for a notifier
+(or any non-committee node) deployed with a fresh database, then for a
+validator whose aggregator fell behind across an epoch boundary. Actors:
+`ika-network` state sync (pull mode), the node's Sui connector (cursor
+feed), every validator (as a serving peer and as a certifier).
 
 ## The failure this closes (2026-07 testnet epoch-close outages)
 
@@ -39,9 +41,34 @@ Rules (both checkpoint streams, dwallet and system):
    returns `Some(0)` within seconds and sync proceeds from sequence 1, so a
    brand-new network is never blocked (`Some(0)` ≠ `None` is exactly why
    the channel carries `Option`).
-3. **Pull mode only.** Validators build checkpoints from consensus and
-   never pull; their behavior is untouched. Nodes without a cursor feed
-   (external users of the builder) keep the old from-1 behavior.
+3. **Nodes without a cursor feed** (external users of the builder) keep
+   the old from-1 behavior.
+
+## The same floor on the validator side
+
+Validators never pull, so the cursor feed above does not reach them — but
+they have the same class of failure and the same on-chain answer.
+
+A validator's checkpoint AGGREGATOR certifies from its own local certified
+store. At each `advance_epoch` the chain records
+`previous_epoch_last_checkpoint_sequence_number =
+last_processed_checkpoint_sequence_number`, and the node reads it at epoch
+entry. The BUILDER already floors its next sequence at that value; the
+aggregator must too:
+
+4. **The aggregator starts at `max(local_last_certified + 1, previous
+   epoch's last + 1)`,** for both streams. Treating that floor as a
+   fallback for an EMPTY store only — which is what it was — wedges any
+   validator whose store sits below it at epoch entry: it asks for a
+   sequence the new epoch's builder table never holds, so it certifies
+   nothing, in that epoch and every later one. A validator gets there by
+   ordinary means — a restart, crash or partition straddling the boundary,
+   or merely lagging in consensus when the epoch's checkpoint tasks are
+   aborted. The condition does not self-heal while the node stays in the
+   committee (it never pulls, and nothing else writes that store), and it
+   ACCUMULATES: each occurrence retires one more validator's aggregator,
+   and the network stalls when the last healthy one goes. The skip is
+   logged at info, as in pull mode.
 
 ## Consequences and invariants
 
@@ -50,7 +77,9 @@ Rules (both checkpoint streams, dwallet and system):
 2. A pull-mode store may legitimately contain a GAP (nothing below the
    first post-floor sequence). Nothing may assume contiguity from 1:
    serving peers already handle absent sequences (`None` response), and the
-   writer only ever reads `cursor + 1` and above.
+   writer only ever reads `cursor + 1` and above. The same now holds for a
+   VALIDATOR's certified store, which may carry a gap where it was below
+   the floor at an epoch entry.
 3. The floor never regresses (monotonic forward in the connector feed) and
    never skips anything the chain still needs (it is derived from the
    chain's own processed cursor).

--- a/dev-docs/specs/checkpoint-writer-observability.md
+++ b/dev-docs/specs/checkpoint-writer-observability.md
@@ -68,7 +68,10 @@ alongside `user_sessions_lag` and names the writer directly; the gate-stuck
 WARN carries the same field. Sustained positive writer lag while the close is
 blocked means: go fix the notifier, not the MPC pipeline. (Negative gauge
 values mean the local certified store trails the chain — local sync lag, a
-different problem.)
+different problem. On a VALIDATOR, a negative value that never recovers is
+its aggregator sitting below the epoch floor; see
+[`checkpoint-sync-floor.md`](checkpoint-sync-floor.md), which is where that
+resolves itself.)
 
 ## Key invariants
 


### PR DESCRIPTION
### The asymmetry

Both checkpoint aggregators — dwallet and system — pick the next sequence to certify from their local certified store, and fall back to `previous_epoch_last_checkpoint_sequence_number + 1` **only when that store is empty**.

The builder sitting next to them already does the right thing: it takes the *max* of its local progress and that same on-chain value.

### What that costs

A validator whose certified store is BELOW the floor at epoch entry asks for a sequence the new epoch's builder table will never hold. `get_built_dwallet_checkpoint_message` returns `None`, the aggregator returns empty, and it re-ticks on that same sequence every second — in that epoch and in every later one.

Getting there needs nothing exotic: a restart, crash, or partition whose downtime straddles the epoch boundary, or simply lagging in consensus when the epoch's checkpoint tasks are aborted.

It does not self-heal while the node stays in the committee — validators never pull (that path is notifier-only), and nothing else writes that store — so recovery means operator action (delete the checkpoint DBs, or run the process once outside the committee). It is also **cumulative**: each occurrence retires one more validator's aggregator, and when the last healthy one goes, nothing certifies, the notifier has nothing to submit, and every validator's epoch-close gate stalls.

It is at least loud while it happens: the aggregator gauge pins at `-1`, `last_certified_dwallet_checkpoint` flatlines, and the writer-lag gauge goes negative.

### What changed

Take the max in both aggregators, mirroring the builder.

Skipping the gap is the correct outcome rather than the convenient one: the floor is set on chain from `last_processed_checkpoint_sequence_number`, so every sequence at or below it has already landed on Sui and is submit-useless. That is the same rationale as the pull-mode sync floor, whose spec already blesses a gapped store. The skip logs at info, as the pull path does.

### Specs

`dev-docs/specs/checkpoint-sync-floor.md` said in rule 3 that the floor was **pull mode only** and that validator behavior was untouched. That is now false, so the spec gains the validator-side rule and its gap invariant, and the title stops claiming to be about pull mode alone.

`checkpoint-writer-observability.md` describes a negative writer-lag gauge as "local sync lag, a different problem" — on a validator, a negative value that never recovers is this, so that note now points here.

### Tests

Ten unit tests across the two modules: below the floor (the regression), ahead of it, exactly at it, empty store, and the first epoch where the chain's floor is still `0` and must not drag a validator backwards.

Fault-validated: reverting the max fails exactly the two below-the-floor cases and leaves the other eight green — the fix only moves the case it is supposed to move.

Getting there required making the decision rule a small pure function so it is testable at all; the aggregator itself needs an epoch store, an authority state and an output sink to construct.

**What this does not cover:** there is no end-to-end test that stops a validator across an epoch close and watches its certified head resume. That wants a cluster test, and nothing in the repo exercises the aggregator floor today. Worth adding separately — the unit tests pin the decision rule, not the scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rLdsjCfcsTMaiLd3TX8w
