### PR TITLE
fix(ocs): skip the boot artifacts-digest probe on a pruned-at-head NotFound

### DIFF
--- a/crates/ika-core/src/sui_connector/setup.rs
+++ b/crates/ika-core/src/sui_connector/setup.rs
@@ -48,7 +48,7 @@ use ika_network::sui_state_mirror::{
 };
 use ika_sui_client::genesis::load_and_verify_sui_genesis;
 use ika_sui_client::grpc::SuiGrpcClient;
-use ika_sui_client::transport::SuiTransport;
+use ika_sui_client::transport::{SuiTransport, TransportError};
 use tracing::{info, warn};
 use typed_store::TypedStoreError;
 
@@ -569,15 +569,47 @@ pub fn configured_mirror_peer_ids(cfg: &SuiConnectorConfig) -> Vec<PeerId> {
 }
 
 async fn probe_artifacts_digest(transport: &Arc<dyn SuiTransport>) -> Result<(), SetupError> {
-    let summary = transport
-        .get_latest_checkpoint()
-        .await
-        .map_err(|e| SetupError::Transport(format!("probe latest checkpoint: {e}")))?;
+    // The probe needs checkpoint CONTENT to inspect the digest, and content
+    // reads go through the fullnode's availability window — which a fullnode
+    // pruning AT head can empty, NotFounding its OWN latest for extended
+    // stretches (measured: 36 minutes on a localnet). A NotFound therefore
+    // says nothing about the chain's capability, only about availability
+    // right now — skip the probe instead of failing the boot; the verifier
+    // stack downstream consumes artifacts digests per checkpoint and still
+    // fails loudly on a chain that truly lacks them. A missing digest on a
+    // FETCHED checkpoint stays a definitive, fatal answer.
+    let summary = match transport.get_latest_checkpoint().await {
+        Ok(summary) => summary,
+        Err(TransportError::NotFound(reason)) => {
+            warn!(
+                reason,
+                "artifacts-digest probe skipped: latest checkpoint unavailable                  (fullnode pruning at head); the verifier stack still enforces                  digests per checkpoint"
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            return Err(SetupError::Transport(format!(
+                "probe latest checkpoint: {e}"
+            )));
+        }
+    };
     let seq = *summary.sequence_number();
-    let data = transport
-        .get_full_checkpoint(seq)
-        .await
-        .map_err(|e| SetupError::Transport(format!("probe full checkpoint {seq}: {e}")))?;
+    let data = match transport.get_full_checkpoint(seq).await {
+        Ok(data) => data,
+        Err(TransportError::NotFound(reason)) => {
+            warn!(
+                seq,
+                reason,
+                "artifacts-digest probe skipped: checkpoint pruned between                  the latest read and the content fetch"
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            return Err(SetupError::Transport(format!(
+                "probe full checkpoint {seq}: {e}"
+            )));
+        }
+    };
     if data
         .checkpoint_summary
         .checkpoint_artifacts_digest()
@@ -596,9 +628,137 @@ async fn probe_artifacts_digest(transport: &Arc<dyn SuiTransport>) -> Result<(),
 mod tests {
     use super::*;
 
+    use async_trait::async_trait;
     use ika_config::node::{SuiChainIdentifier, SuiDataSource};
-    use sui_types::base_types::ObjectID;
+    use ika_sui_client::transport::{DynamicFieldPage, ExecutedTransaction};
+    use sui_types::base_types::{ObjectID, SequenceNumber, TransactionDigest};
     use sui_types::committee::Committee;
+    use sui_types::digests::CheckpointDigest;
+    use sui_types::full_checkpoint_content::CheckpointData;
+    use sui_types::gas::GasCostSummary;
+    use sui_types::messages_checkpoint::{
+        CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber, CheckpointSummary,
+    };
+    use sui_types::object::Object;
+
+    /// A transport whose content reads behave like a fullnode pruning AT
+    /// head: the latest summary (when `latest` is `None`) and every full
+    /// checkpoint NotFound. Replays the boot failure where a validator
+    /// restarting inside such a window died on the artifacts-digest probe.
+    struct PrunedAtHeadStub {
+        latest: Option<CertifiedCheckpointSummary>,
+    }
+
+    #[async_trait]
+    impl SuiTransport for PrunedAtHeadStub {
+        async fn get_latest_checkpoint(
+            &self,
+        ) -> Result<CertifiedCheckpointSummary, TransportError> {
+            self.latest
+                .clone()
+                .ok_or_else(|| TransportError::NotFound("Checkpoint 28166 not found".into()))
+        }
+        async fn get_full_checkpoint(
+            &self,
+            seq: CheckpointSequenceNumber,
+        ) -> Result<CheckpointData, TransportError> {
+            Err(TransportError::NotFound(format!(
+                "Checkpoint {seq} not found"
+            )))
+        }
+        async fn get_chain_identifier(&self) -> Result<String, TransportError> {
+            unimplemented!()
+        }
+        async fn get_current_epoch(&self) -> Result<u64, TransportError> {
+            unimplemented!()
+        }
+        async fn get_committee(
+            &self,
+            _epoch: Option<u64>,
+        ) -> Result<sui_types::committee::Committee, TransportError> {
+            unimplemented!()
+        }
+        async fn get_checkpoint_summary_by_digest(
+            &self,
+            _digest: CheckpointDigest,
+        ) -> Result<CertifiedCheckpointSummary, TransportError> {
+            unimplemented!()
+        }
+        async fn last_checkpoint_of_epoch(
+            &self,
+            _epoch: u64,
+        ) -> Result<CheckpointSequenceNumber, TransportError> {
+            unimplemented!()
+        }
+        async fn get_object(&self, _id: ObjectID) -> Result<Object, TransportError> {
+            unimplemented!()
+        }
+        async fn get_object_with_version(
+            &self,
+            _id: ObjectID,
+            _version: SequenceNumber,
+        ) -> Result<Object, TransportError> {
+            unimplemented!()
+        }
+        async fn batch_get_objects(
+            &self,
+            _ids: &[ObjectID],
+        ) -> Result<Vec<Object>, TransportError> {
+            unimplemented!()
+        }
+        async fn list_dynamic_fields(
+            &self,
+            _parent: ObjectID,
+            _page_size: Option<u32>,
+            _page_token: Option<Vec<u8>>,
+        ) -> Result<DynamicFieldPage, TransportError> {
+            unimplemented!()
+        }
+        async fn get_transaction(
+            &self,
+            _tx: TransactionDigest,
+        ) -> Result<ExecutedTransaction, TransportError> {
+            unimplemented!()
+        }
+    }
+
+    /// The exact run-19 boot failure: latest itself NotFounds. The probe
+    /// must skip (transient availability), not abort the boot.
+    #[tokio::test]
+    async fn artifacts_probe_skips_when_latest_is_pruned_at_head() {
+        let transport: Arc<dyn SuiTransport> = Arc::new(PrunedAtHeadStub { latest: None });
+        probe_artifacts_digest(&transport)
+            .await
+            .expect("a pruned-at-head latest must not fail the boot probe");
+    }
+
+    /// The latest summary reads fine but its content is pruned before the
+    /// full fetch — same verdict: skip, never abort.
+    #[tokio::test]
+    async fn artifacts_probe_skips_when_content_pruned_between_reads() {
+        let (committee, keys) = Committee::new_simple_test_committee();
+        let contents = CheckpointContents::new_with_digests_only_for_tests(vec![]);
+        let summary = CheckpointSummary {
+            epoch: committee.epoch(),
+            sequence_number: 28166,
+            network_total_transactions: 0,
+            content_digest: *contents.digest(),
+            previous_digest: None,
+            epoch_rolling_gas_cost_summary: GasCostSummary::default(),
+            timestamp_ms: 0,
+            checkpoint_commitments: vec![],
+            end_of_epoch_data: None,
+            version_specific_data: Vec::new(),
+        };
+        let latest =
+            CertifiedCheckpointSummary::new_from_keypairs_for_testing(summary, &keys, &committee);
+        let transport: Arc<dyn SuiTransport> = Arc::new(PrunedAtHeadStub {
+            latest: Some(latest),
+        });
+        probe_artifacts_digest(&transport)
+            .await
+            .expect("content pruned between reads must not fail the boot probe");
+    }
 
     /// Minimal `SuiConnectorConfig` for `resolve_bootstrap_plan`: only the
     /// genesis / chain-identifier fields it reads matter; the rest are filler.

--- a/crates/ika-sui-client/src/grpc.rs
+++ b/crates/ika-sui-client/src/grpc.rs
@@ -258,7 +258,13 @@ impl SuiTransport for SuiGrpcClient {
     // -- checkpoints ------------------------------------------------------------------------
     async fn get_latest_checkpoint(&self) -> Result<CertifiedCheckpointSummary, TransportError> {
         let mut rpc = self.rpc.clone();
-        rpc.get_latest_checkpoint().await.map_err(Self::rpc_err)
+        // NotFound must stay distinguishable: a fullnode pruning AT head
+        // empties the availability window and NotFounds its OWN latest, and
+        // callers (the boot artifacts-digest probe) treat that transient
+        // state differently from a real transport failure.
+        rpc.get_latest_checkpoint()
+            .await
+            .map_err(Self::rpc_status_err)
     }
 
     async fn get_full_checkpoint(


### PR DESCRIPTION
## Summary

`build_sui_connector_stack` runs a boot-time probe that fetches the **latest checkpoint's content** to check whether the chain advertises `CheckpointArtifactsDigest`. A fullnode that prunes at head can empty its availability window (`lowest_available..=latest`) and serve NotFound **for its own latest checkpoint** — transiently, but for extended stretches (a localnet has been measured holding that state for ~36 minutes). The probe treated that NotFound as fatal, so a node that starts — or restarts — inside such a window exits instead of coming up:

```
Failed to start node: build OCS connector stack: transport: probe latest checkpoint: transport: code: 'Some requested entity was not found', message: "Checkpoint 28166 not found"
```

The probe conflates "this chain lacks the capability" (a definitive answer, correctly fatal) with "content is unavailable right now" (which says nothing about capability).

**Exposure**: liveness/robustness, not correctness. Production fullnodes with sane retention are unlikely to hit it; localnets and CI — where pruning at head is routine and rolling restarts are constant — hit it as a boot-flake. Observed live in a downstream CI where a rolling restart landed a validator's boot inside the window (exit status 1, log ending at the error above).

## The two defects

1. **`probe_artifacts_digest` (`setup.rs`)** is called unconditionally on every node-start path with `?`, and both of its reads can NotFound transiently: `get_latest_checkpoint` (empty availability window) and `get_full_checkpoint(seq)` (pruned between the two reads).
2. **`get_latest_checkpoint` (`grpc.rs`)** maps errors through the generic `rpc_err`, collapsing a tonic NotFound into `TransportError::Network` — defeating the NotFound-distinguishing mapper (`rpc_status_err`) that exists precisely so callers can tell "upstream returned NotFound" from a real transport failure. Even a caller that wanted to handle the transient case couldn't see it.

## Why not retry or fetch older

Retrying can't be honestly bounded (the window can stay empty for tens of minutes; boot shouldn't stall that long or still abort), and everything below the head is *more* pruned, not less.

## The fix

- `get_latest_checkpoint` maps through `rpc_status_err`, so NotFound survives to the caller.
- The probe **skips with a warning** on `TransportError::NotFound` from either read. Nothing is lost: the probe is an early, friendly error for the capability-absent case — the verifier stack downstream consumes artifacts digests per checkpoint and still fails loudly on a chain that genuinely lacks them. A missing digest on a *fetched* checkpoint remains a definitive, fatal `ArtifactsDigestUnsupported`.

## Tests

Two regression tests against a pruned-at-head stub transport, one per window: latest itself NotFounds (the observed failure), and latest succeeds but the content fetch NotFounds (the between-reads race). Fault-validated: re-fatalizing the NotFound arm makes the first test reproduce the boot abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2PfaVBZowAMYGNwVtae66