### PR TITLE
refactor(presign): assign by demand identity; take the bare pop off the trait

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -353,6 +353,26 @@ pub struct ExecutionIndicesWithStats {
 /// `(presign session id, blending index, raw presign bytes, network key id)`.
 pub(crate) type NoaAssignedPresign = (SessionIdentifier, u16, Vec<u8>, ObjectID);
 
+/// What a presign is being assigned TO — and, because assignment is keyed by
+/// it, the idempotency key.
+///
+/// Every consumer's demand stream is replayed from a per-epoch table after a
+/// restart, so a bare pool pop on replay binds a DIFFERENT presign than the
+/// never-crashed peers bound (fills complete out of sequence order, so the
+/// pool head moves between the original pop and the replayed one). That is a
+/// byte-divergent checkpoint or attestation from an honest validator. Routing
+/// every assignment through a demand identity makes the replay a no-op
+/// instead: a re-seen demand returns what it was already given, without
+/// popping.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PresignDemand {
+    /// A global presign request, identified by its consensus sequence number.
+    GlobalRequest { session_sequence_number: u64 },
+    /// A network-owned-address sign demand, identified by its demand-id
+    /// digest.
+    Noa { digest: [u8; 32] },
+}
+
 /// Trait for the AuthorityPerEpochStore, which gets recreated at the beginning of each epoch.
 pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
     fn insert_pending_dwallet_checkpoint(
@@ -441,34 +461,6 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
         dwallet_network_encryption_key_id: ObjectID,
     ) -> IkaResult<Option<u64>>;
 
