### PR TITLE
fix(handoff): skip a handoff signer with no committee weight instead of failing the cert

### DIFF
--- a/crates/ika-core/src/handoff_cert.rs
+++ b/crates/ika-core/src/handoff_cert.rs
@@ -530,17 +530,47 @@ fn verify_certified_handoff_attestation_inner(
         .map_err(|e| IkaError::Unknown(format!("bcs encode handoff intent message: {e}")))?;
     let mut seen = HashSet::new();
     let mut stake: StakeUnit = 0;
+    let mut non_members: usize = 0;
+    let mut unresolvable: usize = 0;
     for (signer, signature) in &cert.signatures {
         if !seen.insert(*signer) {
+            // A repeated signer is malformed however you read it — a
+            // well-formed cert never carries one — and letting it through
+            // would risk double-counting stake. Unlike the two skips below,
+            // this cannot arise from honest chain state.
             return Err(IkaError::Unknown(format!(
                 "duplicate signer {signer:?} in certified handoff attestation"
             )));
         }
         let weight = committee.weight(signer);
         if weight == 0 {
-            return Err(IkaError::Unknown(format!(
-                "signer {signer:?} is not a member of the verifying committee"
-            )));
+            // Not a member of the committee we are verifying against. Skip
+            // the signature rather than failing the whole cert: it carries
+            // zero stake either way, so the quorum check below stays the
+            // fail-closed gate, and verifying against a wholly wrong
+            // committee still accumulates 0 and is rejected there.
+            //
+            // Rejecting outright made honest chain state fatal. The
+            // verifying committee is named from each member's CURRENT
+            // on-chain consensus key, so a member that rotated that key at
+            // the boundary is named under the new key while the cert names
+            // it under the old one; and a member whose `validator_info`
+            // fails `verify()` — reachable for a departed validator with a
+            // stale record — is absent from the committee entirely. Either
+            // way its signature is in every cert every honest peer serves,
+            // so EVERY candidate failed, and a node with no persisted prior
+            // committee (a joiner, or a restored database) shut itself down.
+            //
+            // It also removes a rejection lever: any peer could kill an
+            // otherwise-valid cert by appending one junk signer entry.
+            debug!(
+                ?signer,
+                "handoff signer is not a member of the verifying committee \
+                 (rotated consensus key, or absent from the committee snapshot); \
+                 skipping its signature"
+            );
+            non_members += 1;
+            continue;
         }
         let Some(pubkey) = provider.consensus_pubkey(signer) else {
             // Genuine prior-committee member (weight > 0, above) whose
@@ -560,6 +590,7 @@ fn verify_certified_handoff_attestation_inner(
                 "prior-committee handoff signer pubkey unresolvable (departed since signing); \
                  skipping its signature"
             );
+            unresolvable += 1;
             continue;
         };
         pubkey
@@ -570,9 +601,15 @@ fn verify_certified_handoff_attestation_inner(
         stake = stake.saturating_add(weight);
     }
     if stake < committee.quorum_threshold() {
+        // Report what was skipped: with both skips above, "stake 0" on its
+        // own no longer distinguishes a cert for the wrong committee from
+        // one whose signers have all departed.
         return Err(IkaError::Unknown(format!(
-            "certified handoff attestation stake {stake} below quorum threshold {}",
-            committee.quorum_threshold()
+            "certified handoff attestation stake {stake} below quorum threshold {} \
+             ({non_members} of {} signer(s) not in the verifying committee, \
+             {unresolvable} with an unresolvable consensus pubkey)",
+            committee.quorum_threshold(),
+            cert.signatures.len(),
         )));
     }
     Ok(())

--- a/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
+++ b/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
@@ -114,16 +114,16 @@ pub async fn fetch_previous_committee<C: SuiClientInner>(
     // validator id (StakingPool.id == BlsCommitteeMember.validator_id).
     // Lossy: a departed prior-committee member with an unparseable protocol
     // pubkey is skipped, not fatal — bootstrap must not crash-loop on one bad
-    // record. NOTE: the skip is NOT graceful quorum degradation. The skipped
-    // member is absent from `voting_rights`, and cert verification
-    // HARD-REJECTS a certificate carrying a weight-0 signer's signature —
-    // and since that member's own node runs fine, its signature is in every
-    // aggregated cert, so every served cert fails verification and bootstrap
-    // surfaces `Rejected`. The warn below makes that outcome attributable to
-    // the corrupt prior-committee record instead of the Rejected log's
-    // default "wrong prior-committee view / wrong peers" guidance. (Trigger
-    // requires registration-validated snapshot bytes to fail BLS parse —
-    // near-unreachable; the pre-lossy behavior was a panic crash-loop.)
+    // record. The skip costs that member's stake from the achievable cert
+    // quorum: it is absent from `voting_rights`, so its signature resolves to
+    // weight 0 and cert verification skips it. A quorum of the remaining
+    // members still validates the handoff; only if enough members drop to put
+    // the rest below quorum does bootstrap fail, which is correct. The warn
+    // below keeps that attributable to the corrupt prior-committee record
+    // rather than the Rejected log's default "wrong prior-committee view /
+    // wrong peers" guidance. (Trigger requires registration-validated
+    // snapshot bytes to fail BLS parse — near-unreachable; the pre-lossy
+    // behavior was a panic crash-loop.)
     let bls_members = system_inner.read_bls_committee_lossy(bls_committee);
     if bls_members.len() < bls_committee.members.len() {
         let parsed_ids: HashSet<ObjectID> = bls_members.iter().map(|(id, _)| *id).collect();
@@ -166,7 +166,9 @@ fn build_prior_committee(
     // (`set_next_epoch_consensus_pubkey_bytes`, effectuated at epoch
     // advance), in which case this names the member under its new key while
     // the cert names it under the old one, and the signer resolves to weight
-    // 0. Rotation under a consensus-key identity is unfinished business; see
+    // 0. Cert verification skips a weight-0 signer, so a rotation costs that
+    // member's stake from the achievable quorum rather than failing the cert.
+    // Rotation under a consensus-key identity is unfinished business; see
     // dev-docs/specs/committee-consensus-keys.md. A member whose
     // validator_info fails verify has no resolvable name and drops out (the
     // verify-failure warn below attributes it).

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -3165,6 +3165,78 @@ mod tests {
         );
     }
 
+    /// A signer that carries no weight in the verifying committee must be
+    /// SKIPPED, not fatal — the remaining stake still decides.
+    ///
+    /// This is the shape the chain read actually produces. The prior
+    /// committee is named from each member's CURRENT on-chain consensus key
+    /// and drops any member whose `validator_info` fails to verify, while the
+    /// quorum threshold comes from the chain and still counts every member.
+    /// So a member that rotated its consensus key at the boundary, or whose
+    /// record is stale, is absent from `voting_rights` while its signature
+    /// sits in every certificate every honest peer serves.
+    ///
+    /// Rejecting the certificate over that signer made every candidate fail,
+    /// so a node with no persisted prior committee — a joiner, or a restored
+    /// database — halted itself for the epoch, deterministically and
+    /// network-wide.
+    #[test]
+    fn verify_certified_handoff_attestation_skips_a_signer_with_no_weight() {
+        let (full_committee, names, consensus_kps, provider) = build_quorum_test_fixture(4);
+        let att = build_handoff_attestation(5, [0x12; 32], vec![]).expect("build");
+        // All four sign: the aggregator keeps collecting past quorum, so a
+        // real cert carries every signature that arrived.
+        let mut agg = HandoffAggregator::new(full_committee.clone(), att.clone());
+        for index in 0..4 {
+            let msg = sign_handoff_attestation(att.clone(), names[index], &consensus_kps[index]);
+            agg.insert_verified(names[index], msg.signature);
+        }
+        let cert = agg.certified().expect("certified").clone();
+        assert_eq!(cert.signatures.len(), 4);
+
+        // The chain read lost one member, so it is absent from
+        // `voting_rights` — but the thresholds still come from the chain and
+        // count all four. Three members remain, exactly quorum.
+        let read_committee = Arc::new(Committee::new(
+            5,
+            names[..3].iter().map(|name| (*name, 1u64)).collect(),
+            HashMap::new(),
+            names[..3]
+                .iter()
+                .copied()
+                .zip(consensus_kps[..3].iter().map(|kp| kp.public().clone()))
+                .collect(),
+            full_committee.quorum_threshold(),
+            full_committee.validity_threshold(),
+        ));
+        verify_certified_handoff_attestation(&cert, &read_committee, &provider)
+            .expect("a signer with no weight must be skipped, leaving the quorum to decide");
+
+        // The quorum check stays the fail-closed gate: lose one more member
+        // and the remaining stake is short, so the cert is rejected — and the
+        // error says how many signers were skipped, so "stake too low" can
+        // still be told apart from "wrong committee entirely".
+        let short_committee = Arc::new(Committee::new(
+            5,
+            names[..2].iter().map(|name| (*name, 1u64)).collect(),
+            HashMap::new(),
+            names[..2]
+                .iter()
+                .copied()
+                .zip(consensus_kps[..2].iter().map(|kp| kp.public().clone()))
+                .collect(),
+            full_committee.quorum_threshold(),
+            full_committee.validity_threshold(),
+        ));
+        let err = verify_certified_handoff_attestation(&cert, &short_committee, &provider)
+            .expect_err("below quorum once too many members are missing");
+        let msg = format!("{err}").to_lowercase();
+        assert!(
+            msg.contains("quorum") && msg.contains("not in the verifying committee"),
+            "expected a below-quorum error naming the skipped signers, got: {msg}"
+        );
+    }
+
     /// Exactly-quorum stake must verify; quorum-minus-one stake
     /// must not. With 4 unit-stake validators, quorum_threshold = 3.
     /// Building a cert with 3 valid signatures and verifying, then

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -177,17 +177,31 @@ next epoch inherits.
     on-chain protocol pubkey — a member that rotated its protocol key
     at the boundary signed under the old name, and current-name keying
     would silently drop its stake from the cert quorum.
-  - **Lossy membership read (and its sharp edge).** A prior-committee
-    member whose frozen snapshot `protocol_pubkey` bytes fail to parse
-    is SKIPPED rather than panicking the reader — but the skip is not
-    graceful degradation: the member is absent from `voting_rights`,
-    and verification hard-rejects any certificate carrying a weight-0
-    signer's signature. Since such a member's own node keeps signing,
-    its signature is in every aggregated cert, so every served cert
-    fails and bootstrap surfaces `Rejected`. The reader logs the
-    dropped ids so that outcome is attributable to the corrupt record
-    (near-unreachable trigger: the bytes are validated at
+  - **Lossy membership read.** A prior-committee member whose frozen
+    snapshot `protocol_pubkey` bytes fail to parse is SKIPPED rather
+    than panicking the reader. The member is then absent from
+    `voting_rights`, so its signature resolves to weight 0 and
+    verification skips that signature — costing its stake from the
+    achievable quorum, not the certificate. Bootstrap fails only if
+    enough members drop to leave the rest below quorum. The reader logs
+    the dropped ids so a near-quorum loss is attributable to the corrupt
+    records (near-unreachable trigger: the bytes are validated at
     registration; the pre-lossy behavior was a panic crash-loop).
+  - **Skipping a signer is safe, and the quorum check is the gate.** A
+    signature is skipped when the signer carries no weight in the
+    verifying committee, or when its consensus pubkey no longer
+    resolves. Neither can smuggle stake in — a skipped signature adds
+    zero — so the below-quorum check remains the fail-closed gate, and a
+    certificate verified against a wholly wrong committee accumulates
+    nothing and is rejected there. Rejecting such a signer outright
+    instead would make honest chain state fatal: a member that rotated
+    its consensus key at the boundary, or one absent from the committee
+    snapshot, has its signature in EVERY cert every honest peer serves,
+    so every candidate would fail and a node with no persisted prior
+    committee would shut itself down for the epoch. It would also let
+    any peer kill an otherwise-valid certificate by appending one junk
+    signer. A DUPLICATE signer is still fatal: it cannot arise from
+    honest chain state and would risk double-counting stake.
 
 ## Consuming the certificate
 
@@ -200,13 +214,16 @@ next epoch inherits.
      genuine trust-anchor mismatch or eclipse: **fail closed** — the
      node must never anchor on an unverified cert. A single bad peer
      cannot cause this (every peer is tried). Enforcement today: the
-     epoch-start bootstrap task logs `Rejected` at error and installs
-     nothing (it does NOT hard-halt the process; a refuse-participation
-     policy layers above it), and the prepare-then-start barrier simply
-     never becomes ready without a verified anchor — the node blocks
-     out of MPC participation. The one place that DOES halt the node is
-     the barrier's re-verification failure of a locally-PERSISTED cert
-     (local DB tampering/corruption — see step 2).
+     epoch-start bootstrap task logs at error and HALTS the process
+     (`fail_closed_shutdown`), rather than limping without a verified
+     anchor. The barrier's re-verification failure of a locally
+     PERSISTED cert (local DB tampering/corruption — see step 2) halts
+     the same way. Because this outcome is chain-derived and
+     deterministic, every node in the same position halts identically —
+     which is why verification skips a signature it cannot attribute
+     rather than rejecting the certificate over it (see above): a defect
+     that made honest chain state unverifiable would take out every
+     joiner at that epoch at once.
    - `Unavailable` (no peer served one) — benign propagation lag;
      retry.
    A validator that already holds the certificate re-verifies it before


### PR DESCRIPTION
### One tolerance, one line apart

Handoff-cert verification walks the signatures. A signer whose consensus pubkey no longer resolves is **skipped**, with a comment explaining that a quorum of the still-resolvable signers can still validate the handoff. The branch immediately above it — a signer with **weight 0** in the verifying committee — returned `Err` and failed the whole certificate.

Honest chain state reaches that branch.

### How

The prior committee a bootstrapping joiner verifies against is read from chain, and two things about that read produce a weight-0 signer:

- each member is **named from its CURRENT on-chain consensus key**, so a member that rotated it at the boundary is filed under the new key while the cert names it under the old one;
- any member whose `validator_info` fails `verify()` is **dropped from the read entirely** — reachable for a departed validator with a stale record, since Move's validation and Rust's `verify()` do not agree exactly (a `/dns4/...` p2p address is Move-valid and Rust-invalid; so is a record where the network and consensus keys coincide).

Neither is misbehaviour, and neither is fixable by anyone once the member has departed.

### Why it took down whole classes of node

That member's own node is fine and keeps signing, and the aggregator deliberately keeps collecting signatures past quorum — so its signature is in **every certificate every honest peer serves**. Every candidate failed, bootstrap surfaced `Rejected`, and `Rejected` halts the process.

Only nodes that read the prior committee from chain are affected — true joiners and validators restored from a fresh database. Continuing validators take the persisted-committee branch and are untouched, so the standing committee keeps running. But the condition is chain-derived and deterministic, so every node in that position halts *identically*, and stays down for the epoch (the alerts playbook explicitly tells operators not to auto-restart into this). If the halted joiners hold more than a third of the epoch's stake, the epoch cannot reach quorum. The error text blamed a "wrong prior-committee view / eclipse" — the wrong place to look.

### Why skipping is safe

This is the part worth checking rather than taking on faith:

- A weight-0 signer contributes **zero stake** whether skipped or rejected. Nothing can be smuggled in.
- The below-quorum check remains the fail-closed gate. A cert verified against a *wholly* wrong committee now accumulates 0 and is rejected there, with a clearer message than before.
- It matches `HandoffAggregator::insert_verified`, which already ignores weight-0 signers.
- It removes a rejection lever: any peer could previously kill an otherwise-valid cert by appending one junk `(signer, signature)` pair.

**A duplicate signer stays fatal.** It cannot arise from honest chain state and would risk double-counting stake — that check is doing real work and keeps its hard reject.

Because "stake 0" alone no longer distinguishes *wrong committee* from *signers all departed*, the below-quorum error now reports how many signatures were skipped for each reason.

### Docs

The same source file documented **both** answers: one path correctly noted the hard-reject consequence, another claimed skipping "costs only that member's handoff signature". Both now describe the same behaviour — the skip costs that member's stake from the achievable quorum, not the certificate.

`dev-docs/specs/handoff.md` loses its "sharp edge" bullet, gains the reasoning for why skipping is safe and why a duplicate is not, and is corrected where it still claimed the epoch-start bootstrap task "does NOT hard-halt the process". It does — `fail_closed_shutdown` at the `Rejected` arm.

### Test

The finding here was that existing coverage tests the *provider*-only gap — the committee keeps all four members, so the soft-skip branch runs and the hard reject never does. Nothing covered a signer absent from `voting_rights`.

The new test builds the real shape: four signers on the cert, but a committee that lost one member from the read, with the quorum threshold still coming from chain and counting all four. The remaining three are exactly quorum, so it must verify. Losing one more must fail, with an error naming the skipped signers.

Fault-validated: restoring the hard reject fails it on the cert that should verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rLdsjCfcsTMaiLd3TX8w
