### PR TITLE
fix(ocs): recover pruned pending-gap checkpoints from the checkpoint archive

### DIFF
--- a/.github/workflows/ts-integration-tests.yaml
+++ b/.github/workflows/ts-integration-tests.yaml
@@ -165,13 +165,18 @@ jobs:
 
       - name: Start Sui localnet
         run: |
-          # Native checkpoint cadence + epoch length. The OCS path is
-          # self-sufficient against this localnet's aggressive pruning
-          # (num_epochs_to_retain=0): committees come from the live
-          # SubscribeCheckpoints follower, and object reads fall back to the
-          # committee-verified local cache when an anchor's defining tx is
-          # pruned upstream — so no Sui-side slowdown is needed.
-          RUST_LOG=error sui start --with-faucet --force-regenesis > sui-localnet.log 2>&1 &
+          # Native checkpoint cadence + epoch length. This localnet prunes
+          # aggressively (num_epochs_to_retain=0), and under a throttled
+          # runner the pruning watermark can outrun the validators' checkpoint
+          # pusher — losing a checkpoint (and any session-request event on it)
+          # permanently, which wedges the epoch close (issue #2018). The
+          # data-ingestion dir keeps every executed checkpoint as a file; the
+          # ika validators are pointed at it (--sui-checkpoint-archive-url
+          # below) as their verified fallback for pruned-before-fetched
+          # checkpoints. Committees still come from the live
+          # SubscribeCheckpoints follower.
+          RUST_LOG=error sui start --with-faucet --force-regenesis \
+            --data-ingestion-dir "$PWD/sui-ingestion" > sui-localnet.log 2>&1 &
           echo $! > sui-localnet.pid
           for i in $(seq 1 60); do
             if ! kill -0 "$(cat sui-localnet.pid)" 2>/dev/null; then
@@ -197,7 +202,8 @@ jobs:
           rm -rf ~/.ika Pub.localnet.toml
           RUST_LOG="${LOCALNET_RUST_LOG:-warn,ika=info,ika_node=info}" RUST_MIN_STACK=67108864 \
             ./target/release/ika start --force-reinitiation \
