### PR TITLE
fix(noa): commit the signature algorithm in a gRPC-attestation demand id

### DIFF
--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -650,15 +650,20 @@ impl DWalletMPCService {
     /// Drains the channel into a pending buffer, then instantiates sessions
     /// for requests whose network key is already available.
     fn process_network_owned_address_sign_requests(&mut self) {
-        // Drain the receiver into the shared pending buffer, deduplicating by message.
+        // Drain the receiver into the shared pending buffer, deduplicating by
+        // the demand IDENTITY rather than by the message: the same message
+        // under two algorithms is two distinct legitimate demands (the
+        // algorithm is part of the identity), and keying on the message alone
+        // would drop the second at intake while a peer's announcement of it
+        // still consumed a presign in the drain.
         while let Ok(request) = self.network_owned_address_sign_requests_receiver.try_recv() {
-            let message_hash: [u8; 32] = DefaultHash::digest(&request.message).into();
-            if self.submitted_noa_sign_messages.contains(&message_hash) {
+            let demand_digest = request.demand_id.digest();
+            if self.submitted_noa_sign_messages.contains(&demand_digest) {
                 ika_types::report_invariant_violation!(
                     "duplicate_noa_sign_request",
                     message_len = request.message.len(),
                     curve = ?request.curve,
-                    algorithm = ?request.signature_algorithm,
+                    algorithm = ?request.demand_id.expected_signature_algorithm(),
                     "Skipping duplicate network-owned-address sign request"
                 );
                 continue;
@@ -666,7 +671,7 @@ impl DWalletMPCService {
             debug!(
                 message_len = request.message.len(),
                 curve = ?request.curve,
-                algorithm = ?request.signature_algorithm,
+                algorithm = ?request.demand_id.expected_signature_algorithm(),
                 "Received network-owned-address sign request"
             );
             self.pending_network_owned_address_sign_requests
@@ -720,7 +725,6 @@ impl DWalletMPCService {
                     .push(ConsensusNOAPresignDemand {
                         authority: self.name,
                         demand_id: request.demand_id.clone(),
-                        signature_algorithm: request.signature_algorithm,
                         network_encryption_key_id,
                     });
                 self.announced_noa_demand_digests.insert(digest);
@@ -758,7 +762,7 @@ impl DWalletMPCService {
                             .instantiate_network_owned_address_sign_session(
                                 request.message.clone(),
                                 request.curve,
-                                request.signature_algorithm,
+                                request.demand_id.expected_signature_algorithm(),
                                 request.hash_scheme,
                                 presign_session_id,
                                 presign_blending_index,
@@ -921,7 +925,6 @@ impl DWalletMPCService {
                 let tx = ConsensusTransaction::new_noa_presign_demand(
                     demand.authority,
                     demand.demand_id.clone(),
-                    demand.signature_algorithm,
                     demand.network_encryption_key_id,
                 );
                 if let Err(e) = self
@@ -1759,42 +1762,30 @@ impl DWalletMPCService {
                     // already assigned) — drop; `Ok(None)` => pool momentarily
                     // empty — keep, preserving order across rounds until the
                     // presign is generated; `Err` => keep for retry.
-                    // Prefer the algorithm DERIVED from the demand identity
-                    // over the one the announcement carries. The consensus
-                    // dedup key is the demand-id digest alone, so the first
-                    // announcement sequenced for a demand supplies the payload
-                    // fields for the whole network and the honest duplicates
-                    // are dropped — an announcer could otherwise pick the
-                    // algorithm, and so the presign pool, for a demand whose id
-                    // it can compute from public checkpoint data.
+                    // The algorithm comes from the demand IDENTITY, never from
+                    // the announcement: the consensus dedup key is the
+                    // demand-id digest alone, so the first announcement
+                    // sequenced for a demand would otherwise supply that field
+                    // for the whole network while the honest duplicates are
+                    // dropped behind it. Carrying no second copy is stronger
+                    // than comparing two: an announcer with a different
+                    // algorithm produces a DIFFERENT identity — a demand no
+                    // honest consumer looks up — and the pool popped here
+                    // cannot disagree with the session instantiated from the
+                    // same id.
                     //
-                    // Deriving is stronger than checking-and-rejecting here:
-                    // rejecting would leave the demand unassigned, and since
-                    // the honest announcements were already deduplicated away,
-                    // its sign would never happen and the epoch could not
-                    // finalize its NOA checkpoints. Every validator derives the
-                    // same value from the same consensus-agreed identity, so
-                    // this stays network-uniform.
-                    //
-                    // The announced value still governs where the identity does
-                    // not determine one. `network_encryption_key_id` is NOT
-                    // derivable — it is frozen at announce time on purpose (see
-                    // above) — and remains as announced.
-                    let signature_algorithm = demand.demand_id.expected_signature_algorithm();
-                    if signature_algorithm != demand.signature_algorithm {
-                        ika_types::report_invariant_violation!(
-                            "noa_presign_demand_signature_algorithm_mismatch",
-                            announcer=?demand.authority,
-                            announced=?demand.signature_algorithm,
-                            derived=?signature_algorithm,
-                            demand_id=?demand.demand_id,
-                            "NOA presign demand announced a signature algorithm its demand \
-                             identity does not imply; using the derived one"
-                        );
-                    }
+                    // `network_encryption_key_id` is the field this reasoning
+                    // does NOT yet cover: it is not derivable from the
+                    // identity (frozen at announce time on purpose, so the
+                    // assignment does not rest on the announce-time and
+                    // instantiate-time key resolutions agreeing), so it stays
+                    // announcer-supplied behind the same dedup key.
+                    // TODO(#2019): close that half — the shape it wants is
+                    // park-rather-than-reject, pending the adopted-key-skew
+                    // question.
                     match self.epoch_store.assign_noa_presign(
                         demand.demand_id_digest(),
-                        signature_algorithm,
+                        demand.demand_id.expected_signature_algorithm(),
                         demand.network_encryption_key_id,
                     ) {
                         Ok(Some(_)) => false,

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -1780,10 +1780,7 @@ impl DWalletMPCService {
                     // not determine one. `network_encryption_key_id` is NOT
                     // derivable — it is frozen at announce time on purpose (see
                     // above) — and remains as announced.
-                    let signature_algorithm = demand
-                        .demand_id
-                        .expected_signature_algorithm()
-                        .unwrap_or(demand.signature_algorithm);
+                    let signature_algorithm = demand.demand_id.expected_signature_algorithm();
                     if signature_algorithm != demand.signature_algorithm {
                         ika_types::report_invariant_violation!(
                             "noa_presign_demand_signature_algorithm_mismatch",

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/idle_status_voting.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/idle_status_voting.rs
@@ -591,7 +591,6 @@ async fn test_split_idle_status_vote_does_not_reach_consensus() {
             .send(NetworkOwnedAddressSignRequest {
                 message: test_message.clone(),
                 curve: DWalletCurve::Curve25519,
-                signature_algorithm: DWalletSignatureAlgorithm::EdDSA,
                 hash_scheme: DWalletHashScheme::SHA512,
                 demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
                     session_identifier: ika_types::crypto::keccak256_digest(&test_message),

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/idle_status_voting.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/idle_status_voting.rs
@@ -593,9 +593,10 @@ async fn test_split_idle_status_vote_does_not_reach_consensus() {
                 curve: DWalletCurve::Curve25519,
                 signature_algorithm: DWalletSignatureAlgorithm::EdDSA,
                 hash_scheme: DWalletHashScheme::SHA512,
-                demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
-                    ika_types::crypto::keccak256_digest(&test_message),
-                ),
+                demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+                    session_identifier: ika_types::crypto::keccak256_digest(&test_message),
+                    signature_algorithm: DWalletSignatureAlgorithm::EdDSA,
+                },
             })
             .await
             .expect("failed to send sign request to validator");

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -625,9 +625,10 @@ async fn test_internal_presign_stops_at_min_pool_size_when_not_idle() {
                     curve: DWalletCurve::Curve25519,
                     signature_algorithm: noa_sign_algorithm,
                     hash_scheme: noa_sign_hash_scheme,
-                    demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
-                        ika_types::crypto::keccak256_digest(&message),
-                    ),
+                    demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+                        session_identifier: ika_types::crypto::keccak256_digest(&message),
+                        signature_algorithm: noa_sign_algorithm,
+                    },
                 })
                 .await
                 .expect("failed to send network-owned-address sign request");

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -623,7 +623,6 @@ async fn test_internal_presign_stops_at_min_pool_size_when_not_idle() {
                 .send(NetworkOwnedAddressSignRequest {
                     message: message.clone(),
                     curve: DWalletCurve::Curve25519,
-                    signature_algorithm: noa_sign_algorithm,
                     hash_scheme: noa_sign_hash_scheme,
                     demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
                         session_identifier: ika_types::crypto::keccak256_digest(&message),

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
@@ -143,7 +143,6 @@ async fn network_owned_address_sign_flow(
             .send(NetworkOwnedAddressSignRequest {
                 message: test_message.clone(),
                 curve,
-                signature_algorithm,
                 hash_scheme,
                 demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
                     session_identifier: ika_types::crypto::keccak256_digest(&test_message),
@@ -487,7 +486,6 @@ async fn test_presign_pool_exhaustion_buffers_excess_sign_requests() {
                 .send(NetworkOwnedAddressSignRequest {
                     message: message.clone(),
                     curve: DWalletCurve::Curve25519,
-                    signature_algorithm: DWalletSignatureAlgorithm::EdDSA,
                     hash_scheme: DWalletHashScheme::SHA512,
                     demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
                         session_identifier: ika_types::crypto::keccak256_digest(&message),
@@ -710,7 +708,6 @@ async fn test_presign_assignment_is_consensus_ordered_not_local() {
                 .send(NetworkOwnedAddressSignRequest {
                     message: (*message).clone(),
                     curve,
-                    signature_algorithm,
                     hash_scheme,
                     demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
                         session_identifier: ika_types::crypto::keccak256_digest(message),
@@ -850,7 +847,6 @@ async fn test_late_instantiating_validator_preserves_buffered_sign_messages() {
             .send(NetworkOwnedAddressSignRequest {
                 message: test_message.clone(),
                 curve,
-                signature_algorithm,
                 hash_scheme,
                 demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
                     session_identifier: ika_types::crypto::keccak256_digest(&test_message),
@@ -916,7 +912,6 @@ async fn test_late_instantiating_validator_preserves_buffered_sign_messages() {
             .send(NetworkOwnedAddressSignRequest {
                 message: test_message.clone(),
                 curve,
-                signature_algorithm,
                 hash_scheme,
                 demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
                     session_identifier: ika_types::crypto::keccak256_digest(&test_message),
@@ -993,7 +988,6 @@ async fn test_instantiation_normalizes_byzantine_native_placeholder() {
         .send(NetworkOwnedAddressSignRequest {
             message: test_message.clone(),
             curve,
-            signature_algorithm,
             hash_scheme,
             demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
                 session_identifier: ika_types::crypto::keccak256_digest(&test_message),
@@ -1095,7 +1089,6 @@ async fn test_instantiation_normalizes_byzantine_native_placeholder() {
         .send(NetworkOwnedAddressSignRequest {
             message: test_message.clone(),
             curve,
-            signature_algorithm,
             hash_scheme,
             demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
                 session_identifier: ika_types::crypto::keccak256_digest(&test_message),
@@ -1193,7 +1186,6 @@ async fn network_owned_address_vss_sign_flow(
             .send(NetworkOwnedAddressSignRequest {
                 message: test_message.clone(),
                 curve,
-                signature_algorithm,
                 hash_scheme,
                 demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
                     session_identifier: ika_types::crypto::keccak256_digest(&test_message),
@@ -1283,19 +1275,19 @@ async fn test_network_owned_address_sign_schnorrkel_substrate_vss() {
 /// presign pool a demand draws from.
 ///
 /// The consensus dedup key for a presign-demand announcement is the demand-id
-/// digest alone, so the first announcement sequenced for a demand supplies the
-/// payload fields for the whole network and the honest duplicates are dropped.
-/// A checkpoint demand id names its checkpoint kind, and the kind determines
-/// the algorithm, so the drain re-derives it and the announced value carries no
-/// authority.
+/// digest alone, so the first announcement sequenced for a demand supplies any
+/// payload field the drain uses and the honest duplicates are dropped behind
+/// it. The algorithm is therefore not a payload field at all: it is part of
+/// the identity, so the pool a demand draws from is fixed by the id every
+/// validator agreed on and an announcer has no way to express a different one.
 ///
-/// Both pools are seeded with distinguishable bytes, so this asserts POSITIVELY
+/// Two pools are seeded with distinguishable bytes, so this asserts POSITIVELY
 /// which one was drawn from rather than inferring it from an empty pool: the
-/// assigned presign must be the derived pool's, while the announced pool is
-/// left untouched and full.
+/// assigned presign must be the identity's, while a pool the identity does not
+/// name is left untouched and full.
 #[tokio::test]
 #[cfg(test)]
-async fn test_noa_presign_demand_derives_its_algorithm_over_the_announced_one() {
+async fn test_noa_presign_demand_draws_from_the_pool_its_identity_names() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
 
@@ -1315,20 +1307,22 @@ async fn test_noa_presign_demand_derives_its_algorithm_over_the_announced_one() 
         retry_round: 0,
     };
     let derived_algorithm = demand_id.expected_signature_algorithm();
-    // Any algorithm the identity does NOT imply serves as the announced lie.
-    let announced_algorithm = DWalletSignatureAlgorithm::ECDSASecp256k1;
+    // A pool for an algorithm the identity does NOT imply. Nothing may be
+    // drawn from it: an announcement cannot name an algorithm at all any
+    // more, so the identity is the only thing that can select a pool.
+    let decoy_algorithm = DWalletSignatureAlgorithm::ECDSASecp256k1;
     assert_ne!(
-        derived_algorithm, announced_algorithm,
-        "the test needs the announced algorithm to differ from the derived one"
+        derived_algorithm, decoy_algorithm,
+        "the test needs the decoy pool to differ from the derived one"
     );
 
     // Seed both pools with recognizable, distinct bytes.
     const DERIVED_POOL_MARKER: u8 = 0xD1;
-    const ANNOUNCED_POOL_MARKER: u8 = 0xA9;
+    const DECOY_POOL_MARKER: u8 = 0xA9;
     let target = 0usize;
     for (algorithm, marker) in [
         (derived_algorithm, DERIVED_POOL_MARKER),
-        (announced_algorithm, ANNOUNCED_POOL_MARKER),
+        (decoy_algorithm, DECOY_POOL_MARKER),
     ] {
         test_state.epoch_stores[target]
             .insert_presigns(
@@ -1341,8 +1335,8 @@ async fn test_noa_presign_demand_derives_its_algorithm_over_the_announced_one() 
             .expect("seed presign pool");
     }
 
-    // A committee member announces the demand with the WRONG algorithm.
-    let byzantine_authority = test_state
+    // Another committee member announces the demand.
+    let announcing_authority = test_state
         .committee
         .names()
         .nth(1)
@@ -1365,9 +1359,8 @@ async fn test_noa_presign_demand_derives_its_algorithm_over_the_announced_one() 
         .entry(round)
         .or_default()
         .push(ConsensusNOAPresignDemand {
-            authority: byzantine_authority,
+            authority: announcing_authority,
             demand_id: demand_id.clone(),
-            signature_algorithm: announced_algorithm,
             network_encryption_key_id: network_key_id,
         });
     test_state.consensus_round += 1;
@@ -1410,24 +1403,25 @@ async fn test_noa_presign_demand_derives_its_algorithm_over_the_announced_one() 
     assert_eq!(
         presign_bytes,
         vec![DERIVED_POOL_MARKER; 16],
-        "the drain must draw from the pool its demand identity implies, not the announced one"
+        "the drain must draw from the pool its demand identity implies"
     );
     assert_eq!(
         assigned_key_id, network_key_id,
-        "the announced network key is still authoritative — it is not derivable"
+        "the announced network key is still authoritative — it is not derivable \
+         from the identity (the open half of #2019)"
     );
-    // The pool the announcement pointed at must be untouched.
+    // No other pool may be reachable: the announcement carries no algorithm.
     assert_eq!(
         test_state.epoch_stores[target]
-            .presign_pool_size(announced_algorithm, network_key_id)
+            .presign_pool_size(decoy_algorithm, network_key_id)
             .expect("pool size"),
         1,
-        "nothing should have been drawn from the announced algorithm's pool"
+        "nothing may be drawn from a pool the demand identity does not name"
     );
 
     info!(
         ?derived_algorithm,
-        ?announced_algorithm,
-        "a mismatched presign-demand announcement drew from the derived pool"
+        ?decoy_algorithm,
+        "the presign-demand drew from the pool its identity names"
     );
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
@@ -145,9 +145,10 @@ async fn network_owned_address_sign_flow(
                 curve,
                 signature_algorithm,
                 hash_scheme,
-                demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
-                    ika_types::crypto::keccak256_digest(&test_message),
-                ),
+                demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+                    session_identifier: ika_types::crypto::keccak256_digest(&test_message),
+                    signature_algorithm,
+                },
             })
             .await
             .expect("failed to send network-owned-address sign request");
@@ -488,9 +489,10 @@ async fn test_presign_pool_exhaustion_buffers_excess_sign_requests() {
                     curve: DWalletCurve::Curve25519,
                     signature_algorithm: DWalletSignatureAlgorithm::EdDSA,
                     hash_scheme: DWalletHashScheme::SHA512,
-                    demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
-                        ika_types::crypto::keccak256_digest(&message),
-                    ),
+                    demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+                        session_identifier: ika_types::crypto::keccak256_digest(&message),
+                        signature_algorithm: DWalletSignatureAlgorithm::EdDSA,
+                    },
                 })
                 .await
                 .expect("failed to send sign request");
@@ -710,9 +712,10 @@ async fn test_presign_assignment_is_consensus_ordered_not_local() {
                     curve,
                     signature_algorithm,
                     hash_scheme,
-                    demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
-                        ika_types::crypto::keccak256_digest(message),
-                    ),
+                    demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+                        session_identifier: ika_types::crypto::keccak256_digest(message),
+                        signature_algorithm,
+                    },
                 })
                 .await
                 .expect("failed to send network-owned-address sign request");
@@ -739,13 +742,15 @@ async fn test_presign_assignment_is_consensus_ordered_not_local() {
     // Direct proof of cross-validator agreement: the presign assigned to each
     // demand is IDENTICAL on validators that received the demands in OPPOSITE
     // local order (0 saw [M1,M2]; 2 saw [M2,M1]).
-    let digest_one = ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
-        ika_types::crypto::keccak256_digest(&message_one),
-    )
+    let digest_one = ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+        session_identifier: ika_types::crypto::keccak256_digest(&message_one),
+        signature_algorithm,
+    }
     .digest();
-    let digest_two = ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
-        ika_types::crypto::keccak256_digest(&message_two),
-    )
+    let digest_two = ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+        session_identifier: ika_types::crypto::keccak256_digest(&message_two),
+        signature_algorithm,
+    }
     .digest();
 
     let assigned_one_v0 = test_state.epoch_stores[0]
@@ -847,9 +852,10 @@ async fn test_late_instantiating_validator_preserves_buffered_sign_messages() {
                 curve,
                 signature_algorithm,
                 hash_scheme,
-                demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
-                    ika_types::crypto::keccak256_digest(&test_message),
-                ),
+                demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+                    session_identifier: ika_types::crypto::keccak256_digest(&test_message),
+                    signature_algorithm,
+                },
             })
             .await
             .expect("failed to send early network-owned-address sign request");
@@ -912,9 +918,10 @@ async fn test_late_instantiating_validator_preserves_buffered_sign_messages() {
                 curve,
                 signature_algorithm,
                 hash_scheme,
-                demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
-                    ika_types::crypto::keccak256_digest(&test_message),
-                ),
+                demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+                    session_identifier: ika_types::crypto::keccak256_digest(&test_message),
+                    signature_algorithm,
+                },
             })
             .await
             .expect("failed to send late network-owned-address sign request");
@@ -988,9 +995,10 @@ async fn test_instantiation_normalizes_byzantine_native_placeholder() {
             curve,
             signature_algorithm,
             hash_scheme,
-            demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
-                ika_types::crypto::keccak256_digest(&test_message),
-            ),
+            demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+                session_identifier: ika_types::crypto::keccak256_digest(&test_message),
+                signature_algorithm,
+            },
         })
         .await
         .expect("failed to send id-source sign request");
@@ -1089,9 +1097,10 @@ async fn test_instantiation_normalizes_byzantine_native_placeholder() {
             curve,
             signature_algorithm,
             hash_scheme,
-            demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
-                ika_types::crypto::keccak256_digest(&test_message),
-            ),
+            demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+                session_identifier: ika_types::crypto::keccak256_digest(&test_message),
+                signature_algorithm,
+            },
         })
         .await
         .expect("failed to send target sign request");
@@ -1186,9 +1195,10 @@ async fn network_owned_address_vss_sign_flow(
                 curve,
                 signature_algorithm,
                 hash_scheme,
-                demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
-                    ika_types::crypto::keccak256_digest(&test_message),
-                ),
+                demand_id: ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+                    session_identifier: ika_types::crypto::keccak256_digest(&test_message),
+                    signature_algorithm,
+                },
             })
             .await
             .expect("failed to send network-owned-address VSS sign request");
@@ -1304,9 +1314,7 @@ async fn test_noa_presign_demand_derives_its_algorithm_over_the_announced_one() 
         },
         retry_round: 0,
     };
-    let derived_algorithm = demand_id
-        .expected_signature_algorithm()
-        .expect("a checkpoint demand determines its own algorithm");
+    let derived_algorithm = demand_id.expected_signature_algorithm();
     // Any algorithm the identity does NOT imply serves as the announced lie.
     let announced_algorithm = DWalletSignatureAlgorithm::ECDSASecp256k1;
     assert_ne!(

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/noa_checkpoint.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/noa_checkpoint.rs
@@ -580,7 +580,6 @@ async fn test_noa_status_update_rebuffers_on_submit_failure() {
             tx_ref,
             retry_round: 0,
         },
-        signature_algorithm: DWalletSignatureAlgorithm::EdDSA,
         network_encryption_key_id: ObjectID::random(),
     };
     service.buffer_noa_observation_for_testing(observation.clone());

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -22,12 +22,15 @@ use tracing::error;
 pub struct NetworkOwnedAddressSignRequest {
     pub message: Vec<u8>,
     pub curve: DWalletCurve,
-    pub signature_algorithm: DWalletSignatureAlgorithm,
     pub hash_scheme: DWalletHashScheme,
     /// Network-uniform identity of this sign demand. Announced through
     /// consensus so every validator assigns it the same presign in
     /// consensus-delivery order (see `dwallet_mpc_service`'s NOA presign-demand
     /// drain).
+    ///
+    /// The signature algorithm is NOT carried beside this: it is derived from
+    /// the identity (`expected_signature_algorithm`), so the pool a demand
+    /// pops from and the session it instantiates cannot disagree.
     pub demand_id: ika_types::noa_checkpoint::NOAPresignDemandId,
 }
 

--- a/crates/ika-core/src/noa_checkpoints/handler.rs
+++ b/crates/ika-core/src/noa_checkpoints/handler.rs
@@ -100,7 +100,6 @@ impl<K: NOACheckpointKind> NOACheckpointHandler<K> {
             .map(|(tx_index, tx_bytes)| NetworkOwnedAddressSignRequest {
                 message: tx_bytes,
                 curve: <K::Counterparty as CounterpartyChain>::CURVE,
-                signature_algorithm: <K::Counterparty as CounterpartyChain>::SIGNATURE_ALGORITHM,
                 hash_scheme: <K::Counterparty as CounterpartyChain>::HASH_SCHEME,
                 // First attempt for this checkpoint tx: retry_round 0.
                 demand_id: NOAPresignDemandId::Checkpoint {
@@ -372,7 +371,6 @@ impl<K: NOACheckpointKind> NOACheckpointHandler<K> {
         Some(NetworkOwnedAddressSignRequest {
             message: tx_bytes,
             curve: <K::Counterparty as CounterpartyChain>::CURVE,
-            signature_algorithm: <K::Counterparty as CounterpartyChain>::SIGNATURE_ALGORITHM,
             hash_scheme: <K::Counterparty as CounterpartyChain>::HASH_SCHEME,
             demand_id: NOAPresignDemandId::Checkpoint {
                 tx_ref: tx_ref.clone(),

--- a/crates/ika-core/src/noa_checkpoints/tests.rs
+++ b/crates/ika-core/src/noa_checkpoints/tests.rs
@@ -316,8 +316,11 @@ fn test_handler_sends_sign_requests() {
         first_requests[0].curve,
         noa_checkpoint::SuiCounterpartyChain::CURVE
     );
+    // The algorithm is not carried beside the request — it is derived from
+    // the demand identity, so this asserts the identity implies the
+    // counterparty chain's algorithm.
     assert_eq!(
-        first_requests[0].signature_algorithm,
+        first_requests[0].demand_id.expected_signature_algorithm(),
         noa_checkpoint::SuiCounterpartyChain::SIGNATURE_ALGORITHM
     );
     assert_eq!(
@@ -350,7 +353,7 @@ async fn test_handler_certifies_and_submits_to_chain() {
             message: req.message.clone(),
             signature: b"mpc_signature".to_vec(),
             curve: req.curve,
-            signature_algorithm: req.signature_algorithm,
+            signature_algorithm: req.demand_id.expected_signature_algorithm(),
             hash_scheme: req.hash_scheme,
         })
         .await;
@@ -383,7 +386,7 @@ async fn test_end_to_end_handler() {
                 )
                 .into_bytes(),
                 curve: req.curve,
-                signature_algorithm: req.signature_algorithm,
+                signature_algorithm: req.demand_id.expected_signature_algorithm(),
                 hash_scheme: req.hash_scheme,
             })
             .await;
@@ -410,7 +413,7 @@ async fn test_end_to_end_system_checkpoint_handler() {
             message: req.message.clone(),
             signature: b"system_sig".to_vec(),
             curve: req.curve,
-            signature_algorithm: req.signature_algorithm,
+            signature_algorithm: req.demand_id.expected_signature_algorithm(),
             hash_scheme: req.hash_scheme,
         })
         .await;

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -654,13 +654,11 @@ impl ConsensusTransaction {
     pub fn new_noa_presign_demand(
         authority: AuthorityName,
         demand_id: crate::noa_checkpoint::NOAPresignDemandId,
-        signature_algorithm: dwallet_mpc_types::dwallet_mpc::DWalletSignatureAlgorithm,
         network_encryption_key_id: ObjectID,
     ) -> Self {
         let msg = ConsensusNOAPresignDemand {
             authority,
             demand_id,
-            signature_algorithm,
             network_encryption_key_id,
         };
         let mut hasher = DefaultHasher::new();
@@ -850,7 +848,6 @@ mod wire_format_tests {
                         session_identifier: [0u8; 32],
                         signature_algorithm: DWalletSignatureAlgorithm::ECDSASecp256k1,
                     },
-                    signature_algorithm: DWalletSignatureAlgorithm::ECDSASecp256k1,
                     network_encryption_key_id: ObjectID::ZERO,
                 }
             )),

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -846,9 +846,10 @@ mod wire_format_tests {
             tag(&ConsensusTransactionKind::NOAPresignDemand(
                 ConsensusNOAPresignDemand {
                     authority: AuthorityName::default(),
-                    demand_id: crate::noa_checkpoint::NOAPresignDemandId::GrpcAttestation(
-                        [0u8; 32],
-                    ),
+                    demand_id: crate::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+                        session_identifier: [0u8; 32],
+                        signature_algorithm: DWalletSignatureAlgorithm::ECDSASecp256k1,
+                    },
                     signature_algorithm: DWalletSignatureAlgorithm::ECDSASecp256k1,
                     network_encryption_key_id: ObjectID::ZERO,
                 }

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -215,7 +215,6 @@ impl ConsensusNOAObservation {
 pub struct ConsensusNOAPresignDemand {
     pub authority: AuthorityName,
     pub demand_id: crate::noa_checkpoint::NOAPresignDemandId,
-    pub signature_algorithm: DWalletSignatureAlgorithm,
     pub network_encryption_key_id: ObjectID,
 }
 

--- a/crates/ika-types/src/noa_checkpoint.rs
+++ b/crates/ika-types/src/noa_checkpoint.rs
@@ -328,13 +328,30 @@ pub struct NOACheckpointTxRef {
 /// demand sources: checkpoint signs (and their per-tx retries) carry the
 /// checkpoint tx coordinate + a retry round (0 for the first attempt); gRPC
 /// attestation signs carry their gRPC session identifier.
+///
+/// Every arm COMMITS to the signature algorithm the demand will use — the
+/// checkpoint arm implicitly (its `kind_name` determines it), the attestation
+/// arm explicitly. That is what lets a consumer derive the algorithm rather
+/// than trust the announcement carrying it; see
+/// [`Self::expected_signature_algorithm`].
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NOAPresignDemandId {
     Checkpoint {
         tx_ref: NOACheckpointTxRef,
         retry_round: u32,
     },
-    GrpcAttestation([u8; 32]),
+    GrpcAttestation {
+        /// The gRPC session identifier the attestation belongs to.
+        session_identifier: [u8; 32],
+        /// The algorithm this demand's presign must be drawn for. Part of the
+        /// IDENTITY, not payload: a demand announced with a different
+        /// algorithm is a DIFFERENT demand — a distinct digest that no honest
+        /// consumer ever looks up — rather than a competing answer for this
+        /// one. The session identifier alone could not carry that, so an
+        /// announcer could otherwise pick the algorithm (and with it the
+        /// presign pool) for any attestation whose identifier it can predict.
+        signature_algorithm: DWalletSignatureAlgorithm,
+    },
 }
 
 impl NOAPresignDemandId {
@@ -345,25 +362,26 @@ impl NOAPresignDemandId {
         keccak256_digest(&bcs::to_bytes(self).expect("NOAPresignDemandId is BCS-serializable"))
     }
 
-    /// The signature algorithm this demand must use, when the demand IDENTITY
-    /// determines it.
+    /// The signature algorithm this demand must use, derived from its
+    /// IDENTITY.
     ///
     /// The consensus dedup key for a presign-demand announcement is the digest
     /// of this identity alone — deliberately, so several validators announcing
     /// the same demand collapse into one transaction. The consequence is that
     /// the first announcement sequenced for a demand supplies the payload
-    /// fields the drain then uses for everyone. Wherever a field is instead
-    /// derivable from the identity, deriving it removes the announcer's say in
-    /// the matter entirely, which is stronger than validating what it sent:
-    /// there is no divergent value left to prefer, and no honest demand can be
-    /// dropped for carrying one.
+    /// fields the drain then uses for everyone. Deriving this one from the
+    /// identity removes the announcer's say in the matter entirely, which is
+    /// stronger than validating what it sent: there is no divergent value left
+    /// to prefer, and no honest demand can be dropped for carrying one.
     ///
-    /// `None` for a source whose identity does not determine the algorithm.
-    /// Such a demand has to keep taking the announced value.
-    pub fn expected_signature_algorithm(&self) -> Option<DWalletSignatureAlgorithm> {
+    /// Total by construction — every arm commits to its algorithm.
+    pub fn expected_signature_algorithm(&self) -> DWalletSignatureAlgorithm {
         match self {
-            Self::Checkpoint { tx_ref, .. } => Some(tx_ref.kind_name.signature_algorithm()),
-            Self::GrpcAttestation(_) => None,
+            Self::Checkpoint { tx_ref, .. } => tx_ref.kind_name.signature_algorithm(),
+            Self::GrpcAttestation {
+                signature_algorithm,
+                ..
+            } => *signature_algorithm,
         }
     }
 }
@@ -420,11 +438,11 @@ mod tests {
         assert_derived_matches_producer::<SuiSystemCheckpoint>();
     }
 
-    /// A checkpoint demand's identity determines its algorithm, so the drain
-    /// can derive it instead of trusting the announcement. A gRPC-attestation
-    /// demand's identity does not, so it must report that rather than guess.
+    /// EVERY demand's identity determines its algorithm — the checkpoint arm
+    /// through its `kind_name`, the attestation arm by carrying it — so the
+    /// drain always derives and never consults the announced value.
     #[test]
-    fn only_a_checkpoint_demand_determines_its_own_algorithm() {
+    fn every_demand_identity_determines_its_own_algorithm() {
         let checkpoint = NOAPresignDemandId::Checkpoint {
             tx_ref: NOACheckpointTxRef {
                 kind_name: NOACheckpointKindName::SuiDWallet,
@@ -436,12 +454,40 @@ mod tests {
         };
         assert_eq!(
             checkpoint.expected_signature_algorithm(),
-            Some(NOACheckpointKindName::SuiDWallet.signature_algorithm()),
+            NOACheckpointKindName::SuiDWallet.signature_algorithm(),
         );
         assert_eq!(
-            NOAPresignDemandId::GrpcAttestation([1u8; 32]).expected_signature_algorithm(),
-            None,
-            "a demand whose identity does not fix the algorithm must not claim one"
+            NOAPresignDemandId::GrpcAttestation {
+                session_identifier: [1u8; 32],
+                signature_algorithm: DWalletSignatureAlgorithm::ECDSASecp256r1,
+            }
+            .expected_signature_algorithm(),
+            DWalletSignatureAlgorithm::ECDSASecp256r1,
+        );
+    }
+
+    /// The algorithm is part of the attestation demand's IDENTITY: announcing
+    /// the same session with a different algorithm yields a DIFFERENT digest,
+    /// so it cannot compete with the honest demand for the same consensus
+    /// dedup key — it is a demand no honest consumer ever looks up. This is
+    /// what closes the substitution hole at the source rather than at the
+    /// consumer.
+    #[test]
+    fn a_different_algorithm_is_a_different_attestation_demand() {
+        let session_identifier = [9u8; 32];
+        let honest = NOAPresignDemandId::GrpcAttestation {
+            session_identifier,
+            signature_algorithm: DWalletSignatureAlgorithm::ECDSASecp256k1,
+        };
+        let substituted = NOAPresignDemandId::GrpcAttestation {
+            session_identifier,
+            signature_algorithm: DWalletSignatureAlgorithm::ECDSASecp256r1,
+        };
+        assert_ne!(
+            honest.digest(),
+            substituted.digest(),
+            "the algorithm must be part of the demand identity, not payload \
+             beside it"
         );
     }
 

--- a/dev-docs/specs/internal-presign-pool.md
+++ b/dev-docs/specs/internal-presign-pool.md
@@ -43,6 +43,46 @@ across the committee. A validator that binds a different presign to a request
 than its peers signs a checkpoint nobody else signs — an honest validator
 producing a divergent computation, the false-malicious class.
 
+## Which pool a demand draws from
+
+A pool is keyed by `(signature algorithm, network encryption key)`, so
+draining a demand starts by choosing an algorithm. That choice comes from
+the demand's IDENTITY (`NOAPresignDemandId::expected_signature_algorithm`),
+never from the announcement that carried it.
+
+The reason is the dedup key. Presign-demand announcements are deduplicated
+on the demand-id digest ALONE — deliberately, so several validators
+announcing the same demand collapse into one consensus transaction — and the
+consequence is that the first announcement sequenced for a demand would
+supply any payload field the drain reads, for the whole network, while every
+honest duplicate is dropped behind it. A committee member could then pick the
+pool for any demand whose id it can predict, and demand ids are derivable
+from public data.
+
+Deriving is what removes that, and it is stronger than validating the
+announced value:
+
+- **Rejecting a mismatch is unsafe.** The honest announcements were already
+  deduplicated away, so no correct one can follow: the demand stays
+  unassigned, its sign never happens, and the epoch cannot finalize its NOA
+  checkpoints. A substitution bug would have been traded for a stall.
+- **Carrying no second copy is stronger than comparing two.** Both demand
+  arms commit to their algorithm — the checkpoint arm through `kind_name`
+  (whose mapping to the counterparty chain's algorithm is pinned by test),
+  the attestation arm by carrying it in the identity — so an announcer
+  naming a different algorithm produces a DIFFERENT identity, a demand no
+  honest consumer looks up, rather than a competing answer for this one.
+  Neither the consensus message nor the internal sign request carries an
+  algorithm beside the id, so the pool drained and the session instantiated
+  cannot disagree.
+
+`network_encryption_key_id` is NOT covered by this reasoning and remains
+announcer-supplied behind the same dedup key: it is frozen at announce time
+on purpose, so the assignment does not depend on the announce-time and
+instantiate-time key resolutions agreeing. Closing that half is issue #2019;
+the shape it wants is park-rather-than-reject, pending the question of
+whether honest validators can transiently hold different adopted key sets.
+
 ## Fills complete out of sequence order
 
 A top-up batch starts *s* sessions at once. They finish in consensus order,


### PR DESCRIPTION
Closes half of #2019 — the half that needs no design decision. The `network_encryption_key_id` half stays open there, since it is blocked on settling whether honest validators can transiently hold different adopted key sets.

## The problem

The consensus dedup key for a presign-demand announcement is the demand-id digest alone. That is deliberate — several validators announcing the same demand collapse into one transaction — but the consequence is that the **first** announcement sequenced supplies any payload field the drain uses, and the honest duplicates are dropped behind it.

#2017 removed the announcer's say over `signature_algorithm` for **checkpoint** demands by deriving it from the demand identity: the id carries `kind_name`, and the kind fixes the algorithm.

The **attestation** arm could not derive. Its identity was `keccak256(message)` alone, which says nothing about the algorithm, so `expected_signature_algorithm` returned `None` there and the drain fell back to the announced value:

```rust
GrpcAttestation([u8; 32]),
...
Self::GrpcAttestation(_) => None,
```

That is inert on main today — nothing announces attestation demands here — but it means #2017's fix does **not** cover gRPC-attestation signing when that lands. A byzantine committee member could pre-announce the id for a message it expects, with an algorithm (and so a presign pool) of its choosing.

## The fix

Make the algorithm part of the demand's **identity** rather than payload beside it:

```rust
GrpcAttestation {
    session_identifier: [u8; 32],
    signature_algorithm: DWalletSignatureAlgorithm,
},
```

A substituted algorithm now yields a **different digest** — a demand no honest consumer ever looks up — instead of a competing answer for the same consensus dedup key. This closes the hole at the source rather than policing it at the consumer, which also avoids the reject-strands-the-demand trap that shaped #2017: there is nothing left to reject.

`expected_signature_algorithm` becomes total, so the `None` arm and the drain's `unwrap_or` both disappear.

## Why now, not after

A demand-id preimage cannot be versioned once demands are flowing. Changing it today costs nothing: the digest keys the consensus dedup and the per-epoch presign-assignment table, both per-epoch, and `noa_checkpoints()` is enabled on no network. #2019 flags this as a prerequisite for enabling gRPC-attestation signing rather than a follow-up to it, and that sequencing is the whole point.

## Tests

- every demand identity determines its own algorithm (both arms);
- a substituted algorithm is a **distinct** demand — the property the fix rests on.

Fault-validated: keying `digest()` on the session identifier alone, as the pre-fix shape did, fails the second test. The existing drain end-to-end test from #2017 still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2PfaVBZowAMYGNwVtae66