### PR TITLE
fix(dwallet-mpc): gate computation spawning while catching up to the consensus tip (#2023)

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/catchup_gate.rs
+++ b/crates/ika-core/src/dwallet_mpc/catchup_gate.rs
@@ -1,0 +1,240 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Catch-up gate for the dWallet MPC service (issue #2023).
+//!
+//! A validator whose MPC processing cursor trails the consensus tip beyond
+//! the *trap radius* falls into a stable non-contributing equilibrium: every
+//! high-volume session it starts computing (internal presigns, user sessions)
+//! has already completed network-wide by the time its contribution would
+//! matter. It observes the terminal state and abandons the work — but the
+//! dead-on-arrival crypto burns enough CPU to pin its round processing just
+//! below the tip rate, so the backlog never drains and the trap sustains
+//! itself until the epoch boundary. Measured in production: with computation
+//! suppressed the round drain runs at ~40x the tip rate (the restart replay
+//! path proves it), so a backlog that takes hours to *not* drain while
+//! computing clears in seconds without.
+//!
+//! This module is the pure hysteresis state machine for that gate, kept free
+//! of service state so it is testable in isolation (same pattern as
+//! `reconfig_watchdog.rs`). The [`DWalletMPCManager`] holds one instance,
+//! feeds it the per-iteration round gap, and consults it at the computation
+//! spawn decision in `perform_cryptographic_computation`.
+//!
+//! [`DWalletMPCManager`]: crate::dwallet_mpc::mpc_manager::DWalletMPCManager
+
+use ika_types::messages_dwallet_mpc::SessionType;
+
+/// Enter catch-up mode when the round gap exceeds this.
+///
+/// The trap radius is roughly session-completion-time x tip-rate — ~1-2k
+/// rounds on mainnet at ~19.5 rounds/s (issue #2023's live capture entered at
+/// ~4-5k behind and oscillated 545-7,346 once trapped). The enter threshold
+/// is ~2x the radius with margin: ordinary load jitter of a healthy at-tip
+/// validator (hundreds of rounds) must never flip the gate, while any gap
+/// that actually sustains the trap comfortably exceeds it.
+pub(crate) const CATCH_UP_ENTER_GAP_ROUNDS: u64 = 5_000;
+
+/// Exit catch-up mode when the round gap falls below this.
+///
+/// Well inside the trap radius (~25s of tip progress at mainnet rates): on
+/// exit the sessions near the cursor are still genuinely live network-wide,
+/// so resumed computations contribute instead of chasing already-terminal
+/// sessions. The wide enter/exit band is the hysteresis that prevents
+/// oscillation at either boundary.
+pub(crate) const CATCH_UP_EXIT_GAP_ROUNDS: u64 = 500;
+
+/// The gate's reaction to one gap observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CatchUpTransition {
+    /// The gap crossed above [`CATCH_UP_ENTER_GAP_ROUNDS`]; computation
+    /// suppression begins.
+    Entered,
+    /// The gap fell below [`CATCH_UP_EXIT_GAP_ROUNDS`]; computation
+    /// suppression ends.
+    Exited,
+    /// No state change (including gaps inside the hysteresis band).
+    Unchanged,
+}
+
+/// Hysteresis state machine over the "MPC cursor behind consensus tip" gap.
+///
+/// Enter when `gap > CATCH_UP_ENTER_GAP_ROUNDS`, exit when
+/// `gap < CATCH_UP_EXIT_GAP_ROUNDS`, hold the current state anywhere in
+/// between. Per-epoch and in-memory by design: the manager that owns it is
+/// rebuilt at every epoch boundary and process restart, and the first
+/// service iteration after a mid-epoch restart re-observes the full replay
+/// backlog as its gap — exactly the entry condition the gate exists for.
+#[derive(Debug)]
+pub(crate) struct CatchUpGate {
+    in_catch_up: bool,
+}
+
+impl CatchUpGate {
+    pub(crate) fn new() -> Self {
+        Self { in_catch_up: false }
+    }
+
+    /// Whether new cryptographic computations for suppressible session types
+    /// should currently be withheld. Cheap enough for a per-session-per-tick
+    /// caller: a single bool read.
+    pub(crate) fn is_catching_up(&self) -> bool {
+        self.in_catch_up
+    }
+
+    /// Feed one gap observation (`tip - cursor`, in consensus rounds) and
+    /// apply the hysteresis.
+    pub(crate) fn update(&mut self, gap_rounds: u64) -> CatchUpTransition {
+        if !self.in_catch_up && gap_rounds > CATCH_UP_ENTER_GAP_ROUNDS {
+            self.in_catch_up = true;
+            CatchUpTransition::Entered
+        } else if self.in_catch_up && gap_rounds < CATCH_UP_EXIT_GAP_ROUNDS {
+            self.in_catch_up = false;
+            CatchUpTransition::Exited
+        } else {
+            CatchUpTransition::Unchanged
+        }
+    }
+}
+
+/// Whether catch-up mode suppresses spawning computations for this session
+/// type.
+///
+/// Suppressed — the volume that creates and sustains the trap (thousands of
+/// active sessions in the live capture):
+/// - [`SessionType::InternalPresign`]: pool top-up batches; the pool is
+///   refilled by the network's live validators either way, and this
+///   validator's own drained rounds mark the already-completed ones terminal.
+/// - [`SessionType::User`]: their outputs reach quorum from the fastest
+///   two-thirds of the committee; a trapped validator's contribution arrives
+///   after quorum and is discarded (the `completion_races` path).
+///
+/// Exempt — system-critical, rare, and epoch-critical, so they must never be
+/// skipped on a mere heuristic:
+/// - [`SessionType::System`]: network DKG, network-key reconfiguration and
+///   the other network-key sessions. Missing one can wedge the epoch
+///   transition for the whole network, and their volume (a handful per
+///   epoch) cannot sustain the trap.
+/// - [`SessionType::NetworkOwnedAddressSign`]: checkpoint-cadence signing
+///   backing the NOA checkpoint flow — low-volume and liveness-relevant.
+///
+/// Suppression only withholds *starting new computations*: round draining,
+/// quorum observation, terminal bookkeeping, output verification, and
+/// already-running computations all continue unchanged.
+pub(crate) fn computation_suppressible_during_catch_up(session_type: SessionType) -> bool {
+    match session_type {
+        SessionType::User | SessionType::InternalPresign => true,
+        SessionType::System | SessionType::NetworkOwnedAddressSign => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_out_of_catch_up() {
+        let gate = CatchUpGate::new();
+        assert!(!gate.is_catching_up());
+    }
+
+    #[test]
+    fn enters_only_strictly_above_the_enter_threshold() {
+        let mut gate = CatchUpGate::new();
+        assert_eq!(
+            gate.update(CATCH_UP_ENTER_GAP_ROUNDS),
+            CatchUpTransition::Unchanged,
+            "a gap AT the enter threshold must not enter"
+        );
+        assert!(!gate.is_catching_up());
+        assert_eq!(
+            gate.update(CATCH_UP_ENTER_GAP_ROUNDS + 1),
+            CatchUpTransition::Entered
+        );
+        assert!(gate.is_catching_up());
+    }
+
+    #[test]
+    fn stays_in_until_strictly_below_the_exit_threshold() {
+        let mut gate = CatchUpGate::new();
+        gate.update(CATCH_UP_ENTER_GAP_ROUNDS + 1);
+        assert_eq!(
+            gate.update(CATCH_UP_EXIT_GAP_ROUNDS),
+            CatchUpTransition::Unchanged,
+            "a gap AT the exit threshold must stay in catch-up"
+        );
+        assert!(gate.is_catching_up());
+        assert_eq!(
+            gate.update(CATCH_UP_EXIT_GAP_ROUNDS - 1),
+            CatchUpTransition::Exited
+        );
+        assert!(!gate.is_catching_up());
+    }
+
+    #[test]
+    fn hysteresis_band_holds_the_prior_state_in_both_directions() {
+        let mid_band = (CATCH_UP_ENTER_GAP_ROUNDS + CATCH_UP_EXIT_GAP_ROUNDS) / 2;
+
+        // Out of catch-up: a mid-band gap must not enter.
+        let mut gate = CatchUpGate::new();
+        assert_eq!(gate.update(mid_band), CatchUpTransition::Unchanged);
+        assert!(!gate.is_catching_up());
+
+        // In catch-up: the same mid-band gap must not exit.
+        gate.update(CATCH_UP_ENTER_GAP_ROUNDS + 1);
+        assert_eq!(gate.update(mid_band), CatchUpTransition::Unchanged);
+        assert!(gate.is_catching_up());
+    }
+
+    #[test]
+    fn no_oscillation_when_the_gap_hovers_at_a_boundary() {
+        // Hovering around the enter threshold while out: never enters.
+        let mut gate = CatchUpGate::new();
+        for gap in [
+            CATCH_UP_ENTER_GAP_ROUNDS - 1,
+            CATCH_UP_ENTER_GAP_ROUNDS,
+            CATCH_UP_ENTER_GAP_ROUNDS - 1,
+            CATCH_UP_ENTER_GAP_ROUNDS,
+        ] {
+            assert_eq!(gate.update(gap), CatchUpTransition::Unchanged);
+        }
+        assert!(!gate.is_catching_up());
+
+        // Hovering around the exit threshold while in: never exits.
+        gate.update(CATCH_UP_ENTER_GAP_ROUNDS + 1);
+        for gap in [
+            CATCH_UP_EXIT_GAP_ROUNDS + 1,
+            CATCH_UP_EXIT_GAP_ROUNDS,
+            CATCH_UP_EXIT_GAP_ROUNDS + 1,
+            CATCH_UP_EXIT_GAP_ROUNDS,
+        ] {
+            assert_eq!(gate.update(gap), CatchUpTransition::Unchanged);
+        }
+        assert!(gate.is_catching_up());
+    }
+
+    #[test]
+    fn full_cycle_enter_hold_exit_reenter() {
+        let mut gate = CatchUpGate::new();
+        assert_eq!(gate.update(10_000), CatchUpTransition::Entered);
+        assert_eq!(gate.update(2_000), CatchUpTransition::Unchanged);
+        assert_eq!(gate.update(499), CatchUpTransition::Exited);
+        assert_eq!(gate.update(499), CatchUpTransition::Unchanged);
+        assert_eq!(gate.update(10_000), CatchUpTransition::Entered);
+        assert!(gate.is_catching_up());
+    }
+
+    #[test]
+    fn suppression_covers_exactly_the_high_volume_session_types() {
+        assert!(computation_suppressible_during_catch_up(SessionType::User));
+        assert!(computation_suppressible_during_catch_up(
+            SessionType::InternalPresign
+        ));
+        assert!(!computation_suppressible_during_catch_up(
+            SessionType::System
+        ));
+        assert!(!computation_suppressible_during_catch_up(
+            SessionType::NetworkOwnedAddressSign
+        ));
+    }
+}

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -106,6 +106,21 @@ pub struct DWalletMPCMetrics {
     /// The last process MPC consensus round.
     pub last_process_mpc_consensus_round: IntGauge,
 
+    /// 1 while the dwallet MPC service is in catch-up mode — its processing
+    /// cursor trails the consensus tip beyond the trap radius (issue #2023)
+    /// and new cryptographic computations for internal-presign and user
+    /// sessions are suppressed so the round backlog can drain at replay
+    /// speed — 0 otherwise. Refreshed once per service iteration.
+    pub(crate) catchup_mode: IntGauge,
+
+    /// Computation spawn decisions withheld by catch-up mode. Labels:
+    /// `session_type` (only the suppressible types — `user` /
+    /// `internal_presign` — ever appear). Incremented once per suppressed
+    /// session per service tick, so its RATE tracks how much would-be
+    /// computation the gate is currently shedding, and it going flat while
+    /// `catchup_mode` is 1 means nothing is left to suppress.
+    pub(crate) catchup_suppressed_computations_total: IntCounterVec,
+
     /// Internal presign pool size per (curve, signature_algorithm, key_role).
     ///
     /// The pool is keyed by `(signature_algorithm, network_key_id)`; to keep
@@ -549,6 +564,22 @@ impl DWalletMPCMetrics {
             last_process_mpc_consensus_round: register_int_gauge_with_registry!(
                 "ika_last_process_mpc_consensus_round",
                 "Last process mpc consensus round",
+                registry
+            )
+            .unwrap(),
+            catchup_mode: register_int_gauge_with_registry!(
+                "ika_dwallet_mpc_catchup_mode",
+                "1 while MPC round processing trails the consensus tip beyond the catch-up \
+                 threshold and new internal-presign/user computations are suppressed \
+                 (issue #2023), 0 otherwise",
+                registry
+            )
+            .unwrap(),
+            catchup_suppressed_computations_total: register_int_counter_vec_with_registry!(
+                "ika_dwallet_mpc_catchup_suppressed_computations_total",
+                "Cryptographic computation spawn decisions withheld by catch-up mode, \
+                 per session type",
+                &["session_type"],
                 registry
             )
             .unwrap(),

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -1122,6 +1122,15 @@ impl DWalletMPCService {
             panic!("failed to get last consensus round from DB");
         };
 
+        // Feed the catch-up gate (issue #2023) BEFORE draining: the tip just
+        // read is the head of the persisted per-round stream, and the cursor
+        // is where this service's processing stands — their distance is the
+        // backlog this iteration is about to drain. The gate this updates is
+        // consulted later in the iteration, at the computation spawn
+        // decision in `perform_cryptographic_computation`.
+        self.dwallet_mpc_manager
+            .observe_consensus_round_gap(last_consensus_round, self.last_read_consensus_round);
+
         while Some(last_consensus_round) > self.last_read_consensus_round {
             self.number_of_consensus_rounds += 1;
 

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/catchup.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/catchup.rs
@@ -1,0 +1,307 @@
+//! Integration coverage for the MPC catch-up gate (issue #2023).
+//!
+//! The production trap: a validator re-entering MPC processing far behind the
+//! consensus tip keeps computing sessions that already completed
+//! network-wide, and that dead-on-arrival crypto pins its round drain just
+//! below tip rate — a stable non-contributing equilibrium. The gate breaks
+//! it by withholding NEW internal-presign and user-session computations while
+//! the per-iteration round gap exceeds the enter threshold, and resuming once
+//! it falls below the exit threshold.
+//!
+//! The harness expresses the entry condition directly: planting a dense
+//! backlog of empty consensus rounds into every validator's epoch store makes
+//! the next service iteration observe `tip - cursor = backlog` at its drain
+//! entry — the exact signal a mid-epoch restart replay produces.
+
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStoreTrait;
+use crate::dwallet_mpc::catchup_gate::CATCH_UP_ENTER_GAP_ROUNDS;
+use crate::dwallet_mpc::dwallet_mpc_metrics::session_type_label;
+use crate::dwallet_mpc::dwallet_mpc_service::DWalletMPCService;
+use crate::dwallet_mpc::integration_tests::network_dkg::create_network_key_test;
+use crate::dwallet_mpc::integration_tests::utils;
+use crate::dwallet_mpc::integration_tests::utils::{IntegrationTestState, build_test_state};
+use crate::dwallet_mpc::mpc_session::SessionStatus;
+use dwallet_mpc_types::dwallet_mpc::DWalletSignatureAlgorithm;
+use ika_types::messages_dwallet_mpc::SessionType;
+use sui_types::base_types::ObjectID;
+use tracing::info;
+
+/// Comfortably above [`CATCH_UP_ENTER_GAP_ROUNDS`], mirroring the observed
+/// production entry gaps (a replay landing thousands of rounds behind).
+const BACKLOG_ROUNDS: u64 = CATCH_UP_ENTER_GAP_ROUNDS + 1_000;
+
+/// Plants `count` dense empty consensus rounds starting at `start_round`
+/// into every validator's epoch store. Only the two per-round streams the
+/// service treats as mandatory-dense (MPC messages and MPC outputs) need
+/// entries; every other stream tolerates a missing round. Also advances the
+/// harness round counter past the planted range.
+fn plant_empty_round_backlog(test_state: &mut IntegrationTestState, start_round: u64, count: u64) {
+    for store in &test_state.epoch_stores {
+        let mut messages = store.round_to_messages.lock().unwrap();
+        let mut outputs = store.round_to_outputs.lock().unwrap();
+        for round in start_round..start_round + count {
+            messages.entry(round).or_default();
+            outputs.entry(round).or_default();
+        }
+    }
+    test_state.consensus_round = (start_round + count) as usize;
+}
+
+/// The shared drain cursor of all services (asserting they agree, since the
+/// backlog must start exactly one past it on every validator).
+fn common_last_read_consensus_round(test_state: &IntegrationTestState) -> u64 {
+    let cursor = test_state.dwallet_mpc_services[0]
+        .last_read_consensus_round()
+        .expect("services must have processed at least one consensus round");
+    for (index, service) in test_state.dwallet_mpc_services.iter().enumerate() {
+        assert_eq!(
+            service.last_read_consensus_round(),
+            Some(cursor),
+            "validator {index}: drain cursor diverged from validator 0"
+        );
+    }
+    cursor
+}
+
+/// Session types of every computation currently running on a service's
+/// orchestrator.
+fn running_computation_session_types(service: &DWalletMPCService) -> Vec<SessionType> {
+    service
+        .dwallet_mpc_manager()
+        .cryptographic_computations_orchestrator
+        .currently_running_cryptographic_computations
+        .iter()
+        .map(|computation_id| computation_id.session_identifier.session_type())
+        .collect()
+}
+
+/// Count of Active sessions of the suppressible types (internal presign /
+/// user) on a service — the suppression assertions are vacuous without them.
+fn active_suppressible_session_count(service: &DWalletMPCService) -> usize {
+    service
+        .dwallet_mpc_manager()
+        .sessions
+        .values()
+        .filter(|session| {
+            matches!(session.status, SessionStatus::Active { .. })
+                && matches!(
+                    session.session_type,
+                    Some(SessionType::InternalPresign | SessionType::User)
+                )
+        })
+        .count()
+}
+
+/// End-to-end exercise of the catch-up gate against the real service loop:
+///
+/// 1. **Engage + suppress**: plant a `BACKLOG_ROUNDS` backlog; the next
+///    iteration drains it, the gate engages (gauge = 1), internal presign
+///    batches instantiated during the drain go computation-less, and the
+///    suppressed-computations counter advances.
+/// 2. **Disengage + resume**: the following iteration observes a zero gap;
+///    the gate exits (gauge = 0) and the withheld sessions immediately spawn
+///    their computations, which then run to completion and fill the presign
+///    pool — proving suppression withheld work without losing it.
+/// 3. **Exemption**: with a fresh backlog AND a live network DKG request, the
+///    re-engaged gate still lets the System session compute while every
+///    running computation remains of an exempt type.
+#[tokio::test]
+#[cfg(test)]
+async fn test_catchup_gate_suppresses_and_resumes_computations() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = utils::create_test_protocol_config_guard();
+
+    let mut test_state = build_test_state(4);
+    let (consensus_round, _network_key_bytes, network_key_id) =
+        create_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+
+    // Settle: nothing in flight, gate disengaged everywhere.
+    utils::wait_for_computations(&mut test_state).await;
+    for (index, service) in test_state.dwallet_mpc_services.iter().enumerate() {
+        let manager = service.dwallet_mpc_manager();
+        assert_eq!(
+            manager.dwallet_mpc_metrics.catchup_mode.get(),
+            0,
+            "validator {index}: gate must start disengaged"
+        );
+        assert!(
+            manager
+                .cryptographic_computations_orchestrator
+                .currently_running_cryptographic_computations
+                .is_empty(),
+            "validator {index}: no computation may be in flight before the backlog"
+        );
+    }
+
+    // === Phase 1: backlog beyond the enter threshold — engage and suppress ===
+    let cursor = common_last_read_consensus_round(&test_state);
+    plant_empty_round_backlog(&mut test_state, cursor + 1, BACKLOG_ROUNDS);
+    for service in test_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration().await;
+    }
+
+    for (index, service) in test_state.dwallet_mpc_services.iter().enumerate() {
+        let manager = service.dwallet_mpc_manager();
+        assert_eq!(
+            manager.dwallet_mpc_metrics.catchup_mode.get(),
+            1,
+            "validator {index}: gate must engage on a {BACKLOG_ROUNDS}-round entry gap"
+        );
+        // The drain itself must have instantiated suppressible work
+        // (internal presign top-up batches), otherwise the suppression
+        // assertion below proves nothing.
+        assert!(
+            active_suppressible_session_count(service) > 0,
+            "validator {index}: the backlog drain should have instantiated internal \
+             presign sessions"
+        );
+        let running = running_computation_session_types(service);
+        assert!(
+            running.is_empty(),
+            "validator {index}: no computation may spawn while catching up, found {running:?}"
+        );
+        assert!(
+            manager
+                .dwallet_mpc_metrics
+                .catchup_suppressed_computations_total
+                .with_label_values(&[session_type_label(SessionType::InternalPresign)])
+                .get()
+                > 0,
+            "validator {index}: the suppressed-computations counter must record the \
+             withheld internal presign spawns"
+        );
+    }
+    info!("Phase 1 passed: gate engaged and computations suppressed on every validator");
+
+    // === Phase 2: the backlog is drained — disengage and resume ===
+    for service in test_state.dwallet_mpc_services.iter_mut() {
+        service.run_service_loop_iteration().await;
+    }
+    for (index, service) in test_state.dwallet_mpc_services.iter().enumerate() {
+        assert_eq!(
+            service
+                .dwallet_mpc_manager()
+                .dwallet_mpc_metrics
+                .catchup_mode
+                .get(),
+            0,
+            "validator {index}: gate must disengage once the gap is back under the \
+             exit threshold"
+        );
+        assert!(
+            !service
+                .dwallet_mpc_manager()
+                .cryptographic_computations_orchestrator
+                .currently_running_cryptographic_computations
+                .is_empty(),
+            "validator {index}: the withheld sessions must spawn computations as soon \
+             as catch-up ends"
+        );
+    }
+    info!("Phase 2 passed: gate disengaged and computations resumed on every validator");
+
+    // Run the resumed sessions to completion: the EdDSA presign pool filling
+    // proves the suppressed batches were deferred, not lost.
+    utils::wait_for_computations(&mut test_state).await;
+    let mut pool_filled = false;
+    for _ in 0..40 {
+        utils::send_advance_results_between_parties(
+            &test_state.committee,
+            &mut test_state.sent_consensus_messages_collectors,
+            &mut test_state.epoch_stores,
+            test_state.consensus_round as u64,
+        );
+        test_state.consensus_round += 1;
+        for service in test_state.dwallet_mpc_services.iter_mut() {
+            service.run_service_loop_iteration().await;
+        }
+        utils::wait_for_computations(&mut test_state).await;
+        if test_state.epoch_stores[0]
+            .presign_pool_size(DWalletSignatureAlgorithm::EdDSA, network_key_id)
+            .unwrap_or(0)
+            > 0
+        {
+            pool_filled = true;
+            break;
+        }
+    }
+    assert!(
+        pool_filled,
+        "after catch-up ends, the previously suppressed presign sessions must complete \
+         and fill the pool"
+    );
+    info!("Resumption proof passed: presign pool filled after the gate disengaged");
+
+    // === Phase 3: system sessions are exempt from suppression ===
+    // Start a second network DKG (a System session) and re-enter catch-up in
+    // the same iteration: the DKG computation must spawn anyway, while no
+    // suppressible-type computation does. The request/activation pipeline may
+    // take more than one iteration, so keep re-planting a fresh backlog (each
+    // iteration then re-observes an above-threshold entry gap and the gate
+    // stays engaged) until the System computation appears.
+    utils::wait_for_computations(&mut test_state).await;
+    let epoch_id = test_state
+        .dwallet_mpc_services
+        .first()
+        .expect("at least one service must exist")
+        .epoch;
+    let second_dkg_key_id = ObjectID::random();
+    let all_parties: Vec<usize> = (0..test_state.sui_data_senders.len()).collect();
+    utils::send_configurable_start_network_dkg_event(
+        epoch_id,
+        &mut test_state.sui_data_senders,
+        [7u8; 32],
+        2,
+        &all_parties,
+        second_dkg_key_id,
+    );
+
+    let mut system_computation_spawned_during_catchup = false;
+    for attempt in 0..5 {
+        let cursor = common_last_read_consensus_round(&test_state);
+        plant_empty_round_backlog(&mut test_state, cursor + 1, BACKLOG_ROUNDS);
+        for service in test_state.dwallet_mpc_services.iter_mut() {
+            service.run_service_loop_iteration().await;
+        }
+
+        for (index, service) in test_state.dwallet_mpc_services.iter().enumerate() {
+            assert_eq!(
+                service
+                    .dwallet_mpc_manager()
+                    .dwallet_mpc_metrics
+                    .catchup_mode
+                    .get(),
+                1,
+                "validator {index}: gate must be engaged while the DKG backlog drains \
+                 (attempt {attempt})"
+            );
+            let running = running_computation_session_types(service);
+            assert!(
+                running.iter().all(|session_type| matches!(
+                    session_type,
+                    SessionType::System | SessionType::NetworkOwnedAddressSign
+                )),
+                "validator {index}: only exempt session types may compute during \
+                 catch-up, found {running:?}"
+            );
+        }
+
+        system_computation_spawned_during_catchup =
+            test_state.dwallet_mpc_services.iter().all(|service| {
+                running_computation_session_types(service).contains(&SessionType::System)
+            });
+        if system_computation_spawned_during_catchup {
+            break;
+        }
+    }
+    assert!(
+        system_computation_spawned_during_catchup,
+        "the network DKG (System session) must spawn its computation on every validator \
+         even while the gate is engaged"
+    );
+    info!("Phase 3 passed: System session computed during catch-up; suppressible types did not");
+
+    // Let the in-flight computations drain so the test tears down cleanly.
+    utils::wait_for_computations(&mut test_state).await;
+}

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
@@ -1,4 +1,5 @@
 mod anomaly_diagnostics;
+mod catchup;
 mod computation_results_batch;
 mod create_dwallet;
 mod encrypt_secret_share;

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -43,6 +43,7 @@ pub struct NetworkOwnedAddressSignOutput {
     pub hash_scheme: DWalletHashScheme,
 }
 
+mod catchup_gate;
 pub mod dwallet_mpc_service;
 mod mpc_diagnostics;
 pub mod mpc_manager;

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -3,6 +3,10 @@
 
 use crate::SuiDataReceivers;
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStoreTrait;
+use crate::dwallet_mpc::catchup_gate::{
+    CATCH_UP_ENTER_GAP_ROUNDS, CATCH_UP_EXIT_GAP_ROUNDS, CatchUpGate, CatchUpTransition,
+    computation_suppressible_during_catch_up,
+};
 use crate::dwallet_mpc::crytographic_computation::{
     ComputationId, ComputationRequest, CryptographicComputationsOrchestrator,
 };
@@ -343,6 +347,15 @@ pub(crate) struct DWalletMPCManager {
     /// next-epoch agreed set is delivered.
     pub(crate) next_epoch_validator_mpc_keys: Option<ValidatorMpcKeysByPartyId>,
     pub(crate) cryptographic_computations_orchestrator: CryptographicComputationsOrchestrator,
+
+    /// Catch-up gate (issue #2023): while the MPC processing cursor trails
+    /// the consensus tip beyond the trap radius, new cryptographic
+    /// computations for internal-presign and user sessions are withheld so
+    /// the round backlog drains at replay speed instead of being pinned
+    /// below tip rate by dead-on-arrival crypto. Fed once per service
+    /// iteration by [`Self::observe_consensus_round_gap`], consulted at the
+    /// spawn decision in [`Self::perform_cryptographic_computation`].
+    catchup_gate: CatchUpGate,
 
     /// The set of malicious actors that were agreed upon by a quorum of validators.
     /// This agreement is done synchronically, and thus is it safe to filter malicious actors.
@@ -816,6 +829,7 @@ impl DWalletMPCManager {
             current_epoch_keys_ingested: false,
             next_epoch_validator_mpc_keys: None,
             cryptographic_computations_orchestrator: mpc_computations_orchestrator,
+            catchup_gate: CatchUpGate::new(),
             malicious_actors: HashSet::new(),
             last_session_to_complete_in_current_epoch: 0,
             recognized_self_as_malicious: false,
@@ -3486,6 +3500,57 @@ impl DWalletMPCManager {
         self.sessions.insert(*session_identifier, new_session);
     }
 
+    /// Feed the catch-up gate (issue #2023) one observation of how far MPC
+    /// round processing trails the consensus tip.
+    ///
+    /// Called by the service once per service-loop iteration at the entry of
+    /// its round drain, with `tip_round` = the head of the persisted
+    /// per-round MPC stream (`last_dwallet_mpc_message_round`, the newest
+    /// consensus round available for this service to read — already in hand
+    /// there, so the gate costs no extra DB read) and `last_processed_round`
+    /// = the drain cursor before this iteration's drain. The drain always
+    /// runs to the tip it read, so this entry gap is exactly the backlog the
+    /// iteration is about to chew through — the live capture's oscillating
+    /// 545-7,346-round gap is this value. `None` cursor (nothing processed
+    /// yet, i.e. the first iteration after a restart) counts the full
+    /// backlog, which is precisely the mid-epoch-restart entry condition.
+    pub(crate) fn observe_consensus_round_gap(
+        &mut self,
+        tip_round: u64,
+        last_processed_round: Option<u64>,
+    ) {
+        let gap_rounds = tip_round.saturating_sub(last_processed_round.unwrap_or(0));
+        match self.catchup_gate.update(gap_rounds) {
+            CatchUpTransition::Entered => {
+                info!(
+                    gap_rounds,
+                    tip_round,
+                    ?last_processed_round,
+                    enter_threshold = CATCH_UP_ENTER_GAP_ROUNDS,
+                    exit_threshold = CATCH_UP_EXIT_GAP_ROUNDS,
+                    "MPC service entered catch-up mode: suppressing new internal-presign and \
+                     user-session computations until the consensus-round backlog drains \
+                     (issue #2023)"
+                );
+            }
+            CatchUpTransition::Exited => {
+                info!(
+                    gap_rounds,
+                    tip_round,
+                    ?last_processed_round,
+                    enter_threshold = CATCH_UP_ENTER_GAP_ROUNDS,
+                    exit_threshold = CATCH_UP_EXIT_GAP_ROUNDS,
+                    "MPC service exited catch-up mode: the consensus-round backlog drained, \
+                     resuming all cryptographic computations"
+                );
+            }
+            CatchUpTransition::Unchanged => {}
+        }
+        self.dwallet_mpc_metrics
+            .catchup_mode
+            .set(self.catchup_gate.is_catching_up() as i64);
+    }
+
     /// Spawns all ready MPC cryptographic computations on separate threads using Rayon.
     /// If no local CPUs are available, computations will execute as CPUs are freed.
     ///
@@ -3508,6 +3573,10 @@ impl DWalletMPCManager {
         HashMap<ComputationId, DwalletMPCResult<mpc::GuaranteedOutputDeliveryRoundResult>>,
         bool,
     ) {
+        let in_catch_up = self.catchup_gate.is_catching_up();
+        let mut catch_up_suppressed_user_sessions: u64 = 0;
+        let mut catch_up_suppressed_internal_presign_sessions: u64 = 0;
+
         let mut ready_to_advance_sessions: Vec<_> = self
             .sessions
             .values()
@@ -3541,6 +3610,24 @@ impl DWalletMPCManager {
                     return None;
                 }
 
+                // Catch-up gate (issue #2023): while the round-processing
+                // cursor trails the consensus tip beyond the trap radius,
+                // withhold NEW computations for the high-volume session
+                // types — computing them would chase sessions that already
+                // completed network-wide and pin the drain below tip rate.
+                // System-critical types are exempt (see
+                // `computation_suppressible_during_catch_up`); everything
+                // else about these sessions (message handling, quorum
+                // observation, terminal bookkeeping) continues unchanged,
+                // and the check is two cheap reads per session per tick.
+                if in_catch_up && computation_suppressible_during_catch_up(request.session_type) {
+                    match request.session_type {
+                        SessionType::User => catch_up_suppressed_user_sessions += 1,
+                        _ => catch_up_suppressed_internal_presign_sessions += 1,
+                    }
+                    return None;
+                }
+
                 // Local-readiness gate for network DKG / reconfig
                 // sessions under v4 off_chain mode. These sessions
                 // consume the frozen-set members' mpc_data blobs
@@ -3568,7 +3655,29 @@ impl DWalletMPCManager {
 
         ready_to_advance_sessions.sort_by_key(|&(_, request)| request);
 
-        let number_of_ready_to_advance_sessions = ready_to_advance_sessions.len();
+        // Publish how much would-be computation the gate is shedding this
+        // tick (bulk `inc_by` — the per-session path stays two integer
+        // reads, no label lookups).
+        if catch_up_suppressed_user_sessions > 0 {
+            self.dwallet_mpc_metrics
+                .catchup_suppressed_computations_total
+                .with_label_values(&[session_type_label(SessionType::User)])
+                .inc_by(catch_up_suppressed_user_sessions);
+        }
+        if catch_up_suppressed_internal_presign_sessions > 0 {
+            self.dwallet_mpc_metrics
+                .catchup_suppressed_computations_total
+                .with_label_values(&[session_type_label(SessionType::InternalPresign)])
+                .inc_by(catch_up_suppressed_internal_presign_sessions);
+        }
+
+        // Suppressed sessions are still pending work: count them toward the
+        // idle computation so a catching-up validator never reports itself
+        // idle — an idle report would drive network-wide internal-presign
+        // idle-fill, minting MORE of exactly the load the gate is shedding.
+        let number_of_ready_to_advance_sessions = ready_to_advance_sessions.len()
+            + (catch_up_suppressed_user_sessions + catch_up_suppressed_internal_presign_sessions)
+                as usize;
 
         // Collected inside the immutable-borrow iteration below, logged
         // (deduped per session) after it ends — a generation failure


### PR DESCRIPTION
## Problem

A validator that re-enters MPC processing more than ~2k consensus rounds behind the tip falls into a stable non-contributing equilibrium (#2023): every internal-presign / user session it starts computing has already completed network-wide by the time its contribution would matter, and the dead-on-arrival crypto burns enough CPU to pin its round drain just below the tip rate — so the backlog never clears, and the validator silently contributes nothing to MPC until the epoch boundary.

Restart makes it worse, not better: a full-epoch replay necessarily re-enters live processing replay-duration x tip-rate rounds behind — inside the trap radius — so a mid-epoch restart re-creates the entry condition instead of healing it. Measured in production, the same drain runs at ~40x tip rate when nothing is computing (the replay path proves it), which is the mechanism this fix exploits.

## The fix

A catch-up gate in the dwallet MPC service: while the round-processing cursor trails the persisted consensus tip beyond a threshold, the manager stops **spawning new cryptographic computations** for high-volume session types. Everything else — round draining, message handling, quorum observation, terminal bookkeeping, output verification, already-running computations — continues unchanged, so the drain runs at replay speed, the backlogged rounds mark the already-completed sessions terminal, and the validator resumes computing at the tip.

- **Signal**: once per service iteration, at the drain entry in `process_consensus_rounds_from_storage`, the gap `tip - cursor` is fed to the gate (`DWalletMPCManager::observe_consensus_round_gap`). Tip = `last_dwallet_mpc_message_round()` (the head of the per-round DB stream, already read there — the gate costs no extra DB read); cursor = `last_read_consensus_round`. The per-session check at the spawn decision is two integer reads.
- **Hysteresis** (`catchup_gate.rs`, a pure state machine in the `reconfig_watchdog.rs` style): enter at gap > 5,000 rounds (~2x the observed trap radius of ~1-2k ≈ session-completion-time x tip-rate, with margin so ordinary jitter never flips it), exit at gap < 500 (well inside the radius, so resumed computations target genuinely live sessions). The wide band prevents oscillation at either boundary. Constants, no env overrides — deliberately simple.
- **Exemption set**: suppression covers `User` and `InternalPresign` only (the volume that creates the trap). `System` (network DKG / reconfiguration / network-key sessions — a handful per epoch, and missing one can wedge the epoch transition network-wide) and `NetworkOwnedAddressSign` (checkpoint-cadence, liveness-relevant, low-volume) are exempt and always compute.
- A validator in catch-up also keeps counting its withheld sessions toward the idle computation, so it never reports itself idle — an idle report would drive network-wide internal-presign idle-fill, minting more of exactly the load the gate is shedding.
- **Observability**: `ika_dwallet_mpc_catchup_mode` gauge (0/1), `ika_dwallet_mpc_catchup_suppressed_computations_total{session_type}` counter, and info logs on enter/exit carrying the gap, tip, cursor and thresholds.
- **Deferred refinement**: the issue's other option — skip-if-terminal-at-read (checking a session's terminal state against the newest locally-known round before each spawn) — is deliberately not included. It reaches sessions the threshold gate misses only in the sub-threshold band, needs a per-spawn lookup against ahead-of-cursor state rather than two integer reads, and the gate alone already breaks the self-sustaining equilibrium. It remains a natural follow-up if sub-threshold waste ever shows up in the new metrics.

## Testing

- 7 unit tests over the hysteresis state machine (enter/exit strictness, band holds prior state in both directions, no oscillation at boundaries, full cycle, exemption classification) — all pass in `--release`.
- A new integration test (`integration_tests/catchup.rs`) drives the real service loop on a 4-validator harness: it plants a 6,000-round dense backlog (the exact shape a replay re-entry produces), asserts the gate engages (gauge = 1), internal-presign batches instantiated during the drain spawn **no** computations while the suppressed counter advances; the next iteration observes gap 0, the gate disengages (gauge = 0), the withheld sessions spawn immediately and run to completion (presign pool fills — deferred, not lost); finally a second network DKG under a fresh backlog proves the System exemption: the DKG computes during catch-up while every running computation is of an exempt type. Passes (210s solo in `--release`).
- **Fault-validation**: with the gate condition inverted (`computation_suppressible_during_catch_up` forced to `false`), the integration test fails exactly where it should — `validator 0: no computation may spawn while catching up, found [InternalPresign, x16]` — confirming the test detects a non-functional gate. Reverted; green again.
- Full `dwallet_mpc::` release suite (`cargo test -p ika-core --release --lib "dwallet_mpc::" -- --test-threads=4`): **128 passed, 1 failed, 4 ignored** in 75 min. The one failure, `network_owned_address_sign::test_network_owned_address_sign_ecdsa_secp256k1`, is a pre-existing load-sensitivity: its assertion requires the consumed presign to predate the test's pool snapshot, but `pop()` serves the pool's newest entry, so a top-up landing mid-test under full-suite load breaks it. It passes solo on this branch (189s), and the gate never engages in that test (it needs a >5,000-round gap). Not a regression from this change.
- `cargo clippy -p ika-core --all-targets`, `cargo fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
