### PR TITLE
ci(upgrade-test): trigger on whole crates instead of a module list

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -80,42 +80,35 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "crates/ika-core/Cargo.toml"
-      # authority.rs holds the protocol-upgrade activation decision
-      # (capability tally / effective threshold); authority/** holds the
-      # per-epoch store — epoch-close timing, EndOfPublish accounting,
-      # reconfiguration state. Both are exactly what the mixed-binary
-      # scenarios assert, and were previously missing from this filter:
-      # the #1917 close-timing fix would have merged without v128_rollout
-      # ever running had it not been dispatched by hand.
-      - "crates/ika-core/src/authority.rs"
-      - "crates/ika-core/src/authority/**"
-      # consensus_handler.rs decides which sequenced transactions are
-      # processed at all (verification order, dedup admission) and
-      # messages_consensus.rs defines the consensus transaction/key types —
-      # whose BCS encoding is persisted and append-only. Both change what a
-      # mixed-binary committee agrees on, which is precisely what the
-      # rollout scenarios assert, and both were missing here for the same
-      # reason authority.rs once was.
-      - "crates/ika-core/src/consensus_handler.rs"
-      - "crates/ika-types/src/messages_consensus.rs"
-      # The whole p2p crate, not just state_sync and mpc_artifacts. This
-      # suite spawns REAL validator processes that reach each other over
-      # anemo: checkpoint sync, handoff-certificate and blob fetch at epoch
-      # entry, and peer discovery are all load-bearing for a cross-binary
-      # run. A per-subdirectory list would re-open this same gap the next
-      # time someone adds a module, which is how consensus_handler.rs and
-      # authority.rs both came to be missing. The cost is that unrelated p2p
-      # churn also triggers the suite; that is the cheaper mistake.
+      # Whole crates, not module lists. This suite spawns REAL validator
+      # processes that reach each other over anemo and swap binaries across
+      # an epoch: consensus admission and ordering, the per-epoch store and
+      # epoch-close accounting, checkpoint build/certify/sync, the
+      # cross-epoch handoff certificate, validator mpc_data announcements
+      # and the freeze, the chain reads at epoch entry, and every BCS type
+      # that crosses the wire between two binary versions — nearly all of
+      # `ika-core` and effectively all of `ika-types` are load-bearing here.
+      #
+      # A per-module list has now rotted three times. `authority.rs` was
+      # missing (the #1917 close-timing fix would have merged without this
+      # suite ever running had it not been dispatched by hand);
+      # `consensus_handler.rs` and `messages_consensus.rs` were missing for
+      # the same reason; then `handoff_cert.rs` — which one scenario
+      # explicitly asserts, "the cross-epoch handoff cert still verifies" —
+      # was missing because it was EXTRACTED out of `validator_metadata.rs`,
+      # which was itself never listed, along with `epoch_tasks/**` and
+      # `sui_connector/**`. Every one of those gaps was found by noticing
+      # after the fact that a merged or in-review change had never triggered
+      # the suite.
+      #
+      # The cost is that unrelated churn in these crates also triggers the
+      # suite. That is the cheaper mistake: a wasted run costs runner time,
+      # a missed run costs a cross-binary regression reaching a release.
+      - "crates/ika-core/src/**"
+      - "crates/ika-types/**"
       - "crates/ika-network/**"
-      - "crates/ika-core/src/dwallet_mpc/**"
-      - "crates/ika-core/src/dwallet_session_request.rs"
-      - "crates/ika-core/src/request_protocol_data.rs"
       - "crates/ika-node/Cargo.toml"
       - "crates/dwallet-mpc-*/**"
-      - "crates/ika-types/Cargo.toml"
-      - "crates/ika-types/src/crypto.rs"
-      - "crates/ika-types/src/message.rs"
-      - "crates/ika-types/src/messages_dwallet_mpc.rs"
       - "crates/ika-protocol-config/**"
       - "crates/ika-upgrade-test/**"
       - ".github/workflows/upgrade-test.yaml"

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -63,9 +63,15 @@ gh run download <run-id> -n <artifact>   # localnet-logs / cluster-tests-log-<at
 `.github/workflows/upgrade-test.yaml` runs the out-of-process harness
 (`crates/ika-upgrade-test/`) — real, separately-compiled `ika-validator`
 child processes against an external `sui` localnet. Manual dispatch remains