-            --epoch-duration-ms "$EPOCH_DURATION_MS" > ika-localnet.log 2>&1 &
+            --epoch-duration-ms "$EPOCH_DURATION_MS" \
+            --sui-checkpoint-archive-url "file://$PWD/sui-ingestion" > ika-localnet.log 2>&1 &
           echo $! > ika-localnet.pid
 
       - name: Wait for ika localnet readiness

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -423,6 +423,14 @@ pub struct DWalletMPCMetrics {
     /// nobody (us included) has seen quorum. Per-tick gauge.
     pub(crate) sessions_with_self_output_no_quorum: IntGauge,
 
+    /// The complement: user sessions Active well past any normal computation
+    /// latency with NO local output submitted — admitted but possibly never
+    /// computing. One such session inside the epoch's locked close set wedges
+    /// the epoch (issue #2018), so any sustained non-zero value is a stall
+    /// signal. Per-tick gauge; the manager also warns once a minute while
+    /// non-zero.
+    pub(crate) user_sessions_active_without_local_output: IntGauge,
+
     /// Per-completion: number of consensus rounds elapsed between this validator submitting
     /// its own output and 2/3 quorum being reached. Wide tails ≡ slow consensus, lots of
     /// retries. Observed once per session at the moment quorum is reached.
@@ -868,6 +876,12 @@ impl DWalletMPCMetrics {
             sessions_with_self_output_no_quorum: register_int_gauge_with_registry!(
                 "ika_dwallet_mpc_sessions_with_self_output_no_quorum",
                 "User sessions where this validator submitted an output but no quorum has been observed.",
+                registry,
+            )
+            .unwrap(),
+            user_sessions_active_without_local_output: register_int_gauge_with_registry!(
+                "ika_dwallet_mpc_user_sessions_active_without_local_output",
+                "User sessions Active past the stall threshold with no local output submitted (admitted but possibly never computing); sustained non-zero can wedge the epoch close — alert on it.",
                 registry,
             )
             .unwrap(),

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -671,6 +671,9 @@ pub(crate) struct DWalletMPCManager {
     /// rate-limited because the service loop ticks every ~20ms and the
     /// refresh iterates every tracked session.
     last_observability_refresh: Option<Instant>,
+    /// When the stalled-user-session warn was last emitted, so a wedged
+    /// session logs once a minute instead of once per refresh.
+    last_stalled_session_log: Option<Instant>,
 
     /// NOA finalization observation votes: tx_ref → set of party IDs that observed finalization.
     noa_finalization_observations: HashMap<NOACheckpointTxRef, HashSet<PartyID>>,
@@ -866,6 +869,7 @@ impl DWalletMPCManager {
             previously_emitted_user_session_seqs: HashSet::new(),
             finalized_emitted_user_session_seqs: HashSet::new(),
             last_observability_refresh: None,
+            last_stalled_session_log: None,
             noa_finalization_observations: HashMap::new(),
             noa_failure_observations: HashMap::new(),
             finalized_tx_refs: HashSet::new(),
@@ -5208,6 +5212,15 @@ impl DWalletMPCManager {
         let mut age_bucket_counts: HashMap<(&str, &str), i64> = HashMap::new();
         let mut sessions_with_self_output_no_quorum = 0i64;
         let mut protocol_sessions_pending: HashMap<String, i64> = HashMap::new();
+        // "We never did our part" — the complement of
+        // `sessions_with_self_output_no_quorum`: a user session that has been
+        // Active well past any normal computation latency without this
+        // validator ever submitting a local output. A session admitted but
+        // never computed is invisible in the log stream (nothing fires after
+        // admission), and one such session wedged an epoch close in issue
+        // #2018 — so it gets a gauge AND a periodic warn.
+        const STALLED_USER_SESSION_THRESHOLD: Duration = Duration::from_secs(120);
+        let mut stalled_user_sessions: Vec<(Option<u64>, u64)> = Vec::new();
         for session in self.sessions.values() {
             *state_counts
                 .entry(session_state_label(&session.status))
@@ -5221,6 +5234,12 @@ impl DWalletMPCManager {
                 *age_bucket_counts
                     .entry((session_type_label(request.session_type), age_bucket))
                     .or_default() += 1;
+                if matches!(session.session_type, Some(SessionType::User))
+                    && session.self_output_consensus_round.is_none()
+                    && age >= STALLED_USER_SESSION_THRESHOLD
+                {
+                    stalled_user_sessions.push((session.session_sequence_number, age.as_secs()));
+                }
             }
             // "We did our part, the network didn't" — the single most useful
             // gauge for "are we stuck waiting on quorum from peers".
@@ -5477,6 +5496,33 @@ impl DWalletMPCManager {
         metrics
             .sessions_with_self_output_no_quorum
             .set(sessions_with_self_output_no_quorum);
+        metrics
+            .user_sessions_active_without_local_output
+            .set(stalled_user_sessions.len() as i64);
+        if !stalled_user_sessions.is_empty()
+            && self
+                .last_stalled_session_log
+                .is_none_or(|last| now.duration_since(last) >= STALLED_SESSION_LOG_INTERVAL)
+        {
+            self.last_stalled_session_log = Some(now);
+            stalled_user_sessions.sort();
+            let oldest_age_secs = stalled_user_sessions
+                .iter()
+                .map(|(_, age)| *age)
+                .max()
+                .unwrap_or(0);
+            stalled_user_sessions.truncate(8);
+            warn!(
+                count = metrics.user_sessions_active_without_local_output.get(),
+                oldest_age_secs,
+                sessions_seq_and_age = ?stalled_user_sessions,
+                threshold_secs = STALLED_USER_SESSION_THRESHOLD.as_secs(),
+                authority=?self.validator_name,
+                "user MPC session(s) active without a local output past the stall \
+                 threshold — admitted but possibly never computing; if it sits in \
+                 the epoch's locked close set this wedges the epoch (issue #2018)"
+            );
+        }
 
         // Sessions that left `self.sessions` since the previous tick get one
         // final emission flipping the state series to 0 and the round gauges
@@ -5531,6 +5577,11 @@ impl DWalletMPCManager {
 /// Minimum interval between observability-gauge refreshes; the caller (the
 /// dwallet MPC service loop) ticks every ~20ms, far faster than gauges need.
 const OBSERVABILITY_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Cadence of the stalled-user-session warn (see
+/// `refresh_observability_metrics`): a wedged session logs once a minute,
+/// not once per one-second refresh.
+const STALLED_SESSION_LOG_INTERVAL: Duration = Duration::from_secs(60);
 pub(crate) const MAX_UNTRACKED_ANOMALIES: usize = 1024;
 
 fn session_state_label(status: &SessionStatus) -> &'static str {

--- a/crates/ika-core/src/sui_connector/ocs_metrics.rs
+++ b/crates/ika-core/src/sui_connector/ocs_metrics.rs
@@ -67,6 +67,17 @@ pub struct OcsMetrics {
     pub pusher_pushed_total: IntCounter,
     pub pusher_skipped_irrelevant_total: IntCounter,
     pub pusher_fetch_failures_total: IntCounter,
+    /// Pending-gap checkpoints the fullnode never served (pruned) that were
+    /// recovered from the checkpoint archive and folded late. Non-zero means
+    /// the archive fallback is doing real work — the fullnode's pruning
+    /// watermark is outrunning the pusher.
+    pub pusher_gap_archive_repairs_total: IntCounter,
+    /// Pending-gap checkpoints dropped at the retry deadline — neither the
+    /// fullnode nor the archive (if any resolved) ever served them. Each drop
+    /// is a PERMANENT verified-cache gap: an Ika object whose only mutation
+    /// rode the checkpoint (e.g. a session_events bag entry) never enters the
+    /// cache, which can wedge an epoch close. Alert on any increase.
+    pub pusher_gap_dropped_total: IntCounter,
     /// Latency of the pre-fold committee verification the pusher runs before
     /// folding a checkpoint into the local cache (committee BLS on the summary +
     /// artifacts-digest binding). `_count` is the number of checkpoints
@@ -168,6 +179,18 @@ impl OcsMetrics {
             pusher_fetch_failures_total: register_int_counter_with_registry!(
                 "ika_ocs_pusher_fetch_failures_total",
                 "Number of get_full_checkpoint failures during the pusher walk",
+                registry,
+            )
+            .unwrap(),
+            pusher_gap_archive_repairs_total: register_int_counter_with_registry!(
+                "ika_ocs_pusher_gap_archive_repairs_total",
+                "Pending-gap checkpoints the fullnode pruned that were recovered from the checkpoint archive and folded late",
+                registry,
+            )
+            .unwrap(),
+            pusher_gap_dropped_total: register_int_counter_with_registry!(
+                "ika_ocs_pusher_gap_dropped_total",
+                "Pending-gap checkpoints dropped at the retry deadline (fullnode pruned them and no archive served them); each is a permanent verified-cache gap that can wedge an epoch close — alert on any increase",
                 registry,
             )
             .unwrap(),

--- a/crates/ika-core/src/sui_connector/ocs_verifier.rs
+++ b/crates/ika-core/src/sui_connector/ocs_verifier.rs
@@ -726,6 +726,20 @@ mod tests {
                 }
             })
         }
+        async fn fetch_checkpoint_data(
+            &self,
+            seq: CheckpointSequenceNumber,
+        ) -> Result<
+            sui_types::full_checkpoint_content::CheckpointData,
+            ika_sui_client::archive::ArchiveError,
+        > {
+            // The ratchet tests never fetch full checkpoint data.
+            Err(ika_sui_client::archive::ArchiveError::Fetch {
+                url: "mock".into(),
+                seq,
+                source: anyhow::anyhow!("full checkpoint data not served by this mock"),
+            })
+        }
     }
 
     /// Build a mock archive holding the end-of-epoch checkpoint of epochs

--- a/crates/ika-core/src/sui_connector/push_worker.rs
+++ b/crates/ika-core/src/sui_connector/push_worker.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use ika_network::proof_provider::VerifiedObjectEntry;
+use ika_sui_client::archive::CheckpointArchive;
 use ika_sui_client::transport::SuiTransport;
 use ika_types::messages_dwallet_mpc::IkaPackageConfig;
 use sui_light_client::proof::ocs::ModifiedObjectTree;
@@ -69,11 +70,30 @@ pub struct IkaCheckpointPusher {
     /// epoch forever). Gaps are retried every tick and folded LATE when
     /// they materialize — safe because the verified state cache is
     /// monotonic-by-version, so an out-of-order fold can only fill gaps,
-    /// never regress state. A gap that outlives the retry deadline is
-    /// dropped with a loud warn (genuinely pruned upstream). In-memory
-    /// only: gaps are lost on restart, where the on-chain uncompleted-
-    /// session re-pull is the backstop.
-    pending_gaps: BTreeMap<CheckpointSequenceNumber, Instant>,
+    /// never regress state. A gap the fullnode keeps refusing is fetched
+    /// from the checkpoint `archive` instead (same committee verification
+    /// at fold time); only a gap that BOTH sources fail to serve until the
+    /// retry deadline is dropped with a loud warn. In-memory only: gaps are
+    /// lost on restart, where the on-chain uncompleted-session re-pull is
+    /// the backstop.
+    pending_gaps: BTreeMap<CheckpointSequenceNumber, PendingGap>,
+    /// Verified-fallback source for gap checkpoints the fullnode pruned
+    /// before the pusher could fetch them. The public Sui checkpoint stores
+    /// retain ordinary checkpoints ~30 days — far beyond any fullnode
+    /// pruning window — and everything fetched is committee-verified at
+    /// fold time, so this is an availability source, never a trust source.
+    /// `None` when no archive resolved (a localnet without one configured):
+    /// gaps then behave as before — retried against the fullnode until the
+    /// deadline, then dropped.
+    archive: Option<Arc<dyn CheckpointArchive>>,
+}
+
+/// Retry state of one scanned-but-unfetchable checkpoint.
+struct PendingGap {
+    first_seen: Instant,
+    /// When the archive was last consulted for this gap, so archive fetches
+    /// are paced at `ARCHIVE_RETRY_INTERVAL` instead of every 250ms tick.
+    last_archive_attempt: Option<Instant>,
 }
 
 impl IkaCheckpointPusher {
@@ -85,6 +105,7 @@ impl IkaCheckpointPusher {
         poll_interval: Duration,
         cache: SharedVerifiedStateCache,
         committees: Arc<CommitteeStore>,
+        archive: Option<Arc<dyn CheckpointArchive>>,
     ) -> anyhow::Result<Self> {
         let mut ika_packages = HashSet::new();
         ika_packages.insert(packages.ika_package_id);
@@ -129,6 +150,7 @@ impl IkaCheckpointPusher {
             cache,
             committees,
             pending_gaps: BTreeMap::new(),
+            archive,
         })
     }
 
@@ -185,8 +207,16 @@ impl IkaCheckpointPusher {
             self.metrics.pusher_cursor_seq.set(new_cursor as i64);
             let _ = self.perpetual.put_sui_pusher_last_seq(new_cursor);
             // Gaps inside the sacrificed span go with it (covered by the
-            // fast-forward warn above).
+            // fast-forward warn above) — but each is still a permanent loss,
+            // so they count toward the drop alarm.
+            let gaps_before_sacrifice = self.pending_gaps.len();
             self.pending_gaps.retain(|&seq, _| seq > new_cursor);
+            let sacrificed = gaps_before_sacrifice - self.pending_gaps.len();
+            if sacrificed > 0 {
+                self.metrics
+                    .pusher_gap_dropped_total
+                    .inc_by(sacrificed as u64);
+            }
         }
 
         for seq in (self.cursor + 1)..=latest_seq {
@@ -206,7 +236,10 @@ impl IkaCheckpointPusher {
                         error = ?e,
                         "full-checkpoint fetch failed; queued as a pending gap"
                     );
-                    self.pending_gaps.entry(seq).or_insert_with(Instant::now);
+                    self.pending_gaps.entry(seq).or_insert_with(|| PendingGap {
+                        first_seen: Instant::now(),
+                        last_archive_attempt: None,
+                    });
                 }
             }
             self.cursor = seq;
@@ -230,14 +263,23 @@ impl IkaCheckpointPusher {
     /// into the local verified state cache that sui-state-direct consumers
     /// read cache-first. Shared by the in-order scan and the pending-gap
     /// retries (a late fold is version-safe — see `pending_gaps`).
+    ///
+    /// `build_entries` runs FIRST: it committee-verifies every end-of-epoch
+    /// or object-folding checkpoint, so the retained end-of-epoch store is
+    /// only ever written after the summary passed verification —
+    /// `persist_end_of_epoch` itself does not verify, and writing before
+    /// verifying would let a forged blob overwrite a genuine retained entry
+    /// (an availability, not forgery, hazard for the mirrored peers served
+    /// from that store — they re-verify — but a needless one).
     fn fold_checkpoint(
         &mut self,
         seq: CheckpointSequenceNumber,
         data: &CheckpointData,
     ) -> anyhow::Result<()> {
+        let entries = self.build_entries(data)?;
         self.capture_committee(data);
         self.persist_end_of_epoch(data, seq);
-        if let Some((summary, entries)) = self.build_entries(data)? {
+        if let Some((summary, entries)) = entries {
             self.cache.absorb_entries(&summary, &entries);
             self.metrics.pusher_pushed_total.inc();
         } else {
@@ -246,11 +288,50 @@ impl IkaCheckpointPusher {
         Ok(())
     }
 
+    /// Verification an archive-served checkpoint must pass BEFORE it may
+    /// clear a pending gap — strictly MORE than the fullnode fold path
+    /// applies, because the archive is the lower-trust source (on the public
+    /// chains it defaults to a third-party HTTP store) and `build_entries`
+    /// verifies nothing for a checkpoint with no Ika-typed outputs — a blob
+    /// that folds vacuously would silently clear the gap and suppress the
+    /// `pusher_gap_dropped_total` alarm this fallback exists to feed:
+    ///
+    /// 1. the blob IS the requested checkpoint: `summary.sequence_number ==
+    ///    seq` (the seq is inside the committee-signed summary, so a
+    ///    mislabeled genuine blob fails here);
+    /// 2. committee BLS on the summary, unconditionally;
+    /// 3. the artifacts-digest binding over the blob's ENTIRE object set,
+    ///    unconditionally — an emptied or altered object set produces a tree
+    ///    root the committee never signed, so "no Ika objects on this
+    ///    checkpoint" cannot be forged.
+    fn verify_archive_checkpoint(
+        &self,
+        seq: CheckpointSequenceNumber,
+        data: &CheckpointData,
+    ) -> anyhow::Result<()> {
+        let summary = &data.checkpoint_summary;
+        if *summary.sequence_number() != seq {
+            anyhow::bail!(
+                "archive served checkpoint {} for requested seq {seq}",
+                summary.sequence_number()
+            );
+        }
+        let artifacts = CheckpointArtifacts::from(data);
+        let tree = ModifiedObjectTree::new(&artifacts)
+            .map_err(|e| anyhow::anyhow!("ModifiedObjectTree over archive blob: {e}"))?;
+        self.verify_before_fold(summary, &tree, true)
+    }
+
     /// Retry every pending gap once. A gap that materializes is folded late
-    /// (version-safe) and cleared; one that keeps failing — fetch OR fold —
-    /// outlives the deadline and is dropped with a loud warn. Fold failures
-    /// stay pending rather than dropping immediately because they are not
-    /// all deterministic: `verify_before_fold` fails with MissingCommittee
+    /// (version-safe) and cleared; one the fullnode keeps refusing past
+    /// `ARCHIVE_FALLBACK_AFTER` is fetched from the checkpoint archive
+    /// instead (paced at `ARCHIVE_RETRY_INTERVAL`, capped per tick) and
+    /// folded through the same committee verification. Only a gap that BOTH
+    /// sources fail to serve until the deadline is dropped with a loud warn
+    /// and counted (`pusher_gap_dropped_total`) — a permanent cache gap
+    /// that can pin an epoch close (issue #2018). Fold failures stay
+    /// pending rather than dropping immediately because they are not all
+    /// deterministic: `verify_before_fold` fails with MissingCommittee
     /// while the checkpoint's epoch committee hasn't installed yet (follower
     /// lag at a Sui epoch boundary, or a restart near one) — exactly the
     /// transient the in-order scan path retries by pinning its cursor. A
@@ -260,12 +341,34 @@ impl IkaCheckpointPusher {
     /// a consumer's network fallback repairs them.
     async fn retry_pending_gaps(&mut self) {
         const GAP_RETRY_DEADLINE: Duration = Duration::from_secs(600);
+        // How long to give the fullnode alone before consulting the archive.
+        // Covers the common late-materialization case (contents certify
+        // seconds after the summary) without taxing the archive; a gap still
+        // missing after this is very likely pruned upstream, and a fast
+        // archive repair is what keeps the session's SDK-side wait (~600s)
+        // from expiring.
+        const ARCHIVE_FALLBACK_AFTER: Duration = Duration::from_secs(5);
+        const ARCHIVE_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+        // Bound the archive fetches of one tick so a prune burst (hundreds of
+        // gaps at once under CI-grade load) rolls through the archive over a
+        // few ticks instead of hammering it — and so a hung archive can stall
+        // one tick by at most ATTEMPTS × FETCH_TIMEOUT (20s). The gap-retry
+        // loop runs BEFORE the head scan, so an unbounded stall here would
+        // hold the cursor back while the fullnode prunes more checkpoints —
+        // the fallback amplifying the very loss it exists to prevent.
+        const ARCHIVE_ATTEMPTS_PER_TICK: usize = 4;
+
+        let mut archive_attempts_this_tick = 0usize;
         let seqs: Vec<CheckpointSequenceNumber> = self.pending_gaps.keys().copied().collect();
         for seq in seqs {
-            let expired = self
+            let Some((first_seen, last_archive_attempt)) = self
                 .pending_gaps
                 .get(&seq)
-                .is_some_and(|since| since.elapsed() > GAP_RETRY_DEADLINE);
+                .map(|gap| (gap.first_seen, gap.last_archive_attempt))
+            else {
+                continue;
+            };
+            let expired = first_seen.elapsed() > GAP_RETRY_DEADLINE;
             match self.transport.get_full_checkpoint(seq).await {
                 Ok(data) => match self.fold_checkpoint(seq, &data) {
                     Ok(()) => {
@@ -274,6 +377,7 @@ impl IkaCheckpointPusher {
                     }
                     Err(e) if expired => {
                         self.pending_gaps.remove(&seq);
+                        self.metrics.pusher_gap_dropped_total.inc();
                         warn!(
                             seq,
                             error = ?e,
@@ -284,16 +388,103 @@ impl IkaCheckpointPusher {
                         warn!(seq, error = ?e, "gap checkpoint fetched but failed to fold — will retry");
                     }
                 },
-                Err(e) => {
+                Err(fullnode_error) => {
+                    let archive_due = self.archive.is_some()
+                        && first_seen.elapsed() > ARCHIVE_FALLBACK_AFTER
+                        && last_archive_attempt
+                            .is_none_or(|at| at.elapsed() > ARCHIVE_RETRY_INTERVAL)
+                        && archive_attempts_this_tick < ARCHIVE_ATTEMPTS_PER_TICK;
+                    if archive_due {
+                        archive_attempts_this_tick += 1;
+                        let first_attempt = last_archive_attempt.is_none();
+                        if self.try_archive_repair(seq, first_attempt, expired).await {
+                            continue;
+                        }
+                    }
                     if expired {
                         self.pending_gaps.remove(&seq);
+                        self.metrics.pusher_gap_dropped_total.inc();
                         warn!(
                             seq,
-                            error = ?e,
+                            error = ?fullnode_error,
+                            archive_configured = self.archive.is_some(),
                             "checkpoint never materialized within the gap retry deadline — dropping"
                         );
                     }
                 }
+            }
+        }
+    }
+
+    /// Try to repair one pending gap from the checkpoint archive: fetch the
+    /// full checkpoint data, pass it through `verify_archive_checkpoint`
+    /// (seq binding + committee BLS + unconditional artifacts-digest
+    /// binding — see there for why the archive path verifies MORE than the
+    /// fullnode path), and fold it. Returns `true` when the gap was repaired
+    /// and removed. On any failure the gap stays pending (the caller applies
+    /// the deadline). The fetch is bounded by `ARCHIVE_FETCH_TIMEOUT`
+    /// because the underlying object-store client retries internally for up
+    /// to 60s on anything but NotFound (e.g. a truncated blob from a
+    /// mid-write fullnode crash) — unbounded, a hung archive would stall the
+    /// whole pusher loop.
+    async fn try_archive_repair(
+        &mut self,
+        seq: CheckpointSequenceNumber,
+        first_attempt: bool,
+        expired: bool,
+    ) -> bool {
+        const ARCHIVE_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+        let Some(archive) = self.archive.clone() else {
+            return false;
+        };
+        if let Some(gap) = self.pending_gaps.get_mut(&seq) {
+            gap.last_archive_attempt = Some(Instant::now());
+        }
+        let fetched = tokio::time::timeout(ARCHIVE_FETCH_TIMEOUT, async {
+            archive.fetch_checkpoint_data(seq).await
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("archive fetch timed out after {ARCHIVE_FETCH_TIMEOUT:?}"))
+        .and_then(|fetch_result| fetch_result.map_err(anyhow::Error::from));
+        match fetched {
+            Ok(data) => {
+                if let Err(e) = self.verify_archive_checkpoint(seq, &data) {
+                    warn!(
+                        seq,
+                        error = %e,
+                        "archive served a checkpoint that failed verification — refusing it"
+                    );
+                    return false;
+                }
+                match self.fold_checkpoint(seq, &data) {
+                    Ok(()) => {
+                        info!(
+                            seq,
+                            "pruned checkpoint recovered from the archive and folded — gap repaired"
+                        );
+                        self.metrics.pusher_gap_archive_repairs_total.inc();
+                        self.pending_gaps.remove(&seq);
+                        true
+                    }
+                    Err(e) => {
+                        // Same transient-vs-deterministic ambiguity as the
+                        // fullnode fold path; the caller's deadline bounds it.
+                        warn!(seq, error = ?e, "archive checkpoint fetched but failed to fold — will retry");
+                        false
+                    }
+                }
+            }
+            Err(e) => {
+                // The first failure per gap warns so a misconfigured archive
+                // (a typo'd file:// path) is visible immediately at the
+                // default log level, not only after gaps start dropping at
+                // the 600s deadline.
+                if first_attempt || expired {
+                    warn!(seq, error = %e, "archive could not serve the gap checkpoint");
+                } else {
+                    debug!(seq, error = %e, "archive fetch for gap checkpoint failed; will retry");
+                }
+                false
             }
         }
     }
@@ -682,6 +873,18 @@ mod tests {
         }
     }
 
+    /// The artifacts commitment matching a checkpoint with no transactions
+    /// (the shape every helper below builds), so archive-path verification —
+    /// which binds the artifacts digest unconditionally — passes for honest
+    /// mock checkpoints.
+    fn empty_artifacts_commitment() -> CheckpointCommitment {
+        CheckpointCommitment::CheckpointArtifactsDigest(
+            CheckpointArtifacts::from_object_states(BTreeMap::new())
+                .digest()
+                .unwrap(),
+        )
+    }
+
     /// An end-of-epoch `CheckpointData` for the committee's epoch at `seq`,
     /// committee-signed and committing to the next epoch's committee (same
     /// members, epoch E+1). `verify_with_contents` passes because the summary's
@@ -700,7 +903,7 @@ mod tests {
             previous_digest: None,
             epoch_rolling_gas_cost_summary: GasCostSummary::default(),
             timestamp_ms: 0,
-            checkpoint_commitments: vec![],
+            checkpoint_commitments: vec![empty_artifacts_commitment()],
             end_of_epoch_data: Some(EndOfEpochData {
                 next_epoch_committee: committee.voting_rights.clone(),
                 next_epoch_protocol_version: ProtocolVersion::MIN,
@@ -744,7 +947,7 @@ mod tests {
             previous_digest: None,
             epoch_rolling_gas_cost_summary: GasCostSummary::default(),
             timestamp_ms: 0,
-            checkpoint_commitments: vec![],
+            checkpoint_commitments: vec![empty_artifacts_commitment()],
             end_of_epoch_data: None,
             version_specific_data: Vec::new(),
         };
@@ -788,6 +991,7 @@ mod tests {
             Duration::from_secs(2),
             cache,
             committees,
+            None,
         )
         .await
         .unwrap()
@@ -1041,6 +1245,239 @@ mod tests {
                 .is_some(),
             "a gap-repaired end-of-epoch checkpoint must be retained"
         );
+    }
+
+    /// A mock checkpoint archive serving full checkpoint data from memory,
+    /// for the pending-gap archive-fallback tests. The ratchet-facing methods
+    /// are never called by the pusher and panic loudly if they ever are.
+    struct MockCheckpointArchive {
+        checkpoints: HashMap<CheckpointSequenceNumber, CheckpointData>,
+    }
+
+    #[async_trait]
+    impl CheckpointArchive for MockCheckpointArchive {
+        async fn enumerate_end_of_epoch_seqs(
+            &self,
+        ) -> Result<Vec<CheckpointSequenceNumber>, ika_sui_client::archive::ArchiveError> {
+            unimplemented!()
+        }
+        async fn fetch_checkpoint(
+            &self,
+            _seq: CheckpointSequenceNumber,
+        ) -> Result<
+            (
+                CertifiedCheckpointSummary,
+                sui_types::messages_checkpoint::CheckpointContents,
+            ),
+            ika_sui_client::archive::ArchiveError,
+        > {
+            unimplemented!()
+        }
+        async fn fetch_checkpoint_data(
+            &self,
+            seq: CheckpointSequenceNumber,
+        ) -> Result<CheckpointData, ika_sui_client::archive::ArchiveError> {
+            self.checkpoints.get(&seq).cloned().ok_or_else(|| {
+                ika_sui_client::archive::ArchiveError::Fetch {
+                    url: "mock".into(),
+                    seq,
+                    source: anyhow::anyhow!("seq {seq} not in mock archive"),
+                }
+            })
+        }
+    }
+
+    /// A gap checkpoint the fullnode NEVER serves (pruned) is recovered from
+    /// the checkpoint archive once the local-materialization grace passes,
+    /// folded through the same committee verification (its committee capture
+    /// and end-of-epoch retention land), and counted as an archive repair —
+    /// instead of being dropped at the deadline (issue #2018).
+    #[tokio::test]
+    async fn pruned_gap_checkpoint_is_recovered_from_the_archive() {
+        let (committee, keys) = Committee::new_simple_test_committee();
+        let dir = tempfile::tempdir().unwrap();
+        let perpetual = Arc::new(AuthorityPerpetualTables::open(dir.path(), None));
+        let committees = Arc::new(
+            CommitteeStore::open(
+                perpetual.clone(),
+                Some(CommitteeBootstrap::Genesis(committee.clone())),
+            )
+            .unwrap(),
+        );
+
+        // The fullnode advertises seq 100 but never serves its contents
+        // (pruned); only the archive has it — as an end-of-epoch checkpoint so
+        // the test can observe the fold's committee capture and retention.
+        let eoe = end_of_epoch_checkpoint(&committee, &keys, 100);
+        let latest = eoe.checkpoint_summary.clone();
+        let transport: Arc<dyn SuiTransport> = Arc::new(MockTransport {
+            latest,
+            checkpoints: HashMap::new(),
+            eoe_seqs: HashMap::new(),
+        });
+        perpetual.put_sui_pusher_last_seq(99).unwrap();
+
+        let cache: SharedVerifiedStateCache = Arc::new(VerifiedStateCache::new());
+        let metrics = OcsMetrics::new_for_testing();
+        let mut pusher = pusher_over_with_cache(
+            perpetual.clone(),
+            committees.clone(),
+            transport,
+            cache,
+            metrics.clone(),
+        )
+        .await;
+        pusher.archive = Some(Arc::new(MockCheckpointArchive {
+            checkpoints: HashMap::from([(100u64, eoe)]),
+        }));
+
+        pusher.advance().await.unwrap();
+        assert!(pusher.pending_gaps.contains_key(&100));
+
+        // Within the local-materialization grace the archive is NOT consulted
+        // yet — the fullnode alone is retried.
+        pusher.advance().await.unwrap();
+        assert!(pusher.pending_gaps.contains_key(&100));
+        assert_eq!(metrics.pusher_gap_archive_repairs_total.get(), 0);
+
+        // Age the gap past the grace; the next tick repairs it from the
+        // archive.
+        pusher.pending_gaps.get_mut(&100).unwrap().first_seen =
+            Instant::now() - Duration::from_secs(6);
+        pusher.advance().await.unwrap();
+
+        assert!(pusher.pending_gaps.is_empty());
+        assert_eq!(metrics.pusher_gap_archive_repairs_total.get(), 1);
+        assert_eq!(metrics.pusher_gap_dropped_total.get(), 0);
+        assert_eq!(committees.head_epoch(), 1);
+        assert!(
+            perpetual
+                .get_sui_end_of_epoch_checkpoint(100)
+                .unwrap()
+                .is_some(),
+            "an archive-repaired end-of-epoch checkpoint must be retained"
+        );
+    }
+
+    /// An archive blob whose committee-signed summary is for a DIFFERENT
+    /// sequence number than the one requested must NOT clear the gap.
+    /// Gap-clearance would otherwise trust the archive's file naming: a
+    /// mislabeled-but-genuine blob (or one substituted by a malicious
+    /// store) would "repair" the gap vacuously, the real checkpoint's
+    /// events would stay lost, and the dropped-gap alarm this fallback
+    /// feeds would be suppressed — the issue #2018 loss shape, silently.
+    #[tokio::test]
+    async fn archive_blob_for_a_different_seq_is_refused() {
+        let (committee, keys) = Committee::new_simple_test_committee();
+        let dir = tempfile::tempdir().unwrap();
+        let perpetual = Arc::new(AuthorityPerpetualTables::open(dir.path(), None));
+        let committees = Arc::new(
+            CommitteeStore::open(
+                perpetual.clone(),
+                Some(CommitteeBootstrap::Genesis(committee.clone())),
+            )
+            .unwrap(),
+        );
+
+        let latest = plain_checkpoint(&committee, &keys, 100).checkpoint_summary;
+        let transport: Arc<dyn SuiTransport> = Arc::new(MockTransport {
+            latest,
+            checkpoints: HashMap::new(),
+            eoe_seqs: HashMap::new(),
+        });
+        perpetual.put_sui_pusher_last_seq(99).unwrap();
+
+        let cache: SharedVerifiedStateCache = Arc::new(VerifiedStateCache::new());
+        let metrics = OcsMetrics::new_for_testing();
+        let mut pusher = pusher_over_with_cache(
+            perpetual.clone(),
+            committees.clone(),
+            transport,
+            cache,
+            metrics.clone(),
+        )
+        .await;
+        // The archive's entry FOR seq 100 is a genuine, correctly-signed
+        // end-of-epoch checkpoint — of seq 999.
+        pusher.archive = Some(Arc::new(MockCheckpointArchive {
+            checkpoints: HashMap::from([(100u64, end_of_epoch_checkpoint(&committee, &keys, 999))]),
+        }));
+
+        pusher.advance().await.unwrap();
+        assert!(pusher.pending_gaps.contains_key(&100));
+
+        pusher.pending_gaps.get_mut(&100).unwrap().first_seen =
+            Instant::now() - Duration::from_secs(6);
+        pusher.advance().await.unwrap();
+
+        assert!(
+            pusher.pending_gaps.contains_key(&100),
+            "a wrong-seq archive blob must not clear the gap"
+        );
+        assert_eq!(metrics.pusher_gap_archive_repairs_total.get(), 0);
+        assert_eq!(
+            committees.head_epoch(),
+            0,
+            "the refused blob's committee transition must not install"
+        );
+    }
+
+    /// A gap that neither the fullnode nor the archive can serve is dropped
+    /// at the retry deadline and counted (`pusher_gap_dropped_total`) — the
+    /// loud permanent-loss signal — while a younger co-pending gap stays.
+    #[tokio::test]
+    async fn gap_missing_from_fullnode_and_archive_is_dropped_at_the_deadline() {
+        let (committee, keys) = Committee::new_simple_test_committee();
+        let dir = tempfile::tempdir().unwrap();
+        let perpetual = Arc::new(AuthorityPerpetualTables::open(dir.path(), None));
+        let committees = Arc::new(
+            CommitteeStore::open(
+                perpetual.clone(),
+                Some(CommitteeBootstrap::Genesis(committee.clone())),
+            )
+            .unwrap(),
+        );
+
+        let latest = plain_checkpoint(&committee, &keys, 101).checkpoint_summary;
+        let transport: Arc<dyn SuiTransport> = Arc::new(MockTransport {
+            latest,
+            checkpoints: HashMap::new(),
+            eoe_seqs: HashMap::new(),
+        });
+        perpetual.put_sui_pusher_last_seq(99).unwrap();
+
+        let cache: SharedVerifiedStateCache = Arc::new(VerifiedStateCache::new());
+        let metrics = OcsMetrics::new_for_testing();
+        let mut pusher = pusher_over_with_cache(
+            perpetual.clone(),
+            committees.clone(),
+            transport,
+            cache,
+            metrics.clone(),
+        )
+        .await;
+        pusher.archive = Some(Arc::new(MockCheckpointArchive {
+            checkpoints: HashMap::new(),
+        }));
+
+        pusher.advance().await.unwrap();
+        assert_eq!(
+            pusher.pending_gaps.keys().copied().collect::<Vec<_>>(),
+            vec![100, 101]
+        );
+
+        // Age seq 100 past the retry deadline; seq 101 stays young.
+        pusher.pending_gaps.get_mut(&100).unwrap().first_seen =
+            Instant::now() - Duration::from_secs(601);
+        pusher.advance().await.unwrap();
+
+        assert_eq!(
+            pusher.pending_gaps.keys().copied().collect::<Vec<_>>(),
+            vec![101],
+            "only the expired gap is dropped"
+        );
+        assert_eq!(metrics.pusher_gap_dropped_total.get(), 1);
+        assert_eq!(metrics.pusher_gap_archive_repairs_total.get(), 0);
     }
 
     /// The pusher resumes from its persisted cursor across a restart: once

--- a/crates/ika-core/src/sui_connector/setup.rs
+++ b/crates/ika-core/src/sui_connector/setup.rs
@@ -90,6 +90,12 @@ pub struct SuiConnectorStack {
     /// spawns `.run()` once the anemo network is up (like the pusher). `None`
     /// on sui-state-direct.
     pub changeset_receiver: Option<ChangesetReceiver>,
+    /// The resolved checkpoint archive (explicit config, or the public chain
+    /// default), shared with the ratchet. The caller hands it to the
+    /// `IkaCheckpointPusher` as the verified fallback for gap checkpoints the
+    /// fullnode pruned before the pusher could fetch them. `None` when no
+    /// archive resolved (localnet without one configured).
+    pub checkpoint_archive: Option<Arc<dyn ika_sui_client::archive::CheckpointArchive>>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -377,7 +383,7 @@ pub async fn build_sui_connector_stack(
         });
     let ratchet = Arc::new(
         OcsVerifyingClient::new(raw_for_ratchet, committees.clone(), metrics.clone())
-            .with_archive(archive),
+            .with_archive(archive.clone()),
     );
 
     // Mirrored / peer-only currency: a changeset index the reader consults,
@@ -529,6 +535,7 @@ pub async fn build_sui_connector_stack(
         state_cache,
         metrics,
         changeset_receiver,
+        checkpoint_archive: archive,
     })
 }
 

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -808,6 +808,7 @@ impl IkaNode {
             sui_state_mirror_server,
             raw_transport_for_pushing,
             mut state_cache_opt,
+            archive_for_pushing,
         ) = {
             // Spread a built stack into the individually-wired component
             // slots the rest of boot threads around.
@@ -818,6 +819,7 @@ impl IkaNode {
                     stack.mirror_server,
                     stack.raw_transport_for_pushing,
                     Some(stack.state_cache),
+                    stack.checkpoint_archive,
                 )
             };
             if is_sui_state_direct {
@@ -870,7 +872,7 @@ impl IkaNode {
                     .expect("peer-only OCS stack built in the transport gate above");
                 unpack(stack)
             } else {
-                (None, None, None, None, None)
+                (None, None, None, None, None, None)
             }
         };
 
@@ -1112,6 +1114,11 @@ impl IkaNode {
                         std::time::Duration::from_millis(250),
                         cache_for_push.clone(),
                         committees_for_push.clone(),
+                        // Verified fallback for gap checkpoints the fullnode
+                        // prunes before the pusher fetches them (issue #2018):
+                        // the pusher re-fetches them from the archive and folds
+                        // them through the same committee verification.
+                        archive_for_pushing.clone(),
                     )
                     .await
                     {

--- a/crates/ika-sui-client/src/archive.rs
+++ b/crates/ika-sui-client/src/archive.rs
@@ -33,6 +33,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use object_store::ObjectStore;
 use sui_storage::object_store::util::{build_object_store, end_of_epoch_data, fetch_checkpoint};
+use sui_types::full_checkpoint_content::CheckpointData;
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
 };
@@ -74,6 +75,19 @@ pub trait CheckpointArchive: Send + Sync {
         &self,
         seq: CheckpointSequenceNumber,
     ) -> Result<(CertifiedCheckpointSummary, CheckpointContents), ArchiveError>;
+
+    /// Fetch a checkpoint by sequence number with its FULL contents —
+    /// transactions and output objects — as (still-unverified)
+    /// [`CheckpointData`]. Used by the checkpoint pusher to fold a checkpoint
+    /// its own fullnode pruned before it could fetch it; the caller runs the
+    /// same committee verification it applies to fullnode-served checkpoints
+    /// before trusting any of it. The public Sui checkpoint stores retain
+    /// ordinary checkpoints for ~30 days (far beyond a fullnode's pruning
+    /// window), and a local data-ingestion dir retains them until cleaned.
+    async fn fetch_checkpoint_data(
+        &self,
+        seq: CheckpointSequenceNumber,
+    ) -> Result<CheckpointData, ArchiveError>;
 }
 
 /// A read-only client over a Sui checkpoint object store.
@@ -130,6 +144,21 @@ impl CheckpointArchive for SuiCheckpointArchive {
                     source,
                 })?;
         Ok((checkpoint.summary, checkpoint.contents))
+    }
+
+    async fn fetch_checkpoint_data(
+        &self,
+        seq: CheckpointSequenceNumber,
+    ) -> Result<CheckpointData, ArchiveError> {
+        let checkpoint =
+            fetch_checkpoint(&self.store, seq)
+                .await
+                .map_err(|source| ArchiveError::Fetch {
+                    url: self.url.clone(),
+                    seq,
+                    source,
+                })?;
+        Ok(checkpoint.into())
     }
 }
 

--- a/crates/ika-swarm-config/src/network_config_builder.rs
+++ b/crates/ika-swarm-config/src/network_config_builder.rs
@@ -77,6 +77,10 @@ pub struct ConfigBuilder<R = OsRng> {
     fullnode_supported_protocol_versions_config: Option<ProtocolVersionsConfig>,
     fullnode_run_with_range: Option<RunWithRange>,
     genesis_global_presign_config: GenesisGlobalPresignConfig,
+    /// Checkpoint-archive URL pasted into every validator's
+    /// `sui_checkpoint_archive` (see `ValidatorConfigBuilder`); on a localnet
+    /// this points at the Sui fullnode's data-ingestion dir (`file://…`).
+    sui_checkpoint_archive_url: Option<String>,
 }
 
 impl ConfigBuilder {
@@ -104,6 +108,7 @@ impl ConfigBuilder {
             fullnode_supported_protocol_versions_config: None,
             fullnode_run_with_range: None,
             genesis_global_presign_config: GenesisGlobalPresignConfig::Full,
+            sui_checkpoint_archive_url: None,
         }
     }
 
@@ -162,6 +167,11 @@ impl<R> ConfigBuilder<R> {
 
     pub fn with_epoch_duration(mut self, epoch_duration_ms: u64) -> Self {
         self.epoch_duration_ms = Some(epoch_duration_ms);
+        self
+    }
+
+    pub fn with_sui_checkpoint_archive_url(mut self, url: String) -> Self {
+        self.sui_checkpoint_archive_url = Some(url);
         self
     }
 
@@ -252,6 +262,7 @@ impl<R> ConfigBuilder<R> {
                 .fullnode_supported_protocol_versions_config,
             fullnode_run_with_range: self.fullnode_run_with_range,
             genesis_global_presign_config: self.genesis_global_presign_config,
+            sui_checkpoint_archive_url: self.sui_checkpoint_archive_url,
         }
     }
 }
@@ -381,6 +392,10 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                 let mut builder = ValidatorConfigBuilder::new()
                     .with_config_directory(self.config_directory.clone())
                     .with_sui_genesis(sui_genesis_path.clone());
+
+                if let Some(archive_url) = &self.sui_checkpoint_archive_url {
+                    builder = builder.with_sui_checkpoint_archive_url(archive_url.clone());
+                }
 
                 if let Some(max_submit_position) = self.max_submit_position {
                     builder = builder.with_max_submit_position(max_submit_position);

--- a/crates/ika-swarm-config/src/node_config_builder.rs
+++ b/crates/ika-swarm-config/src/node_config_builder.rs
@@ -10,8 +10,9 @@ use fastcrypto::encoding::{Encoding, Hex};
 use fastcrypto::traits::KeyPair;
 use ika_config::node::{
     AuthorityKeyPairWithPath, AuthorityOverloadConfig, IkaIdentityOverride, KeyPairWithPath,
-    RootSeedWithPath, RunWithRange, StateArchiveConfig, SuiChainIdentifier, SuiConnectorConfig,
-    SuiDataSource, default_end_of_epoch_broadcast_channel_capacity,
+    RootSeedWithPath, RunWithRange, StateArchiveConfig, SuiChainIdentifier,
+    SuiCheckpointArchiveConfig, SuiConnectorConfig, SuiDataSource,
+    default_end_of_epoch_broadcast_channel_capacity,
 };
 use std::path::PathBuf;
 use sui_types::base_types::ObjectID;
@@ -53,6 +54,14 @@ pub struct ValidatorConfigBuilder {
     /// `NodeConfig.sui_connector_config.sui_genesis`. When set, the validator
     /// genesis-bootstraps the OCS committee chain from it.
     sui_genesis: Option<PathBuf>,
+    /// Optional checkpoint-archive URL, pasted into
+    /// `NodeConfig.sui_connector_config.sui_checkpoint_archive`. Localnets
+    /// (`Custom` chain) resolve no default archive, so without this a gap
+    /// checkpoint the localnet fullnode prunes before the pusher fetches it
+    /// is lost permanently; pointing this at the fullnode's data-ingestion
+    /// dir (`file://…`) gives the pusher the same verified fallback the
+    /// public chains get from their public checkpoint stores.
+    sui_checkpoint_archive_url: Option<String>,
 }
 
 impl ValidatorConfigBuilder {
@@ -112,6 +121,11 @@ impl ValidatorConfigBuilder {
 
     pub fn with_sui_state_mirror_peers(mut self, peers: Vec<String>) -> Self {
         self.sui_state_mirror_peers_override = Some(peers);
+        self
+    }
+
+    pub fn with_sui_checkpoint_archive_url(mut self, url: String) -> Self {
+        self.sui_checkpoint_archive_url = Some(url);
         self
     }
 
@@ -189,7 +203,12 @@ impl ValidatorConfigBuilder {
                     .map(Into::into)
                     .collect(),
                 sui_genesis: self.sui_genesis.clone(),
-                sui_checkpoint_archive: None,
+                sui_checkpoint_archive: self.sui_checkpoint_archive_url.clone().map(|url| {
+                    SuiCheckpointArchiveConfig {
+                        url,
+                        options: vec![],
+                    }
+                }),
                 sui_chain_identifier: SuiChainIdentifier::Custom,
                 // Localnet (`Custom`): the freshly-published ids travel in the
                 // unsafe override — the only config-surface source on chains

--- a/crates/ika-swarm/src/memory/swarm.rs
+++ b/crates/ika-swarm/src/memory/swarm.rs
@@ -46,6 +46,7 @@ pub struct SwarmBuilder<R = OsRng> {
     fullnode_run_with_range: Option<RunWithRange>,
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
+    sui_checkpoint_archive_url: Option<String>,
 }
 
 impl SwarmBuilder {
@@ -65,6 +66,7 @@ impl SwarmBuilder {
             fullnode_run_with_range: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
+            sui_checkpoint_archive_url: None,
         }
     }
 }
@@ -86,6 +88,7 @@ impl<R> SwarmBuilder<R> {
             fullnode_run_with_range: self.fullnode_run_with_range,
             max_submit_position: self.max_submit_position,
             submit_delay_step_override_millis: self.submit_delay_step_override_millis,
+            sui_checkpoint_archive_url: self.sui_checkpoint_archive_url,
         }
     }
 
@@ -124,6 +127,15 @@ impl<R> SwarmBuilder<R> {
 
     pub fn with_epoch_duration_ms(mut self, epoch_duration_ms: u64) -> Self {
         self.epoch_duration_ms = Some(epoch_duration_ms);
+        self
+    }
+
+    /// Point every validator's `sui_checkpoint_archive` at a checkpoint store
+    /// (on a localnet, the Sui fullnode's data-ingestion dir as a `file://`
+    /// URL) so the checkpoint pusher can recover gap checkpoints the fullnode
+    /// prunes before the pusher fetches them.
+    pub fn with_sui_checkpoint_archive_url(mut self, url: String) -> Self {
+        self.sui_checkpoint_archive_url = Some(url);
         self
     }
 
@@ -238,6 +250,10 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
 
             if let Some(epoch_duration_ms) = self.epoch_duration_ms {
                 config_builder = config_builder.with_epoch_duration(epoch_duration_ms);
+            }
+
+            if let Some(archive_url) = self.sui_checkpoint_archive_url {
+                config_builder = config_builder.with_sui_checkpoint_archive_url(archive_url);
             }
 
             if let Some(protocol_version) = self.protocol_version {

--- a/crates/ika/src/ika_commands.rs
+++ b/crates/ika/src/ika_commands.rs
@@ -99,6 +99,18 @@ pub enum IkaCommand {
         #[clap(long)]
         epoch_duration_ms: Option<u64>,
 
+        /// Checkpoint-archive URL written into every validator's
+        /// `sui-checkpoint-archive` config (object-store layout:
+        /// `{seq}.binpb.zst` blobs). Point it at the Sui localnet fullnode's
+        /// data-ingestion dir (e.g. `file:///path/to/ingestion`, from
+        /// `sui start --data-ingestion-dir <path>`) so validators can recover
+        /// checkpoints the fullnode prunes before they fetch them; without it
+        /// a pruned-before-fetched checkpoint is lost permanently and can
+        /// wedge an epoch close. Only takes effect when validator configs are
+        /// (re)generated (`--force-reinitiation` or a fresh config dir).
+        #[clap(long, value_name = "URL")]
+        sui_checkpoint_archive_url: Option<String>,
+
         /// Start the network without a fullnode
         #[clap(long = "no-full-node")]
         no_full_node: bool,
@@ -227,6 +239,7 @@ impl IkaCommand {
                 sui_faucet_url,
                 no_full_node,
                 epoch_duration_ms,
+                sui_checkpoint_archive_url,
                 clean,
             } => {
                 // Clean persisted DB directories if requested
@@ -251,6 +264,7 @@ impl IkaCommand {
                             sui_fullnode_grpc_url,
                             sui_faucet_url,
                             no_full_node,
+                            sui_checkpoint_archive_url,
                         )
                         .await
                         {
@@ -369,6 +383,7 @@ async fn start(
     sui_fullnode_grpc_url: String,
     _sui_faucet_url: String,
     no_full_node: bool,
+    sui_checkpoint_archive_url: Option<String>,
 ) -> Result<(), anyhow::Error> {
     if force_reinitiation {
         ensure!(
@@ -415,6 +430,9 @@ async fn start(
             .join(IKA_NETWORK_CONFIG)
     };
     let mut swarm_builder = Swarm::builder();
+    if let Some(archive_url) = sui_checkpoint_archive_url {
+        swarm_builder = swarm_builder.with_sui_checkpoint_archive_url(archive_url);
+    }
     // If this is set, then no data will be persisted between runs, and a new initiation will be
     // generated each run.
     let ika_network_config_not_exists =

--- a/dev-docs/playbooks/localnet.md
+++ b/dev-docs/playbooks/localnet.md
@@ -10,7 +10,13 @@ For SDK integration tests, reproduction rigs, and manual poking.
 #    the network DKG but silently stalls reconfiguration — the failure
 #    appears one epoch later and nothing points back at the version.
 sui --version   # must match the mainnet-vX.Y.Z tag in root Cargo.toml
-sui start --with-faucet --force-regenesis > /tmp/sui.log 2>&1 &
+#    The data-ingestion dir doubles as a checkpoint archive for the ika
+#    validators (next step): the localnet fullnode prunes aggressively,
+#    and a checkpoint pruned before the validators' pusher fetches it is
+#    otherwise lost permanently — one lost session-request event can
+#    wedge an epoch close (issue #2018).
+sui start --with-faucet --force-regenesis \
+  --data-ingestion-dir /tmp/sui-ingestion > /tmp/sui.log 2>&1 &
 
 # 2. ika localnet on top (it expects the Sui RPC at 127.0.0.1:9000).
 #    5-minute epochs are the validated sweet spot: too long stalls the
@@ -18,6 +24,7 @@ sui start --with-faucet --force-regenesis > /tmp/sui.log 2>&1 &
 #    InvalidMPCPartyType (3/4 convergence).
 RUST_LOG="warn,ika=info,ika_node=info,ika_core=info" \
   ./target/release/ika start --force-reinitiation --epoch-duration-ms 300000 \
+  --sui-checkpoint-archive-url file:///tmp/sui-ingestion \
   > /tmp/ika.log 2>&1 &
 ```
 

--- a/dev-docs/playbooks/mpc-stall-postmortem.md
+++ b/dev-docs/playbooks/mpc-stall-postmortem.md
@@ -141,16 +141,28 @@ four fixed; kept for the diagnostic shapes):
   pending-gap repair in `push_worker.rs`), and the dynamic-fields walk
   permanently dropped live-listed bag children whose defining checkpoint
   was pruned (fixed: the provider reports the skipped ids and the reader
-  resolves them from the committee-verified cache). Diagnosis, if the
-  shape recurs:
+  resolves them from the committee-verified cache). Issue #2018 showed
+  both recovery paths can still lose the race when pruning outruns them
+  (a throttled CI runner, `num_epochs_to_retain=0`): one lost DKG-request
+  entry inside the locked close set wedged the epoch. The pusher now has
+  a third layer — pending gaps the fullnode keeps refusing are fetched
+  from the checkpoint archive (public store on mainnet/testnet; the Sui
+  fullnode's data-ingestion dir on a localnet via `ika start
+  --sui-checkpoint-archive-url`) and folded through the same committee
+  verification. Diagnosis, if the shape recurs:
   ```bash
   grep -E "holding .*re-pulled next epoch" $L | tail -3   # the held session + its seq
   # then confirm that seq never returns (no completion, no re-pull):
   grep "session_sequence_number=<SEQ>" $L
-  # pusher losing checkpoints? (should be absent post-fix)
+  # pusher losing checkpoints? (only fires when the ARCHIVE also failed —
+  # check ika_ocs_pusher_gap_dropped_total / _gap_archive_repairs_total)
   grep -E "never materialized within the gap retry deadline" $L
+  grep -E "recovered from the archive and folded" $L
   # walk dropping children the cache can't serve either?
   grep -E "could not be resolved from the verified cache" $L
+  # a session admitted but never computing (the issue #2018 open shape —
+  # warned once a minute per validator while it persists):
+  grep -E "active without a local output past the stall" $L
   ```
   The end-to-end guards are `sim_user_flows_across_boundaries` and the
   presign-traffic sim tests (deterministic reproducers of the original

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -686,16 +686,47 @@ fetches them, and any checkpoint the folder never folds is a PERMANENT
 cache gap (an Ika object whose only mutation rode it — e.g. a
 `session_events` bag entry — never enters the cache; observed pinning
 epoch closes when the entry belonged to a session re-pulled across an
-epoch boundary). A full-checkpoint fetch failure must therefore neither
+epoch boundary, and again in issue #2018 where the lost entry was a live
+DKG request that sat inside the epoch's locked close set). A
+full-checkpoint fetch failure must therefore neither
 stall the scan (one unfetchable checkpoint would freeze the whole cache
 behind it) nor be skipped silently (the historical behavior, and the
 root cause above). Instead the scan continues and the failed seq becomes
 a **pending gap**, retried at the top of every tick and folded LATE when
 it materializes — out-of-order folding is safe because the cache is
 monotonic-by-version and its fold head is monotone-max, so a late fold
-can only fill gaps, never regress state. A gap that outlives a generous
-retry deadline is dropped with a loud warn (genuinely pruned upstream);
-gaps inside a far-behind fast-forward's sacrificed span go with it.
+can only fill gaps, never regress state. A gap the fullnode keeps
+refusing past a short grace (5 s) is fetched from the resolved
+**checkpoint archive** instead (the same object store the ratchet falls
+back to; the public stores retain *ordinary* checkpoints ~30 days, and a
+localnet points this at the Sui fullnode's `--data-ingestion-dir` via
+`ika start --sui-checkpoint-archive-url file://…`). Archive fetches are
+paced per gap, capped per tick, and bounded by a per-fetch timeout (the
+object-store client otherwise retries internally for up to 60 s, and an
+unbounded stall here would hold the scan cursor back while the fullnode
+prunes more — the fallback amplifying the loss it prevents). An
+archive-served checkpoint must pass verification STRICTLY beyond what
+the fullnode fold path applies before it may clear a gap — because the
+archive is the lower-trust source (a third-party HTTP store by default
+on public chains) and the fold path verifies nothing for a checkpoint
+with no Ika-typed outputs, a blob that folds vacuously would clear the
+gap silently and suppress the dropped-gap alarm: (1) the blob's
+committee-signed `sequence_number` must equal the requested seq (file
+naming is untrusted), (2) committee BLS on the summary, and (3) the
+artifacts-digest binding over the blob's ENTIRE object set — both
+unconditionally, so an emptied or mislabeled object set produces a tree
+root the committee never signed and is refused
+(`verify_archive_checkpoint` in `push_worker.rs`). The archive is thus
+an availability source, never a trust source; repairs are counted by
+`ika_ocs_pusher_gap_archive_repairs_total`. Only a gap that BOTH sources
+fail to serve until the generous retry deadline is dropped, with a loud
+warn and `ika_ocs_pusher_gap_dropped_total` (alert on any increase — each
+drop is a potential wedged epoch); gaps inside a far-behind
+fast-forward's sacrificed span go with it (counted in the same metric).
+The end-of-epoch retained store is written only after the fold's
+committee verification passes (`fold_checkpoint` verifies before
+`persist_end_of_epoch`), so no source — fullnode or archive — can
+overwrite a genuine retained entry with an unverified blob.
 Gaps are in-memory only — after a restart the on-chain
 uncompleted-session re-pull is the backstop.
 


### PR DESCRIPTION
Closes #2018.

## Problem

CI run 31353003990 wedged epoch 5 permanently: the Sui localnet fullnode (aggressive pruning, throttled runner) pruned a checkpoint before the validators' OCS checkpoint pusher could fetch it. The checkpoint carried a user DKG-request `session_events` bag entry; both existing recovery layers (pending-gap retry against the fullnode, verified-cache resolution of pruned dynamic-field children) ran and still failed, so all four validators permanently lost the request event. The lost session sat inside the epoch's locked close target, `all_epoch_sessions_finished` could never become true, and the epoch never closed — the residual tail of #1736.

## Fix: a third, verified recovery layer — the checkpoint archive

The pusher's pending-gap repair now falls back to the resolved **checkpoint archive** (the same object store the committee ratchet already uses as its verified fallback):

- A gap the fullnode keeps refusing past a 5s grace is fetched from the archive (paced at 5s per gap, capped at 4 fetches/tick, 5s per-fetch timeout — the object-store client otherwise retries internally up to 60s, and an unbounded stall would hold the scan cursor back while the fullnode prunes more).
- An archive-served checkpoint must pass verification **strictly beyond** what the fullnode fold path applies before it may clear a gap (`verify_archive_checkpoint`): the blob's committee-signed `sequence_number` must equal the requested seq (file naming is untrusted), committee BLS on the summary, and the artifacts-digest binding over the blob's **entire** object set — both unconditionally. Without this, a blob with no Ika-typed outputs folds vacuously (`build_entries` verifies nothing on that path) and a mislabeled or emptied blob would silently "repair" the gap while suppressing the dropped-gap alarm. The archive stays an availability source, never a trust source.
- Only a gap that BOTH sources fail to serve until the 600s deadline is dropped, still with the loud warn.
- The end-of-epoch retained store is now written only **after** the fold's committee verification passes (previously `persist_end_of_epoch` ran first, letting an unverified blob overwrite a genuine retained entry — availability-only exposure, since mirrored peers re-verify, but needless).
- The public Sui checkpoint stores (mainnet/testnet defaults) retain *ordinary* checkpoints ~30 days — far beyond any fullnode pruning window — so on the public chains this closes the pruning race outright.

The seq-binding/vacuous-fold hazard, the persist-before-verify ordering, the fetch-timeout stall amplification, and the fast-forward-sacrificed gaps not counting as drops were all found by an adversarial consensus review of the first draft and are fixed + regression-tested in this PR.

New plumbing: `CheckpointArchive::fetch_checkpoint_data` (full checkpoint with transactions + objects), the archive shared from `SuiConnectorStack` into `IkaCheckpointPusher`.

## Localnet/CI coverage for the same race

Localnets resolve no default archive, so the race stayed open exactly where it fired. Now:

- `sui start --data-ingestion-dir <dir>` makes the localnet fullnode dump every executed checkpoint as `{seq}.binpb.zst` — the archive layout.
- New `ika start --sui-checkpoint-archive-url file://<dir>` threads that into every validator's `sui_checkpoint_archive` (CLI → SwarmBuilder → ConfigBuilder → ValidatorConfigBuilder).
- The TS-integration workflow wires both, replacing the step comment that claimed the OCS path was "self-sufficient against this localnet's aggressive pruning" (disproved by the incident).

## Observability

- `ika_ocs_pusher_gap_archive_repairs_total` — gaps recovered from the archive (the fallback doing real work).
- `ika_ocs_pusher_gap_dropped_total` — gaps lost by both sources; each is a potential wedged epoch. Alert on any increase (previously drops were only a warn line).
- `ika_dwallet_mpc_user_sessions_active_without_local_output` + a once-a-minute warn ("active without a local output past the stall threshold") for the issue's open sub-question: a user session admitted by all validators that never computes (session seq 234 in the incident was invisible in logs from admission to test timeout). This makes the shape diagnosable from CI artifacts at info-level logging.

## Not addressed here (deliberately)

The epoch-close blast radius — a protocol-level path to exclude a locked session that no validator can ever complete — is direction 2 in #2018 and needs a consensus/Move design discussion; this PR closes the event-loss root cause and makes any recurrence loudly visible instead.

## Testing

- New unit tests: `pruned_gap_checkpoint_is_recovered_from_the_archive` (archive repair: fold verified, committee captured, end-of-epoch retained, metric counted; archive NOT consulted within the fullnode grace), `archive_blob_for_a_different_seq_is_refused` (a genuine, correctly-signed blob for the WRONG seq must not clear the gap nor install its committee transition), and `gap_missing_from_fullnode_and_archive_is_dropped_at_the_deadline` (both-sources failure: expired gap dropped + counted, younger gap kept).
- Full `sui_connector` module run in release (includes the ratchet `MockArchive` trait-extension change).
- Docs updated in the same PR: `ocs-verified-sui-reads.md` (pending-gap repair section), `mpc-stall-postmortem.md` (new grep signals + #2018 shape), `localnet.md` (archive-wired startup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YatnLynE9nf39wQptFiv26
