### PR TITLE
chore(node): node hygiene pass — Debug redaction, non-fatal metrics bind, catch-up gap gauge

### DIFF
--- a/crates/dwallet-rng/src/lib.rs
+++ b/crates/dwallet-rng/src/lib.rs
@@ -25,7 +25,7 @@ pub struct RootSeed([u8; RootSeed::SEED_LENGTH]);
 ///
 /// A derived `Debug` prints the full seed array, and this type is held —
 /// directly and behind wrappers — inside structs that are themselves `Debug`
-/// and get formatted wholesale (node config dumps, `?`-fielded tracing events,
+/// and get formatted wholesale (`NodeConfig` dumps, `?`-fielded tracing events,
 /// panic/error context). Redacting at the type covers every current and future
 /// holder at once, so no caller has to remember to skip the field.
 impl fmt::Debug for RootSeed {

--- a/crates/dwallet-rng/src/lib.rs
+++ b/crates/dwallet-rng/src/lib.rs
@@ -6,14 +6,33 @@ use merlin::Transcript;
 use rand_chacha::ChaCha20Rng;
 use rand_chacha::rand_core::{CryptoRng, RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use zeroize::ZeroizeOnDrop;
 
 /// The Root Seed for this validator, used to deterministically derive purpose-specific child seeds
 /// for all cryptographically-secure random generation operations.
 ///
 /// SECURITY NOTICE: *MUST BE KEPT PRIVATE*.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ZeroizeOnDrop)]
+///
+/// `Debug` is hand-written (see below) rather than derived, so the seed bytes
+/// never render in debug output. Every other trait here is derived as before —
+/// in particular `Serialize`/`Deserialize` still carry the real bytes, which is
+/// what config round-tripping depends on.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, ZeroizeOnDrop)]
 pub struct RootSeed([u8; RootSeed::SEED_LENGTH]);
+
+/// Render the root seed without its bytes.
+///
+/// A derived `Debug` prints the full seed array, and this type is held —
+/// directly and behind wrappers — inside structs that are themselves `Debug`
+/// and get formatted wholesale (node config dumps, `?`-fielded tracing events,
+/// panic/error context). Redacting at the type covers every current and future
+/// holder at once, so no caller has to remember to skip the field.
+impl fmt::Debug for RootSeed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("RootSeed").field(&"[REDACTED]").finish()
+    }
+}
 
 impl RootSeed {
     pub const SEED_LENGTH: usize = 32;
@@ -330,6 +349,53 @@ impl CryptoRng for ZeroRng {}
 /// **NEVER** use this RNG in any context where randomness is expected to provide security.
 /// See the [`ZeroRng`] type documentation for details on the intended use case.
 impl CsRng for ZeroRng {}
+
+#[cfg(test)]
+mod root_seed_tests {
+    use super::*;
+
+    /// The seed bytes must not appear in `Debug` output, in either the compact
+    /// or the alternate (`{:#?}`) form, while the type name still shows so the
+    /// rendering stays useful for debugging.
+    #[test]
+    fn debug_does_not_render_the_seed_bytes() {
+        // A marker whose decimal (`171`) and hex (`ab`) renderings are both
+        // easy to search for in the formatted output.
+        let seed = RootSeed::new([0xAB; RootSeed::SEED_LENGTH]);
+
+        for rendered in [format!("{seed:?}"), format!("{seed:#?}")] {
+            assert!(
+                !rendered.contains("171"),
+                "seed bytes must not render in decimal: {rendered}"
+            );
+            assert!(
+                !rendered.to_lowercase().contains("ab, ab"),
+                "seed bytes must not render in hex: {rendered}"
+            );
+            assert!(
+                rendered.contains("RootSeed"),
+                "the type name must survive redaction: {rendered}"
+            );
+            assert!(
+                rendered.contains("REDACTED"),
+                "the redaction marker must be visible: {rendered}"
+            );
+        }
+    }
+
+    /// Redaction is a `Debug`-only change: the value itself is untouched, so
+    /// derivation stays deterministic and equality still compares the bytes.
+    #[test]
+    fn redaction_does_not_change_the_value() {
+        let seed = RootSeed::new([0xAB; RootSeed::SEED_LENGTH]);
+        assert_eq!(seed, RootSeed::new([0xAB; RootSeed::SEED_LENGTH]));
+        assert_ne!(seed, RootSeed::new([0xCD; RootSeed::SEED_LENGTH]));
+        assert_eq!(
+            seed.class_groups_decryption_key_seed(),
+            RootSeed::new([0xAB; RootSeed::SEED_LENGTH]).class_groups_decryption_key_seed()
+        );
+    }
+}
 
 #[cfg(test)]
 mod zero_rng_tests {

--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -2185,6 +2185,84 @@ headers:
         }
     }
 
