### PR TITLE
fix(node): bound the epoch-reconfiguration critical section with a watchdog (#1864)

### DIFF
--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -92,6 +92,7 @@ pub mod admin;
 mod handle;
 pub mod metrics;
 mod node_runner;
+mod reconfig_watchdog;
 mod validator_metrics;
 
 pub use node_runner::{NodeArgs, run_node, run_node_with_name};
@@ -2987,6 +2988,13 @@ impl IkaNode {
             }) = self.validator_components.lock().await.take()
             {
                 info!("Reconfiguring the validator.");
+                // Consensus subscriptions die in this window and only come
+                // back when the new epoch's components start, so a hang
+                // anywhere in it is a permanent, silent consensus-dead node.
+                let watchdog = reconfig_watchdog::ReconfigWatchdog::arm(
+                    self.metrics.reconfig_phase.clone(),
+                    next_epoch,
+                );
                 // Cancel the old dwallet checkpoint service & system checkpoint service tasks.
                 // Waiting for checkpoint builder to finish gracefully is not possible, because it
                 // may wait on transactions while consensus on peers have already shut down.
@@ -3018,9 +3026,11 @@ impl IkaNode {
                 }
                 info!("System checkpoint service was shut down");
 
+                watchdog.phase(reconfig_watchdog::phase::CONSENSUS_SHUTDOWN);
                 consensus_manager.shutdown().await;
                 info!("Consensus was shut down");
 
+                watchdog.phase(reconfig_watchdog::phase::RECONFIGURE_STATE);
                 let new_epoch_store = self
                     .reconfigure_state(
                         &cur_epoch_store,
@@ -3030,7 +3040,12 @@ impl IkaNode {
                     .await;
                 info!("Epoch store finished reconfiguration.");
 
+                watchdog.phase(reconfig_watchdog::phase::CONSENSUS_STORE_PRUNE);
                 consensus_store_pruner.prune(next_epoch).await;
+                // The prepare-then-start barrier below can legitimately
+                // block for minutes and carries its own gauge, retry counter
+                // and alert, so the watchdog's coverage ends here.
+                watchdog.disarm();
 
                 // Prepare-then-start barrier. Block here until the full
                 // verified handoff data for the epoch we are entering is
@@ -3093,6 +3108,14 @@ impl IkaNode {
                     None
                 }
             } else {
+                // No consensus to tear down here, but reconfigure_state
+                // crosses the same unbounded awaits; a fullnode parked in
+                // them silently stops following epochs.
+                let watchdog = reconfig_watchdog::ReconfigWatchdog::arm(
+                    self.metrics.reconfig_phase.clone(),
+                    next_epoch,
+                );
+                watchdog.phase(reconfig_watchdog::phase::RECONFIGURE_STATE);
                 let new_epoch_store = self
                     .reconfigure_state(
                         &cur_epoch_store,
@@ -3100,6 +3123,7 @@ impl IkaNode {
                         epoch_start_system_state,
                     )
                     .await;
+                watchdog.disarm();
 
                 let is_committee_member = self.state.is_validator(&new_epoch_store);
                 if is_committee_member && !self.mode.is_validator() {

--- a/crates/ika-node/src/metrics.rs
+++ b/crates/ika-node/src/metrics.rs
@@ -37,6 +37,13 @@ pub struct IkaNodeMetrics {
     /// signal; a high `transport_error` rate explains slow ready-signal
     /// coverage.
     pub mpc_data_blob_fetch_total: IntCounterVec,
+
+    /// Sub-phase of the epoch-reconfiguration critical section while the
+    /// reconfig watchdog is armed (see `reconfig_watchdog::phase`); 0
+    /// outside it. Any nonzero value that persists is a node parked in the
+    /// teardown-to-restart window (#1864), and the value names the hanging
+    /// await.
+    pub reconfig_phase: IntGauge,
 }
 
 impl IkaNodeMetrics {
@@ -98,6 +105,13 @@ impl IkaNodeMetrics {
                 "ika_dwallet_mpc_data_blob_fetch_total",
                 "P2P mpc_data blob fetch outcomes",
                 &["result"],
+                registry,
+            )
+            .unwrap(),
+            reconfig_phase: register_int_gauge_with_registry!(
+                "ika_reconfig_phase",
+                "Sub-phase of the epoch-reconfiguration critical section while the reconfig \
+                 watchdog is armed; 0 outside it",
                 registry,
             )
             .unwrap(),

--- a/crates/ika-node/src/reconfig_watchdog.rs
+++ b/crates/ika-node/src/reconfig_watchdog.rs
@@ -1,0 +1,267 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Bounded watchdog over the epoch-reconfiguration critical section.
+//!
+//! Between tearing down the outgoing epoch's services and creating the new
+//! epoch store, `monitor_reconfiguration` crosses several unbounded awaits:
+//! joining the aborted checkpoint services, `ConsensusManager::shutdown`,
+//! and — inside `AuthorityState::reconfigure` — the `execution_lock` write
+//! acquisition and the `epoch_terminated` barrier. A validator that parks
+//! on any of them has already torn down its consensus subscriptions, so it
+//! emerges consensus-dead with no retry and no crash: the #1864 zombie,
+//! observed live twice (testnet 356→357, mainnet 372→373), both times
+//! parked for days until an operator restarted the process — and both
+//! times the restart recovered it.
+//!
+//! The watchdog makes that recovery automatic: if the covered window does
+//! not complete within the bound, the node exits so its supervisor
+//! restarts it. While armed, the current sub-phase is exported on the
+//! `ika_reconfig_phase` gauge, so if a node ever breaches (or wedges with
+//! the watchdog disabled) the hanging await is attributable from metrics
+//! alone — external operators' nodes included, where logs are never
+//! available to us.
+
+use prometheus::IntGauge;
+use std::time::Duration;
+use tokio::sync::oneshot;
+use tracing::{error, warn};
+
+/// Values exported on `ika_reconfig_phase` while the watchdog is armed.
+pub(crate) mod phase {
+    /// Not inside the watchdog-covered reconfiguration window.
+    pub(crate) const IDLE: i64 = 0;
+    /// Aborting + joining the outgoing epoch's checkpoint services and
+    /// signalling the MPC service to exit.
+    pub(crate) const SERVICE_TEARDOWN: i64 = 1;
+    /// Awaiting `ConsensusManager::shutdown`.
+    pub(crate) const CONSENSUS_SHUTDOWN: i64 = 2;
+    /// Inside `reconfigure_state`: `execution_lock` write acquisition, the
+    /// `epoch_terminated` barrier, and new epoch store creation.
+    pub(crate) const RECONFIGURE_STATE: i64 = 3;
+    /// Pruning the outgoing epoch's consensus stores.
+    pub(crate) const CONSENSUS_STORE_PRUNE: i64 = 4;
+}
+
+/// Generous by an order of magnitude: the covered window normally
+/// completes in seconds, and the wedges this exists for sat in it for
+/// days. Deliberately excludes the prepare-then-start handoff barrier,
+/// which can legitimately block for minutes and has its own gauge, retry
+/// counter, and alert.
+const DEFAULT_BOUND: Duration = Duration::from_secs(600);
+
+/// Environment override for the bound, in seconds. `0` disables the
+/// watchdog entirely — an operator escape hatch if a slow host ever
+/// breaches on a legitimate transition.
+const BOUND_ENV_VAR: &str = "IKA_RECONFIG_WATCHDOG_SECS";
+
+fn resolve_bound() -> Option<Duration> {
+    parse_bound(std::env::var(BOUND_ENV_VAR).ok().as_deref())
+}
+
+fn parse_bound(raw: Option<&str>) -> Option<Duration> {
+    match raw {
+        None => Some(DEFAULT_BOUND),
+        Some(raw) => match raw.trim().parse::<u64>() {
+            Ok(0) => None,
+            Ok(secs) => Some(Duration::from_secs(secs)),
+            Err(_) => {
+                warn!(
+                    value = raw,
+                    default_secs = DEFAULT_BOUND.as_secs(),
+                    "unparseable {BOUND_ENV_VAR}; using the default bound"
+                );
+                Some(DEFAULT_BOUND)
+            }
+        },
+    }
+}
+
+fn default_breach_action() {
+    #[cfg(not(msim))]
+    std::process::exit(1);
+
+    #[cfg(msim)]
+    sui_simulator::task::shutdown_current_node();
+}
+
+/// RAII guard for the covered window: arming starts the timer and sets the
+/// phase gauge; dropping (or `disarm`) cancels the timer and returns the
+/// gauge to `IDLE`, so every exit path — including `?` and panic unwinds —
+/// disarms.
+pub(crate) struct ReconfigWatchdog {
+    cancel: Option<oneshot::Sender<()>>,
+    phase_gauge: IntGauge,
+}
+
+impl ReconfigWatchdog {
+    /// Arms the watchdog for the transition into `next_epoch`. On breach
+    /// the node exits (real nodes) or shuts down the simulated node
+    /// (simtests) so the supervisor restarts it.
+    pub(crate) fn arm(phase_gauge: IntGauge, next_epoch: u64) -> Self {
+        Self::arm_with(
+            phase_gauge,
+            next_epoch,
+            resolve_bound(),
+            default_breach_action,
+        )
+    }
+
+    fn arm_with(
+        phase_gauge: IntGauge,
+        next_epoch: u64,
+        bound: Option<Duration>,
+        breach_action: impl FnOnce() + Send + 'static,
+    ) -> Self {
+        phase_gauge.set(phase::SERVICE_TEARDOWN);
+        let cancel = bound.map(|bound| {
+            let (cancel_tx, cancel_rx) = oneshot::channel();
+            let gauge = phase_gauge.clone();
+            tokio::spawn(async move {
+                tokio::select! {
+                    _ = tokio::time::sleep(bound) => {
+                        error!(
+                            next_epoch,
+                            phase = gauge.get(),
+                            bound_secs = bound.as_secs(),
+                            "the epoch transition's teardown-to-restart window exceeded the \
+                             watchdog bound; the node is presumed wedged (#1864) and a process \
+                             restart is the demonstrated recovery — exiting so the supervisor \
+                             restarts us"
+                        );
+                        breach_action();
+                    }
+                    _ = cancel_rx => {}
+                }
+            });
+            cancel_tx
+        });
+        Self {
+            cancel,
+            phase_gauge,
+        }
+    }
+
+    /// Records progress into a sub-phase of the covered window.
+    pub(crate) fn phase(&self, phase: i64) {
+        self.phase_gauge.set(phase);
+    }
+
+    /// Marks the covered window complete. (Equivalent to dropping the
+    /// guard; named so the completion point is visible in the caller.)
+    pub(crate) fn disarm(self) {}
+}
+
+impl Drop for ReconfigWatchdog {
+    fn drop(&mut self) {
+        self.phase_gauge.set(phase::IDLE);
+        if let Some(cancel) = self.cancel.take() {
+            let _ = cancel.send(());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    fn gauge() -> IntGauge {
+        IntGauge::new("test_reconfig_phase", "test gauge").unwrap()
+    }
+
+    fn flag() -> (Arc<AtomicBool>, impl FnOnce() + Send + 'static) {
+        let fired = Arc::new(AtomicBool::new(false));
+        let setter = {
+            let fired = fired.clone();
+            move || fired.store(true, Ordering::SeqCst)
+        };
+        (fired, setter)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn breach_fires_when_the_window_never_completes() {
+        let (fired, on_breach) = flag();
+        let gauge = gauge();
+        let watchdog = ReconfigWatchdog::arm_with(
+            gauge.clone(),
+            373,
+            Some(Duration::from_secs(600)),
+            on_breach,
+        );
+        watchdog.phase(phase::RECONFIGURE_STATE);
+        assert_eq!(gauge.get(), phase::RECONFIGURE_STATE);
+
+        tokio::time::sleep(Duration::from_secs(601)).await;
+        assert!(
+            fired.load(Ordering::SeqCst),
+            "an armed watchdog must fire once the bound elapses"
+        );
+        drop(watchdog);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn disarm_before_the_bound_never_fires() {
+        let (fired, on_breach) = flag();
+        let gauge = gauge();
+        let watchdog = ReconfigWatchdog::arm_with(
+            gauge.clone(),
+            373,
+            Some(Duration::from_secs(600)),
+            on_breach,
+        );
+        assert_eq!(gauge.get(), phase::SERVICE_TEARDOWN);
+        watchdog.disarm();
+        assert_eq!(gauge.get(), phase::IDLE);
+
+        tokio::time::sleep(Duration::from_secs(10_000)).await;
+        assert!(
+            !fired.load(Ordering::SeqCst),
+            "a disarmed watchdog must never fire"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dropping_the_guard_disarms() {
+        let (fired, on_breach) = flag();
+        let gauge = gauge();
+        {
+            let _watchdog = ReconfigWatchdog::arm_with(
+                gauge.clone(),
+                373,
+                Some(Duration::from_secs(600)),
+                on_breach,
+            );
+        }
+        assert_eq!(gauge.get(), phase::IDLE);
+
+        tokio::time::sleep(Duration::from_secs(10_000)).await;
+        assert!(
+            !fired.load(Ordering::SeqCst),
+            "dropping the guard must disarm the watchdog"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn disabled_watchdog_never_fires() {
+        let (fired, on_breach) = flag();
+        let watchdog = ReconfigWatchdog::arm_with(gauge(), 373, None, on_breach);
+
+        tokio::time::sleep(Duration::from_secs(10_000)).await;
+        assert!(
+            !fired.load(Ordering::SeqCst),
+            "a disabled watchdog must never fire"
+        );
+        drop(watchdog);
+    }
+
+    #[test]
+    fn bound_parsing() {
+        assert_eq!(parse_bound(None), Some(DEFAULT_BOUND));
+        assert_eq!(parse_bound(Some("0")), None);
+        assert_eq!(parse_bound(Some("120")), Some(Duration::from_secs(120)));
+        assert_eq!(parse_bound(Some(" 45 ")), Some(Duration::from_secs(45)));
+        assert_eq!(parse_bound(Some("not-a-number")), Some(DEFAULT_BOUND));
+    }
+}


### PR DESCRIPTION
## What

Bounds the epoch-reconfiguration critical section — teardown of the outgoing epoch's services through creation of the new epoch store — with a watchdog. On breach the node logs and exits so its supervisor restarts it (`shutdown_current_node` under msim). While armed, the sub-phase is exported on a new `ika_reconfig_phase` gauge.

## Why

#1864, now observed live twice:

- **NODERS**, testnet 356→357 (July 19): came out of the handoff consensus-dead — zero Mysticeti subscriptions both directions, round processing 0, process alive, no retry.
- **Studio Mirai**, mainnet 372→373 (Aug 6): identical signature, parked **3 days** across three epoch boundaries. Its gauges pin the parking spot: `ika_consensus_subscribed_to = 0` (consensus torn down), `ika_current_epoch` frozen at 372 (the gauge is set only in `AuthorityPerEpochStore::new`, so the new epoch store never existed), `ika_handoff_prepare_waiting = 0` (never reached the barrier).

That places the hang in the window between `consensus_manager.shutdown()` and epoch-store creation, where every await is unbounded: the aborted-service joins, consensus shutdown itself, and — inside `AuthorityState::reconfigure` — the `execution_lock` write acquisition and the `epoch_terminated` barrier. A validator parked there has already lost consensus and nothing retries, crashes, or alerts on the node itself.

Both observed instances recovered on process restart. The watchdog makes that recovery automatic and converts a silent multi-day zombie into a supervised ~30s restart.

## Design decisions

- **Coverage ends before the prepare-then-start handoff barrier** — it can legitimately block for minutes and already has its own gauge, retry counter, and alert.
- **The fullnode-path `reconfigure_state` is also covered** (same unbounded awaits; a fullnode parked there silently stops following epochs).
- **`ika_reconfig_phase`** makes any future wedge attributable from metrics alone — external operators' nodes included, where we never get logs. Phase values: 1 service teardown, 2 consensus shutdown, 3 reconfigure_state, 4 consensus-store prune, 0 idle.
- **Bound 600s** (window normally completes in seconds), overridable via `IKA_RECONFIG_WATCHDOG_SECS`; `0` disables — operator escape hatch.
- Breach action follows the existing `check_protocol_version` idiom: `process::exit(1)` on real nodes, `sui_simulator::task::shutdown_current_node()` under msim, so simtests exercise the code path safely.
- RAII guard: every exit path (including `?` and panic unwinds) disarms.

## Validation

- 5 unit tests (`cargo test -p ika-node --lib reconfig_watchdog`): breach fires when armed past the bound; disarm/drop/disabled never fire; env parsing. The armed/disarmed pair fault-validate each other.
- The wiring's false-positive risk is exercised by every reconfiguration in Simtest + the Upgrade Test matrix (dispatched on this branch): any healthy transition tripping the watchdog would kill the node mid-suite and fail the run.
- clippy + fmt clean.

Root cause of the *trigger* (the wedged state carried into the boundary) remains open under #1864 — the phase gauge is designed to attribute it on the next occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
