### PR TITLE
docs: correct the protocol-version section of CLAUDE.md to v7-only

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -12,16 +12,18 @@ name: Upgrade Test
 # `v128_rollout`, avoiding the full expensive matrix on unrelated changes.
 # (The v3/v4-era rehearsals — cross_binary, v118_*, v121_rollout — were
 # retired when protocol v3/v4 support was removed; v128_rollout is their
-# successor against the current v1.2.7 release.) Pick the scenario with
+# successor against the current v1.2.8 release.) Pick the scenario with
 # the `test` input:
 #
 #   smoke        — go/no-go plumbing: 4 same-binary processes reach epoch 2.
 #                  Needs only the current build. Fastest.
 #   workload     — full user DKG -> Presign -> Sign on-chain at genesis
-#                  protocol v6. Current build only.
+#                  protocol v7. Current build only.
 #   v128_rollout — the deployed-release compatibility gate, and with it the
-#                  strict-only dependency gate: boot the literal v1.2.7
-#                  release (deployed on mainnet AND testnet, protocol v6),
+#                  strict-only dependency gate: boot the literal v1.2.8
+#                  release (deployed on mainnet AND testnet, which run
+#                  protocol v7 — the only version this binary supports, so
+#                  the run genesises there),
 #                  upgrade exactly one validator to the current build,
 #                  converge two mixed aggregated STRICT-BOUND reshares with
 #                  zero malicious reports and per-authority output
@@ -32,22 +34,12 @@ name: Upgrade Test
 #                  gate and a separate strict-only one — but there is a single
 #                  scenario and a single harness target; the strict bound is a
 #                  property of the candidate binary, not a second topology.)
-#                  transition counterpart): boot the literal v1.2.7 release
-#                  at protocol v6, swap the whole committee to the current
-#                  build, and cross v6 -> v7 — the boundary where
-#                  AuthorityName stops being emitted zero-padded to 48 bytes
-#                  and starts being emitted as the raw 32-byte consensus key.
-#                  Asserts the upgrade actually activates (a silent stay-at-v6
-#                  would make it vacuous), the boundary reshare converges, the
-#                  committee keeps all 4 members, and the cross-epoch handoff
-#                  cert (signed padded, verified short) still verifies. Same
-#                  OLD defaults as v128_rollout.
 #   v128_churn   — v128_rollout's churn counterpart: full sequential swap
-#                  over the literal v1.2.7 committee, then a mirrored OCS
-#                  joiner folds into the reshared v1.2.7-origin key (4→5)
+#                  over the literal v1.2.8 committee, then a mirrored OCS
+#                  joiner folds into the reshared v1.2.8-origin key (4→5)
 #                  and a shrink reshare removes an original (5→4). Same OLD
 #                  defaults as v128_rollout.
-#   malicious_v128 — test-testing counterpart: honest literal-v1.2.7
+#   malicious_v128 — test-testing counterpart: honest literal-v1.2.8
 #                  committee + ONE current validator built with the
 #                  test-testing reconfiguration-message fault; honest
 #                  validators must convict it and reshare without it
@@ -71,7 +63,7 @@ name: Upgrade Test
 # worktree's rust-toolchain.toml). All binaries build with default features —
 # enforcement (enforce-minimum-cpu) is runtime-gated to validators on the ika
 # testnet/mainnet networks, so it is inert on the CI localnet (its ika
-# system object maps to Chain::Unknown), and v1.2.7 already carries the
+# system object maps to Chain::Unknown), and v1.2.8 already carries the
 # runtime gate.
 
 on:
@@ -490,7 +482,7 @@ jobs:
           echo "resolved OLD_REF=$OLD_REF to immutable commit $OLD_COMMIT"
           git worktree add --force --detach "$WT" "$OLD_COMMIT"
           # Build at the OLD ref's own toolchain (rustup reads the worktree's
-          # rust-toolchain.toml). Default features: v1.2.7's
+          # rust-toolchain.toml). Default features: v1.2.8's
           # enforce-minimum-cpu is runtime-gated (inert on the CI localnet),
           # matching its production build.
           ( cd "$WT" && cargo build --release -p ika-node --bin "$OLD_BIN_NAME" )

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ methods/macros: unbounded channels, `block_on`,
 here. The rules below are the ones lints can't check:
 
 - **NEVER use `unsafe`** — no exceptions (also denied by workspace lint)
-- Rust 1.93 toolchain (`rust-toolchain.toml`), rustfmt 2024 edition
+- Rust 1.97 toolchain (`rust-toolchain.toml`), rustfmt 2024 edition
 - Prefer functional style; iterators (`map`/`filter`/`fold`) over loops;
   avoid mutable variables unless necessary
 - Shadow variables when transforming and the old value won't be used
@@ -276,49 +276,43 @@ already validated, branch names, and in-flight CI run IDs/URLs.
   the commit/round semantics ika's freeze and epoch-close logic rely on
   (leader rounds, commit boundaries) live in Sui's `consensus/core`, not
   in ika (see the upstream reference above)