+    /// `RootSeedWithPath` reaches the seed bytes through two independent
+    /// fields — the `InPlace` location variant and the `OnceCell` cache — and
+    /// both render whenever the wrapper (or anything holding it, up to a whole
+    /// `NodeConfig`) is formatted with `{:?}`/`{:#?}`. `RootSeed`'s
+    /// hand-written `Debug` redacts at the type, which is what closes both
+    /// paths at once and covers any future holder; this pins that.
+    ///
+    /// `RootSeedWithPath::new` populates the cache eagerly, so both fields
+    /// carry the marker here — the strictest case.
+    #[test]
+    fn root_seed_debug_redacts_the_seed_and_stays_useful() {
+        // 0xAB renders as `171` under the derived array `Debug`; searching for
+        // both that and the hex spelling catches either formatting.
+        let marker = [0xABu8; 32];
+        let wrapper = RootSeedWithPath::new(RootSeed::new(marker));
+
+        for rendered in [format!("{wrapper:?}"), format!("{wrapper:#?}")] {
+            assert!(
+                !rendered.contains("171"),
+                "the seed bytes must not render in decimal: {rendered}"
+            );
+            assert!(
+                !rendered.to_lowercase().contains("ab, ab"),
+                "the seed bytes must not render in hex: {rendered}"
+            );
+            assert!(
+                rendered.contains("REDACTED"),
+                "the redaction marker must be visible: {rendered}"
+            );
+            // Still useful for debugging: the wrapper, the location variant
+            // and the field names all survive.
+            for expected in [
+                "RootSeedWithPath",
+                "location",
+                "InPlace",
+                "seed",
+                "RootSeed",
+            ] {
+                assert!(
+                    rendered.contains(expected),
+                    "`{expected}` must survive redaction so the dump stays readable: {rendered}"
+                );
+            }
+        }
+
+        // A whole `NodeConfig` dump is the shape that actually gets formatted
+        // in practice; it must be redacted too.
+        let mut config = config_for_mode(NodeMode::Validator);
+        config.root_seed_key_pair = Some(RootSeedWithPath::new(RootSeed::new(marker)));
+        let rendered = format!("{config:#?}");
+        assert!(
+            !rendered.contains("171"),
+            "a full node-config dump must not render the seed bytes"
+        );
+
+        // Only `Debug` changed: serialization is untouched and still carries
+        // the real bytes, so a config file round-trips byte-identically.
+        let wrapper = RootSeedWithPath::new(RootSeed::new(marker));
+        let yaml = serde_yaml::to_string(&wrapper).expect("the seed must serialize");
+        assert_eq!(
+            yaml.matches("171").count(),
+            marker.len(),
+            "serialization must still emit every seed byte: {yaml}"
+        );
+        let round_trip: RootSeedWithPath =
+            serde_yaml::from_str(&yaml).expect("the serialized seed must deserialize");
+        assert_eq!(
+            round_trip.root_seed(),
+            &RootSeed::new(marker),
+            "the seed must survive a serialization round-trip unchanged"
+        );
+        assert_eq!(
+            serde_yaml::to_string(&round_trip).expect("re-serialize"),
+            yaml,
+            "the serialized form must be byte-identical across a round-trip"
+        );
+    }
+
     /// The compiled-in `ika_system_package_id` must be the ORIGINAL (defining)
     /// system package, not a later upgrade. Every consumer of this field
     /// matches Sui type tags (event filters, the system object's own type, the