-available. Pull requests that touch MPC, crypto dependencies, serialization,
-protocol configuration, the upgrade harness, or `Cargo.lock` automatically
-run the `v128_rollout` deployed-release gate rather than the entire matrix.
+available. Pull requests that touch `ika-core/src`, `ika-types`,
+`ika-network`, the MPC or crypto crates, protocol configuration, the upgrade
+harness, or `Cargo.lock` automatically run the `v128_rollout` deployed-release
+gate rather than the entire matrix. Those are whole-crate globs on purpose:
+the filter previously listed individual modules and silently stopped covering
+code three separate times as modules were added or split out — if you are
+adding a trigger for a module, widen to its crate instead. A change outside
+those crates that could still affect cross-binary behaviour needs a manual
+dispatch; the suite not appearing on a PR is not evidence that it passed.
 There is currently **no protocol-version transition gate**: `MIN` and `MAX`
 are both 7, so no boundary exists to cross. `v127_v7_upgrade` and the
 in-process `protocol_version_transition` cluster test were retired with the
@@ -191,7 +197,7 @@ gh workflow run upgrade-test.yaml --ref <branch> -f test=v128_churn
 
 ### Scenario differences
 
-All scenarios genesis at `ProtocolVersion::MIN` (= MAX = 5) with one
+All scenarios genesis at `ProtocolVersion::MIN` (= MAX = 7) with one
 notifier + a validator committee:
 
 | Scenario | Binary topology | Primary invariant |


### PR DESCRIPTION
### The same gap, three times

The upgrade suite's path filter lists individual modules. It has now stopped covering code three separate times:

1. **`authority.rs`** — added after the fact; the workflow's own comment records that a close-timing fix "would have merged without `v128_rollout` ever running had it not been dispatched by hand."
2. **`consensus_handler.rs` / `messages_consensus.rs`** — missing for the same reason, added later.
3. **`handoff_cert.rs`** — missing right now. One scenario explicitly asserts *"the cross-epoch handoff cert (signed padded, verified short) still verifies"*, so the suite tests this code but does not trigger on it. It went missing because it was **extracted out of `validator_metadata.rs`** — which was itself never listed, along with `epoch_tasks/**` and `sui_connector/**`.

That third gap is not hypothetical: two in-review changes to exactly that code — the ready-signal emit gate at the epoch boundary, and handoff-cert verification at epoch entry — got **no upgrade run at all**. Both had to be dispatched by hand.

The workflow already diagnosed this in a comment justifying `crates/ika-network/**`:

> A per-subdirectory list would re-open this same gap the next time someone adds a module, which is how `consensus_handler.rs` and `authority.rs` both came to be missing.

That reasoning was right and was applied to one crate only.

### What changed

Whole-crate globs for `ika-core/src`, `ika-types` and `ika-network`, replacing the module enumeration. **Every path previously listed is subsumed** — `authority.rs`, `authority/**`, `consensus_handler.rs`, `dwallet_mpc/**`, `dwallet_session_request.rs`, `request_protocol_data.rs`, and the four `ika-types` files. `crates/ika-core/Cargo.toml` stays listed, since it sits outside `src/`.

The scope is justified by what the suite actually does — spawn real validator processes and swap binaries across an epoch. Consensus admission and ordering, the per-epoch store and epoch-close accounting, checkpoint build/certify/sync, the cross-epoch handoff certificate, mpc_data announcements and the freeze, epoch-entry chain reads, and every BCS type crossing between binary versions are all in these crates.

The cost is that unrelated churn triggers the suite too. That is the cheaper mistake: **a wasted run costs runner time; a missed run costs a cross-binary regression reaching a release.**

### Also

- The CI playbook said the harness genesises at `ProtocolVersion::MIN (= MAX = 5)`. It is 7.
- The playbook now states which crates auto-trigger, says why they are whole-crate globs, and notes the trap directly: **the suite not appearing on a PR is not evidence that it passed.**

### Verification

YAML parses; the resulting path list was read back and checked entry by entry against the list it replaces. This PR touches `.github/workflows/upgrade-test.yaml`, which is itself in the filter, so it triggers the suite on itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rLdsjCfcsTMaiLd3TX8w