-- **Protocol v6–v7 (`MIN_PROTOCOL_VERSION = 6`, `MAX_PROTOCOL_VERSION = 7`)**:
-  **v6 is LIVE on both mainnet and testnet**; v7 is advertised and not yet
-  activated. The binary supports nothing older than v6, so every formerly
-  v4/v5/v6-gated behavior is unconditional. That includes off-chain validator metadata,
-  the cross-epoch handoff, deferred epoch close, aggregated (V4-tagged)
-  network-key outputs, and both of what v6 itself flipped:
-  (a) `AuthorityName` IS the Ed25519 consensus key (zero-padded into the
-  same 48-byte container, so the wire encoding is unchanged); the BLS
-  protocol key stays on chain and on `Committee` for BLS
-  checkpoint-certificate verification, and BLS-basis committees stay
-  READABLE through `Committee`'s `expanded_keys` alias translation, which
-  is structural rather than version-gated; and (b) the network-key
-  DKG/reconfiguration equality-of-coefficients proof uses the STRICT
-  discrete-log bound.
+- **Protocol v7 only (`MIN_PROTOCOL_VERSION = MAX_PROTOCOL_VERSION = 7`)**:
+  **v7 is LIVE on both mainnet and testnet.** There is exactly ONE
+  supported version, so **no protocol transition exists to cross** and
+  every formerly gated behavior is unconditional —
+  off-chain validator metadata, the cross-epoch handoff, deferred epoch
+  close, aggregated (V4-tagged) network-key outputs, the STRICT
+  equality-of-coefficients discrete-log bound, and short `AuthorityName`s.
+  Do not add a `protocol_config.<flag>()` check for any of them.
+  `noa_checkpoints` is the next flag, planned for v8 and off everywhere.
+  When you introduce v8, the transition gates below have to be REBUILT —
+  they were deleted, not merely disabled.
+  **`AuthorityName` IS the Ed25519 consensus key, emitted as raw 32
+  bytes.** The 48-byte zero-padded container (which the BLS protocol key
+  occupied through v5) is no longer emitted by any supported version, so
+  the ambient-width process global, the dual-width cross-epoch retry in
+  handoff-cert verification, and the transition gates around them are all
+  GONE. DECODING stays lenient on purpose: records written before the
+  boundary hold the padded form and a node must keep reading its own
+  history. The BLS protocol key still exists on chain and on `Committee`
+  for BLS checkpoint-certificate verification, but it is NOT recoverable
+  from a name — it is carried explicitly via
+  `Committee::new_with_protocol_keys`, and a committee built through
+  `Committee::new` has an empty map and fails closed at `public_key()`.
   **The inkrypto revision is strict-only**: the relaxed `-10` bound and
   the `backward_compatible` selector no longer EXIST, along with the
   backward-compatible (class-groups-only) DKG/reconfiguration parties and
-  pre-aggregation (V3-tagged) output production. So this binary is not
-  wire-compatible with a protocol-v5 committee even where v5 state
-  survives.
+  pre-aggregation (V3-tagged) output production. This binary is not
+  wire-compatible with a pre-v7 committee even where older state survives.
   The `FeatureFlags` fields and the per-version arms in `get_for_version`
   stay for versions below MIN — the flag set is BCS-serialized into the
   `ProtocolConfig` digest that rides `AuthorityCapabilitiesV1` through
   consensus, so dropping a field would move every supported version's
   digest relative to deployed binaries.
