### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-classgroups-types"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bcs",
  "class_groups",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-rng"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "commitment",
  "fastcrypto",
@@ -6552,7 +6552,7 @@ dependencies = [
 
 [[package]]
 name = "ika"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6598,7 +6598,7 @@ dependencies = [
 
 [[package]]
 name = "ika-archival"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6769,7 +6769,7 @@ dependencies = [
 
 [[package]]
 name = "ika-node"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6840,7 +6840,7 @@ dependencies = [
 
 [[package]]
 name = "ika-proxy"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -6988,7 +6988,7 @@ dependencies = [
 
 [[package]]
 name = "ika-test-cluster"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7072,7 +7072,7 @@ dependencies = [
 
 [[package]]
 name = "ika-upgrade-test"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 [workspace.package]
 # This version string will be inherited by ika-core, ika-node, ika-tools, and ika crates.
-version = "1.3.0"
+version = "1.3.1"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/sdk/ika-wasm/Cargo.lock
+++ b/sdk/ika-wasm/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bcs",


### PR DESCRIPTION
Version bump for the v1.3.1 release. Pure version-string change: `Cargo.toml` plus the two lockfiles, 13 identical `1.3.0` → `1.3.1` lines and nothing else — same shape as the 1.3.0 bump (#2003).

Merge LAST, after the full suite is green on main, so the tagged commit differs from the validated tree only by these version strings.

### What v1.3.1 carries over v1.3.0

- **MPC catch-up gate** (#2024, closes #2023) — a validator re-entering more than ~2k consensus rounds behind the tip fell into a stable non-contributing equilibrium that a restart could not clear, only an epoch boundary. Computation is now withheld while the round backlog drains at replay speed. This is the fix the fleet rollout was held for.
- **Boot survives a pruned-at-head fullnode** (#2025) — the artifacts-digest probe treated a transient NotFound as fatal, so a node restarting inside a pruning window exited instead of starting.
- **Boot survives an AddrInUse race on the admin server** (#2027, closes #2026) — an occupied admin port aborted the whole node at boot; now a bounded retry with a loud give-up.
- **Node hygiene pass** (#2030) — secret material no longer renders in `Debug` output; a squatted Prometheus port no longer aborts the node at boot; new `ika_dwallet_mpc_catchup_gap_rounds` gauge so a catch-up-gated validator's drain progress is visible.
- **Metric namespace fix** (#2028, closes #2022 and #2029) — the vendored consensus-core registry moved from `ika_consensus_*` to `consensus_ika_*`, so ika's own metrics and upstream's can no longer collide. **Operator-visible: ~127 consensus-core metric names change.**
- Fork cleanup (#2031, #2032, #2033) — narwhal naming, dead scripts, orphaned crates; repairs the simtest coverage path, which had been silently unrunnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)