### PR TITLE
fix(consensus): exclude internal MPC output from dedup LRU; regression coverage for the hardening series

### DIFF
--- a/crates/ika-core/src/consensus_handler.rs
+++ b/crates/ika-core/src/consensus_handler.rs
@@ -339,11 +339,12 @@ impl<C: DWalletCheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 let in_set = !processed_set.insert(key.clone());
                 // The LRU is a local fast path in front of the durable
                 // `is_consensus_message_processed` check, so declining to cache
-                // a key costs one DB read and nothing else. Two key variants
-                // embed their whole MPC payload, so admitting them budgets
-                // `PROCESSED_CACHE_CAP` entries times an unbounded per-entry
-                // size — a cap in name only. They are the ones least worth
-                // caching anyway: an MPC message or output is submitted once.
+                // a key costs one DB read and nothing else. The MPC-payload key
+                // variants (see `embeds_payload`) embed their whole payload, so
+                // admitting them budgets `PROCESSED_CACHE_CAP` entries times an
+                // unbounded per-entry size — a cap in name only. They are the
+                // ones least worth caching anyway: an MPC message or output is
+                // submitted once.
                 let in_cache = if key.embeds_payload() {
                     false
                 } else {

--- a/crates/ika-core/src/sui_connector/mod.rs
+++ b/crates/ika-core/src/sui_connector/mod.rs
@@ -526,6 +526,35 @@ const SWEEP_MIN_COIN_TOTAL: u64 = 1_000_000_000;
 /// 256 objects per transaction.
 const SWEEP_MAX_GAS_COINS: usize = 256;
 
+/// The sweep's go/no-go decision and split amount, extracted pure so the
+/// guards are unit-testable (the async sweep needs a signing client).
+///
+/// `Err` on: no coins listed; a listing AT or over the gas-payment cap —
+/// `>=`, not `>`, because `list_owned_gas_coins` truncates at the same cap,
+/// so a set of exactly that length may be a truncation of a larger holding
+/// while `coin_total` still counts every coin, and proceeding would smash a
+/// capped payment while splitting the full balance, aborting on chain
+/// instead of bailing here; and a total that does not exceed the sweep's
+/// own gas budget (splitting zero is churn, not funding).
+fn sweep_split_amount(gas_coin_count: usize, coin_total: u64) -> anyhow::Result<u64> {
+    if gas_coin_count == 0 {
+        anyhow::bail!("coin balance is {coin_total} MIST but no gas-coin objects were listed");
+    }
+    if gas_coin_count >= SWEEP_MAX_GAS_COINS {
+        // The subset's value is unknown, so a correct split amount can't be
+        // computed. This does not happen to a writer address in practice.
+        anyhow::bail!(
+            "{gas_coin_count} gas coins exceed the {SWEEP_MAX_GAS_COINS}-object gas payment cap; \
+             consolidate them manually",
+        );
+    }
+    let sweep_amount = coin_total.saturating_sub(SWEEP_GAS_BUDGET);
+    if sweep_amount == 0 {
+        anyhow::bail!("coin balance {coin_total} MIST does not exceed the sweep gas budget");
+    }
+    Ok(sweep_amount)
+}
+
 /// Deposit the notifier's gas-coin objects into its SIP-58 address balance.
 /// Returns the amount deposited (MIST). The sweep transaction uses ALL owned
 /// gas coins as its own gas payment (Sui merges them into the first), splits
@@ -539,27 +568,7 @@ async fn sweep_gas_coins_into_address_balance<C: SuiClientInner>(
     coin_total: u64,
 ) -> anyhow::Result<u64> {
     let gas_coins = sui_client.get_gas_objects(sui_address).await;
-    if gas_coins.is_empty() {
-        anyhow::bail!("coin balance is {coin_total} MIST but no gas-coin objects were listed");
-    }
-    if gas_coins.len() >= SWEEP_MAX_GAS_COINS {
-        // The subset's value is unknown, so a correct split amount can't be
-        // computed. This does not happen to a writer address in practice.
-        //
-        // `>=`, not `>`: the lister truncates at the same cap, so a returned
-        // set of exactly this length may be a truncation of a larger holding.
-        // `coin_total` still counts every coin, so proceeding would smash a
-        // 256-coin payment while splitting the full balance, and the
-        // SplitCoins would abort on chain instead of bailing here.
-        anyhow::bail!(
-            "{} gas coins exceed the {SWEEP_MAX_GAS_COINS}-object gas payment cap;              consolidate them manually",
-            gas_coins.len()
-        );
-    }
-    let sweep_amount = coin_total.saturating_sub(SWEEP_GAS_BUDGET);
-    if sweep_amount == 0 {
-        anyhow::bail!("coin balance {coin_total} MIST does not exceed the sweep gas budget");
-    }
+    let sweep_amount = sweep_split_amount(gas_coins.len(), coin_total)?;
     let computation_price = sui_client.get_reference_gas_price_until_success().await;
     let tx_data = sweep_transaction_data(sui_address, gas_coins, sweep_amount, computation_price)?;
     let signature = Signature::new_secure(
@@ -783,5 +792,37 @@ mod tests {
         let instant = std::time::Instant::now();
         retry_with_max_elapsed_time!(example_func_err(), max_elapsed_time).unwrap_err();
         assert!(instant.elapsed() < max_elapsed_time);
+    }
+
+    /// The sweep must refuse a coin listing AT the gas-payment cap, not just
+    /// over it: `list_owned_gas_coins` truncates at that same cap, so exactly
+    /// 256 coins may be a truncation of a larger holding while `coin_total`
+    /// counts everything — proceeding would split the full balance against a
+    /// capped payment and abort on chain instead of bailing client-side.
+    /// (#1996 review finding; the guard was `>` before.)
+    #[test]
+    fn sweep_refuses_a_listing_at_the_gas_payment_cap() {
+        let plenty = SWEEP_GAS_BUDGET + SWEEP_MIN_COIN_TOTAL;
+        let err = sweep_split_amount(SWEEP_MAX_GAS_COINS, plenty)
+            .expect_err("exactly at the cap may be a truncated listing");
+        assert!(format!("{err}").contains("consolidate them manually"));
+        assert!(sweep_split_amount(SWEEP_MAX_GAS_COINS + 40, plenty).is_err());
+        // One under the cap is a complete listing and sweeps normally.
+        assert_eq!(
+            sweep_split_amount(SWEEP_MAX_GAS_COINS - 1, plenty).unwrap(),
+            plenty - SWEEP_GAS_BUDGET
+        );
+    }
+
+    #[test]
+    fn sweep_refuses_no_coins_and_dust_totals() {
+        assert!(sweep_split_amount(0, SWEEP_GAS_BUDGET * 10).is_err());
+        // A total at or under the sweep's own gas budget splits nothing.
+        assert!(sweep_split_amount(3, SWEEP_GAS_BUDGET).is_err());
+        assert_eq!(
+            sweep_split_amount(3, SWEEP_GAS_BUDGET + 1).unwrap(),
+            1,
+            "everything above the sweep budget is deposited"
+        );
     }
 }

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -837,3 +837,37 @@ mod wire_format_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod consensus_key_tests {
+    use super::*;
+    use crate::messages_dwallet_mpc::SessionType;
+
+    /// The dedup LRU budgets by ENTRY COUNT, so any variant that embeds its
+    /// whole MPC payload must be excluded from it (#1997). This pins which
+    /// variants those are: if a new payload-carrying variant is added, it
+    /// must be added to `embeds_payload` — and to this test.
+    #[test]
+    fn payload_embedding_variants_are_exactly_the_two_mpc_ones() {
+        let name = AuthorityName([9; 32]);
+        let session = SessionIdentifier::new(SessionType::User, [0u8; 32]);
+        assert!(
+            ConsensusTransactionKey::DWalletMPCMessage(name, session, vec![0u8; 64])
+                .embeds_payload(),
+            "the MPC message variant carries its payload in the key"
+        );
+        assert!(
+            ConsensusTransactionKey::DWalletMPCOutput(name, session, vec![], vec![])
+                .embeds_payload(),
+            "the MPC output variant carries its payload in the key"
+        );
+        assert!(
+            !ConsensusTransactionKey::NOAPresignDemand([0u8; 32]).embeds_payload(),
+            "a digest-shaped key must not be classified as payload-embedding"
+        );
+        assert!(
+            !ConsensusTransactionKey::EndOfPublishV2(name).embeds_payload(),
+            "an authority-shaped key must not be classified as payload-embedding"
+        );
+    }
+}

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -144,14 +144,36 @@ impl ConsensusTransactionKey {
     /// digest or a small tuple.
     ///
     /// Most variants are a digest or an `(authority, u64)`-shaped tuple —
-    /// tens of bytes. Two carry their whole MPC payload, so anything that
-    /// budgets by ENTRY COUNT rather than by bytes is really budgeting
-    /// `count * unbounded`.
+    /// tens of bytes. Three carry their whole MPC payload (a message body,
+    /// an output's checkpoint-message kinds, or an internal output's
+    /// `Vec<u8>`s), so anything that budgets by ENTRY COUNT rather than by
+    /// bytes is really budgeting `count * unbounded`.
+    ///
+    /// The match is deliberately EXHAUSTIVE, no wildcard: a new variant
+    /// fails to compile until it is classified here, which is what keeps a
+    /// future payload-carrying key from silently re-entering the
+    /// count-budgeted dedup LRU. (`DWalletInternalMPCOutput` did exactly
+    /// that — it postdated the original two-variant list and was admitted
+    /// unbounded until this classification was made exhaustive.)
     pub fn embeds_payload(&self) -> bool {
-        matches!(
-            self,
-            Self::DWalletMPCMessage(..) | Self::DWalletMPCOutput(..)
-        )
+        match self {
+            Self::DWalletMPCMessage(..)
+            | Self::DWalletMPCOutput(..)
+            | Self::DWalletInternalMPCOutput(..) => true,
+            Self::DWalletCheckpointSignature(..)
+            | Self::CapabilityNotification(..)
+            | Self::EndOfPublish(..)
+            | Self::SystemCheckpointSignature(..)
+            | Self::IdleStatusUpdate(..)
+            | Self::SuiChainObservationUpdate(..)
+            | Self::GlobalPresignRequest(..)
+            | Self::NOAObservation(..)
+            | Self::ValidatorMpcDataAnnouncement(..)
+            | Self::RelayedValidatorMpcDataAnnouncement(..)
+            | Self::EpochMpcDataReadySignal(..)
+            | Self::EndOfPublishV2(..)
+            | Self::NOAPresignDemand(..) => false,
+        }
     }
 }
 
@@ -842,15 +864,26 @@ mod wire_format_tests {
 mod consensus_key_tests {
     use super::*;
     use crate::messages_dwallet_mpc::SessionType;
+    use dwallet_mpc_types::dwallet_mpc::{DWalletCurve, DWalletSignatureAlgorithm};
+    use sui_types::base_types::ObjectID;
 
-    /// The dedup LRU budgets by ENTRY COUNT, so any variant that embeds its
-    /// whole MPC payload must be excluded from it (#1997). This pins which
-    /// variants those are: if a new payload-carrying variant is added, it
-    /// must be added to `embeds_payload` — and to this test.
+    /// The dedup LRU budgets by ENTRY COUNT, so a key that embeds an
+    /// unbounded MPC payload must be kept out of it (#1997) — otherwise the
+    /// cap is `count * unbounded`. This pins which keys carry a payload.
+    ///
+    /// The point of `embeds_payload` being an exhaustive `match` is that a
+    /// new variant is a COMPILE error until classified, so this test does
+    /// not need to (and cannot) enumerate future variants — it locks the
+    /// three payload-carrying ones as `true` and a representative sample of
+    /// the digest/authority-shaped ones as `false`. `DWalletInternalMPCOutput`
+    /// is the one this PR corrected: it postdated the original two-variant
+    /// list and was silently admitted to the LRU until now.
     #[test]
-    fn payload_embedding_variants_are_exactly_the_two_mpc_ones() {
+    fn every_mpc_payload_key_is_excluded_from_the_dedup_lru() {
         let name = AuthorityName([9; 32]);
         let session = SessionIdentifier::new(SessionType::User, [0u8; 32]);
+
+        // The three payload-carrying keys.
         assert!(
             ConsensusTransactionKey::DWalletMPCMessage(name, session, vec![0u8; 64])
                 .embeds_payload(),
@@ -861,9 +894,33 @@ mod consensus_key_tests {
                 .embeds_payload(),
             "the MPC output variant carries its payload in the key"
         );
+        let internal_kind = DWalletInternalMPCOutputKind::InternalPresign {
+            output: vec![0u8; 64],
+            curve: DWalletCurve::Secp256k1,
+            signature_algorithm: DWalletSignatureAlgorithm::ECDSASecp256k1,
+            session_sequence_number: 0,
+            dwallet_network_encryption_key_id: ObjectID::ZERO,
+        };
+        assert!(
+            ConsensusTransactionKey::DWalletInternalMPCOutput(
+                name,
+                session,
+                internal_kind,
+                vec![],
+            )
+            .embeds_payload(),
+            "the internal MPC output variant embeds unbounded Vec<u8> in its key"
+        );
+
+        // Representative non-payload keys: a digest, a small tuple, a bare
+        // authority. These must stay in the LRU.
         assert!(
             !ConsensusTransactionKey::NOAPresignDemand([0u8; 32]).embeds_payload(),
             "a digest-shaped key must not be classified as payload-embedding"
+        );
+        assert!(
+            !ConsensusTransactionKey::GlobalPresignRequest(name, 7).embeds_payload(),
+            "an (authority, u64) key must not be classified as payload-embedding"
         );
         assert!(
             !ConsensusTransactionKey::EndOfPublishV2(name).embeds_payload(),

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -1178,3 +1178,61 @@ pub mod test_helpers {
         }
     }
 }
+
+#[cfg(test)]
+mod session_identifier_tests {
+    use super::*;
+
+    /// Build a `SessionIdentifier` with an arbitrary (type, digest, preimage)
+    /// triple, the way the wire can: `Deserialize` is derived, so nothing
+    /// forces the digest to actually commit to the other two fields.
+    fn wire_triple(
+        session_type: SessionType,
+        digest: [u8; 32],
+        preimage: [u8; 32],
+    ) -> SessionIdentifier {
+        #[derive(serde::Serialize)]
+        struct Raw {
+            session_type: SessionType,
+            session_identifier: [u8; 32],
+            session_identifier_preimage: [u8; 32],
+        }
+        let bytes = bcs::to_bytes(&Raw {
+            session_type,
+            session_identifier: digest,
+            session_identifier_preimage: preimage,
+        })
+        .unwrap();
+        bcs::from_bytes(&bytes).unwrap()
+    }
+
+    /// `Ord` must agree with the derived `Eq`: values that are `!=` must
+    /// never compare `Equal`. Before the #2000 fix, `cmp` looked only at
+    /// the digest, so two wire-crafted values sharing a digest but
+    /// differing in type or preimage broke the total-order contract that
+    /// `BTreeMap`, `sort` and `dedup` rely on.
+    #[test]
+    fn ord_agrees_with_eq_on_digest_collisions() {
+        let a = wire_triple(SessionType::User, [7; 32], [1; 32]);
+        let b = wire_triple(SessionType::User, [7; 32], [2; 32]);
+        let c = wire_triple(SessionType::System, [7; 32], [1; 32]);
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(a.cmp(&b), std::cmp::Ordering::Equal);
+        assert_ne!(a.cmp(&c), std::cmp::Ordering::Equal);
+        // And Eq still implies Equal.
+        let a2 = wire_triple(SessionType::User, [7; 32], [1; 32]);
+        assert_eq!(a, a2);
+        assert_eq!(a.cmp(&a2), std::cmp::Ordering::Equal);
+    }
+
+    /// Digest-first: whenever digests differ — every honestly-constructed
+    /// pair, since the digest commits to the other fields — the order is
+    /// exactly the digest order, unchanged from before the fix.
+    #[test]
+    fn ordering_is_digest_first_for_distinct_digests() {
+        let low = wire_triple(SessionType::System, [1; 32], [9; 32]);
+        let high = wire_triple(SessionType::User, [2; 32], [0; 32]);
+        assert!(low < high, "digest order must dominate type and preimage");
+    }
+}

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -1216,6 +1216,17 @@ mod session_identifier_tests {
         let a = wire_triple(SessionType::User, [7; 32], [1; 32]);
         let b = wire_triple(SessionType::User, [7; 32], [2; 32]);
         let c = wire_triple(SessionType::System, [7; 32], [1; 32]);
+        // Guard the crafting itself against silent field-order drift: the
+        // digest and preimage are both `[u8; 32]`, so a swap of the two
+        // fields would deserialize transposed and turn this collision pair
+        // into a distinct-digest pair whose assertions pass vacuously. The
+        // `From<&SessionIdentifier>` accessor returns the digest field.
+        assert_eq!(
+            <[u8; 32]>::from(&a),
+            [7; 32],
+            "digest field mismatch — Raw layout drifted from SessionIdentifier"
+        );
+        assert_eq!(<[u8; 32]>::from(&b), [7; 32]);
         assert_ne!(a, b);
         assert_ne!(a, c);
         assert_ne!(a.cmp(&b), std::cmp::Ordering::Equal);


### PR DESCRIPTION
Started as test-only coverage for the #1995–#2011 hardening series. Writing the #1997 test **surfaced a live gap in #1997 itself**, so this PR now carries that fix too.

## The fix (surfaced by the test)

`ConsensusTransactionKey` has **three** variants that embed an unbounded MPC payload, not two: `DWalletInternalMPCOutput` carries a `DWalletInternalMPCOutputKind` holding `Vec<u8>` `output`/`message` bytes, and its key is built with `output.output.clone()`. `embeds_payload` matched only the original `DWalletMPCMessage | DWalletMPCOutput`, so the internal output was admitted to the `PROCESSED_CACHE_CAP` (1,048,576-entry) **count-budgeted** LRU in `consensus_handler` — the exact `count × unbounded` 'cap in name only' failure mode #1997 fixed for the other two. **Live, not gated**: `internal_presign_sessions` turns on at protocol v4, below both networks.

- Classify `DWalletInternalMPCOutput` as payload-embedding.
- Make `embeds_payload` an **exhaustive** `match`, no wildcard — a future key variant is now a compile error until classified, which is what keeps this from recurring (the original two-variant list predated this variant and silently missed it).

Digest-safe and correctness-neutral: `embeds_payload` only decides whether to *cache* a key in the local fast path before the durable `is_consensus_message_processed` check, so declining to cache costs one DB read and changes no wire or DB format. **Fault-validated**: moving the internal variant back to the non-payload set fails the test.

## Regression tests (the original intent)

- **#1996 — sweep gas-payment guard.** Extracted the go/no-go + split-amount decision into a pure `sweep_split_amount`; tests the `>=`-at-cap case (a listing at 256 may be a truncated view of more), plus the no-coins and dust bails. (The extraction also normalized a stray 14-space run in one error string to a single space — an incidental cleanup, not a verbatim copy.)
- **#2000 — `SessionIdentifier` Ord/Eq agreement.** Wire-crafted digest-colliding values must not compare `Equal`; distinct digests still order digest-first. Hardened against silent field-order drift by asserting the crafted digest through the `From<&SessionIdentifier>` accessor.
- **#1997 — `embeds_payload` classification.** Now builds all three payload keys plus representative digest/authority keys, and is renamed from the false 'exactly the two' to `every_mpc_payload_key_is_excluded_from_the_dedup_lru`.

All fault-validated (revert each fix → only its test fails).

## Deliberately not added

- **#1998** (metrics re-registration) needs a real committee **rejoin**; **#2005** (epoch-end read guards) needs a reconfiguration-timing race. Neither is unit-stageable; both are covered by the upgrade/cluster suites (now triggering on these crates via #2012, full matrix green on main).

## Verification

`cargo test -p ika-types` (28/28), `cargo test -p ika-core --lib sweep` (3/3), `cargo build -p ika-core` (exhaustive match compiles), `cargo clippy -p ika-types -p ika-core`, `cargo fmt --all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)