### PR TITLE
fix(noa): derive a presign demand's signature algorithm from its identity

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -1750,9 +1750,45 @@ impl DWalletMPCService {
                     // already assigned) — drop; `Ok(None)` => pool momentarily
                     // empty — keep, preserving order across rounds until the
                     // presign is generated; `Err` => keep for retry.
+                    // Prefer the algorithm DERIVED from the demand identity
+                    // over the one the announcement carries. The consensus
+                    // dedup key is the demand-id digest alone, so the first
+                    // announcement sequenced for a demand supplies the payload
+                    // fields for the whole network and the honest duplicates
+                    // are dropped — an announcer could otherwise pick the
+                    // algorithm, and so the presign pool, for a demand whose id
+                    // it can compute from public checkpoint data.
+                    //
+                    // Deriving is stronger than checking-and-rejecting here:
+                    // rejecting would leave the demand unassigned, and since
+                    // the honest announcements were already deduplicated away,
+                    // its sign would never happen and the epoch could not
+                    // finalize its NOA checkpoints. Every validator derives the
+                    // same value from the same consensus-agreed identity, so
+                    // this stays network-uniform.
+                    //
+                    // The announced value still governs where the identity does
+                    // not determine one. `network_encryption_key_id` is NOT
+                    // derivable — it is frozen at announce time on purpose (see
+                    // above) — and remains as announced.
+                    let signature_algorithm = demand
+                        .demand_id
+                        .expected_signature_algorithm()
+                        .unwrap_or(demand.signature_algorithm);
+                    if signature_algorithm != demand.signature_algorithm {
+                        ika_types::report_invariant_violation!(
+                            "noa_presign_demand_signature_algorithm_mismatch",
+                            announcer=?demand.authority,
+                            announced=?demand.signature_algorithm,
+                            derived=?signature_algorithm,
+                            demand_id=?demand.demand_id,
+                            "NOA presign demand announced a signature algorithm its demand \
+                             identity does not imply; using the derived one"
+                        );
+                    }
                     match self.epoch_store.assign_noa_presign(
                         demand.demand_id_digest(),
-                        demand.signature_algorithm,
+                        signature_algorithm,
                         demand.network_encryption_key_id,
                     ) {
                         Ok(Some(_)) => false,

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
@@ -25,7 +25,8 @@ use dwallet_mpc_types::dwallet_mpc::{
     DWalletCurve, DWalletHashScheme, DWalletSignatureAlgorithm,
 };
 use ika_types::message::{DWalletCheckpointMessageKind, MakeDWalletUserSecretKeySharesPublicOutput};
-use ika_types::messages_dwallet_mpc::{
+use ika_types::noa_checkpoint::{NOACheckpointKindName, NOACheckpointTxRef, NOAPresignDemandId};
+use ika_types::messages_dwallet_mpc::{ConsensusNOAPresignDemand,
     DWalletMPCOutput, DWalletMPCOutputReport, SessionIdentifier, SessionType,
 };
 use std::collections::HashSet;
@@ -1265,4 +1266,160 @@ async fn test_network_owned_address_sign_schnorrkel_substrate_vss() {
         DWalletHashScheme::Merlin,
     )
     .await;
+}
+
+/// A presign demand's signature algorithm is DERIVED from its identity, not
+/// taken from the announcement — so a byzantine announcer cannot choose which
+/// presign pool a demand draws from.
+///
+/// The consensus dedup key for a presign-demand announcement is the demand-id
+/// digest alone, so the first announcement sequenced for a demand supplies the
+/// payload fields for the whole network and the honest duplicates are dropped.
+/// A checkpoint demand id names its checkpoint kind, and the kind determines
+/// the algorithm, so the drain re-derives it and the announced value carries no
+/// authority.
+///
+/// Both pools are seeded with distinguishable bytes, so this asserts POSITIVELY
+/// which one was drawn from rather than inferring it from an empty pool: the
+/// assigned presign must be the derived pool's, while the announced pool is
+/// left untouched and full.
+#[tokio::test]
+#[cfg(test)]
+async fn test_noa_presign_demand_derives_its_algorithm_over_the_announced_one() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
+
+    let mut test_state = build_test_state(4);
+    let (consensus_round, _network_key_bytes, network_key_id) =
+        create_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+
+    // A checkpoint demand names its kind, and the kind fixes the algorithm.
+    let demand_id = NOAPresignDemandId::Checkpoint {
+        tx_ref: NOACheckpointTxRef {
+            kind_name: NOACheckpointKindName::SuiDWallet,
+            sequence_number: 1,
+            tx_index: 0,
+            epoch: 1,
+        },
+        retry_round: 0,
+    };
+    let derived_algorithm = demand_id
+        .expected_signature_algorithm()
+        .expect("a checkpoint demand determines its own algorithm");
+    // Any algorithm the identity does NOT imply serves as the announced lie.
+    let announced_algorithm = DWalletSignatureAlgorithm::ECDSASecp256k1;
+    assert_ne!(
+        derived_algorithm, announced_algorithm,
+        "the test needs the announced algorithm to differ from the derived one"
+    );
+
+    // Seed both pools with recognizable, distinct bytes.
+    const DERIVED_POOL_MARKER: u8 = 0xD1;
+    const ANNOUNCED_POOL_MARKER: u8 = 0xA9;
+    let target = 0usize;
+    for (algorithm, marker) in [
+        (derived_algorithm, DERIVED_POOL_MARKER),
+        (announced_algorithm, ANNOUNCED_POOL_MARKER),
+    ] {
+        test_state.epoch_stores[target]
+            .insert_presigns(
+                algorithm,
+                network_key_id,
+                0,
+                SessionIdentifier::new(SessionType::InternalPresign, [marker; 32]),
+                vec![vec![marker; 16]],
+            )
+            .expect("seed presign pool");
+    }
+
+    // A committee member announces the demand with the WRONG algorithm.
+    let byzantine_authority = test_state
+        .committee
+        .names()
+        .nth(1)
+        .copied()
+        .expect("committee has a second member");
+    // Every round gets a row on every validator, so the per-round streams have
+    // no gaps to skip; create this round's rows the way the harness does, then
+    // plant the demand in the target's row for it.
+    let round = test_state.consensus_round as u64;
+    utils::send_advance_results_between_parties(
+        &test_state.committee,
+        &mut test_state.sent_consensus_messages_collectors,
+        &mut test_state.epoch_stores,
+        round,
+    );
+    test_state.epoch_stores[target]
+        .round_to_noa_presign_demands
+        .lock()
+        .unwrap()
+        .entry(round)
+        .or_default()
+        .push(ConsensusNOAPresignDemand {
+            authority: byzantine_authority,
+            demand_id: demand_id.clone(),
+            signature_algorithm: announced_algorithm,
+            network_encryption_key_id: network_key_id,
+        });
+    test_state.consensus_round += 1;
+
+    // Drain it: the service walks rounds in order, so keep rounds flowing
+    // until it reaches the planted one and assigns.
+    const MAX_DRAIN_ROUNDS: usize = 20;
+    let digest = demand_id.digest();
+    let mut drain_rounds = 0usize;
+    loop {
+        test_state.dwallet_mpc_services[target]
+            .run_service_loop_iteration()
+            .await;
+        if test_state.epoch_stores[target]
+            .has_noa_assigned_presign(&digest)
+            .expect("read assignment")
+        {
+            break;
+        }
+        utils::send_advance_results_between_parties(
+            &test_state.committee,
+            &mut test_state.sent_consensus_messages_collectors,
+            &mut test_state.epoch_stores,
+            test_state.consensus_round as u64,
+        );
+        test_state.consensus_round += 1;
+        drain_rounds += 1;
+        assert!(
+            drain_rounds < MAX_DRAIN_ROUNDS,
+            "the demand was never assigned a presign within {MAX_DRAIN_ROUNDS} rounds"
+        );
+    }
+
+    let (_session_identifier, _blending_index, presign_bytes, assigned_key_id) = test_state
+        .epoch_stores[target]
+        .noa_assigned_presign(&digest)
+        .expect("read assignment")
+        .expect("assignment exists");
+
+    assert_eq!(
+        presign_bytes,
+        vec![DERIVED_POOL_MARKER; 16],
+        "the drain must draw from the pool its demand identity implies, not the announced one"
+    );
+    assert_eq!(
+        assigned_key_id, network_key_id,
+        "the announced network key is still authoritative — it is not derivable"
+    );
+    // The pool the announcement pointed at must be untouched.
+    assert_eq!(
+        test_state.epoch_stores[target]
+            .presign_pool_size(announced_algorithm, network_key_id)
+            .expect("pool size"),
+        1,
+        "nothing should have been drawn from the announced algorithm's pool"
+    );
+
+    info!(
+        ?derived_algorithm,
+        ?announced_algorithm,
+        "a mismatched presign-demand announcement drew from the derived pool"
+    );
 }

--- a/crates/ika-types/src/noa_checkpoint.rs
+++ b/crates/ika-types/src/noa_checkpoint.rs
@@ -143,6 +143,31 @@ pub enum NOACheckpointKindName {
     SuiSystem,
 }
 
+impl NOACheckpointKindName {
+    /// The signature algorithm a demand for this checkpoint kind must use.
+    ///
+    /// Read from the same counterparty-chain constant the producer reads, so
+    /// the two cannot drift: the handler builds a request with
+    /// `<K::Counterparty as CounterpartyChain>::SIGNATURE_ALGORITHM` and a
+    /// demand id carrying `K::KIND_NAME`, and this maps the second back to the
+    /// first. The match is exhaustive, so a new checkpoint kind cannot be
+    /// added without deciding its answer here.
+    ///
+    /// This is what lets a consumer DERIVE the algorithm from the demand
+    /// identity instead of trusting the value an announcement carries
+    /// alongside it — see `NOAPresignDemandId::expected_signature_algorithm`.
+    pub fn signature_algorithm(self) -> DWalletSignatureAlgorithm {
+        match self {
+            Self::SuiDWallet => {
+                <<SuiDWalletCheckpoint as NOACheckpointKind>::Counterparty as CounterpartyChain>::SIGNATURE_ALGORITHM
+            }
+            Self::SuiSystem => {
+                <<SuiSystemCheckpoint as NOACheckpointKind>::Counterparty as CounterpartyChain>::SIGNATURE_ALGORITHM
+            }
+        }
+    }
+}
+
 /// Defines a kind of NOA-signed checkpoint (e.g., DWallet or System).
 pub trait NOACheckpointKind: Clone + Debug + Send + Sync + 'static {
     /// The type of individual messages within a checkpoint.
@@ -319,6 +344,28 @@ impl NOAPresignDemandId {
     pub fn digest(&self) -> [u8; 32] {
         keccak256_digest(&bcs::to_bytes(self).expect("NOAPresignDemandId is BCS-serializable"))
     }
+
+    /// The signature algorithm this demand must use, when the demand IDENTITY
+    /// determines it.
+    ///
+    /// The consensus dedup key for a presign-demand announcement is the digest
+    /// of this identity alone — deliberately, so several validators announcing
+    /// the same demand collapse into one transaction. The consequence is that
+    /// the first announcement sequenced for a demand supplies the payload
+    /// fields the drain then uses for everyone. Wherever a field is instead
+    /// derivable from the identity, deriving it removes the announcer's say in
+    /// the matter entirely, which is stronger than validating what it sent:
+    /// there is no divergent value left to prefer, and no honest demand can be
+    /// dropped for carrying one.
+    ///
+    /// `None` for a source whose identity does not determine the algorithm.
+    /// Such a demand has to keep taking the announced value.
+    pub fn expected_signature_algorithm(&self) -> Option<DWalletSignatureAlgorithm> {
+        match self {
+            Self::Checkpoint { tx_ref, .. } => Some(tx_ref.kind_name.signature_algorithm()),
+            Self::GrpcAttestation(_) => None,
+        }
+    }
 }
 
 /// A single validator's observation of a checkpoint tx's on-chain status.
@@ -345,6 +392,88 @@ mod tests {
     use super::*;
     use crate::message::DWalletCheckpointMessageKind;
     use crate::messages_system_checkpoints::SystemCheckpointMessageKind;
+
+    /// The algorithm a consumer DERIVES from a demand identity must equal the
+    /// one the producer puts in the request. The producer reads
+    /// `<K::Counterparty>::SIGNATURE_ALGORITHM` and stamps the demand id with
+    /// `K::KIND_NAME`; the consumer maps that name back. If the two ever
+    /// disagreed, deriving would hand honest demands the wrong presign pool —
+    /// the failure would look like a stuck NOA sign, not a wrong constant.
+    ///
+    /// Written generically over the kind so it pins the LINK between the two
+    /// constants rather than restating either.
+    fn assert_derived_matches_producer<K: NOACheckpointKind>() {
+        assert_eq!(
+            K::KIND_NAME.signature_algorithm(),
+            <K::Counterparty as CounterpartyChain>::SIGNATURE_ALGORITHM,
+            "{} derives an algorithm its producer does not use",
+            K::KIND_NAME,
+        );
+    }
+
+    /// EVERY checkpoint kind belongs in this list. A new kind is forced to add
+    /// a `signature_algorithm` match arm by the compiler, but nothing forces it
+    /// to be asserted here — so add it when you add the arm.
+    #[test]
+    fn derived_signature_algorithm_matches_every_producer() {
+        assert_derived_matches_producer::<SuiDWalletCheckpoint>();
+        assert_derived_matches_producer::<SuiSystemCheckpoint>();
+    }
+
+    /// A checkpoint demand's identity determines its algorithm, so the drain
+    /// can derive it instead of trusting the announcement. A gRPC-attestation
+    /// demand's identity does not, so it must report that rather than guess.
+    #[test]
+    fn only_a_checkpoint_demand_determines_its_own_algorithm() {
+        let checkpoint = NOAPresignDemandId::Checkpoint {
+            tx_ref: NOACheckpointTxRef {
+                kind_name: NOACheckpointKindName::SuiDWallet,
+                sequence_number: 7,
+                tx_index: 0,
+                epoch: 3,
+            },
+            retry_round: 0,
+        };
+        assert_eq!(
+            checkpoint.expected_signature_algorithm(),
+            Some(NOACheckpointKindName::SuiDWallet.signature_algorithm()),
+        );
+        assert_eq!(
+            NOAPresignDemandId::GrpcAttestation([1u8; 32]).expected_signature_algorithm(),
+            None,
+            "a demand whose identity does not fix the algorithm must not claim one"
+        );
+    }
+
+    /// The retry round is not part of what fixes the algorithm: a per-tx retry
+    /// is a distinct demand (distinct id, distinct presign) for the same
+    /// checkpoint tx, and must still derive the same algorithm.
+    #[test]
+    fn a_retry_derives_the_same_algorithm_as_its_first_attempt() {
+        let tx_ref = NOACheckpointTxRef {
+            kind_name: NOACheckpointKindName::SuiSystem,
+            sequence_number: 11,
+            tx_index: 2,
+            epoch: 4,
+        };
+        let first = NOAPresignDemandId::Checkpoint {
+            tx_ref: tx_ref.clone(),
+            retry_round: 0,
+        };
+        let retry = NOAPresignDemandId::Checkpoint {
+            tx_ref,
+            retry_round: 3,
+        };
+        assert_ne!(
+            first.digest(),
+            retry.digest(),
+            "a retry is a distinct demand"
+        );
+        assert_eq!(
+            first.expected_signature_algorithm(),
+            retry.expected_signature_algorithm(),
+        );
+    }
 
     #[test]
     fn test_dwallet_build_tx_bytes_roundtrip() {


### PR DESCRIPTION
Closes half of #2015 — the half that needs no design decision.

### The problem

The consensus dedup key for a presign-demand announcement is the demand-id digest alone. That is deliberate and correct: several validators announcing the same demand collapse into one transaction.

The consequence is that the **first** announcement sequenced supplies the payload fields the drain then uses for everyone, and the honest duplicates are dropped as duplicates. Nothing validated those fields, so one committee member could pin an attacker-chosen `signature_algorithm` — and with it the presign pool — for any demand whose id it could compute. Checkpoint demand ids are derivable from public data.

### The fix

For the only demand source that exists in production, the algorithm is not information the announcement needs to supply at all. The handler builds the request from the same type parameter it stamps the id with:

```rust
signature_algorithm: <K::Counterparty as CounterpartyChain>::SIGNATURE_ALGORITHM,
...
kind_name: K::KIND_NAME,
```

So `kind_name`, already inside the demand id, determines the answer. The drain now maps it back and uses that.

### Why derive rather than validate-and-reject

This is the part worth pausing on, because check-then-reject is the obvious shape and it is wrong here.

Rejecting a mismatched demand would leave it **unassigned** — and the honest announcements for it were already deduplicated away, so no correct one is coming. Its sign would never happen, and the epoch could not finalize its NOA checkpoints. That trades a substitution bug for a stall, on a path where a stall is worse.

Deriving has neither failure mode: there is no divergent value left to prefer, and no honest demand can be dropped for carrying one. Every validator derives the same value from the same consensus-agreed identity, so the assignment stays network-uniform. A disagreement between announced and derived is still reported and attributed to the announcer.

### What is NOT fixed here

`network_encryption_key_id` still comes from the announcement, and #2015 stays open for it.

It is not derivable — it is frozen at announce time on purpose, so the assignment does not rest on the announce-time and instantiate-time key resolutions agreeing. A local recomputation at the drain would not be safe either: key adoption is a **per-tick local pass** gated on the prior epoch's handoff certificate, not a consensus-synchronised step. A validator whose certificate read errors skips adoption entirely for that tick, and individual keys can be skipped on a digest mismatch while others are adopted. Since the selector takes the minimum over the adopted set, two honest validators can hold different answers at the same round.

So that half needs the adoption-skew question settled before it can be written, and the shape it wants is probably park-rather-than-reject. Tracked in the issue.

### Exposure

None. Announcement is gated behind `noa_checkpoints()`, planned for protocol v8 and enabled on neither mainnet nor testnet.

### Tests

Three, in `ika-types`:

- **the load-bearing one** — written generically over the checkpoint kind, asserting that what a consumer derives equals what the producer uses. It pins the *link* between `K::KIND_NAME` and `<K::Counterparty>::SIGNATURE_ALGORITHM` rather than restating either constant. If those ever drifted, honest demands would get the wrong presign pool, and the symptom would be a stuck NOA sign rather than an obviously wrong constant;
- a checkpoint demand determines its algorithm, a gRPC-attestation demand reports that it does not rather than guessing;
- a per-tx retry is a distinct demand (distinct digest) but derives the same algorithm.

Fault-validated: pointing one kind at a different algorithm fails the producer-agreement test with the kind named.

The `match` in the mapping is exhaustive, so a new checkpoint kind cannot be added without deciding its answer. Nothing forces it into the test list, though, so that test carries a comment saying to add it.

**Scope caveat on those tests, worth stating plainly:** both current checkpoint kinds route to the same counterparty chain and therefore the same algorithm, so the mapping's codomain is a single value today. That test proves the mapping is not hardcoded to something *wrong*; it cannot detect an arm-swap, and an arm-swap is currently behaviourally identical anyway. It starts doing real work when a kind with a different chain exists.

### End-to-end test

Added in `network_owned_address_sign`, exercising the drain rather than the mapping: a committee member announces a checkpoint demand carrying the WRONG algorithm, and the assignment must come from the pool the demand identity implies.

Both pools are seeded with distinguishable bytes, so it asserts **positively** which one was drawn from rather than inferring it from an empty pool — and additionally asserts the announced algorithm's pool is left untouched, and that the announced network key IS still honoured (it is not derivable, so it must not be "corrected").

Fault-validated, and this is the informative one: with the derivation removed, the assigned presign is `[169, ...]` — the announced pool — instead of `[209, ...]`. That is the substitution landing, demonstrated rather than inferred.

This fixture is deliberately reusable: the remaining half of #2015 needs exactly this shape (a consensus-delivered demand with mismatched payload fields, driven through the drain) to test park-vs-reject behaviour for the key id.

### Test runs

`network_owned_address_sign` module: 14/15 passed. `test_network_owned_address_sign_ecdsa_secp256r1` failed under `--test-threads=4` and **passes in isolation** — heavy MPC tests flaking under parallelism is a known property of this module.

Beyond the isolated pass, that test cannot be affected by this change on structural grounds: every existing flow test uses a `GrpcAttestation` demand id, for which `expected_signature_algorithm()` returns `None` and `unwrap_or` yields the announced value — byte-identical to the previous behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rLdsjCfcsTMaiLd3TX8w