--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -2237,7 +2237,7 @@ headers:
         let rendered = format!("{config:#?}");
         assert!(
             !rendered.contains("171"),
-            "a full node-config dump must not render the seed bytes"
+            "a rendered NodeConfig must not contain the seed bytes"
         );
 
         // Only `Debug` changed: serialization is untouched and still carries

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -113,6 +113,19 @@ pub struct DWalletMPCMetrics {
     /// speed — 0 otherwise. Refreshed once per service iteration.
     pub(crate) catchup_mode: IntGauge,
 
+    /// How far MPC round processing trails the consensus tip, in consensus
+    /// rounds, as of the most recent service iteration.
+    ///
+    /// `catchup_mode` says whether the gate is engaged; this says whether a
+    /// gated validator is *draining or stuck*. The gate's log lines only fire
+    /// on the enter/exit transitions, so between them — which is the entire
+    /// duration of a catch-up, potentially hours — there is otherwise no
+    /// signal at all. This gauge is refreshed on every observation, so its
+    /// slope answers the operational question directly: falling means the
+    /// backlog is draining and the validator will return on its own, flat or
+    /// rising means it is trapped and needs intervention.
+    pub(crate) catchup_gap_rounds: IntGauge,
+
     /// Computation spawn decisions withheld by catch-up mode. Labels:
     /// `session_type` (only the suppressible types — `user` /
     /// `internal_presign` — ever appear). Incremented once per suppressed
@@ -572,6 +585,14 @@ impl DWalletMPCMetrics {
                 "1 while MPC round processing trails the consensus tip beyond the catch-up \
                  threshold and new internal-presign/user computations are suppressed \
                  (issue #2023), 0 otherwise",
+                registry
+            )
+            .unwrap(),
+            catchup_gap_rounds: register_int_gauge_with_registry!(
+                "ika_dwallet_mpc_catchup_gap_rounds",
+                "How far MPC round processing trails the consensus tip, in consensus rounds, \
+                 as of the most recent service iteration; answers whether a catch-up-gated \
+                 validator is draining or stuck (issue #2023)",
                 registry
             )
             .unwrap(),

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/catchup.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/catchup.rs
@@ -14,7 +14,7 @@
 //! entry — the exact signal a mid-epoch restart replay produces.
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStoreTrait;
-use crate::dwallet_mpc::catchup_gate::CATCH_UP_ENTER_GAP_ROUNDS;
+use crate::dwallet_mpc::catchup_gate::{CATCH_UP_ENTER_GAP_ROUNDS, CATCH_UP_EXIT_GAP_ROUNDS};
 use crate::dwallet_mpc::dwallet_mpc_metrics::session_type_label;
 use crate::dwallet_mpc::dwallet_mpc_service::DWalletMPCService;
 use crate::dwallet_mpc::integration_tests::network_dkg::create_network_key_test;
@@ -90,6 +90,80 @@ fn active_suppressible_session_count(service: &DWalletMPCService) -> usize {
                 )
         })
         .count()
+}
+
+/// The catch-up gap gauge must follow EVERY observation, not just the
+/// enter/exit transitions.
+///
+/// That is the whole point of the metric: the gate logs only on transitions,
+/// so during a long catch-up (the production case is hours) the transitions
+/// have already happened and nothing further is emitted. A gauge that only
+/// updated on transitions would freeze at the entry gap and report a draining
+/// validator as indistinguishable from a stuck one.
+///
+/// Driven by feeding the manager gap observations directly, so the assertion
+/// is about the gauge and nothing else — the end-to-end path through the
+/// service loop is covered by the test below.
+#[tokio::test]
+#[cfg(test)]
+async fn test_catchup_gap_gauge_tracks_every_observation() {
+    let _guard = utils::create_test_protocol_config_guard();
+    let mut test_state = build_test_state(1);
+    let manager = test_state.dwallet_mpc_services[0].dwallet_mpc_manager_mut();
+    let gap_gauge = manager.dwallet_mpc_metrics.catchup_gap_rounds.clone();
+    let mode_gauge = manager.dwallet_mpc_metrics.catchup_mode.clone();
+
+    // Below the enter threshold: no transition, but the gap is still reported.
+    manager.observe_consensus_round_gap(1_200, Some(200));
+    assert_eq!(mode_gauge.get(), 0, "no transition: the gate stays out");
+    assert_eq!(gap_gauge.get(), 1_000);
+
+    // Still no transition, different gap — the gauge must move anyway.
+    manager.observe_consensus_round_gap(1_500, Some(200));
+    assert_eq!(mode_gauge.get(), 0, "still no transition");
+    assert_eq!(
+        gap_gauge.get(),
+        1_300,
+        "the gauge must track a non-transition update"
+    );
+
+    // Enter catch-up.
+    let entry_gap = CATCH_UP_ENTER_GAP_ROUNDS + 3_000;
+    manager.observe_consensus_round_gap(entry_gap, None);
+    assert_eq!(mode_gauge.get(), 1);
+    assert_eq!(gap_gauge.get(), entry_gap as i64);
+
+    // The draining span: every one of these is inside the hysteresis band, so
+    // the gate never transitions and never logs — the gauge is the only
+    // signal that the backlog is shrinking.
+    let mut previous = gap_gauge.get();
+    for gap in [
+        CATCH_UP_ENTER_GAP_ROUNDS,
+        CATCH_UP_ENTER_GAP_ROUNDS / 2,
+        CATCH_UP_EXIT_GAP_ROUNDS + 1,
+    ] {
+        manager.observe_consensus_round_gap(gap, Some(0));
+        assert_eq!(
+            mode_gauge.get(),
+            1,
+            "gap {gap} is inside the hysteresis band: still no transition"
+        );
+        assert_eq!(
+            gap_gauge.get(),
+            gap as i64,
+            "the gauge must follow the gap while the gate holds its state"
+        );
+        assert!(
+            gap_gauge.get() < previous,
+            "a draining backlog must show as a falling gauge"
+        );
+        previous = gap_gauge.get();
+    }
+
+    // And it reaches zero when the cursor catches the tip.
+    manager.observe_consensus_round_gap(9_000, Some(9_000));
+    assert_eq!(mode_gauge.get(), 0, "a zero gap exits catch-up");
+    assert_eq!(gap_gauge.get(), 0);
 }
 
 /// End-to-end exercise of the catch-up gate against the real service loop:

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -3549,6 +3549,14 @@ impl DWalletMPCManager {
         self.dwallet_mpc_metrics
             .catchup_mode
             .set(self.catchup_gate.is_catching_up() as i64);
+        // Exported on EVERY observation, not just on a transition: the logs
+        // above only fire when the gate flips, so the whole span in between —
+        // which is the entire catch-up — would otherwise show no progress
+        // signal at all. The gauge's slope is what says whether the backlog is
+        // draining or the validator is stuck.
+        self.dwallet_mpc_metrics
+            .catchup_gap_rounds
+            .set(i64::try_from(gap_rounds).unwrap_or(i64::MAX));
     }
 
     /// Spawns all ready MPC cryptographic computations on separate threads using Rayon.