-  **v7 gates `short_authority_names`**: `AuthorityName` is emitted as the raw
-  32-byte consensus key instead of that key zero-padded into the 48-byte
-  container. Readers have accepted both widths since v1.2.7, so the gate is
-  about when validators start EMITTING the short form — they must do so
-  together, because signature and digest bytes are reconstructed by
-  RE-SERIALIZING locally (`verify_handoff_signature`,
-  `hash_next_committee_pubkey_set`), so mixed widths split the quorum. This
-  is the ONE protocol flag consumed outside its call site: serde has no
-  access to the config, so the width lives in the
-  `AUTHORITY_NAME_SHORT_ENCODING` process global, set from the epoch store.
-  Its consequence — a handoff cert signed in epoch N and verified in N+1
-  straddles the flip — is handled by a dual-width retry in
-  `verify_certified_handoff_attestation`. **Anything new that verifies a
-  re-serialized cross-epoch payload must do the same.** `noa_checkpoints`
-  moves to v8. What REMAINS constrained: the networks persist pre-v6
-  state, so old `Versioned*` enum variants must stay (BCS variant indices
-  are wire format). V1-tagged chain DKG anchors must remain DECODABLE
-  (never rewritten on chain; they decode via the still-current
+  What REMAINS constrained: the networks persist pre-v7 state, so old
+  `Versioned*` enum variants must stay (BCS variant indices are wire
+  format). V1-tagged chain DKG anchors must remain DECODABLE (never
+  rewritten on chain; they decode via the still-current
   `class_groups::dkg::PublicOutput`), and V2-tagged outputs still decode as
   `PublicOutputCore` where only the core is needed. **V3-tagged
   (pre-aggregation) outputs and the bwd-compat party outputs are NO LONGER
@@ -327,7 +321,9 @@ already validated, branch names, and in-flight CI run IDs/URLs.
   this binary, and their decode arms are hard errors. And MPC outputs must
   reach byte-identical quorum across a mixed-binary committee, so
   serialization changes to active paths need a new protocol version gate,
-  never a binary-driven flip. A node whose persisted epoch-start record
+  never a binary-driven flip — including anything that verifies a
+  RE-SERIALIZED cross-epoch payload, which is what the deleted dual-width
+  retry existed to handle.
 - **NOA not live**: the network-owned-address (NOA) system — both NOA
   signing AND the NOA checkpoint system (`crates/ika-core/src/noa_checkpoints/`)
   — is under active development and not deployed at all. No backward

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -804,7 +804,7 @@ impl ProtocolConfig {
         cfg.feature_flags.enforce_checkpoint_timestamp_monotonicity = true;
         cfg.feature_flags.bls_checkpoints = true;
 
-        // Versions below MIN (= 6) are unreachable via `get_for_version` (it
+        // Versions below MIN (= 7) are unreachable via `get_for_version` (it
         // asserts `version >= MIN`), but their arms are kept as the readable
         // history of how each version changed the config — every supported
         // version's config is still built by replaying them from the start.


### PR DESCRIPTION
`CLAUDE.md` is the instruction file every agent session loads, so a stale claim there propagates into code. Its protocol section described a world with two supported versions and a transition pending between them. Dropping v6 left it wrong in ways that don't fail loudly — they just produce quietly wrong work.

### What it said that is no longer true

| Claim | Reality |
|---|---|
| `MIN = 6`, `MAX = 7` | `MIN = MAX = 7` |
| "v6 is LIVE on both mainnet and testnet" | v6 is not supported at all |
| "v7 is advertised and not yet activated" | v7 is the only version |
| "`AuthorityName` … zero-padded into the same 48-byte container, so the wire encoding is unchanged" | emitted as the raw 32 bytes; the padded form is no longer emitted by any supported version |
| "the width lives in the `AUTHORITY_NAME_SHORT_ENCODING` process global" | that global no longer exists |
| "**Anything new that verifies a re-serialized cross-epoch payload must do the same**" (mirror the dual-width retry) | the retry was deleted; there is nothing to mirror |
| "BLS-basis committees stay READABLE through `Committee`'s `expanded_keys` alias translation" | not recoverable from a name — carried explicitly via `Committee::new_with_protocol_keys`; `Committee::new` leaves it empty and fails closed at `public_key()` |

Followed literally, that text would have someone preserve v6 compatibility that no longer needs preserving, gate behavior that is now unconditional, and reproduce a retry that no longer exists.

### What replaces it

The v7-only reality, plus the two things a reader most needs and could not previously infer:

- **Do not re-gate.** With one supported version, every formerly gated behavior is unconditional — including short `AuthorityName`s, which the old text presented as pending.
- **The transition machinery must be REBUILT for v8, not re-enabled.** It was deleted, not disabled. That is exactly the sort of thing that is expensive to rediscover.

### What was verified and kept

Not everything was stale. Re-checked against the code and retained: the strict-only inkrypto revision; why the below-MIN `FeatureFlags` fields and `get_for_version` arms must stay (the flag set is BCS-serialized into the `ProtocolConfig` digest riding `AuthorityCapabilitiesV1` through consensus); and the V1/V2/V3/V4 decodability constraints, each re-read against `VersionedNetworkDkgOutput`'s own documentation.

### Also

- Toolchain 1.93 → **1.97**, per `rust-toolchain.toml`. (Sui pin `mainnet-v1.76.1` checked and correct.)
- The section ended mid-clause — "A node whose persisted epoch-start record" — with no continuation. Removed.
- `ika-protocol-config/src/lib.rs` had its own stale "Versions below MIN (= **6**)" comment. Now 7.

### Verification

`cargo test -p ika-protocol-config` — 6 passed, snapshots green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rLdsjCfcsTMaiLd3TX8w

---

## Second commit: the upgrade-suite scenario header

Rebased onto #2012, which unblocked a fix in the same file.

**An orphaned fragment.** The retired protocol-transition scenario's heading was deleted but its BODY was left behind, dangling under `v128_rollout` — so the comment described that gate as crossing `v6 -> v7`, two lines after correctly stating it is *"a pure binary swap, no protocol transition"*. Removed; the playbook already records that scenario as retired.

**The old-release version was wrong in seven places.** `OLD_REF` defaults to `release/mainnet-v1.2.8` and the scenarios are named `v128_*`, but the prose said *"the literal v1.2.7 release"* throughout — carried over when they were renamed from `v127`.

**And the protocol version.** Both networks run v7 and the candidate binary supports nothing else, so the harness genesises at v7 — not the v6 the comment claimed. Verified against the tag: `release/mainnet-v1.2.8` is `MIN=6, MAX=7`, so it can run at v7, which is what makes the mixed-binary topology possible at all.

Comment-only; no workflow behaviour changes. YAML re-validated (12 path entries, both jobs intact).