-    /// Pop a presign from the internal pool for the given algorithm and key.
-    ///
-    /// Concurrency safety: This method is only called from the MPC manager
-    /// during consensus round processing, which is single-threaded (one round
-    /// at a time). There is no concurrent access to the presign pool.
-    ///
-    /// Self-committing and NOT idempotent — see the note on the inherent
-    /// method. Work that is replayed from a consensus round stream must use
-    /// `serve_global_presign` / `assign_noa_presign` / `assign_presign`.
-    fn pop_presign(
-        &self,
-        signature_algorithm: DWalletSignatureAlgorithm,
-        dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>>;
-
-    /// Serves a global presign request out of the internal pool atomically and
-    /// idempotently: an already-served sequence number returns the SAME presign
-    /// without popping, otherwise the pop and the record of what it served land
-    /// in ONE committed batch (they must not be separable — a replayed request
-    /// that re-pops binds a different presign than its peers). Returns `None`
-    /// only when the pool is empty.
-    fn serve_global_presign(
-        &self,
-        session_sequence_number: u64,
-        signature_algorithm: DWalletSignatureAlgorithm,
-        dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>>;
-
     /// Returns the next idle status updates after the given consensus round.
     fn next_idle_status_update(
         &self,
@@ -480,6 +472,18 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
         &self,
         last_consensus_round: Option<Round>,
     ) -> IkaResult<Option<(Round, Vec<SuiChainObservationUpdate>)>>;
+
+    /// Assign a presign to a demand — atomically, and idempotently in the
+    /// demand's identity, so the per-epoch replay every consumer performs
+    /// after a restart re-reads the same assignment instead of popping a
+    /// second, different presign. See
+    /// [`AuthorityEpochTables::assign_presign_for_demand`].
+    fn assign_presign_for_demand(
+        &self,
+        demand: &PresignDemand,
+        signature_algorithm: DWalletSignatureAlgorithm,
+        dwallet_network_encryption_key_id: ObjectID,
+    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>>;
 
     /// Returns the next global presign requests after the given consensus round.
     fn next_global_presign_request(
@@ -501,20 +505,6 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
 
     /// Reads the presign assigned (in consensus order) to a NOA sign demand.
     fn noa_assigned_presign(&self, digest: &[u8; 32]) -> IkaResult<Option<NoaAssignedPresign>>;
-
-    /// Assigns a presign to a NOA sign demand atomically and idempotently: if
-    /// the demand is already assigned, returns the existing assignment without
-    /// popping; otherwise pops a presign and records the assignment in a SINGLE
-    /// committed batch (the pop and the record must not be separable — a crash
-    /// between them would let a re-drain after replay pop a different presign
-    /// than peers assigned). Mirrors `assign_presign`. The network key id is
-    /// stored so the sign instantiates under the SAME key the presign came from.
-    fn assign_noa_presign(
-        &self,
-        digest: [u8; 32],
-        signature_algorithm: DWalletSignatureAlgorithm,
-        network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16)>>;
 
     /// Whether a presign has already been assigned to a NOA sign demand.
     fn has_noa_assigned_presign(&self, digest: &[u8; 32]) -> IkaResult<bool>;
@@ -553,8 +543,10 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
         presign_blending_index: u16,
     ) -> IkaResult<Option<Vec<u8>>>;
 
-    /// Assigns a presign to a user by moving it from the internal pool to the assigned pool.
-    /// This is used for external presign requests.
+    /// Assigns a presign to a USER by moving it from the internal pool to the
+    /// assigned pool. NOT idempotent — see
+    /// [`Self::assign_presign_for_demand`] for the demand-keyed form every
+    /// replayed consumer must use.
     fn assign_presign(
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
@@ -784,29 +776,6 @@ impl AuthorityPerEpochStoreTrait for AuthorityPerEpochStore {
         tables.max_filled_presign_pool_slot(signature_algorithm, dwallet_network_encryption_key_id)
     }
 
-    fn pop_presign(
-        &self,
-        signature_algorithm: DWalletSignatureAlgorithm,
-        dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
-        let tables = self.tables()?;
-        tables.pop_presign(signature_algorithm, dwallet_network_encryption_key_id)
-    }
-
-    fn serve_global_presign(
-        &self,
-        session_sequence_number: u64,
-        signature_algorithm: DWalletSignatureAlgorithm,
-        dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
-        let tables = self.tables()?;
-        tables.serve_global_presign(
-            session_sequence_number,
-            signature_algorithm,
-            dwallet_network_encryption_key_id,
-        )
-    }
-
     fn next_idle_status_update(
         &self,
         last_consensus_round: Option<Round>,
@@ -851,14 +820,17 @@ impl AuthorityPerEpochStoreTrait for AuthorityPerEpochStore {
         Ok(self.tables()?.noa_assigned_presigns.get(digest)?)
     }
 
-    fn assign_noa_presign(
+    fn assign_presign_for_demand(
         &self,
-        digest: [u8; 32],
+        demand: &PresignDemand,
         signature_algorithm: DWalletSignatureAlgorithm,
-        network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16)>> {
-        self.tables()?
-            .assign_noa_presign(digest, signature_algorithm, network_encryption_key_id)
+        dwallet_network_encryption_key_id: ObjectID,
+    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
+        self.tables()?.assign_presign_for_demand(
+            demand,
+            signature_algorithm,
+            dwallet_network_encryption_key_id,
+        )
     }
 
     fn has_noa_assigned_presign(&self, digest: &[u8; 32]) -> IkaResult<bool> {
@@ -2141,42 +2113,12 @@ impl AuthorityEpochTables {
     /// answered with a different presign than the never-crashed peers put in
     /// their checkpoint message for the same presign id: byte-divergent
     /// checkpoints from an honest validator. Mirrors `assign_noa_presign`.
-    pub fn serve_global_presign(
-        &self,
-        session_sequence_number: u64,
-        signature_algorithm: DWalletSignatureAlgorithm,
-        dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
-        if let Some(served) = self.served_global_presigns.get(&session_sequence_number)? {
-            return Ok(Some(served));
-        }
-        let Some((mut batch, session_identifier, blending_index, presign)) =
-            self.prepare_pop_presign(signature_algorithm, dwallet_network_encryption_key_id)?
-        else {
-            return Ok(None);
-        };
-        batch.insert_batch(
-            &self.served_global_presigns,
-            [(
-                &session_sequence_number,
-                &(session_identifier, blending_index, presign.clone()),
-            )],
-        )?;
-        batch.write()?;
-        Ok(Some((session_identifier, blending_index, presign)))
-    }
-
-    /// Pops a single presign from the pool for the given signature algorithm and network
-    /// encryption key. Returns the session identifier, the presign's blending index, and presign
-    /// bytes, or None if the pool is empty. Presigns are consumed in order of session sequence
-    /// number (lowest first).
-    ///
-    /// Self-committing and NOT idempotent: the pool advances the moment this
-    /// returns. Any caller whose work is replayed from a consensus round stream
-    /// must instead pop through a method that records what it popped in the pop's
-    /// own batch (`serve_global_presign`, `assign_noa_presign`, `assign_presign`),
-    /// or the replay binds a different presign than its peers did.
-    pub fn pop_presign(
+    /// Test-only raw pool pop for pool-inspection assertions. Production has
+    /// no bare pop — every consumer assigns through an idempotent
+    /// [`PresignDemand`], because a bare pop on a replayed demand stream binds
+    /// a different presign than peers bound.
+    #[cfg(test)]
+    pub fn pop_presign_for_testing(
         &self,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
@@ -2186,6 +2128,92 @@ impl AuthorityEpochTables {
         else {
             return Ok(None);
         };
+        batch.write()?;
+        Ok(Some((session_identifier, blending_index, presign)))
+    }
+
+    /// Assign a presign to a demand — atomically, and idempotently in the
+    /// demand's identity.
+    ///
+    /// A re-seen demand returns the presign it was already given WITHOUT
+    /// popping. That is what makes the per-epoch replay every consumer
+    /// performs after a restart safe: a bare re-pop would bind a different
+    /// presign than the never-crashed peers bound (fills complete out of
+    /// sequence order, so the pool head moves), and the checkpoint or
+    /// attestation built from it would be byte-divergent from an honest
+    /// validator.
+    ///
+    /// The pop and the record land in ONE committed batch. Separating them is
+    /// not merely untidy: `prepare_pop_presign` self-commits its half, so a
+    /// crash in between would leave the pool advanced with no record of where
+    /// the presign went, and the replay would pop again.
+    pub fn assign_presign_for_demand(
+        &self,
+        demand: &PresignDemand,
+        signature_algorithm: DWalletSignatureAlgorithm,
+        dwallet_network_encryption_key_id: ObjectID,
+    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
+        // Already assigned? Return it; never pop again.
+        match demand {
+            PresignDemand::GlobalRequest {
+                session_sequence_number,
+            } => {
+                if let Some(served) = self.served_global_presigns.get(session_sequence_number)? {
+                    return Ok(Some(served));
+                }
+            }
+            PresignDemand::Noa { digest } => {
+                if let Some((session_identifier, blending_index, presign, _)) =
+                    self.noa_assigned_presigns.get(digest)?
+                {
+                    return Ok(Some((session_identifier, blending_index, presign)));
+                }
+            }
+        }
+
+        let Some((mut batch, session_identifier, blending_index, presign)) =
+            self.prepare_pop_presign(signature_algorithm, dwallet_network_encryption_key_id)?
+        else {
+            return Ok(None);
+        };
+
+        match demand {
+            PresignDemand::GlobalRequest {
+                session_sequence_number,
+            } => {
+                batch.insert_batch(
+                    &self.served_global_presigns,
+                    [(
+                        session_sequence_number,
+                        &(session_identifier, blending_index, presign.clone()),
+                    )],
+                )?;
+            }
+            PresignDemand::Noa { digest } => {
+                batch.insert_batch(
+                    &self.noa_assigned_presigns,
+                    [(
+                        digest,
+                        &(
+                            session_identifier,
+                            blending_index,
+                            presign.clone(),
+                            dwallet_network_encryption_key_id,
+                        ),
+                    )],
+                )?;
+                // Mark the popped presign used, in the SAME batch as the
+                // assignment. This is the point of actual consumption (the pool
+                // pop happens in `prepare_pop_presign` above); the sign session
+                // later reads the presign from the assignment table and never
+                // pops again, so this is the only place the consumption is
+                // recorded.
+                batch.insert_batch(
+                    &self.used_presigns,
+                    [(&(session_identifier, blending_index), &())],
+                )?;
+            }
+        }
         batch.write()?;
         Ok(Some((session_identifier, blending_index, presign)))
     }
@@ -2371,59 +2399,6 @@ impl AuthorityEpochTables {
         )?;
         batch.write()?;
 
-        Ok(Some((session_identifier, blending_index)))
-    }
-
-    /// Atomically + idempotently assign a presign to a NOA sign demand.
-    ///
-    /// If the demand is already assigned, return the existing assignment
-    /// without popping. Otherwise pop a presign and record the assignment
-    /// (raw presign bytes + the network key id it came from) in the SAME
-    /// committed batch as the pop. Atomicity is load-bearing: `pop_presign`
-    /// self-commits, so a separate record write would leave a crash window
-    /// where, after a consensus-round replay, the demand looks unassigned but
-    /// its presign is gone from the pool — a re-drain would then pop a
-    /// DIFFERENT presign than the (non-crashed) peers assigned, reintroducing
-    /// the cross-validator divergence this fix exists to remove. Mirrors
-    /// `assign_presign`.
-    pub fn assign_noa_presign(
-        &self,
-        digest: [u8; 32],
-        signature_algorithm: DWalletSignatureAlgorithm,
-        network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16)>> {
-        if let Some((session_identifier, blending_index, _, _)) =
-            self.noa_assigned_presigns.get(&digest)?
-        {
-            return Ok(Some((session_identifier, blending_index)));
-        }
-        let Some((mut batch, session_identifier, blending_index, presign)) =
-            self.prepare_pop_presign(signature_algorithm, network_encryption_key_id)?
-        else {
-            return Ok(None);
-        };
-        batch.insert_batch(
-            &self.noa_assigned_presigns,
-            [(
-                &digest,
-                &(
-                    session_identifier,
-                    blending_index,
-                    presign,
-                    network_encryption_key_id,
-                ),
-            )],
-        )?;
-        // Mark the popped presign used, in the SAME batch as the assignment.
-        // This is the point of actual consumption (the pool pop happens in
-        // `prepare_pop_presign` above); the sign session later reads the presign
-        // from the assignment table and never pops again, so this is the only
-        // place the consumption is recorded.
-        batch.insert_batch(
-            &self.used_presigns,
-            [(&(session_identifier, blending_index), &())],
-        )?;
-        batch.write()?;
         Ok(Some((session_identifier, blending_index)))
     }
 
@@ -8324,20 +8299,29 @@ mod tests {
 
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 2);
 
-        let (popped_session, first_blending_index, first_presign) =
-            tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (popped_session, first_blending_index, first_presign) = tables
+            .pop_presign_for_testing(algorithm, key_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(popped_session, session_id);
         assert_eq!(first_blending_index, 0);
         assert_eq!(first_presign, vec![1u8, 2, 3]);
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 1);
 
-        let (_, second_blending_index, second_presign) =
-            tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, second_blending_index, second_presign) = tables
+            .pop_presign_for_testing(algorithm, key_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(second_blending_index, 1);
         assert_eq!(second_presign, vec![4u8, 5, 6]);
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 0);
 
-        assert!(tables.pop_presign(algorithm, key_id).unwrap().is_none());
+        assert!(
+            tables
+                .pop_presign_for_testing(algorithm, key_id)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -8361,26 +8345,41 @@ mod tests {
         assert_eq!(tables.presign_pool_size(algorithm, key_id_a).unwrap(), 2);
         assert_eq!(tables.presign_pool_size(algorithm, key_id_b).unwrap(), 3);
 
-        let (popped_session, _, presign) =
-            tables.pop_presign(algorithm, key_id_a).unwrap().unwrap();
+        let (popped_session, _, presign) = tables
+            .pop_presign_for_testing(algorithm, key_id_a)
+            .unwrap()
+            .unwrap();
         assert_eq!(popped_session, session_id_a);
         assert_eq!(presign, vec![10u8]);
         assert_eq!(tables.presign_pool_size(algorithm, key_id_a).unwrap(), 1);
         assert_eq!(tables.presign_pool_size(algorithm, key_id_b).unwrap(), 3);
 
-        let (popped_session, _, presign) =
-            tables.pop_presign(algorithm, key_id_b).unwrap().unwrap();
+        let (popped_session, _, presign) = tables
+            .pop_presign_for_testing(algorithm, key_id_b)
+            .unwrap()
+            .unwrap();
         assert_eq!(popped_session, session_id_b);
         assert_eq!(presign, vec![20u8]);
 
         // Exhaust key_id_a
-        tables.pop_presign(algorithm, key_id_a).unwrap().unwrap();
-        assert!(tables.pop_presign(algorithm, key_id_a).unwrap().is_none());
+        tables
+            .pop_presign_for_testing(algorithm, key_id_a)
+            .unwrap()
+            .unwrap();
+        assert!(
+            tables
+                .pop_presign_for_testing(algorithm, key_id_a)
+                .unwrap()
+                .is_none()
+        );
         assert_eq!(tables.presign_pool_size(algorithm, key_id_a).unwrap(), 0);
 
         // key_id_b still has presigns
         assert_eq!(tables.presign_pool_size(algorithm, key_id_b).unwrap(), 2);
-        let (_, _, presign) = tables.pop_presign(algorithm, key_id_b).unwrap().unwrap();
+        let (_, _, presign) = tables
+            .pop_presign_for_testing(algorithm, key_id_b)
+            .unwrap()
+            .unwrap();
         assert_eq!(presign, vec![21u8]);
     }
 
@@ -8422,16 +8421,30 @@ mod tests {
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 3);
 
         // Should pop in ascending session_sequence_number order
-        let (_, _, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables
+            .pop_presign_for_testing(algorithm, key_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(presign, vec![5u8]);
 
-        let (_, _, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables
+            .pop_presign_for_testing(algorithm, key_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(presign, vec![10u8]);
 
-        let (_, _, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables
+            .pop_presign_for_testing(algorithm, key_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(presign, vec![20u8]);
 
-        assert!(tables.pop_presign(algorithm, key_id).unwrap().is_none());
+        assert!(
+            tables
+                .pop_presign_for_testing(algorithm, key_id)
+                .unwrap()
+                .is_none()
+        );
     }
 
     /// One replayed consensus round's effect on the presign pool: either an
@@ -8478,8 +8491,10 @@ mod tests {
                     request_sequence_number,
                 } => Some(
                     tables
-                        .serve_global_presign(
-                            *request_sequence_number,
+                        .assign_presign_for_demand(
+                            &PresignDemand::GlobalRequest {
+                                session_sequence_number: *request_sequence_number,
+                            },
                             signature_algorithm,
                             dwallet_network_encryption_key_id,
                         )
@@ -8550,11 +8565,23 @@ mod tests {
         // on-chain presign id.
         let fresh_request_sequence_number = 13;
         let crashed_fresh = crashed
-            .serve_global_presign(fresh_request_sequence_number, signature_algorithm, key_id)
+            .assign_presign_for_demand(
+                &PresignDemand::GlobalRequest {
+                    session_sequence_number: fresh_request_sequence_number,
+                },
+                signature_algorithm,
+                key_id,
+            )
             .unwrap()
             .map(|(_, _, presign)| presign);
         let control_fresh = control
-            .serve_global_presign(fresh_request_sequence_number, signature_algorithm, key_id)
+            .assign_presign_for_demand(
+                &PresignDemand::GlobalRequest {
+                    session_sequence_number: fresh_request_sequence_number,
+                },
+                signature_algorithm,
+                key_id,
+            )
             .unwrap()
             .map(|(_, _, presign)| presign);
         assert!(
@@ -8581,13 +8608,73 @@ mod tests {
         );
     }
 
+    /// Assignment is idempotent in the demand IDENTITY, for every demand kind.
+    ///
+    /// This is the property the whole API exists for: each consumer replays
+    /// its demand stream from a per-epoch table after a restart, and a second
+    /// pop would bind a different presign than the never-crashed peers bound
+    /// (fills complete out of sequence order, so the pool head moves between
+    /// the two pops) — a byte-divergent checkpoint or attestation from an
+    /// honest validator.
+    #[tokio::test]
+    async fn assignment_is_idempotent_in_the_demand_identity() {
+        let key_id = ObjectID::random();
+        let algorithm = DWalletSignatureAlgorithm::ECDSASecp256k1;
+
+        for demand in [
+            PresignDemand::GlobalRequest {
+                session_sequence_number: 7,
+            },
+            PresignDemand::Noa { digest: [3u8; 32] },
+        ] {
+            let tables = create_tables();
+            for (sequence_number, marker) in [(0u64, 0xAAu8), (1, 0xBB)] {
+                tables
+                    .insert_presigns(
+                        algorithm,
+                        key_id,
+                        sequence_number,
+                        SessionIdentifier::new(SessionType::InternalPresign, [marker; 32]),
+                        vec![vec![marker; 8]],
+                    )
+                    .unwrap();
+            }
+
+            let first = tables
+                .assign_presign_for_demand(&demand, algorithm, key_id)
+                .unwrap()
+                .expect("pool is non-empty");
+            let pool_after_first = tables.presign_pool_size(algorithm, key_id).unwrap();
+
+            let second = tables
+                .assign_presign_for_demand(&demand, algorithm, key_id)
+                .unwrap()
+                .expect("a re-seen demand still resolves");
+
+            assert_eq!(
+                first, second,
+                "{demand:?}: a re-seen demand must return the presign it was already                  given, not a fresh one"
+            );
+            assert_eq!(
+                tables.presign_pool_size(algorithm, key_id).unwrap(),
+                pool_after_first,
+                "{demand:?}: re-seeing a demand must not pop the pool a second time"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_pop_from_empty_pool() {
         let tables = create_tables();
         let key_id = ObjectID::random();
         let algorithm = DWalletSignatureAlgorithm::ECDSASecp256k1;
 
-        assert!(tables.pop_presign(algorithm, key_id).unwrap().is_none());
+        assert!(
+            tables
+                .pop_presign_for_testing(algorithm, key_id)
+                .unwrap()
+                .is_none()
+        );
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 0);
     }
 
@@ -8605,19 +8692,33 @@ mod tests {
 
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 3);
 
-        let (_, _, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables
+            .pop_presign_for_testing(algorithm, key_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(presign, vec![1u8]);
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 2);
 
-        let (_, _, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables
+            .pop_presign_for_testing(algorithm, key_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(presign, vec![2u8]);
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 1);
 
-        let (_, _, presign) = tables.pop_presign(algorithm, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables
+            .pop_presign_for_testing(algorithm, key_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(presign, vec![3u8]);
         assert_eq!(tables.presign_pool_size(algorithm, key_id).unwrap(), 0);
 
-        assert!(tables.pop_presign(algorithm, key_id).unwrap().is_none());
+        assert!(
+            tables
+                .pop_presign_for_testing(algorithm, key_id)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -8639,13 +8740,19 @@ mod tests {
         assert_eq!(tables.presign_pool_size(ecdsa, key_id).unwrap(), 1);
         assert_eq!(tables.presign_pool_size(eddsa, key_id).unwrap(), 1);
 
-        let (_, _, presign) = tables.pop_presign(ecdsa, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables
+            .pop_presign_for_testing(ecdsa, key_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(presign, vec![100u8]);
         assert_eq!(tables.presign_pool_size(ecdsa, key_id).unwrap(), 0);
 
         // EdDSA pool unaffected
         assert_eq!(tables.presign_pool_size(eddsa, key_id).unwrap(), 1);
-        let (_, _, presign) = tables.pop_presign(eddsa, key_id).unwrap().unwrap();
+        let (_, _, presign) = tables
+            .pop_presign_for_testing(eddsa, key_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(presign, vec![200u8]);
     }
 

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -83,6 +83,7 @@ use ika_types::messages_system_checkpoints::{
     SystemCheckpointMessage, SystemCheckpointMessageKind, SystemCheckpointSequenceNumber,
     SystemCheckpointSignatureMessage,
 };
+use ika_types::noa_checkpoint::NOAPresignDemandId;
 use ika_types::sui::epoch_start_system::{EpochStartSystem, EpochStartSystemTrait};
 use ika_types::validator_metadata::{
     SignedValidatorMpcDataAnnouncement, ValidatorMpcDataAnnouncement,
@@ -368,9 +369,12 @@ pub(crate) type NoaAssignedPresign = (SessionIdentifier, u16, Vec<u8>, ObjectID)
 pub enum PresignDemand {
     /// A global presign request, identified by its consensus sequence number.
     GlobalRequest { session_sequence_number: u64 },
-    /// A network-owned-address sign demand, identified by its demand-id
-    /// digest.
-    Noa { digest: [u8; 32] },
+    /// A network-owned-address sign demand, identified by its demand id.
+    ///
+    /// Carries the identity TYPE, not a bare digest: the assignment table is
+    /// keyed by `NOAPresignDemandId::digest()`, and any other 32-byte value
+    /// would type-check at a call site while keying the assignment wrong.
+    Noa { demand_id: NOAPresignDemandId },
 }
 
 /// Trait for the AuthorityPerEpochStore, which gets recreated at the beginning of each epoch.
@@ -1508,7 +1512,7 @@ pub struct AuthorityEpochTables {
     /// than peers bound to it — the false-malicious class — for any consumer
     /// that requires pool-head determinism. The NOA path closed this by
     /// batching the pop with an idempotent assignment record (see
-    /// `noa_assigned_presigns` / `assign_noa_presign`); the external
+    /// `noa_assigned_presigns` / `assign_presign_for_demand`); the external
     /// `assign_presign` path has not been audited to the same standard.
     /// Do not add a consumer that assumes cross-validator pop identity until
     /// #1928 lands.
@@ -1655,7 +1659,7 @@ pub struct AuthorityEpochTables {
     ///
     /// write-discipline: direct — safe because idempotent-replay: keyed by the
     /// demand digest and written in the SAME batch as the pool pop and the
-    /// `used_presigns` marker (`assign_noa_presign`), so a re-drain after a
+    /// `used_presigns` marker (`assign_presign_for_demand`), so a re-drain after a
     /// crash returns the recorded assignment instead of popping again. This is
     /// the shape the raw pool tables lack (#1928): the consumer that needs
     /// cross-validator identity — sign-session instantiation — reads THIS
@@ -1670,7 +1674,7 @@ pub struct AuthorityEpochTables {
     ///
     /// write-discipline: direct — safe because idempotent-replay: a monotone
     /// marker keyed by the presign it retires, written either inside
-    /// `assign_noa_presign`'s pop batch or standalone by
+    /// `assign_presign_for_demand`'s pop batch or standalone by
     /// `mark_presign_as_used`. Re-writing it is a no-op, and the consumer
     /// (`is_presign_used`) only ever gates THIS node's reuse of a presign it
     /// already consumed.
@@ -2094,29 +2098,14 @@ impl AuthorityEpochTables {
             .unwrap_or(0))
     }
 
-    /// Serves a global presign request out of the internal pool, atomically and
-    /// idempotently.
+    /// Test-only raw pool pop, for tests that inspect pool contents directly.
     ///
-    /// If this request's sequence number was already served, returns the SAME
-    /// presign without popping. Otherwise pops the pool head and records the
-    /// serve in the SAME committed batch as the pop.
-    ///
-    /// Both halves are load-bearing. The request stream is a per-epoch table
-    /// that the DWallet MPC service replays in full after a restart, so a bare
-    /// `pop_presign` here re-pops on replay — and the replayed pool is not the
-    /// pool the original run popped from, because the surviving entries were
-    /// never cleared. An entry whose sequence number is lower than the head at
-    /// that round wins the replayed pop even though it did not exist yet when
-    /// the round was first processed (internal presign sessions in one batch
-    /// complete in consensus order, not sequence order, so a lower sequence
-    /// number filling later is ordinary). The replayed request would then be
-    /// answered with a different presign than the never-crashed peers put in
-    /// their checkpoint message for the same presign id: byte-divergent
-    /// checkpoints from an honest validator. Mirrors `assign_noa_presign`.
-    /// Test-only raw pool pop for pool-inspection assertions. Production has
-    /// no bare pop — every consumer assigns through an idempotent
-    /// [`PresignDemand`], because a bare pop on a replayed demand stream binds
-    /// a different presign than peers bound.
+    /// No REPLAYED path pops bare: every consumer whose demand stream is
+    /// replayed after a restart assigns through an idempotent
+    /// [`PresignDemand`], because a bare pop on replay binds a different
+    /// presign than peers bound. ([`Self::assign_presign`] does still pop
+    /// unconditionally, but it has no consumer; a future one must gain a
+    /// demand identity before it can be replay-safe.)
     #[cfg(test)]
     pub fn pop_presign_for_testing(
         &self,
@@ -2143,10 +2132,12 @@ impl AuthorityEpochTables {
     /// attestation built from it would be byte-divergent from an honest
     /// validator.
     ///
-    /// The pop and the record land in ONE committed batch. Separating them is
-    /// not merely untidy: `prepare_pop_presign` self-commits its half, so a
-    /// crash in between would leave the pool advanced with no record of where
-    /// the presign went, and the replay would pop again.
+    /// The pop and the record land in ONE committed batch, which is why
+    /// [`Self::prepare_pop_presign`] hands back an UNCOMMITTED batch for this
+    /// method to extend. Committing them separately would open a crash window
+    /// between the two writes: the pool would be advanced with no record of
+    /// where the presign went, so the replay would pop again — the very
+    /// divergence the identity key exists to prevent.
     pub fn assign_presign_for_demand(
         &self,
         demand: &PresignDemand,
@@ -2162,9 +2153,9 @@ impl AuthorityEpochTables {
                     return Ok(Some(served));
                 }
             }
-            PresignDemand::Noa { digest } => {
+            PresignDemand::Noa { demand_id } => {
                 if let Some((session_identifier, blending_index, presign, _)) =
-                    self.noa_assigned_presigns.get(digest)?
+                    self.noa_assigned_presigns.get(&demand_id.digest())?
                 {
                     return Ok(Some((session_identifier, blending_index, presign)));
                 }
@@ -2189,11 +2180,11 @@ impl AuthorityEpochTables {
                     )],
                 )?;
             }
-            PresignDemand::Noa { digest } => {
+            PresignDemand::Noa { demand_id } => {
                 batch.insert_batch(
                     &self.noa_assigned_presigns,
                     [(
-                        digest,
+                        &demand_id.digest(),
                         &(
                             session_identifier,
                             blending_index,
@@ -6722,6 +6713,7 @@ impl From<LockDetails> for LockDetailsWrapper {
 mod tests {
     use super::*;
     use crate::authority::authority_perpetual_tables::AuthorityPerpetualTables;
+    use ika_types::noa_checkpoint::{NOACheckpointKindName, NOACheckpointTxRef};
     use tokio::time::advance;
 
     /// `next_round_row` must return the first row STRICTLY after the anchor —
@@ -8625,7 +8617,17 @@ mod tests {
             PresignDemand::GlobalRequest {
                 session_sequence_number: 7,
             },
-            PresignDemand::Noa { digest: [3u8; 32] },
+            PresignDemand::Noa {
+                demand_id: NOAPresignDemandId::Checkpoint {
+                    tx_ref: NOACheckpointTxRef {
+                        kind_name: NOACheckpointKindName::SuiDWallet,
+                        sequence_number: 4,
+                        tx_index: 0,
+                        epoch: 1,
+                    },
+                    retry_round: 0,
+                },
+            },
         ] {
             let tables = create_tables();
             for (sequence_number, marker) in [(0u64, 0xAAu8), (1, 0xBB)] {
@@ -8653,13 +8655,39 @@ mod tests {
 
             assert_eq!(
                 first, second,
-                "{demand:?}: a re-seen demand must return the presign it was already                  given, not a fresh one"
+                "{demand:?}: a re-seen demand must return the presign it was \
+                 already given, not a fresh one"
             );
             assert_eq!(
                 tables.presign_pool_size(algorithm, key_id).unwrap(),
                 pool_after_first,
                 "{demand:?}: re-seeing a demand must not pop the pool a second time"
             );
+
+            // The NOA arm carries two writes the returned triple does not
+            // show, and a merge dropping either would pass every assertion
+            // above while failing at signing time: the used-presign marker
+            // (without it the presign can be handed out twice) and the network
+            // key id (the sign must instantiate under the SAME key the presign
+            // came from).
+            if let PresignDemand::Noa { demand_id } = &demand {
+                let (session_identifier, blending_index, _) = first;
+                assert!(
+                    tables
+                        .is_presign_used(session_identifier, blending_index)
+                        .unwrap(),
+                    "the NOA arm must mark its popped presign used"
+                );
+                let (_, _, _, recorded_key_id) = tables
+                    .noa_assigned_presigns
+                    .get(&demand_id.digest())
+                    .unwrap()
+                    .expect("the assignment was recorded");
+                assert_eq!(
+                    recorded_key_id, key_id,
+                    "the assignment must record the network key the presign came from"
+                );
+            }
         }
     }
 

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -1611,10 +1611,10 @@ impl DWalletMPCService {
                         return false;
                     }
 
-                    // Atomic + idempotent (see `serve_global_presign`): pops the
+                    // Atomic + idempotent (see `assign_presign_for_demand`): pops the
                     // pool head and records what it served in ONE committed
                     // batch, or returns the presign already served for this
-                    // sequence number without popping. A bare `pop_presign`
+                    // sequence number without popping. A bare pop
                     // here would re-pop when this loop replays the epoch's
                     // rounds after a restart — against a pool the replay never
                     // reset — and answer the request with a different presign
@@ -1728,7 +1728,7 @@ impl DWalletMPCService {
             //   (d) the presign pool is network-uniform (keyed by the
             //       consensus-assigned presign sequence), so popping in the same
             //       order yields the same presign per demand on every validator.
-            // `assign_noa_presign` is atomic + idempotent: it pops and records
+            // `assign_presign_for_demand` is atomic + idempotent: it pops and records
             // in one committed batch, and returns an already-assigned demand
             // without popping again (so re-delivery, and a re-drain after a
             // consensus-round replay, are both safe). Keeping a demand when the
@@ -1753,7 +1753,7 @@ impl DWalletMPCService {
                 .extend(noa_presign_demand_messages);
             if !self.agreed_noa_presign_demands_queue.is_empty() {
                 self.agreed_noa_presign_demands_queue.retain(|demand| {
-                    // Atomic + idempotent (see `assign_noa_presign`): pops a
+                    // Atomic + idempotent (see `assign_presign_for_demand`): pops a
                     // presign and records the assignment (raw presign + the
                     // demand's network key id) in ONE committed batch, or
                     // returns the existing assignment without popping. The pop
@@ -1787,7 +1787,7 @@ impl DWalletMPCService {
                     // question.
                     match self.epoch_store.assign_presign_for_demand(
                         &PresignDemand::Noa {
-                            digest: demand.demand_id_digest(),
+                            demand_id: demand.demand_id.clone(),
                         },
                         demand.demand_id.expected_signature_algorithm(),
                         demand.network_encryption_key_id,

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -7,7 +7,7 @@
 //! and forward them to the [`DWalletMPCManager`].
 
 use crate::SuiDataReceivers;
-use crate::authority::authority_per_epoch_store::AuthorityPerEpochStoreTrait;
+use crate::authority::authority_per_epoch_store::{AuthorityPerEpochStoreTrait, PresignDemand};
 use crate::authority::{AuthorityState, AuthorityStateTrait};
 use crate::consensus_manager::ReplayWaiter;
 use crate::dwallet_checkpoints::{
@@ -1620,8 +1620,10 @@ impl DWalletMPCService {
                     // reset — and answer the request with a different presign
                     // than the never-crashed peers put in their checkpoint
                     // message for the same presign id.
-                    match self.epoch_store.serve_global_presign(
-                        request.session_sequence_number,
+                    match self.epoch_store.assign_presign_for_demand(
+                        &PresignDemand::GlobalRequest {
+                            session_sequence_number: request.session_sequence_number,
+                        },
                         request.signature_algorithm,
                         request.dwallet_network_encryption_key_id,
                     ) {
@@ -1783,8 +1785,10 @@ impl DWalletMPCService {
                     // TODO(#2019): close that half — the shape it wants is
                     // park-rather-than-reject, pending the adopted-key-skew
                     // question.
-                    match self.epoch_store.assign_noa_presign(
-                        demand.demand_id_digest(),
+                    match self.epoch_store.assign_presign_for_demand(
+                        &PresignDemand::Noa {
+                            digest: demand.demand_id_digest(),
+                        },
                         demand.demand_id.expected_signature_algorithm(),
                         demand.network_encryption_key_id,
                     ) {

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -1823,7 +1823,7 @@ async fn test_mid_epoch_restart_resumes_internal_presign_ordinals_from_pool_high
     // provably fires the same top-up committee-wide.
     for epoch_store in &test_state.epoch_stores {
         while epoch_store
-            .pop_presign(algorithm, network_key_id)
+            .pop_presign_for_testing(algorithm, network_key_id)
             .expect("pop_presign")
             .is_some()
         {}
@@ -1930,7 +1930,7 @@ async fn test_mid_epoch_restart_resumes_internal_presign_ordinals_from_pool_high
         .expect("phase 3 refilled the pool");
     restart_validator_zero(&mut test_state, &seeds, &bundles);
     while test_state.epoch_stores[0]
-        .pop_presign(algorithm, network_key_id)
+        .pop_presign_for_testing(algorithm, network_key_id)
         .expect("pop_presign")
         .is_some()
     {}
@@ -2144,7 +2144,7 @@ fn drain_pools(
 ) {
     for service_index in service_indices {
         while test_state.epoch_stores[service_index]
-            .pop_presign(algorithm, network_key_object_id)
+            .pop_presign_for_testing(algorithm, network_key_object_id)
             .expect("pop_presign")
             .is_some()
         {}

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -1824,7 +1824,7 @@ async fn test_mid_epoch_restart_resumes_internal_presign_ordinals_from_pool_high
     for epoch_store in &test_state.epoch_stores {
         while epoch_store
             .pop_presign_for_testing(algorithm, network_key_id)
-            .expect("pop_presign")
+            .expect("pop_presign_for_testing")
             .is_some()
         {}
     }
@@ -1931,7 +1931,7 @@ async fn test_mid_epoch_restart_resumes_internal_presign_ordinals_from_pool_high
     restart_validator_zero(&mut test_state, &seeds, &bundles);
     while test_state.epoch_stores[0]
         .pop_presign_for_testing(algorithm, network_key_id)
-        .expect("pop_presign")
+        .expect("pop_presign_for_testing")
         .is_some()
     {}
 
@@ -2145,7 +2145,7 @@ fn drain_pools(
     for service_index in service_indices {
         while test_state.epoch_stores[service_index]
             .pop_presign_for_testing(algorithm, network_key_object_id)
-            .expect("pop_presign")
+            .expect("pop_presign_for_testing")
             .is_some()
         {}
     }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -175,7 +175,18 @@ impl TestingAuthorityPerEpochStore {
     ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
         let mut pools = self.presign_pools.lock().unwrap();
         let key = (signature_algorithm, dwallet_network_encryption_key_id);
-        Ok(pools.get_mut(&key).and_then(|pool| pool.pop()))
+        // FIFO — oldest first — mirroring the real store, which pops the head
+        // of a slot-ordered range. Popping LIFO here would prove idempotency
+        // against an ordering the real store never produces, and could not
+        // reproduce the scenario these tests exist for: a lower sequence
+        // number filling AFTER the original pop and winning the replayed one.
+        Ok(pools.get_mut(&key).and_then(|pool| {
+            if pool.is_empty() {
+                None
+            } else {
+                Some(pool.remove(0))
+            }
+        }))
     }
 
     fn new() -> Self {
@@ -521,12 +532,12 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
                     return Ok(Some(served));
                 }
             }
-            PresignDemand::Noa { digest } => {
+            PresignDemand::Noa { demand_id } => {
                 if let Some((session_id, blending_index, presign, _)) = self
                     .noa_assigned_presigns
                     .lock()
                     .unwrap()
-                    .get(digest)
+                    .get(&demand_id.digest())
                     .cloned()
                 {
                     return Ok(Some((session_id, blending_index, presign)));
@@ -549,9 +560,9 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
                     (session_id, blending_index, presign.clone()),
                 );
             }
-            PresignDemand::Noa { digest } => {
+            PresignDemand::Noa { demand_id } => {
                 self.noa_assigned_presigns.lock().unwrap().insert(
-                    *digest,
+                    demand_id.digest(),
                     (
                         session_id,
                         blending_index,

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -1,6 +1,6 @@
 use crate::authority::AuthorityStateTrait;
 use crate::authority::authority_per_epoch_store::{
-    AuthorityPerEpochStore, AuthorityPerEpochStoreTrait, NoaAssignedPresign,
+    AuthorityPerEpochStore, AuthorityPerEpochStoreTrait, NoaAssignedPresign, PresignDemand,
 };
 use crate::dwallet_checkpoints::{DWalletCheckpointServiceNotify, PendingDWalletCheckpoint};
 use crate::dwallet_mpc::dwallet_mpc_service::DWalletMPCService;
@@ -164,6 +164,20 @@ impl TestingDWalletCheckpointNotify {
 }
 
 impl TestingAuthorityPerEpochStore {
+    /// Test-only raw pool pop for pool-inspection assertions. The production
+    /// trait surface has no bare pop — every consumer assigns through an
+    /// idempotent [`PresignDemand`] — so this exists solely so tests can
+    /// observe pool contents.
+    pub(crate) fn pop_presign_for_testing(
+        &self,
+        signature_algorithm: DWalletSignatureAlgorithm,
+        dwallet_network_encryption_key_id: ObjectID,
+    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
+        let mut pools = self.presign_pools.lock().unwrap();
+        let key = (signature_algorithm, dwallet_network_encryption_key_id);
+        Ok(pools.get_mut(&key).and_then(|pool| pool.pop()))
+    }
+
     fn new() -> Self {
         Self {
             pending_checkpoints: Arc::new(Mutex::new(vec![])),
@@ -358,43 +372,6 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
             .copied())
     }
 
-    fn pop_presign(
-        &self,
-        signature_algorithm: DWalletSignatureAlgorithm,
-        dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
-        let mut pools = self.presign_pools.lock().unwrap();
-        let key = (signature_algorithm, dwallet_network_encryption_key_id);
-        Ok(pools.get_mut(&key).and_then(|pool| pool.pop()))
-    }
-
-    fn serve_global_presign(
-        &self,
-        session_sequence_number: u64,
-        signature_algorithm: DWalletSignatureAlgorithm,
-        dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
-        if let Some(served) = self
-            .served_global_presigns
-            .lock()
-            .unwrap()
-            .get(&session_sequence_number)
-            .cloned()
-        {
-            return Ok(Some(served));
-        }
-        let Some(served) =
-            self.pop_presign(signature_algorithm, dwallet_network_encryption_key_id)?
-        else {
-            return Ok(None);
-        };
-        self.served_global_presigns
-            .lock()
-            .unwrap()
-            .insert(session_sequence_number, served.clone());
-        Ok(Some(served))
-    }
-
     fn mark_presign_as_used(
         &self,
         presign_session_id: SessionIdentifier,
@@ -516,50 +493,81 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
             .cloned())
     }
 
-    fn assign_noa_presign(
-        &self,
-        digest: [u8; 32],
-        signature_algorithm: DWalletSignatureAlgorithm,
-        network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16)>> {
-        if let Some((session_id, blending_index, _, _)) = self
-            .noa_assigned_presigns
-            .lock()
-            .unwrap()
-            .get(&digest)
-            .cloned()
-        {
-            return Ok(Some((session_id, blending_index)));
-        }
-        let Some((session_id, blending_index, presign)) =
-            self.pop_presign(signature_algorithm, network_encryption_key_id)?
-        else {
-            return Ok(None);
-        };
-        self.noa_assigned_presigns.lock().unwrap().insert(
-            digest,
-            (
-                session_id,
-                blending_index,
-                presign,
-                network_encryption_key_id,
-            ),
-        );
-        // Mirror the real store: mark the popped presign used at the point of
-        // consumption (the pool pop above).
-        self.used_presigns
-            .lock()
-            .unwrap()
-            .insert((session_id, blending_index), ());
-        Ok(Some((session_id, blending_index)))
-    }
-
     fn has_noa_assigned_presign(&self, digest: &[u8; 32]) -> IkaResult<bool> {
         Ok(self
             .noa_assigned_presigns
             .lock()
             .unwrap()
             .contains_key(digest))
+    }
+
+    fn assign_presign_for_demand(
+        &self,
+        demand: &PresignDemand,
+        signature_algorithm: DWalletSignatureAlgorithm,
+        dwallet_network_encryption_key_id: ObjectID,
+    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
+        match demand {
+            PresignDemand::GlobalRequest {
+                session_sequence_number,
+            } => {
+                if let Some(served) = self
+                    .served_global_presigns
+                    .lock()
+                    .unwrap()
+                    .get(session_sequence_number)
+                    .cloned()
+                {
+                    return Ok(Some(served));
+                }
+            }
+            PresignDemand::Noa { digest } => {
+                if let Some((session_id, blending_index, presign, _)) = self
+                    .noa_assigned_presigns
+                    .lock()
+                    .unwrap()
+                    .get(digest)
+                    .cloned()
+                {
+                    return Ok(Some((session_id, blending_index, presign)));
+                }
+            }
+        }
+
+        let Some((session_id, blending_index, presign)) =
+            self.pop_presign_for_testing(signature_algorithm, dwallet_network_encryption_key_id)?
+        else {
+            return Ok(None);
+        };
+
+        match demand {
+            PresignDemand::GlobalRequest {
+                session_sequence_number,
+            } => {
+                self.served_global_presigns.lock().unwrap().insert(
+                    *session_sequence_number,
+                    (session_id, blending_index, presign.clone()),
+                );
+            }
+            PresignDemand::Noa { digest } => {
+                self.noa_assigned_presigns.lock().unwrap().insert(
+                    *digest,
+                    (
+                        session_id,
+                        blending_index,
+                        presign.clone(),
+                        dwallet_network_encryption_key_id,
+                    ),
+                );
+                // Mirror the real store: mark the popped presign used at the
+                // point of consumption (the pool pop above).
+                self.used_presigns
+                    .lock()
+                    .unwrap()
+                    .insert((session_id, blending_index), ());
+            }
+        }
+        Ok(Some((session_id, blending_index, presign)))
     }
 
     fn assign_presign(
@@ -570,7 +578,8 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
         dwallet_id: Option<ObjectID>,
         current_epoch: u64,
     ) -> IkaResult<Option<(SessionIdentifier, u16)>> {
-        let popped = self.pop_presign(signature_algorithm, dwallet_network_encryption_key_id)?;
+        let popped =
+            self.pop_presign_for_testing(signature_algorithm, dwallet_network_encryption_key_id)?;
         match popped {
             Some((session_id, blending_index, presign_bytes)) => {
                 let assigned = AssignedPresign {

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/validator_restart.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/validator_restart.rs
@@ -369,7 +369,7 @@ async fn test_epoch_store_presign_pool_operations() {
 
     // Test consuming a presign
     let consumed = test_epoch_store
-        .pop_presign(DWalletSignatureAlgorithm::ECDSASecp256k1, ObjectID::ZERO)
+        .pop_presign_for_testing(DWalletSignatureAlgorithm::ECDSASecp256k1, ObjectID::ZERO)
         .expect("failed to pop presign");
     assert!(consumed.is_some(), "should have consumed a presign");
 
@@ -456,7 +456,7 @@ async fn test_epoch_store_presign_pool_operations() {
     // Test pop from empty pool
     let empty_key = ObjectID::random();
     let empty_pop = test_epoch_store
-        .pop_presign(DWalletSignatureAlgorithm::ECDSASecp256k1, empty_key)
+        .pop_presign_for_testing(DWalletSignatureAlgorithm::ECDSASecp256k1, empty_key)
         .expect("pop from empty pool should not error");
     assert!(
         empty_pop.is_none(),

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -3261,7 +3261,7 @@ impl DWalletMPCManager {
         };
 
         // The presign is assigned in consensus-delivery order by the service
-        // layer (`assign_noa_presign`) and passed in as raw bytes, so every
+        // layer (`assign_presign_for_demand`) and passed in as raw bytes, so every
         // validator pairs the same presign with the same demand. This function
         // no longer pops from the pool — doing so used LOCAL instantiation
         // order, which diverged across a staggered restart and wedged the epoch.

--- a/dev-docs/specs/internal-presign-pool.md
+++ b/dev-docs/specs/internal-presign-pool.md
@@ -122,22 +122,39 @@ idempotency marker in the same committed batch as the state it guards:**
 | operation | idempotency key | marker table |
 |---|---|---|
 | fill (`insert_presigns`) | `(signature algorithm, network key id, session sequence number)` — the slot | `filled_presign_pool_slots` |
-| global presign serve (`serve_global_presign`) | request's session sequence number | `served_global_presigns` |
-| NOA demand assign (`assign_noa_presign`) | demand id digest | `noa_assigned_presigns` |
+| drain (`assign_presign_for_demand`) | the `PresignDemand` identity — see below | per demand kind, below |
 
-A repeated fill is a no-op. A repeated serve or assign returns the presign it
-returned the first time, without touching the pool. Replay is then a no-op on
-the pool by construction, and the restarted validator's checkpoint messages
-match its peers' regardless of where it crashed.
+Draining is ONE entry point, `assign_presign_for_demand`, taking the demand a
+presign is being assigned to. The demand's identity IS the idempotency key,
+and it selects the marker table:
+
+| `PresignDemand` | idempotency key | marker table |
+|---|---|---|
+| `GlobalRequest { session_sequence_number }` | the request's session sequence number | `served_global_presigns` |
+| `Noa { demand_id }` | `NOAPresignDemandId::digest()` | `noa_assigned_presigns` |
+
+There is deliberately no way to drain the pool without naming a demand: a
+consumer that could pop bare would have to know this hazard to avoid it,
+and the next consumer's author is exactly who the type is protecting. (The
+`Noa` arm carries the identity type rather than a bare digest for the same
+reason — any other 32-byte value would type-check while keying the
+assignment wrong.)
+
+A repeated fill is a no-op. A repeated drain returns the presign it returned
+the first time, without touching the pool. Replay is then a no-op on the pool
+by construction, and the restarted validator's checkpoint messages match its
+peers' regardless of where it crashed.
 
 The batching is load-bearing in both directions: a pool mutation that landed
 without its marker is re-applied on the next replay, and a marker that landed
 without its mutation loses the presigns (fill) or serves a presign the pool
 never gave up (drain).
 
-`pop_presign` is the bare, self-committing pop. It is correct only for
-callers whose work is never replayed from the round stream — in practice,
-tests. Production drains go through the recorded variants above.
+The pool has no bare pop on any replayed path. `pop_presign_for_testing`
+exists only so tests can inspect pool contents directly, and is
+`#[cfg(test)]`-gated. (`assign_presign` — the user-facing pool-to-assigned-pool
+move — does still pop unconditionally, but it has no consumer; a future one
+must gain a demand identity before its stream can be replayed safely.)
 
 ## Ordinal-stream convergence
 


### PR DESCRIPTION
## The hazard

Every presign consumer replays its demand stream from a per-epoch table after a restart. A bare pool pop on that replay binds a **different** presign than the never-crashed peers bound — fills complete out of sequence order, so the pool head moves between the original pop and the replayed one — and the checkpoint or attestation built from it is byte-divergent from an honest validator.

Both live consumers already defend against this, **separately**:

| Consumer | Idempotency key |
|---|---|
| `serve_global_presign` | session sequence number |
| `assign_noa_presign` | demand-id digest |

The two implementations were near-identical. Meanwhile `pop_presign` — the bare, self-committing pop with **no** idempotency key — sat on the same trait beside them, with no production caller.

## Why now

That is a latent defect rather than a live one: nothing pops bare today, so this PR fixes no bug. The exposure is entirely in the *next* consumer, which can reach for the bare pop exactly as easily as for the safe path, and whose author has to know this hazard to choose correctly.

So the fix is to remove the choice. The two implementations collapse into one `assign_presign_for_demand`, keyed by a `PresignDemand` whose identity **is** the idempotency key, and the bare pop comes off the trait. A consumer can now only obtain a presign by naming what it is for. Tests that legitimately need a raw pop for pool inspection get an explicit `pop_presign_for_testing`.

**No behavior change.** The merged bodies keep each arm's exact semantics, including the NOA arm's used-presign marking inside the same committed batch as the pop.

## Scope note

The user-facing `assign_presign` is deliberately left alone. It is *also* uncalled here — as is the entire assigned-pool path it writes — but it carries real test coverage, and removing it is a separate question that belongs with the user-presign flow that will eventually consume it. Flagging it because a reader may notice the same dead-code smell and wonder why only half of it moved.

## Tests

- New: assignment is idempotent in the demand identity, for **both** demand kinds — re-seeing a demand returns the same presign and does not pop the pool again. Fault-validated by removing the short-circuit, which fails it.
- Existing: the crashed-vs-control replay test (a replayed round must bind the presign it bound before the crash) now exercises the unified API.
- Store tests 28/28; `internal_presign` + `validator_restart` 13/13; clippy clean under `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2PfaVBZowAMYGNwVtae66