### PR TITLE
fix(node): survive an AddrInUse race on the admin server instead of dying at boot (#2026)

### DIFF
--- a/crates/ika-node/src/admin.rs
+++ b/crates/ika-node/src/admin.rs
@@ -12,8 +12,11 @@ use humantime::parse_duration;
 use serde::Deserialize;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 use telemetry_subscribers::TracingHandle;
-use tracing::info;
+use tokio::net::TcpListener;
+use tokio::time::sleep;
+use tracing::{error, info, warn};
 
 // Example commands:
 //
@@ -56,6 +59,13 @@ const CLEAR_BUFFER_STAKE_ROUTE: &str = "/clear-override-buffer-stake";
 const CAPABILITIES: &str = "/capabilities";
 const NODE_CONFIG: &str = "/node-config";
 
+/// How long to wait between admin-server bind attempts.
+const BIND_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+/// How many times to attempt the bind before giving up on the admin server.
+/// Together with the interval this keeps trying for ~2 minutes, comfortably
+/// past the ~60s a socket spends in `TIME_WAIT` after a restart.
+const BIND_ATTEMPTS: u32 = 25;
+
 struct AppState {
     node: Arc<IkaNode>,
     tracing_handle: TracingHandle,
@@ -93,15 +103,73 @@ pub async fn run_admin_server(node: Arc<IkaNode>, port: u16, tracing_handle: Tra
         "starting admin server"
     );
 
-    let listener = tokio::net::TcpListener::bind(&socket_address)
-        .await
-        .unwrap();
-    axum::serve(
+    serve_admin(app, socket_address, BIND_ATTEMPTS, BIND_RETRY_INTERVAL).await;
+}
+
+/// Serve `app` on `socket_address`, riding out a transient bind failure and
+/// then giving up quietly — never panicking.
+///
+/// The admin endpoint is an operational convenience, not a correctness
+/// component, and losing it is the entire cost of a failure here. Since
+/// panics kill the process by default, an `unwrap` on this bind turned a
+/// transient `AddrInUse` — a port race on a shared CI runner, or a restart
+/// racing its own port through `TIME_WAIT` — into node death at boot. A node
+/// without an admin endpoint is strictly healthier than a dead node.
+///
+/// The retries are bounded so a genuinely misconfigured duplicate port ends
+/// in a single loud give-up rather than an unbounded background loop; each
+/// attempt warns with the address, so that misconfiguration is visible
+/// immediately either way.
+async fn serve_admin(
+    app: Router,
+    socket_address: SocketAddr,
+    attempts: u32,
+    retry_interval: Duration,
+) {
+    let Some(listener) = bind_with_retry(socket_address, attempts, retry_interval).await else {
+        error!(
+            address =% socket_address,
+            "gave up binding the admin server; the node continues without the admin endpoint"
+        );
+        return;
+    };
+    if let Err(err) = axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
     )
     .await
-    .unwrap();
+    {
+        error!(
+            address =% socket_address,
+            error =? err,
+            "admin server stopped; the node continues without the admin endpoint"
+        );
+    }
+}
+
+/// Bind the admin listener, retrying `attempts` times at `retry_interval`.
+/// `None` once the attempts are exhausted.
+async fn bind_with_retry(
+    socket_address: SocketAddr,
+    attempts: u32,
+    retry_interval: Duration,
+) -> Option<TcpListener> {
+    for attempt in 1..=attempts {
+        match TcpListener::bind(&socket_address).await {
+            Ok(listener) => return Some(listener),
+            Err(err) => warn!(
+                address =% socket_address,
+                attempt,
+                attempts,
+                error =? err,
+                "failed to bind the admin server, retrying"
+            ),
+        }
+        if attempt < attempts {
+            sleep(retry_interval).await;
+        }
+    }
+    None
 }
 
 #[derive(Deserialize)]
@@ -264,5 +332,102 @@ async fn set_override_protocol_upgrade_buffer_stake(
             format!("protocol upgrade buffer stake set to '{buffer_bps}'\n"),
         ),
         Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+    use tokio::time::timeout;
+
+    /// A stand-in for the real admin router: `serve_admin` only ever sees an
+    /// already-stateless `Router`, so the routes it carries are irrelevant to
+    /// the bind path under test.
+    fn test_router() -> Router {
+        Router::new().route("/ping", get(|| async { "pong" }))
+    }
+
+    /// A listener squatting on an ephemeral port, plus that port's address.
+    async fn squatted_port() -> (TcpListener, SocketAddr) {
+        let squatter = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+            .await
+            .expect("bind a squatter on an ephemeral port");
+        let address = squatter.local_addr().expect("squatter local address");
+        (squatter, address)
+    }
+
+    async fn get_ping(address: SocketAddr) -> Option<String> {
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}/ping"))
+            .send()
+            .await
+            .ok()?;
+        response.text().await.ok()
+    }
+
+    /// The node-side failure this guards: another process holds the admin
+    /// port, and the node dies at boot because the bind panicked on a runtime
+    /// where panics are fatal. `serve_admin` must exhaust its retries and
+    /// return normally instead — the node runs on, minus the admin endpoint.
+    #[tokio::test]
+    async fn a_squatted_admin_port_does_not_take_the_node_down() {
+        let (_squatter, address) = squatted_port().await;
+
+        timeout(
+            Duration::from_secs(30),
+            serve_admin(test_router(), address, 3, Duration::from_millis(50)),
+        )
+        .await
+        .expect("a permanently squatted admin port must be given up on, not waited on forever");
+    }
+
+    /// The retries ride out a transient squatter: once the port is released
+    /// the admin server comes up on its own, with no node restart.
+    #[tokio::test]
+    async fn the_admin_server_comes_up_once_the_port_is_released() {
+        let (squatter, address) = squatted_port().await;
+
+        let server = tokio::spawn(serve_admin(
+            test_router(),
+            address,
+            600,
+            Duration::from_millis(50),
+        ));
+
+        // Let the first attempts fail against the squatter before it lets go.
+        sleep(Duration::from_millis(120)).await;
+        drop(squatter);
+
+        let body = timeout(Duration::from_secs(30), async {
+            loop {
+                if let Some(body) = get_ping(address).await {
+                    return body;
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("the admin server must come up once the port is released");
+        assert_eq!(body, "pong");
+
+        server.abort();
+    }
+
+    /// The retry budget is a bound, not a loop: a duplicate port that is
+    /// never released ends in one give-up after the configured attempts.
+    #[tokio::test]
+    async fn the_bind_retry_is_bounded() {
+        let (_squatter, address) = squatted_port().await;
+
+        let started = Instant::now();
+        assert!(
+            bind_with_retry(address, 4, Duration::from_millis(50))
+                .await
+                .is_none()
+        );
+        // Four attempts are three sleeps; no sleep is wasted after the last.
+        assert!(started.elapsed() >= Duration::from_millis(150));
+        assert!(started.elapsed() < Duration::from_secs(10));
     }
 }


### PR DESCRIPTION
## Problem

Fixes #2026. The admin server's bind `unwrap` (`crates/ika-node/src/admin.rs:98`) predates the crash-on-panic default (#1984), which changed its blast radius from "lose the admin endpoint" to "kill the node". A transient `AddrInUse` — a port race on a shared CI runner, or an operator's fast restart racing its own port through TIME_WAIT — panics the `metrics-runtime` thread and takes the process down at boot. The issue has the observed CI failure.

## The fix

`run_admin_server` now hands the built router to `serve_admin`, which binds through a bounded retry: **25 attempts, 5s apart (~2 minutes)** — comfortably past the ~60s a socket spends in TIME_WAIT. Each failed attempt logs a `warn` with the address, attempt number, and OS error, so a genuinely misconfigured duplicate port is visible from the first second rather than only after the deadline. When the attempts are exhausted, one `error!` and a plain `return`: no panic, and the node runs on without the admin endpoint.

Give-up-without-panic is the right terminal behavior because the admin endpoint is an operational convenience, not a correctness component — losing it is the *entire* cost of a bind failure, and a node without it is strictly healthier than a dead node. Bounded rather than infinite so a permanent misconfiguration ends in a single loud give-up instead of an unbounded background loop. #1984's intent is untouched: real invariants still panic; a transient OS-level port race is not a code invariant.

The `axum::serve(...).await.unwrap()` two lines below had the same blast radius for the same non-reason, and is now logged the same way.

### Deferred: harness port assignment

The issue's second direction (allocate the admin port by binding port 0 and passing the bound listener) does **not** apply as written to the harness that flaked, and I did not force it:

- The upgrade-test harness does not "pick a number". `ValidatorConfigBuilder::build` already sets `admin_interface_port` from `local_ip_utils::get_available_port`, which *is* bind-port-0 — plus a connect/accept that parks the port in TIME_WAIT to reserve it. The exposure is that the reservation is best-effort and the window is long: the node only binds the admin port after `IkaNode::start` completes (`node_runner.rs` awaits the node once-cell first), which in the failing run was ~25s after allocation.
- Passing the bound listener is not available here: the harness spawns a separate `ika-validator` **process** that loads a YAML config, so handing over a listener means fd inheritance / socket activation, not a contained change.

The contained alternative is to give the out-of-process harness a deterministic port block below the ephemeral range, as `ika-test-cluster` already does via `local_ip_utils::deterministic_port_base` — but that means adding an admin-port setter to `ValidatorConfigBuilder`, laying out a block for the upgrade-test cluster, and doing the same for the network/metrics ports (which are ephemeral through the same path, and whose collisions would still be fatal). That is a separate PR.

### Remaining exposure worth flagging

`mysten_metrics::start_prometheus_server` (upstream sui crate) has the identical `unwrap` on bind *and* on serve, for the Prometheus port, spawned on the same runtime. An `AddrInUse` on `metrics_address` is still boot-fatal and cannot be fixed from this repo — it needs a pre-bound listener or a patched dependency. Follow-up, not a regression from this PR.

## Testing

`cargo test -p ika-node --release` — 17 passed, 0 failed (3 new). `cargo clippy -p ika-node --all-targets` clean, `cargo fmt --all --check` clean.

New tests in `admin.rs` bind a `TcpListener` on an ephemeral port first, then point the admin server at that exact port:

- `a_squatted_admin_port_does_not_take_the_node_down` — a permanently squatted port makes `serve_admin` exhaust its retries and return normally.
- `the_admin_server_comes_up_once_the_port_is_released` — squatter released mid-retry; the server binds on a later attempt and serves a real HTTP request, no node restart.
- `the_bind_retry_is_bounded` — the budget is a bound, not an infinite loop.

**Fault validation.** Restoring the pre-fix fatal bind (`TcpListener::bind(&socket_address).await.unwrap()` in place of the retry) makes both behavioral tests fail with exactly the panic from the issue:

```
thread 'admin::tests::a_squatted_admin_port_does_not_take_the_node_down' panicked at crates/ika-node/src/admin.rs:131:61:
called `Result::unwrap()` on an `Err` value: Os { code: 48, kind: AddrInUse, message: "Address already in use" }
```

(`code: 48` is macOS's `EADDRINUSE`; CI reported `code: 98`, the Linux number for the same error.) `test result: FAILED. 1 passed; 2 failed` — the one pass is `the_bind_retry_is_bounded`, which exercises `bind_with_retry` directly and so is unaffected by a fault injected in its caller. Reverted; all three green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