--- a/crates/ika-node/src/admin.rs
+++ b/crates/ika-node/src/admin.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 use crate::IkaNode;
+use crate::bind_retry::{BIND_ATTEMPTS, BIND_RETRY_INTERVAL, bind_with_retry};
 use axum::{
     Router,
     extract::{Query, State},
@@ -14,9 +15,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 use telemetry_subscribers::TracingHandle;
-use tokio::net::TcpListener;
-use tokio::time::sleep;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 // Example commands:
 //
@@ -59,12 +58,11 @@ const CLEAR_BUFFER_STAKE_ROUTE: &str = "/clear-override-buffer-stake";
 const CAPABILITIES: &str = "/capabilities";
 const NODE_CONFIG: &str = "/node-config";
 
-/// How long to wait between admin-server bind attempts.
-const BIND_RETRY_INTERVAL: Duration = Duration::from_secs(5);
-/// How many times to attempt the bind before giving up on the admin server.
-/// Together with the interval this keeps trying for ~2 minutes, comfortably
-/// past the ~60s a socket spends in `TIME_WAIT` after a restart.
-const BIND_ATTEMPTS: u32 = 25;
+/// Stand-in for the current log filter when the tracing handle can't report
+/// it. Only ever used for the "starting admin server" log line, so an
+/// unreadable filter must not stop the admin server from coming up (matching
+/// sui-node's tolerant handling of the same call).
+const UNKNOWN_LOG_FILTER: &str = "log filter not available";
 
 struct AppState {
     node: Arc<IkaNode>,
@@ -72,7 +70,10 @@ struct AppState {
 }
 
 pub async fn run_admin_server(node: Arc<IkaNode>, port: u16, tracing_handle: TracingHandle) {
-    let filter = tracing_handle.get_log().unwrap();
+    let filter = tracing_handle
+        .get_log()
+        .ok()
+        .unwrap_or_else(|| UNKNOWN_LOG_FILTER.to_string());
 
     let app_state = AppState {
         node,
@@ -116,17 +117,16 @@ pub async fn run_admin_server(node: Arc<IkaNode>, port: u16, tracing_handle: Tra
 /// racing its own port through `TIME_WAIT` — into node death at boot. A node
 /// without an admin endpoint is strictly healthier than a dead node.
 ///
-/// The retries are bounded so a genuinely misconfigured duplicate port ends
-/// in a single loud give-up rather than an unbounded background loop; each
-/// attempt warns with the address, so that misconfiguration is visible
-/// immediately either way.
+/// The retry policy lives in [`crate::bind_retry`], shared with the metrics
+/// server, which has the same "must not kill the node" property.
 async fn serve_admin(
     app: Router,
     socket_address: SocketAddr,
     attempts: u32,
     retry_interval: Duration,
 ) {
-    let Some(listener) = bind_with_retry(socket_address, attempts, retry_interval).await else {
+    let Some(listener) = bind_with_retry("admin", socket_address, attempts, retry_interval).await
+    else {
         error!(
             address =% socket_address,
             "gave up binding the admin server; the node continues without the admin endpoint"
@@ -145,31 +145,6 @@ async fn serve_admin(
             "admin server stopped; the node continues without the admin endpoint"
         );
     }
-}
-
-/// Bind the admin listener, retrying `attempts` times at `retry_interval`.
-/// `None` once the attempts are exhausted.
-async fn bind_with_retry(
-    socket_address: SocketAddr,
-    attempts: u32,
-    retry_interval: Duration,
-) -> Option<TcpListener> {
-    for attempt in 1..=attempts {
-        match TcpListener::bind(&socket_address).await {
-            Ok(listener) => return Some(listener),
-            Err(err) => warn!(
-                address =% socket_address,
-                attempt,
-                attempts,
-                error =? err,
-                "failed to bind the admin server, retrying"
-            ),
-        }
-        if attempt < attempts {
-            sleep(retry_interval).await;
-        }
-    }
-    None
 }
 
 #[derive(Deserialize)]
@@ -338,23 +313,14 @@ async fn set_override_protocol_upgrade_buffer_stake(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Instant;
-    use tokio::time::timeout;
+    use crate::bind_retry::test_support::squatted_port;
+    use tokio::time::{sleep, timeout};
 
     /// A stand-in for the real admin router: `serve_admin` only ever sees an
     /// already-stateless `Router`, so the routes it carries are irrelevant to
     /// the bind path under test.
     fn test_router() -> Router {
         Router::new().route("/ping", get(|| async { "pong" }))
-    }
-
-    /// A listener squatting on an ephemeral port, plus that port's address.
-    async fn squatted_port() -> (TcpListener, SocketAddr) {
-        let squatter = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
-            .await
-            .expect("bind a squatter on an ephemeral port");
-        let address = squatter.local_addr().expect("squatter local address");
-        (squatter, address)
     }
 
     async fn get_ping(address: SocketAddr) -> Option<String> {
@@ -412,22 +378,5 @@ mod tests {
         assert_eq!(body, "pong");
 
         server.abort();
-    }
-
-    /// The retry budget is a bound, not a loop: a duplicate port that is
-    /// never released ends in one give-up after the configured attempts.
-    #[tokio::test]
-    async fn the_bind_retry_is_bounded() {
-        let (_squatter, address) = squatted_port().await;
-
-        let started = Instant::now();
-        assert!(
-            bind_with_retry(address, 4, Duration::from_millis(50))
-                .await
-                .is_none()
-        );
-        // Four attempts are three sleeps; no sleep is wasted after the last.
-        assert!(started.elapsed() >= Duration::from_millis(150));
-        assert!(started.elapsed() < Duration::from_secs(10));
     }
 }

--- a/crates/ika-node/src/bind_retry.rs
+++ b/crates/ika-node/src/bind_retry.rs
@@ -1,0 +1,102 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Bind-with-retry plumbing shared by the node's local HTTP servers — the
+//! admin endpoint (`admin.rs`) and the Prometheus metrics endpoint
+//! (`metrics.rs`).
+//!
+//! Both servers are spawned onto a runtime where a panic ends the process:
+//! the release profile sets `panic = 'abort'`, and the node turns
+//! `crash_on_panic` on by default. An `unwrap` on `TcpListener::bind`
+//! therefore turns a transient `AddrInUse` — a port race on a shared CI
+//! runner, or a restart racing its own port through `TIME_WAIT` — into node
+//! death at boot, for a server that is not a correctness component.
+//!
+//! Retrying rides out the transient case; the bound on the retries means a
+//! genuinely misconfigured duplicate port ends in a single loud give-up rather
+//! than an unbounded background loop. Every attempt warns with the address, so
+//! a misconfiguration is visible immediately either way.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::time::sleep;
+use tracing::warn;
+
+/// How long to wait between bind attempts.
+pub(crate) const BIND_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How many times to attempt the bind before giving up on the server.
+/// Together with the interval this keeps trying for ~2 minutes, comfortably
+/// past the ~60s a socket spends in `TIME_WAIT` after a restart.
+pub(crate) const BIND_ATTEMPTS: u32 = 25;
+
+/// Bind a listener on `socket_address`, retrying `attempts` times at
+/// `retry_interval`. `None` once the attempts are exhausted — never panics.
+///
+/// `server_name` only labels the log lines, so a give-up is attributable to
+/// the right endpoint.
+pub(crate) async fn bind_with_retry(
+    server_name: &str,
+    socket_address: SocketAddr,
+    attempts: u32,
+    retry_interval: Duration,
+) -> Option<TcpListener> {
+    for attempt in 1..=attempts {
+        match TcpListener::bind(&socket_address).await {
+            Ok(listener) => return Some(listener),
+            Err(err) => warn!(
+                server = server_name,
+                address =% socket_address,
+                attempt,
+                attempts,
+                error =? err,
+                "failed to bind the server, retrying"
+            ),
+        }
+        if attempt < attempts {
+            sleep(retry_interval).await;
+        }
+    }
+    None
+}
+
+/// Helpers shared by the bind-path tests in `admin.rs` and `metrics.rs`.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use tokio::net::TcpListener;
+
+    /// A listener squatting on an ephemeral port, plus that port's address.
+    pub(crate) async fn squatted_port() -> (TcpListener, SocketAddr) {
+        let squatter = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+            .await
+            .expect("bind a squatter on an ephemeral port");
+        let address = squatter.local_addr().expect("squatter local address");
+        (squatter, address)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::squatted_port;
+    use super::*;
+    use std::time::Instant;
+
+    /// The retry budget is a bound, not a loop: a duplicate port that is
+    /// never released ends in one give-up after the configured attempts.
+    #[tokio::test]
+    async fn the_bind_retry_is_bounded() {
+        let (_squatter, address) = squatted_port().await;
+
+        let started = Instant::now();
+        assert!(
+            bind_with_retry("test", address, 4, Duration::from_millis(50))
+                .await
+                .is_none()
+        );
+        // Four attempts are three sleeps; no sleep is wasted after the last.
+        assert!(started.elapsed() >= Duration::from_millis(150));
+        assert!(started.elapsed() < Duration::from_secs(10));
+    }
+}

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -89,6 +89,7 @@ use typed_store::rocks::default_db_options;
 use crate::metrics::IkaNodeMetrics;
 
 pub mod admin;
+mod bind_retry;
 mod handle;
 pub mod metrics;
 mod node_runner;

--- a/crates/ika-node/src/metrics.rs
+++ b/crates/ika-node/src/metrics.rs
@@ -1,10 +1,86 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
+use crate::bind_retry::{BIND_ATTEMPTS, BIND_RETRY_INTERVAL, bind_with_retry};
+use axum::{Extension, Router, routing::get};
+use mysten_metrics::{METRICS_ROUTE, RegistryService};
 use prometheus::{
     Histogram, IntCounter, IntCounterVec, IntGauge, Registry, register_histogram_with_registry,
     register_int_counter_vec_with_registry, register_int_counter_with_registry,
     register_int_gauge_with_registry,
 };
+use std::net::SocketAddr;
+use std::time::Duration;
+use tracing::{error, warn};
+
+/// Start the Prometheus scrape endpoint on `addr` and return the
+/// [`RegistryService`] backing it.
+///
+/// A local equivalent of `mysten_metrics::start_prometheus_server`, which
+/// `unwrap`s both the `TcpListener::bind` and the `axum::serve` inside its
+/// spawned task. Under this node those `unwrap`s are fatal — the release
+/// profile sets `panic = 'abort'` and the node enables `crash_on_panic` — so
+/// a squatted metrics port (a shared CI runner, a duplicated port in a
+/// deployment, or a restart racing its own port through `TIME_WAIT`) takes the
+/// whole process down at boot, before telemetry is even initialized. This
+/// version retries the bind and then gives up loudly, exactly like the admin
+/// server; a node without a scrape endpoint is strictly healthier than a dead
+/// node.
+///
+/// Metrics are more load-bearing than the admin endpoint — losing them blinds
+/// every dashboard and alert for this validator — so the give-up logs at
+/// `error!` and names the address.
+///
+/// The rest of the behaviour is upstream's, unchanged: same route, same
+/// handler, same registry wiring, and the same simulator short-circuit.
+pub fn start_prometheus_server(addr: SocketAddr) -> RegistryService {
+    let registry = Registry::new();
+
+    let registry_service = RegistryService::new(registry);
+
+    if cfg!(msim) {
+        // prometheus uses difficult-to-support features such as
+        // TcpSocket::from_raw_fd(), so it can't run in the simulator.
+        // Identical to upstream: return the registry service without ever
+        // spawning a server.
+        warn!("not starting prometheus server in simulator");
+        return registry_service;
+    }
+
+    let app = Router::new()
+        .route(METRICS_ROUTE, get(mysten_metrics::metrics))
+        .layer(Extension(registry_service.clone()));
+
+    tokio::spawn(serve_metrics(app, addr, BIND_ATTEMPTS, BIND_RETRY_INTERVAL));
+
+    registry_service
+}
+
+/// Serve the metrics `app` on `socket_address`, riding out a transient bind
+/// failure and then giving up loudly — never panicking.
+async fn serve_metrics(
+    app: Router,
+    socket_address: SocketAddr,
+    attempts: u32,
+    retry_interval: Duration,
+) {
+    let Some(listener) = bind_with_retry("metrics", socket_address, attempts, retry_interval).await
+    else {
+        error!(
+            address =% socket_address,
+            "gave up binding the metrics server; the node continues without a metrics \
+             endpoint and will not be scrapable"
+        );
+        return;
+    };
+    if let Err(err) = axum::serve(listener, app.into_make_service()).await {
+        error!(
+            address =% socket_address,
+            error =? err,
+            "metrics server stopped; the node continues without a metrics endpoint and \
+             will not be scrapable"
+        );
+    }
+}
 
 pub struct IkaNodeMetrics {
     pub current_protocol_version: IntGauge,
@@ -121,9 +197,11 @@ impl IkaNodeMetrics {
 
 #[cfg(test)]
 mod tests {
-    use mysten_metrics::start_prometheus_server;
+    use super::*;
+    use crate::bind_retry::test_support::squatted_port;
     use prometheus::{IntCounter, Registry};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use tokio::time::{sleep, timeout};
 
     #[tokio::test]
     pub async fn test_metrics_endpoint_with_multiple_registries_add_remove() {
@@ -194,5 +272,93 @@ ika_counter_2 1"
             .await
             .unwrap();
         response.text().await.unwrap()
+    }
+
+    /// A stand-in for the real metrics router: `serve_metrics` only ever sees
+    /// an already-built `Router`, so the routes it carries are irrelevant to
+    /// the bind path under test.
+    fn test_router() -> Router {
+        Router::new().route("/ping", get(|| async { "pong" }))
+    }
+
+    async fn get_ping(address: SocketAddr) -> Option<String> {
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}/ping"))
+            .send()
+            .await
+            .ok()?;
+        response.text().await.ok()
+    }
+
+    /// The node-side failure this guards: something already holds the metrics
+    /// port, and the node dies at boot because the bind panicked on a runtime
+    /// where panics are fatal — before telemetry is even initialized, so the
+    /// death is close to silent. `serve_metrics` must exhaust its retries and
+    /// return normally instead: the node runs on, minus the scrape endpoint.
+    #[tokio::test]
+    async fn a_squatted_metrics_port_does_not_take_the_node_down() {
+        let (_squatter, address) = squatted_port().await;
+
+        timeout(
+            Duration::from_secs(30),
+            serve_metrics(test_router(), address, 3, Duration::from_millis(50)),
+        )
+        .await
+        .expect("a permanently squatted metrics port must be given up on, not waited on forever");
+    }
+
+    /// The retries ride out a transient squatter: once the port is released
+    /// the metrics server comes up on its own, with no node restart.
+    #[tokio::test]
+    async fn the_metrics_server_comes_up_once_the_port_is_released() {
+        let (squatter, address) = squatted_port().await;
+
+        let server = tokio::spawn(serve_metrics(
+            test_router(),
+            address,
+            600,
+            Duration::from_millis(50),
+        ));
+
+        // Let the first attempts fail against the squatter before it lets go.
+        sleep(Duration::from_millis(120)).await;
+        drop(squatter);
+
+        let body = timeout(Duration::from_secs(30), async {
+            loop {
+                if let Some(body) = get_ping(address).await {
+                    return body;
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("the metrics server must come up once the port is released");
+        assert_eq!(body, "pong");
+
+        server.abort();
+    }
+
+    /// `start_prometheus_server` must hand back a usable `RegistryService`
+    /// even when the port can never be bound — the node keeps recording
+    /// metrics into the registry, it just has nothing serving them.
+    #[tokio::test]
+    async fn a_squatted_port_still_yields_a_working_registry_service() {
+        let (_squatter, address) = squatted_port().await;
+
+        let registry_service = start_prometheus_server(address);
+        let registry = Registry::new_custom(Some("ika".to_string()), None).unwrap();
+        let counter = IntCounter::new("counter", "a sample counter").unwrap();
+        registry.register(Box::new(counter.clone())).unwrap();
+        registry_service.add(registry);
+        counter.inc();
+
+        assert!(
+            registry_service
+                .gather_all()
+                .iter()
+                .any(|family| family.name() == "ika_counter"),
+            "the registry service must keep collecting even with no server bound"
+        );
     }
 }

--- a/crates/ika-node/src/node_runner.rs
+++ b/crates/ika-node/src/node_runner.rs
@@ -159,7 +159,9 @@ pub fn run_node_with_name(
 
     let runtimes = IkaRuntimes::new(&config, node_mode);
     let metrics_rt = runtimes.metrics.enter();
-    let registry_service = mysten_metrics::start_prometheus_server(config.metrics_address);
+    // Local equivalent of `mysten_metrics::start_prometheus_server` that
+    // retries the bind instead of panicking on it — see `crate::metrics`.
+    let registry_service = crate::metrics::start_prometheus_server(config.metrics_address);
     let prometheus_registry = registry_service.default_registry();
     ika_types::metrics::init_invariant_violation_metric(&prometheus_registry);
 
@@ -275,13 +277,17 @@ pub fn run_node_with_name(
     runtimes.metrics.spawn(async move {
         let node = node_once_cell_clone.get().await;
         info!("Ika chain identifier: {chain_identifier}");
-        prometheus_registry
-            .register(mysten_metrics::uptime_metric(
-                uptime_label,
-                version,
-                &chain_identifier.to_string(),
-            ))
-            .unwrap();
+        // The uptime metric is informational; the admin server is started on
+        // the same task right below it. Losing one must not cost the other, so
+        // a failed registration is logged and stepped over rather than
+        // unwrapped (a panic here is fatal to the process).
+        if let Err(err) = prometheus_registry.register(mysten_metrics::uptime_metric(
+            uptime_label,
+            version,
+            &chain_identifier.to_string(),
+        )) {
+            error!("Failed to register the uptime metric, continuing without it: {err:?}");
+        }
 
         crate::admin::run_admin_server(node, admin_interface_port, filter_handle).await
     });


### PR DESCRIPTION
Four small, independent node changes, bundled because they all sit on the same
startup/observability path and are individually too small for their own PR.

## 1. `RootSeed` redacts itself in `Debug`

`RootSeed` derived `Debug`, so it printed all 32 bytes. Secret material should
never render in debug output — this is plain hygiene, not a response to
anything observed.

`Debug` is now hand-written, exactly like the existing `SuiGrpcHeaderValue`
precedent in `ika-config`:

```
before: RootSeed([171, 171, 171, ... , 171])
after:  RootSeed("[REDACTED]")
```

Redacting at the type rather than at a caller is deliberate: `RootSeedWithPath`
reaches the seed through **two** independent fields — the
`RootSeedLocation::InPlace { value }` variant and the `seed: OnceCell<RootSeed>`
cache, which `new()` populates eagerly and `root_seed()` populates lazily — and
both render. One `impl` closes both, and covers any future holder for free.

**Only `Debug` changes.** `Clone`, `PartialEq`, `Eq`, `Serialize`,
`Deserialize` and `ZeroizeOnDrop` are untouched, and the test pins that: it
asserts the serialized form still emits every seed byte, deserializes back to
an equal value, and re-serializes byte-identically. The regression test
constructs a `RootSeedWithPath` over a `0xAB` marker and asserts the rendered
`{:?}` and `{:#?}` contain neither the decimal (`171`) nor the hex spelling,
while still containing the struct and field names so the dump stays useful.

## 2. A squatted metrics port no longer takes the node down at boot

`mysten_metrics::start_prometheus_server` does
`TcpListener::bind(&addr).await.unwrap()` and `axum::serve(...).await.unwrap()`
inside a spawned task. Our release profile sets `panic = 'abort'` and the node
turns `crash_on_panic` on by default, so either `unwrap` ends the process — and
it runs *before* telemetry init, so the death is close to silent.

`ika-node` now has a local equivalent in `metrics.rs` that retries the bind and
then gives up at `error!` instead. This is the same fix #2026/#2027 made for the
admin server; metrics are more load-bearing than the admin endpoint (losing them
blinds every dashboard and alert for the validator), so the give-up logs at
`error!` and names the address.

- The retry helper is **extracted**, not duplicated: `bind_retry.rs` now holds
  `bind_with_retry` plus the attempt/interval constants, and `admin.rs` and
  `metrics.rs` share it. Only the `axum::serve` call differs between the two
  (the admin router needs `ConnectInfo`), so that part stays at each site.
- Everything else is upstream's, unchanged: same `METRICS_ROUTE`, the same
  `mysten_metrics::metrics` handler, the same `RegistryService` wiring, and the
  same `cfg!(msim)` short-circuit that returns the registry service without
  spawning a server under simulation.

Tests mirror the admin ones: a permanently squatted port must be given up on
rather than panicked on or waited on forever; a transiently squatted port must
come up on its own once released; and `start_prometheus_server` must still hand
back a working `RegistryService` when the port can never be bound.

## 3. `ika_dwallet_mpc_catchup_gap_rounds`

`observe_consensus_round_gap` computed `gap_rounds` but only logged it on the
gate's Entered/Exited transitions. The span *between* those transitions is the
entire catch-up — potentially hours — and nothing was emitted during it, so a
gated validator's drain progress was invisible.

New no-label `IntGauge`, `.set()` on **every** observation. Its slope answers
the operational question directly: falling means the backlog is draining and the
validator will return on its own; flat or rising means it is stuck.

## 4. Two leftover unwraps on the same path

Hygiene, not bugs — both are practically unreachable today.

- `admin.rs`: `tracing_handle.get_log().unwrap()` → `.ok()` with a fallback
  string, matching sui-node's handling of the same call. It only feeds a log
  line, so it should not be able to stop the admin server from starting.
- `node_runner.rs`: the uptime metric registration is logged and stepped over
  instead of unwrapped. It shares a task with `run_admin_server`, so a failure
  there must not cost us the admin server.

## Testing

- `cargo fmt --check` and `cargo clippy --all-targets` clean on every touched
  crate (`dwallet-rng`, `ika-config`, `ika-node`, `ika-core`).
- All in `--release` (the debug profile runs real MPC crypto at `opt-level=0`
  and times out). `dwallet-rng` lib: 5/5. `ika-config`: 27/27. `ika-node` lib:
  20/20. `ika-core` `dwallet_mpc::catchup*`: 9/9, including the full
  end-to-end catch-up gate test. A wider `ika-core dwallet_mpc::` sweep was
  still running at the time of writing with no failures so far.
- Each of 1, 2 and 3 was fault-validated: reverting the change makes its test
  fail, restoring it makes it pass.
