### PR TITLE
fix(noa): bound the presign-demand park with a durable, consensus-uniform drop

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -350,9 +350,47 @@ pub struct ExecutionIndicesWithStats {
     pub stats: ConsensusStats,
 }
 
-/// A presign assigned (in consensus order) to a NOA sign demand:
-/// `(presign session id, blending index, raw presign bytes, network key id)`.
-pub(crate) type NoaAssignedPresign = (SessionIdentifier, u16, Vec<u8>, ObjectID);
+/// The terminal resolution of a NOA sign demand: exactly one per demand
+/// digest, per epoch, written by the consensus-order drain.
+///
+/// Both arms are terminal, and recording BOTH durably is what keeps a
+/// restarted validator consistent with its peers. The drain replays the
+/// epoch's consensus rounds after a restart while the presign pool — durable
+/// per-epoch state — is not rewound with them, so a demand the park bound
+/// dropped would otherwise be re-read at its delivery round against a pool
+/// that filled after the drop, and the replayed drain would pop for a demand
+/// every peer had already given up on.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum NoaPresignDemandResolution {
+    /// A presign was popped for this demand and is bound to it.
+    Assigned {
+        session_identifier: SessionIdentifier,
+        blending_index: u16,
+        presign: Vec<u8>,
+        network_encryption_key_id: ObjectID,
+    },
+    /// The demand stayed unassigned for the whole park bound and was dropped;
+    /// it must never be assigned a presign in this epoch.
+    Evicted,
+}
+
+/// What one drain attempt at a demand resolved to.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PresignAssignmentOutcome {
+    /// A presign is bound to the demand — popped by this call, or already
+    /// recorded by an earlier drain of the same rounds.
+    Assigned {
+        session_identifier: SessionIdentifier,
+        blending_index: u16,
+        presign: Vec<u8>,
+    },
+    /// The demand was dropped at the park bound in an earlier round, and must
+    /// never be assigned a presign in this epoch. Reachable only for
+    /// [`PresignDemand::Noa`] — a global presign request has no park bound.
+    Evicted,
+    /// No presign exists for the demand's network encryption key yet.
+    PoolEmpty,
+}
 
 /// What a presign is being assigned TO — and, because assignment is keyed by
 /// it, the idempotency key.
@@ -487,7 +525,7 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
         demand: &PresignDemand,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>>;
+    ) -> IkaResult<PresignAssignmentOutcome>;
 
     /// Returns the next global presign requests after the given consensus round.
     fn next_global_presign_request(
@@ -507,11 +545,28 @@ pub trait AuthorityPerEpochStoreTrait: Sync + Send + 'static {
         last_consensus_round: Option<Round>,
     ) -> IkaResult<Option<(Round, Vec<ConsensusNOAPresignDemand>)>>;
 
-    /// Reads the presign assigned (in consensus order) to a NOA sign demand.
-    fn noa_assigned_presign(&self, digest: &[u8; 32]) -> IkaResult<Option<NoaAssignedPresign>>;
+    /// Reads a NOA sign demand's terminal resolution, if it has one.
+    ///
+    /// Keyed by the identity, never a bare digest — the same reason
+    /// [`PresignDemand::Noa`] carries one.
+    fn noa_presign_demand_resolution(
+        &self,
+        demand_id: &NOAPresignDemandId,
+    ) -> IkaResult<Option<NoaPresignDemandResolution>>;
 
-    /// Whether a presign has already been assigned to a NOA sign demand.
-    fn has_noa_assigned_presign(&self, digest: &[u8; 32]) -> IkaResult<bool>;
+    /// Durably records that a demand was dropped at the park bound, so a
+    /// replay of the epoch's rounds cannot assign it a presign the rest of the
+    /// committee never assigned. Idempotent, and never overwrites an existing
+    /// resolution.
+    ///
+    /// NOA-only: a global presign request has no bound to outlive, and its
+    /// marker table holds served presigns alone.
+    fn evict_noa_presign_demand(&self, demand_id: &NOAPresignDemandId) -> IkaResult<()>;
+
+    /// Whether a NOA sign demand already has a terminal resolution — assigned
+    /// OR dropped at the park bound. Both end the demand, so neither needs a
+    /// (re-)announcement.
+    fn has_noa_presign_demand_resolution(&self, demand_id: &NOAPresignDemandId) -> IkaResult<bool>;
 
     /// Marks a presign as used so it cannot be reused.
     fn mark_presign_as_used(
@@ -820,8 +875,14 @@ impl AuthorityPerEpochStoreTrait for AuthorityPerEpochStore {
         next_round_row(&tables.noa_presign_demands, last_consensus_round)
     }
 
-    fn noa_assigned_presign(&self, digest: &[u8; 32]) -> IkaResult<Option<NoaAssignedPresign>> {
-        Ok(self.tables()?.noa_assigned_presigns.get(digest)?)
+    fn noa_presign_demand_resolution(
+        &self,
+        demand_id: &NOAPresignDemandId,
+    ) -> IkaResult<Option<NoaPresignDemandResolution>> {
+        Ok(self
+            .tables()?
+            .noa_presign_demand_resolutions
+            .get(&demand_id.digest())?)
     }
 
     fn assign_presign_for_demand(
@@ -829,7 +890,7 @@ impl AuthorityPerEpochStoreTrait for AuthorityPerEpochStore {
         demand: &PresignDemand,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
+    ) -> IkaResult<PresignAssignmentOutcome> {
         self.tables()?.assign_presign_for_demand(
             demand,
             signature_algorithm,
@@ -837,8 +898,15 @@ impl AuthorityPerEpochStoreTrait for AuthorityPerEpochStore {
         )
     }
 
-    fn has_noa_assigned_presign(&self, digest: &[u8; 32]) -> IkaResult<bool> {
-        Ok(self.tables()?.noa_assigned_presigns.contains_key(digest)?)
+    fn evict_noa_presign_demand(&self, demand_id: &NOAPresignDemandId) -> IkaResult<()> {
+        self.tables()?.evict_noa_presign_demand(demand_id)
+    }
+
+    fn has_noa_presign_demand_resolution(&self, demand_id: &NOAPresignDemandId) -> IkaResult<bool> {
+        Ok(self
+            .tables()?
+            .noa_presign_demand_resolutions
+            .contains_key(&demand_id.digest())?)
     }
 
     fn mark_presign_as_used(
@@ -1512,7 +1580,7 @@ pub struct AuthorityEpochTables {
     /// than peers bound to it — the false-malicious class — for any consumer
     /// that requires pool-head determinism. The NOA path closed this by
     /// batching the pop with an idempotent assignment record (see
-    /// `noa_assigned_presigns` / `assign_presign_for_demand`); the external
+    /// `noa_presign_demand_resolutions` / `assign_presign_for_demand`); the external
     /// `assign_presign` path has not been audited to the same standard.
     /// Do not add a consumer that assumes cross-validator pop identity until
     /// #1928 lands.
@@ -1603,7 +1671,7 @@ pub struct AuthorityEpochTables {
     /// sessions in one batch complete in consensus order, not sequence order),
     /// so a bare re-pop serves a DIFFERENT presign than the never-crashed peers
     /// put in their checkpoint message for the same presign id. Per-epoch, like
-    /// `noa_assigned_presigns`, whose idempotency this mirrors.
+    /// `noa_presign_demand_resolutions`, whose idempotency this mirrors.
     ///
     /// write-discipline: direct — safe because idempotent-replay: written in
     /// the pop's own batch and read back on a re-served sequence number, so a
@@ -1649,12 +1717,14 @@ pub struct AuthorityEpochTables {
     #[default_options_override_fn = "internal_sessions_status_updates_table_default_config"]
     noa_presign_demands: DBMap<Round, Vec<ConsensusNOAPresignDemand>>,
 
-    /// Presign assigned to each NOA sign demand, keyed by the demand's
-    /// `demand_id` digest. Written by the consensus-order drain and read by the
-    /// sign-session instantiation, so all validators pair the same presign with
-    /// the same demand. Value is a [`NoaAssignedPresign`]. Per-epoch (physically
-    /// dropped on rotation) like `used_presigns`; the demand queue that feeds it
-    /// is rebuilt empty when the per-epoch service restarts, and idempotency here
+    /// Terminal resolution of each NOA sign demand, keyed by the demand's
+    /// `demand_id` digest: the presign assigned to it, or a marker that the
+    /// park bound dropped it. Written by the consensus-order drain and read by
+    /// the sign-session instantiation, so all validators pair the same presign
+    /// with the same demand — and give up on the same demands. Value is a
+    /// [`NoaPresignDemandResolution`]. Per-epoch (physically dropped on
+    /// rotation) like `used_presigns`; the demand queue that feeds it is
+    /// rebuilt empty when the per-epoch service restarts, and idempotency here
     /// makes re-drains safe.
     ///
     /// write-discipline: direct — safe because idempotent-replay: keyed by the
@@ -1663,8 +1733,11 @@ pub struct AuthorityEpochTables {
     /// crash returns the recorded assignment instead of popping again. This is
     /// the shape the raw pool tables lack (#1928): the consumer that needs
     /// cross-validator identity — sign-session instantiation — reads THIS
-    /// table, never the pool head.
-    noa_assigned_presigns: DBMap<[u8; 32], NoaAssignedPresign>,
+    /// table, never the pool head. The drop marker needs the same durability
+    /// for the same reason: the pool is not rewound by the replay, so a drop
+    /// held only in memory would let the replayed drain pop for a demand the
+    /// committee had already abandoned.
+    noa_presign_demand_resolutions: DBMap<[u8; 32], NoaPresignDemandResolution>,
 
     /// Tracks presigns that have been consumed for signing.
     /// Key: (SessionIdentifier, blending_index) - uniquely identifies a single presign within
@@ -1689,7 +1762,7 @@ pub struct AuthorityEpochTables {
     /// `assign_presign`'s pop batch (so an assignment can never exist without
     /// its pool removal), but that batch is the pool's own, not the consuming
     /// commit's — so WHICH presign a replayed assignment binds inherits the
-    /// pool's re-pop exposure. Unlike `noa_assigned_presigns` the key is the
+    /// pool's re-pop exposure. Unlike `noa_presign_demand_resolutions` the key is the
     /// popped presign, not the request, so a re-pop yields a new row rather
     /// than hitting an idempotence guard.
     #[default_options_override_fn = "assigned_presign_pool_table_default_config"]
@@ -2138,26 +2211,54 @@ impl AuthorityEpochTables {
     /// between the two writes: the pool would be advanced with no record of
     /// where the presign went, so the replay would pop again — the very
     /// divergence the identity key exists to prevent.
+    /// A NOA demand carries a second terminal outcome the global arm has no
+    /// equivalent of: the park bound can DROP it (see
+    /// [`NoaPresignDemandResolution`]). That drop is recorded in the same
+    /// per-demand table as its assignment, so this method reports it rather
+    /// than popping — which is what stops a restart's replay from assigning a
+    /// presign for a demand the whole committee already gave up on.
     pub fn assign_presign_for_demand(
         &self,
         demand: &PresignDemand,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
-        // Already assigned? Return it; never pop again.
+    ) -> IkaResult<PresignAssignmentOutcome> {
+        // Already resolved? Report it; never pop again.
         match demand {
             PresignDemand::GlobalRequest {
                 session_sequence_number,
             } => {
-                if let Some(served) = self.served_global_presigns.get(session_sequence_number)? {
-                    return Ok(Some(served));
+                if let Some((session_identifier, blending_index, presign)) =
+                    self.served_global_presigns.get(session_sequence_number)?
+                {
+                    return Ok(PresignAssignmentOutcome::Assigned {
+                        session_identifier,
+                        blending_index,
+                        presign,
+                    });
                 }
             }
             PresignDemand::Noa { demand_id } => {
-                if let Some((session_identifier, blending_index, presign, _)) =
-                    self.noa_assigned_presigns.get(&demand_id.digest())?
+                match self
+                    .noa_presign_demand_resolutions
+                    .get(&demand_id.digest())?
                 {
-                    return Ok(Some((session_identifier, blending_index, presign)));
+                    Some(NoaPresignDemandResolution::Assigned {
+                        session_identifier,
+                        blending_index,
+                        presign,
+                        ..
+                    }) => {
+                        return Ok(PresignAssignmentOutcome::Assigned {
+                            session_identifier,
+                            blending_index,
+                            presign,
+                        });
+                    }
+                    Some(NoaPresignDemandResolution::Evicted) => {
+                        return Ok(PresignAssignmentOutcome::Evicted);
+                    }
+                    None => {}
                 }
             }
         }
@@ -2165,7 +2266,7 @@ impl AuthorityEpochTables {
         let Some((mut batch, session_identifier, blending_index, presign)) =
             self.prepare_pop_presign(signature_algorithm, dwallet_network_encryption_key_id)?
         else {
-            return Ok(None);
+            return Ok(PresignAssignmentOutcome::PoolEmpty);
         };
 
         match demand {
@@ -2182,15 +2283,15 @@ impl AuthorityEpochTables {
             }
             PresignDemand::Noa { demand_id } => {
                 batch.insert_batch(
-                    &self.noa_assigned_presigns,
+                    &self.noa_presign_demand_resolutions,
                     [(
                         &demand_id.digest(),
-                        &(
+                        &NoaPresignDemandResolution::Assigned {
                             session_identifier,
                             blending_index,
-                            presign.clone(),
-                            dwallet_network_encryption_key_id,
-                        ),
+                            presign: presign.clone(),
+                            network_encryption_key_id: dwallet_network_encryption_key_id,
+                        },
                     )],
                 )?;
                 // Mark the popped presign used, in the SAME batch as the
@@ -2206,7 +2307,11 @@ impl AuthorityEpochTables {
             }
         }
         batch.write()?;
-        Ok(Some((session_identifier, blending_index, presign)))
+        Ok(PresignAssignmentOutcome::Assigned {
+            session_identifier,
+            blending_index,
+            presign,
+        })
     }
 
     /// Prepares a presign pop without committing, returning the uncommitted batch.
@@ -2391,6 +2496,24 @@ impl AuthorityEpochTables {
         batch.write()?;
 
         Ok(Some((session_identifier, blending_index)))
+    }
+
+    /// Durably record that the park bound dropped a NOA sign demand.
+    ///
+    /// Idempotent, and never replaces an existing resolution: an assignment
+    /// already recorded for this demand is the truth the whole committee holds,
+    /// and a second drop marker is the same fact written twice. The read and
+    /// the write need not be one batch — the drain is the single writer of this
+    /// table, and it only calls this after the same round's
+    /// `assign_presign_for_demand` reported an empty pool.
+    pub fn evict_noa_presign_demand(&self, demand_id: &NOAPresignDemandId) -> IkaResult<()> {
+        let digest = demand_id.digest();
+        if self.noa_presign_demand_resolutions.contains_key(&digest)? {
+            return Ok(());
+        }
+        Ok(self
+            .noa_presign_demand_resolutions
+            .insert(&digest, &NoaPresignDemandResolution::Evicted)?)
     }
 
     /// Retrieves an assigned presign by session identifier, blending index, and signature algorithm.
@@ -8481,7 +8604,7 @@ mod tests {
                 }
                 PresignPoolRound::Serve {
                     request_sequence_number,
-                } => Some(
+                } => Some(bound_presign(
                     tables
                         .assign_presign_for_demand(
                             &PresignDemand::GlobalRequest {
@@ -8490,11 +8613,21 @@ mod tests {
                             signature_algorithm,
                             dwallet_network_encryption_key_id,
                         )
-                        .unwrap()
-                        .map(|(_, _, presign)| presign),
-                ),
+                        .unwrap(),
+                )),
             })
             .collect()
+    }
+
+    /// The presign a drain bound to the demand, or `None` if it bound none —
+    /// an empty pool, or (NOA only) a demand the park bound dropped. These
+    /// tests compare WHICH presign a demand got, so the identifiers the
+    /// outcome also carries are not part of the comparison.
+    fn bound_presign(outcome: PresignAssignmentOutcome) -> Option<Vec<u8>> {
+        match outcome {
+            PresignAssignmentOutcome::Assigned { presign, .. } => Some(presign),
+            PresignAssignmentOutcome::PoolEmpty | PresignAssignmentOutcome::Evicted => None,
+        }
     }
 
     /// The DWallet MPC service replays EVERY consensus round of the epoch after
@@ -8556,26 +8689,28 @@ mod tests {
         // resurrected already-served presigns and handed one to a second
         // on-chain presign id.
         let fresh_request_sequence_number = 13;
-        let crashed_fresh = crashed
-            .assign_presign_for_demand(
-                &PresignDemand::GlobalRequest {
-                    session_sequence_number: fresh_request_sequence_number,
-                },
-                signature_algorithm,
-                key_id,
-            )
-            .unwrap()
-            .map(|(_, _, presign)| presign);
-        let control_fresh = control
-            .assign_presign_for_demand(
-                &PresignDemand::GlobalRequest {
-                    session_sequence_number: fresh_request_sequence_number,
-                },
-                signature_algorithm,
-                key_id,
-            )
-            .unwrap()
-            .map(|(_, _, presign)| presign);
+        let crashed_fresh = bound_presign(
+            crashed
+                .assign_presign_for_demand(
+                    &PresignDemand::GlobalRequest {
+                        session_sequence_number: fresh_request_sequence_number,
+                    },
+                    signature_algorithm,
+                    key_id,
+                )
+                .unwrap(),
+        );
+        let control_fresh = bound_presign(
+            control
+                .assign_presign_for_demand(
+                    &PresignDemand::GlobalRequest {
+                        session_sequence_number: fresh_request_sequence_number,
+                    },
+                    signature_algorithm,
+                    key_id,
+                )
+                .unwrap(),
+        );
         assert!(
             !control_served.contains(&crashed_fresh),
             "the replay must not resurrect an already-served presign into the pool: \
@@ -8644,14 +8779,16 @@ mod tests {
 
             let first = tables
                 .assign_presign_for_demand(&demand, algorithm, key_id)
-                .unwrap()
-                .expect("pool is non-empty");
+                .unwrap();
+            assert!(
+                matches!(first, PresignAssignmentOutcome::Assigned { .. }),
+                "{demand:?}: the pool is non-empty, so the demand must be assigned"
+            );
             let pool_after_first = tables.presign_pool_size(algorithm, key_id).unwrap();
 
             let second = tables
                 .assign_presign_for_demand(&demand, algorithm, key_id)
-                .unwrap()
-                .expect("a re-seen demand still resolves");
+                .unwrap();
 
             assert_eq!(
                 first, second,
@@ -8671,20 +8808,32 @@ mod tests {
             // key id (the sign must instantiate under the SAME key the presign
             // came from).
             if let PresignDemand::Noa { demand_id } = &demand {
-                let (session_identifier, blending_index, _) = first;
+                let PresignAssignmentOutcome::Assigned {
+                    session_identifier,
+                    blending_index,
+                    ..
+                } = first
+                else {
+                    panic!("{demand:?}: expected an assignment, found {first:?}");
+                };
                 assert!(
                     tables
                         .is_presign_used(session_identifier, blending_index)
                         .unwrap(),
                     "the NOA arm must mark its popped presign used"
                 );
-                let (_, _, _, recorded_key_id) = tables
-                    .noa_assigned_presigns
+                let Some(NoaPresignDemandResolution::Assigned {
+                    network_encryption_key_id,
+                    ..
+                }) = tables
+                    .noa_presign_demand_resolutions
                     .get(&demand_id.digest())
                     .unwrap()
-                    .expect("the assignment was recorded");
+                else {
+                    panic!("the assignment was recorded as this demand's resolution");
+                };
                 assert_eq!(
-                    recorded_key_id, key_id,
+                    network_encryption_key_id, key_id,
                     "the assignment must record the network key the presign came from"
                 );
             }

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -188,6 +188,18 @@ pub struct DWalletMPCMetrics {
     /// can compute serve rate vs top-up rate and predict exhaustion.
     pub(crate) global_presigns_served_total: IntCounterVec,
 
+    /// Network-owned-address presign demands dropped from the assignment
+    /// drain because they stayed unassigned for the whole park bound, by
+    /// signature_algorithm.
+    ///
+    /// A demand parks when no presign pool exists for the network encryption
+    /// key its announcement named, and is retried every consensus round until
+    /// the bound. Any non-zero value means a demand's sign did not happen in
+    /// that epoch: either a committee member announced a key the network never
+    /// adopts, or a key legitimately took longer than the bound to arrive.
+    /// Both are worth an alert.
+    pub(crate) noa_presign_demands_evicted_total: IntCounterVec,
+
     /// Duration of each network-key instantiation sub-call (per-curve
     /// protocol/decryption-share public parameters + NOA DKG outputs), for
     /// both the network-DKG and reconfiguration instantiation paths.
@@ -635,6 +647,14 @@ impl DWalletMPCMetrics {
             global_presigns_served_total: register_int_counter_vec_with_registry!(
                 "ika_dwallet_mpc_global_presigns_served_total",
                 "Global presign requests served from the internal pool",
+                &["signature_algorithm"],
+                registry
+            )
+            .unwrap(),
+            noa_presign_demands_evicted_total: register_int_counter_vec_with_registry!(
+                "ika_dwallet_mpc_noa_presign_demands_evicted_total",
+                "Network-owned-address presign demands dropped from the assignment drain \
+                 after staying unassigned for the whole park bound",
                 &["signature_algorithm"],
                 registry
             )

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -7,7 +7,10 @@
 //! and forward them to the [`DWalletMPCManager`].
 
 use crate::SuiDataReceivers;
-use crate::authority::authority_per_epoch_store::{AuthorityPerEpochStoreTrait, PresignDemand};
+use crate::authority::authority_per_epoch_store::{
+    AuthorityPerEpochStoreTrait, NoaPresignDemandResolution, PresignAssignmentOutcome,
+    PresignDemand,
+};
 use crate::authority::{AuthorityState, AuthorityStateTrait};
 use crate::consensus_manager::ReplayWaiter;
 use crate::dwallet_checkpoints::{
@@ -85,6 +88,56 @@ const FIVE_KILO_BYTES: usize = 5 * 1024;
 
 pub const NETWORK_OWNED_ADDRESS_SIGN_CHANNEL_CAPACITY: usize = 1024;
 
+/// How many consensus rounds a network-owned-address presign demand may stay
+/// parked in the assignment drain before it is dropped.
+///
+/// A demand carries the network encryption key it was announced under, and the
+/// presign pool is keyed by that id, so a demand naming a key this validator
+/// holds no pool for cannot be assigned. It parks (kept in consensus-delivery
+/// order, retried every round) rather than being rejected, because honest
+/// validators do transiently hold different adopted key sets and a local
+/// reject would turn that lag into a permanent drop — the reasoning is in
+/// `dev-docs/specs/internal-presign-pool.md`. Without an upper bound, a demand
+/// naming a key NO validator will ever adopt parks for the rest of the epoch
+/// and blocks that epoch's NOA checkpoint finalization.
+///
+/// Rounds, not wall clock, so the drop decision is identical on every
+/// validator (see the drain in `process_consensus_rounds_from_storage`).
+///
+/// The value is ~1 hour of mainnet consensus at ~19.5 rounds/s (the rate the
+/// catch-up gate is calibrated against — see `CATCH_UP_ENTER_GAP_ROUNDS`).
+/// That sits far above every window in which an honest validator can still be
+/// missing a key or its pool:
+/// - the network-key syncer re-merges the overlay every 5s (~100 rounds);
+/// - a restarting or joining validator recovers a stranded key by chain read
+///   and then instantiates class groups for it — minutes, so at most low tens
+///   of thousands of rounds;
+/// - a freshly adopted key's presign pool is filled by internal-presign MPC,
+///   again minutes.
+///
+/// And far below the epoch it has to fit inside: a 24h epoch is ~1.7M rounds,
+/// so the bound spends ~4% of an epoch waiting before giving up on a demand.
+///
+/// A compile-time constant is safe only while demands cannot reach the wire:
+/// announcements are gated on `noa_checkpoints()`, which is off on every live
+/// network, so no committee can currently be split across two values of it.
+/// Once that flag is on, changing this number is a consensus-affecting change
+/// — validators running different values would drop different demands — and
+/// it has to move into `ProtocolConfig`, where a change is version-gated
+/// rather than binary-driven.
+const NOA_PRESIGN_DEMAND_PARK_ROUNDS: u64 = 70_000;
+
+/// A consensus-agreed NOA presign demand waiting in the assignment drain,
+/// together with the consensus round that delivered it.
+///
+/// The delivery round is what the park bound measures from. It comes from the
+/// consensus stream, so it holds the same value on every validator, and it
+/// rebuilds identically when a restarted validator replays the epoch's rounds.
+struct ParkedNOAPresignDemand {
+    demand: ConsensusNOAPresignDemand,
+    delivered_at_consensus_round: Round,
+}
+
 fn diagnostic_output_digest(message: &ConsensusTransaction) -> Option<[u8; 32]> {
     let report = match &message.kind {
         ConsensusTransactionKind::DWalletMPCOutput(output) => {
@@ -159,17 +212,26 @@ pub struct DWalletMPCService {
     ///
     /// These three fields are per-epoch: they rebuild empty when the per-epoch
     /// service is reconstructed at an epoch boundary. The presign pool and the
-    /// `noa_assigned_presigns` table they feed are also per-epoch, so a rebuild
-    /// simply re-announces any still-pending demand (consensus dedup and the
-    /// idempotent assignment table absorb the duplicate).
+    /// `noa_presign_demand_resolutions` table they feed are also per-epoch, so a
+    /// rebuild simply re-announces any still-pending demand (consensus dedup and
+    /// the idempotent resolution table absorb the duplicate) — while a demand
+    /// the drain already resolved is not re-announced at all, because that
+    /// resolution outlives the rebuild.
     buffered_noa_presign_demands: Vec<ConsensusNOAPresignDemand>,
     /// NOA sign presign demands agreed via consensus, drained in
     /// consensus-delivery order to assign each a presign (kept across rounds
-    /// when the pool is momentarily empty).
-    agreed_noa_presign_demands_queue: Vec<ConsensusNOAPresignDemand>,
+    /// when the pool is momentarily empty, up to
+    /// [`NOA_PRESIGN_DEMAND_PARK_ROUNDS`]).
+    agreed_noa_presign_demands_queue: Vec<ParkedNOAPresignDemand>,
     /// Digests of demands this validator has already announced this epoch, so it
     /// announces each demand at most once.
     announced_noa_demand_digests: HashSet<[u8; 32]>,
+    /// Consensus rounds a demand may stay parked before the drain drops it.
+    /// [`NOA_PRESIGN_DEMAND_PARK_ROUNDS`] in production; only tests override
+    /// it. The value is part of a consensus-uniform predicate, so every
+    /// validator must run the same one — it is deliberately NOT node
+    /// configuration.
+    noa_presign_demand_park_rounds: u64,
     /// Receiver for sign outputs from MPC manager to route to NOA checkpoint handlers.
     network_owned_address_sign_output_receiver:
         tokio::sync::mpsc::Receiver<NetworkOwnedAddressSignOutput>,
@@ -292,6 +354,7 @@ impl DWalletMPCService {
             buffered_noa_presign_demands: Vec::new(),
             agreed_noa_presign_demands_queue: Vec::new(),
             announced_noa_demand_digests: HashSet::new(),
+            noa_presign_demand_park_rounds: NOA_PRESIGN_DEMAND_PARK_ROUNDS,
             network_owned_address_sign_output_receiver,
             dwallet_checkpoint_handler,
             system_checkpoint_handler,
@@ -377,6 +440,7 @@ impl DWalletMPCService {
             buffered_noa_presign_demands: Vec::new(),
             agreed_noa_presign_demands_queue: Vec::new(),
             announced_noa_demand_digests: HashSet::new(),
+            noa_presign_demand_park_rounds: NOA_PRESIGN_DEMAND_PARK_ROUNDS,
             network_owned_address_sign_output_receiver: tokio::sync::mpsc::channel(
                 NETWORK_OWNED_ADDRESS_SIGN_CHANNEL_CAPACITY,
             )
@@ -426,6 +490,28 @@ impl DWalletMPCService {
     #[allow(dead_code)]
     pub(crate) fn last_read_consensus_round(&self) -> Option<Round> {
         self.last_read_consensus_round
+    }
+
+    /// Shrinks the demand park bound so a test can reach it in a handful of
+    /// rounds instead of [`NOA_PRESIGN_DEMAND_PARK_ROUNDS`]. Never call this
+    /// outside tests: validators that disagree on the bound disagree on which
+    /// demands were dropped.
+    #[cfg(test)]
+    pub(crate) fn set_noa_presign_demand_park_rounds_for_testing(&mut self, rounds: u64) {
+        self.noa_presign_demand_park_rounds = rounds;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn dwallet_mpc_metrics(&self) -> &Arc<DWalletMPCMetrics> {
+        &self.dwallet_mpc_metrics
+    }
+
+    /// How many consensus-agreed demands are still parked in the assignment
+    /// drain — what tells a demand still waiting for its presign pool apart
+    /// from one the park bound already dropped.
+    #[cfg(test)]
+    pub(crate) fn parked_noa_presign_demand_count(&self) -> usize {
+        self.agreed_noa_presign_demands_queue.len()
     }
 
     #[cfg(any(test, feature = "test-utils"))]
@@ -689,8 +775,10 @@ impl DWalletMPCService {
         // reach a peer that predates it — and on the signing network key being
         // known (the demand carries its id, and the presign pool is keyed by it;
         // announcing before adoption would let validators disagree on the key).
-        // Announce each demand at most once; one already assigned a presign needs
-        // no (re-)announcement. Do NOT pop/instantiate here.
+        // Announce each demand at most once; one the drain already resolved —
+        // assigned a presign, or dropped at the park bound — needs no
+        // (re-)announcement, and the resolution is durable, so this holds after
+        // a restart too. Do NOT pop/instantiate here.
         if self.protocol_config.noa_checkpoints()
             && let Some(network_encryption_key_id) = self
                 .dwallet_mpc_manager
@@ -701,9 +789,12 @@ impl DWalletMPCService {
                 if self.announced_noa_demand_digests.contains(&digest) {
                     continue;
                 }
-                match self.epoch_store.has_noa_assigned_presign(&digest) {
+                match self
+                    .epoch_store
+                    .has_noa_presign_demand_resolution(&request.demand_id)
+                {
                     Ok(true) => {
-                        // Already assigned — no (re-)announcement needed.
+                        // Already resolved — no (re-)announcement needed.
                         self.announced_noa_demand_digests.insert(digest);
                         continue;
                     }
@@ -715,9 +806,9 @@ impl DWalletMPCService {
                         // announce anyway — the consensus-ordered drain is
                         // idempotent, so a redundant announcement is harmless.
                         ika_types::report_invariant_violation!(
-                            "noa_assigned_presign_read",
+                            "noa_presign_demand_resolution_read",
                             error=?e,
-                            "failed to read NOA assigned-presign state during announcement; announcing anyway"
+                            "failed to read NOA presign-demand resolution during announcement; announcing anyway"
                         );
                     }
                 }
@@ -734,29 +825,67 @@ impl DWalletMPCService {
         let mut newly_submitted: Vec<[u8; 32]> = Vec::new();
         self.pending_network_owned_address_sign_requests
             .retain(|request| {
-                if !self
-                    .dwallet_mpc_manager
-                    .has_network_owned_address_signing_network_key()
-                {
-                    return true; // key not yet available, keep in buffer
-                }
-
-                // Instantiate only once this demand's presign has been assigned
-                // in consensus order (written to `noa_assigned_presigns` by the
-                // drain). Until then keep the request pending; never pop the pool
-                // here — that reintroduces the local-order pairing this fix
-                // removes. The raw presign and the network key it was popped
-                // from are both read from the assignment, so the sign
-                // instantiates under the SAME key the presign came from (never a
-                // locally re-resolved key that could have shifted since announce).
                 let digest = request.demand_id.digest();
-                match self.epoch_store.noa_assigned_presign(&digest) {
-                    Ok(Some((
-                        presign_session_id,
-                        presign_blending_index,
+                // A request is driven entirely by its demand's DURABLE
+                // resolution: instantiate on an assignment, release on a drop,
+                // wait while there is neither. Reading the drop from the store
+                // rather than from process memory is what keeps this working
+                // across a restart, which is also where the resolution itself
+                // has to be durable (see `NoaPresignDemandResolution`).
+                //
+                // Only the assignment path needs the signing network key
+                // locally; a release must not wait on it, or a validator that
+                // never adopts the key would hold the request forever.
+                let resolution = match self
+                    .epoch_store
+                    .noa_presign_demand_resolution(&request.demand_id)
+                {
+                    Ok(resolution) => resolution,
+                    Err(e) => {
+                        error!(error = ?e, "failed to read NOA presign-demand resolution; keeping request pending");
+                        return true;
+                    }
+                };
+                match resolution {
+                    // The demand was dropped at the park bound: no presign will
+                    // ever be assigned to it this epoch, so keeping the request
+                    // only feeds the starvation warn below forever. Recovery,
+                    // where it exists at all, comes from a HIGHER layer minting
+                    // a FRESH demand id — a checkpoint demand carries its retry
+                    // round, so a retry is a different demand with a different
+                    // consensus dedup key — and today that only happens after
+                    // an on-chain failure quorum. A dropped checkpoint sign
+                    // therefore stays unsigned for the rest of the epoch.
+                    Some(NoaPresignDemandResolution::Evicted) => {
+                        warn!(
+                            demand_id = ?request.demand_id,
+                            demand_id_digest = hex::encode(digest),
+                            "releasing a pending network-owned-address sign request whose presign \
+                             demand was dropped at the park bound; it will not be signed this epoch"
+                        );
+                        false
+                    }
+                    // Instantiate only once this demand's presign has been
+                    // assigned in consensus order (written to
+                    // `noa_presign_demand_resolutions` by the drain); never pop
+                    // the pool here — that reintroduces the local-order pairing
+                    // this fix removes. The raw presign and the network key it
+                    // was popped from are both read from the assignment, so the
+                    // sign instantiates under the SAME key the presign came from
+                    // (never a locally re-resolved key that could have shifted
+                    // since announce).
+                    Some(NoaPresignDemandResolution::Assigned {
+                        session_identifier,
+                        blending_index,
                         presign,
                         network_encryption_key_id,
-                    ))) => {
+                    }) => {
+                        if !self
+                            .dwallet_mpc_manager
+                            .has_network_owned_address_signing_network_key()
+                        {
+                            return true; // key not yet available, keep in buffer
+                        }
                         let instantiated = self
                             .dwallet_mpc_manager
                             .instantiate_network_owned_address_sign_session(
@@ -764,8 +893,8 @@ impl DWalletMPCService {
                                 request.curve,
                                 request.demand_id.expected_signature_algorithm(),
                                 request.hash_scheme,
-                                presign_session_id,
-                                presign_blending_index,
+                                session_identifier,
+                                blending_index,
                                 presign,
                                 network_encryption_key_id,
                             );
@@ -774,11 +903,8 @@ impl DWalletMPCService {
                         }
                         !instantiated // keep in buffer if instantiation failed
                     }
-                    Ok(None) => true, // presign not yet assigned in consensus order
-                    Err(e) => {
-                        error!(error = ?e, "failed to read NOA assigned presign; keeping request pending");
-                        true
-                    }
+                    // Not yet resolved in consensus order — keep waiting.
+                    None => true,
                 }
             });
         // Starvation signal: requests are waiting and this pass made no
@@ -1627,7 +1753,7 @@ impl DWalletMPCService {
                         request.signature_algorithm,
                         request.dwallet_network_encryption_key_id,
                     ) {
-                        Ok(Some((_presign_session_id, _presign_blending_index, presign))) => {
+                        Ok(PresignAssignmentOutcome::Assigned { presign, .. }) => {
                             match bcs::to_bytes(&VersionedPresignOutput::V2(presign)) {
                                 Ok(presign) => {
                                     // Info on purpose: a pool-served presign
@@ -1688,8 +1814,23 @@ impl DWalletMPCService {
                                 }
                             }
                         }
-                        Ok(None) => {
+                        Ok(PresignAssignmentOutcome::PoolEmpty) => {
                             // No presign available in internal pool - keep in queue (return true)
+                            true
+                        }
+                        Ok(PresignAssignmentOutcome::Evicted) => {
+                            // Unreachable by construction: only a NOA demand can
+                            // be dropped at the park bound, and only the NOA arm
+                            // of the resolution table records such a drop. A
+                            // global request reaching this arm means the two
+                            // marker tables were crossed, so say so loudly and
+                            // keep the request rather than answering it wrong.
+                            ika_types::report_invariant_violation!(
+                                "global_presign_request_evicted",
+                                session_sequence_number = request.session_sequence_number,
+                                "a global presign request resolved as dropped-at-the-park-bound, \
+                                 which only a NOA demand can be — keeping it queued"
+                            );
                             true
                         }
                         Err(e) => {
@@ -1717,8 +1858,9 @@ impl DWalletMPCService {
 
             // NOA sign presign demands: assign each a presign in consensus-
             // delivery order, so the sign session that later reads
-            // `noa_assigned_presigns` pairs the SAME presign with the SAME demand
-            // on every validator. This is the determinism crux of the fix:
+            // `noa_presign_demand_resolutions` pairs the SAME presign with the
+            // SAME demand on every validator. This is the determinism crux of
+            // the fix:
             //   (a) every validator processes consensus rounds in identical order
             //       (this loop reads the per-round DB stream in ascending
             //       round order);
@@ -1727,16 +1869,33 @@ impl DWalletMPCService {
             //       order, so demands drain in consensus order;
             //   (d) the presign pool is network-uniform (keyed by the
             //       consensus-assigned presign sequence), so popping in the same
-            //       order yields the same presign per demand on every validator.
-            // `assign_presign_for_demand` is atomic + idempotent: it pops and records
-            // in one committed batch, and returns an already-assigned demand
+            //       order yields the same presign per demand on every validator;
+            //   (e) a demand that stays unassigned is dropped on a predicate
+            //       built only from (a)-(d): its consensus delivery round, the
+            //       consensus round being drained, and whether the pool of
+            //       (a)-(d) could serve it. Nothing per-validator — not the
+            //       locally adopted key set, not the network-key overlay, not
+            //       wall clock — enters it, so every validator drops the same
+            //       demand at the same round. A drop decided on local state
+            //       would put back exactly the disagreement this queue exists
+            //       to remove.
+            // `assign_presign_for_demand` is atomic + idempotent: it pops and
+            // records in one committed batch, and reports an already-resolved demand
             // without popping again (so re-delivery, and a re-drain after a
-            // consensus-round replay, are both safe). Keeping a demand when the
-            // pool is momentarily empty (`Ok(None)` => keep) preserves ordering
-            // across rounds until its presign is generated. Both the queue and
-            // the assignment table it writes are per-epoch (the queue rebuilds
+            // consensus-round replay, are both safe). Keeping a demand while the
+            // pool is empty (`PoolEmpty` => keep) preserves ordering across
+            // rounds until its presign is generated, up to
+            // `noa_presign_demand_park_rounds`. Both the queue and the
+            // resolution table it writes are per-epoch (the queue rebuilds
             // empty on the per-epoch service restart; the table is physically
-            // dropped on epoch rotation).
+            // dropped on epoch rotation), and so are the delivery rounds
+            // recorded here — a replay of the epoch's rounds rebuilds them
+            // identically. The RESOLUTION, however, must survive that replay
+            // rather than be recomputed: the pool is not rewound with the
+            // rounds, so a demand this validator dropped while its key had no
+            // pool would be re-read against a pool that has since filled. Both
+            // outcomes are therefore written to the same durable per-demand
+            // table, and the replay reads them instead of deciding again.
             //
             // The assignment step reads ONLY the consensus-delivered demand
             // queue and the consensus-generated presign pool — there is no
@@ -1749,10 +1908,21 @@ impl DWalletMPCService {
             // assignment), so the key is fully consensus-uniform — it does not
             // rest on the announce-time and instantiate-time key resolutions
             // agreeing.
-            self.agreed_noa_presign_demands_queue
-                .extend(noa_presign_demand_messages);
+            self.agreed_noa_presign_demands_queue.extend(
+                noa_presign_demand_messages
+                    .into_iter()
+                    .map(|demand| ParkedNOAPresignDemand {
+                        demand,
+                        delivered_at_consensus_round: consensus_round,
+                    }),
+            );
             if !self.agreed_noa_presign_demands_queue.is_empty() {
-                self.agreed_noa_presign_demands_queue.retain(|demand| {
+                let park_rounds = self.noa_presign_demand_park_rounds;
+                self.agreed_noa_presign_demands_queue.retain(|parked| {
+                    let ParkedNOAPresignDemand {
+                        demand,
+                        delivered_at_consensus_round,
+                    } = parked;
                     // Atomic + idempotent (see `assign_presign_for_demand`): pops a
                     // presign and records the assignment (raw presign + the
                     // demand's network key id) in ONE committed batch, or
@@ -1760,10 +1930,11 @@ impl DWalletMPCService {
                     // and the record MUST be one commit — a crash between a
                     // self-committed pop and a separate record would let a
                     // re-drain after a consensus-round replay pop a different
-                    // presign than peers assigned. `Ok(Some(_))` => assigned (or
-                    // already assigned) — drop; `Ok(None)` => pool momentarily
-                    // empty — keep, preserving order across rounds until the
-                    // presign is generated; `Err` => keep for retry.
+                    // presign than peers assigned. `Assigned` (just now, or by
+                    // an earlier drain) and `Evicted` are both terminal — drop
+                    // from the queue; `PoolEmpty` => keep, preserving order
+                    // across rounds until the presign is generated or the park
+                    // bound expires; `Err` => keep for retry.
                     // The algorithm comes from the demand IDENTITY, never from
                     // the announcement: the consensus dedup key is the
                     // demand-id digest alone, so the first announcement
@@ -1776,15 +1947,27 @@ impl DWalletMPCService {
                     // cannot disagree with the session instantiated from the
                     // same id.
                     //
-                    // `network_encryption_key_id` is the field this reasoning
-                    // does NOT yet cover: it is not derivable from the
-                    // identity (frozen at announce time on purpose, so the
-                    // assignment does not rest on the announce-time and
+                    // `network_encryption_key_id` is NOT derivable from the
+                    // identity (it is frozen at announce time on purpose, so
+                    // the assignment does not rest on the announce-time and
                     // instantiate-time key resolutions agreeing), so it stays
-                    // announcer-supplied behind the same dedup key.
-                    // TODO(#2019): close that half — the shape it wants is
-                    // park-rather-than-reject, pending the adopted-key-skew
-                    // question.
+                    // announcer-supplied behind the same dedup key. It is
+                    // deliberately NOT validated against the locally adopted
+                    // key set: honest validators transiently hold different
+                    // adopted sets (every epoch start has such a window), so a
+                    // local reject would drop honest demands. A demand naming a
+                    // key this validator has no pool for therefore parks, in
+                    // order, and is retried every round — and is dropped only
+                    // once it has been parked for `park_rounds` consensus
+                    // rounds, which is what stops a demand naming a key nobody
+                    // will ever adopt from parking for the whole epoch and
+                    // blocking that epoch's NOA checkpoint finalization. The
+                    // bound cannot tell that case apart from a key still on its
+                    // way, because no consensus-uniform signal distinguishes
+                    // them; it is sized so that no honest window comes near it
+                    // (see `NOA_PRESIGN_DEMAND_PARK_ROUNDS`), and
+                    // `dev-docs/specs/internal-presign-pool.md` records why
+                    // parking-with-a-bound is the only safe shape here.
                     match self.epoch_store.assign_presign_for_demand(
                         &PresignDemand::Noa {
                             demand_id: demand.demand_id.clone(),
@@ -1792,8 +1975,70 @@ impl DWalletMPCService {
                         demand.demand_id.expected_signature_algorithm(),
                         demand.network_encryption_key_id,
                     ) {
-                        Ok(Some(_)) => false,
-                        Ok(None) => true,
+                        Ok(PresignAssignmentOutcome::Assigned { .. }) => false,
+                        // Dropped by an earlier round of this same stream and
+                        // recorded durably, so this is a re-drain (a restart
+                        // replaying the epoch's rounds). Terminal already: leave
+                        // the store alone, and do not re-log or re-count what
+                        // the original pass already reported.
+                        Ok(PresignAssignmentOutcome::Evicted) => {
+                            debug!(
+                                demand_id = ?demand.demand_id,
+                                demand_id_digest = hex::encode(demand.demand_id_digest()),
+                                "replayed a NOA presign demand that was already dropped at the \
+                                 park bound; leaving it dropped"
+                            );
+                            false
+                        }
+                        Ok(PresignAssignmentOutcome::PoolEmpty) => {
+                            let parked_rounds =
+                                consensus_round.saturating_sub(*delivered_at_consensus_round);
+                            if parked_rounds < park_rounds {
+                                return true;
+                            }
+                            // Record the drop DURABLY before dropping the demand
+                            // from the queue. The pool is not rewound by a
+                            // replay, so a drop kept only in memory would let a
+                            // restart re-read this demand at its delivery round
+                            // against a pool that filled after the drop and pop
+                            // for a demand every peer abandoned. On a write
+                            // error, keep the demand and retry next round —
+                            // the same failure posture as an assignment error.
+                            if let Err(e) =
+                                self.epoch_store.evict_noa_presign_demand(&demand.demand_id)
+                            {
+                                error!(
+                                    error = ?e,
+                                    demand_id = ?demand.demand_id,
+                                    "failed to record a NOA presign demand's drop — keeping it \
+                                     parked for retry"
+                                );
+                                return true;
+                            }
+                            self.dwallet_mpc_metrics
+                                .noa_presign_demands_evicted_total
+                                .with_label_values(&[&format!(
+                                    "{:?}",
+                                    demand.demand_id.expected_signature_algorithm()
+                                )])
+                                .inc();
+                            error!(
+                                demand_id = ?demand.demand_id,
+                                demand_id_digest = hex::encode(demand.demand_id_digest()),
+                                network_encryption_key_id = ?demand.network_encryption_key_id,
+                                announcing_authority = ?demand.authority,
+                                delivered_at_consensus_round,
+                                eviction_consensus_round = consensus_round,
+                                parked_rounds,
+                                "dropping a NOA presign demand that stayed unassigned for the \
+                                 whole park bound: no presign pool exists for the network \
+                                 encryption key its announcement named. This demand's sign will \
+                                 NOT happen in this epoch — either the announcer named a key the \
+                                 network never adopts, or that key took longer than the bound to \
+                                 arrive"
+                            );
+                            false
+                        }
                         Err(e) => {
                             ika_types::report_invariant_violation!(
                                 "noa_presign_assignment",

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
@@ -15,6 +15,7 @@ mod network_dkg;
 mod network_key_adoption;
 mod network_owned_address_sign;
 mod noa_checkpoint;
+mod noa_signing_key_skew;
 mod presign_consensus;
 mod session;
 mod sign;

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
@@ -10,7 +10,9 @@
 //! 3. Network-owned-address sign session triggering
 //! 4. Signature verification against the network key
 
-use crate::authority::authority_per_epoch_store::AuthorityPerEpochStoreTrait;
+use crate::authority::authority_per_epoch_store::{
+    AuthorityPerEpochStoreTrait, NoaPresignDemandResolution,
+};
 use crate::dwallet_mpc::NetworkOwnedAddressSignRequest;
 use crate::dwallet_mpc::crytographic_computation::mpc_computations::network_owned_address_sign_dkg_emulation::network_owned_address_sign_dkg_session_identifier;
 use crate::dwallet_mpc::mpc_session::{SessionComputationType, SessionStatus};
@@ -29,9 +31,37 @@ use ika_types::noa_checkpoint::{NOACheckpointKindName, NOACheckpointTxRef, NOAPr
 use ika_types::messages_dwallet_mpc::{ConsensusNOAPresignDemand,
     DWalletMPCOutput, DWalletMPCOutputReport, SessionIdentifier, SessionType,
 };
-use std::collections::HashSet;
+use crate::validator_metadata::OffChainCommitteeBundles;
+use dwallet_rng::RootSeed;
+use ika_types::crypto::AuthorityName;
+use std::collections::{HashMap, HashSet};
 use itertools::Itertools;
+use sui_types::base_types::ObjectID;
 use tracing::info;
+
+/// Unwraps the presign a demand was assigned, failing with what was found
+/// instead — an unresolved demand and one dropped at the park bound are
+/// different outcomes, and a test asserting on an assignment wants to say which
+/// one it hit.
+fn expect_assigned_presign(
+    resolution: Option<NoaPresignDemandResolution>,
+    context: &str,
+) -> (SessionIdentifier, u16, Vec<u8>, ObjectID) {
+    match resolution {
+        Some(NoaPresignDemandResolution::Assigned {
+            session_identifier,
+            blending_index,
+            presign,
+            network_encryption_key_id,
+        }) => (
+            session_identifier,
+            blending_index,
+            presign,
+            network_encryption_key_id,
+        ),
+        other => panic!("{context}: expected an assigned presign, found {other:?}"),
+    }
+}
 
 /// All (curve, algorithm, hash_scheme) triples for network-owned-address signing E2E tests.
 const ALL_SIGNATURE_CONFIGURATIONS: &[(
@@ -739,33 +769,39 @@ async fn test_presign_assignment_is_consensus_ordered_not_local() {
     // Direct proof of cross-validator agreement: the presign assigned to each
     // demand is IDENTICAL on validators that received the demands in OPPOSITE
     // local order (0 saw [M1,M2]; 2 saw [M2,M1]).
-    let digest_one = ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+    let demand_id_one = ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
         session_identifier: ika_types::crypto::keccak256_digest(&message_one),
         signature_algorithm,
-    }
-    .digest();
-    let digest_two = ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
+    };
+    let demand_id_two = ika_types::noa_checkpoint::NOAPresignDemandId::GrpcAttestation {
         session_identifier: ika_types::crypto::keccak256_digest(&message_two),
         signature_algorithm,
-    }
-    .digest();
+    };
 
-    let assigned_one_v0 = test_state.epoch_stores[0]
-        .noa_assigned_presign(&digest_one)
-        .expect("read assignment")
-        .expect("M1 should have been assigned a presign on validator 0");
-    let assigned_one_v2 = test_state.epoch_stores[2]
-        .noa_assigned_presign(&digest_one)
-        .expect("read assignment")
-        .expect("M1 should have been assigned a presign on validator 2");
-    let assigned_two_v0 = test_state.epoch_stores[0]
-        .noa_assigned_presign(&digest_two)
-        .expect("read assignment")
-        .expect("M2 should have been assigned a presign on validator 0");
-    let assigned_two_v2 = test_state.epoch_stores[2]
-        .noa_assigned_presign(&digest_two)
-        .expect("read assignment")
-        .expect("M2 should have been assigned a presign on validator 2");
+    let assigned_one_v0 = expect_assigned_presign(
+        test_state.epoch_stores[0]
+            .noa_presign_demand_resolution(&demand_id_one)
+            .expect("read resolution"),
+        "M1 on validator 0",
+    );
+    let assigned_one_v2 = expect_assigned_presign(
+        test_state.epoch_stores[2]
+            .noa_presign_demand_resolution(&demand_id_one)
+            .expect("read resolution"),
+        "M1 on validator 2",
+    );
+    let assigned_two_v0 = expect_assigned_presign(
+        test_state.epoch_stores[0]
+            .noa_presign_demand_resolution(&demand_id_two)
+            .expect("read resolution"),
+        "M2 on validator 0",
+    );
+    let assigned_two_v2 = expect_assigned_presign(
+        test_state.epoch_stores[2]
+            .noa_presign_demand_resolution(&demand_id_two)
+            .expect("read resolution"),
+        "M2 on validator 2",
+    );
 
     // (session_id, blending_index) must match across validators for each demand.
     assert_eq!(
@@ -1368,15 +1404,14 @@ async fn test_noa_presign_demand_draws_from_the_pool_its_identity_names() {
     // Drain it: the service walks rounds in order, so keep rounds flowing
     // until it reaches the planted one and assigns.
     const MAX_DRAIN_ROUNDS: usize = 20;
-    let digest = demand_id.digest();
     let mut drain_rounds = 0usize;
     loop {
         test_state.dwallet_mpc_services[target]
             .run_service_loop_iteration()
             .await;
         if test_state.epoch_stores[target]
-            .has_noa_assigned_presign(&digest)
-            .expect("read assignment")
+            .has_noa_presign_demand_resolution(&demand_id)
+            .expect("read resolution")
         {
             break;
         }
@@ -1394,11 +1429,13 @@ async fn test_noa_presign_demand_draws_from_the_pool_its_identity_names() {
         );
     }
 
-    let (_session_identifier, _blending_index, presign_bytes, assigned_key_id) = test_state
-        .epoch_stores[target]
-        .noa_assigned_presign(&digest)
-        .expect("read assignment")
-        .expect("assignment exists");
+    let (_session_identifier, _blending_index, presign_bytes, assigned_key_id) =
+        expect_assigned_presign(
+            test_state.epoch_stores[target]
+                .noa_presign_demand_resolution(&demand_id)
+                .expect("read resolution"),
+            "the planted demand",
+        );
 
     assert_eq!(
         presign_bytes,
@@ -1423,5 +1460,477 @@ async fn test_noa_presign_demand_draws_from_the_pool_its_identity_names() {
         ?derived_algorithm,
         ?decoy_algorithm,
         "the presign-demand drew from the pool its identity names"
+    );
+}
+
+/// The validator index every demand-park test drives.
+const PARK_TEST_TARGET: usize = 0;
+
+/// A checkpoint demand id — its kind fixes the signature algorithm, so the
+/// pool it draws from is decided by the identity alone.
+fn checkpoint_demand_id(sequence_number: u64) -> NOAPresignDemandId {
+    NOAPresignDemandId::Checkpoint {
+        tx_ref: NOACheckpointTxRef {
+            kind_name: NOACheckpointKindName::SuiDWallet,
+            sequence_number,
+            tx_index: 0,
+            epoch: 1,
+        },
+        retry_round: 0,
+    }
+}
+
+/// Delivers a presign demand to the target validator in the current consensus
+/// round, the way an agreed announcement reaches the drain, and returns the
+/// round it was delivered in.
+///
+/// Every round needs a row in the per-round streams or the service's reader
+/// never advances to it, so the round's rows are created first (exactly as the
+/// harness creates them) and the demand is planted into that round's entry.
+fn deliver_noa_presign_demand(
+    test_state: &mut IntegrationTestState,
+    demand_id: &NOAPresignDemandId,
+    network_encryption_key_id: ObjectID,
+) -> u64 {
+    let announcing_authority = test_state
+        .committee
+        .names()
+        .nth(1)
+        .copied()
+        .expect("committee has a second member");
+    let round = test_state.consensus_round as u64;
+    utils::send_advance_results_between_parties(
+        &test_state.committee,
+        &mut test_state.sent_consensus_messages_collectors,
+        &mut test_state.epoch_stores,
+        round,
+    );
+    test_state.epoch_stores[PARK_TEST_TARGET]
+        .round_to_noa_presign_demands
+        .lock()
+        .unwrap()
+        .entry(round)
+        .or_default()
+        .push(ConsensusNOAPresignDemand {
+            authority: announcing_authority,
+            demand_id: demand_id.clone(),
+            network_encryption_key_id,
+        });
+    test_state.consensus_round += 1;
+    round
+}
+
+/// Runs `rounds` consensus rounds through the target validator's service, then
+/// one final iteration so the last round created is actually drained.
+async fn flow_consensus_rounds(test_state: &mut IntegrationTestState, rounds: usize) {
+    for _ in 0..rounds {
+        test_state.dwallet_mpc_services[PARK_TEST_TARGET]
+            .run_service_loop_iteration()
+            .await;
+        utils::send_advance_results_between_parties(
+            &test_state.committee,
+            &mut test_state.sent_consensus_messages_collectors,
+            &mut test_state.epoch_stores,
+            test_state.consensus_round as u64,
+        );
+        test_state.consensus_round += 1;
+    }
+    test_state.dwallet_mpc_services[PARK_TEST_TARGET]
+        .run_service_loop_iteration()
+        .await;
+}
+
+/// A demand announced under a network encryption key this validator has no
+/// presign pool for PARKS: it is neither assigned nor dropped, and stays in the
+/// queue in consensus-delivery order to be retried every round.
+///
+/// Rejecting such a demand locally is unsafe — honest validators transiently
+/// hold different adopted network-key sets (issue #2019 measured the windows),
+/// so the announcement of a key this validator has not adopted yet is the
+/// normal case, not evidence of misbehavior.
+#[tokio::test]
+#[cfg(test)]
+async fn test_noa_presign_demand_parks_on_an_unrecognised_network_key() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
+
+    let mut test_state = build_test_state(4);
+    let (consensus_round, _network_key_bytes, _network_key_id) =
+        create_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+
+    // A key no validator in this test holds a pool for.
+    let unrecognised_key_id = ObjectID::random();
+    let demand_id = checkpoint_demand_id(1);
+    deliver_noa_presign_demand(&mut test_state, &demand_id, unrecognised_key_id);
+
+    // Well short of the park bound, which is left at its production value.
+    flow_consensus_rounds(&mut test_state, 5).await;
+
+    assert_eq!(
+        test_state.epoch_stores[PARK_TEST_TARGET]
+            .noa_presign_demand_resolution(&demand_id)
+            .expect("read resolution"),
+        None,
+        "a parked demand has no resolution yet: no presign exists for the announced key, \
+         and the bound is nowhere near"
+    );
+    assert_eq!(
+        test_state.dwallet_mpc_services[PARK_TEST_TARGET].parked_noa_presign_demand_count(),
+        1,
+        "the demand must stay parked in the drain queue, not be dropped"
+    );
+}
+
+/// A validator that is merely LAGGING adoption of the announced key assigns the
+/// demand as soon as that key's pool appears: the demand parked in the
+/// meantime, so nothing was lost.
+///
+/// This is the honest-skew case the park exists for. The assignment must record
+/// the ANNOUNCED key — the consensus-agreed one the presign was drawn under —
+/// not a key resolved locally at assignment time.
+#[tokio::test]
+#[cfg(test)]
+async fn test_noa_presign_demand_assigns_once_the_announced_key_pool_arrives() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
+
+    let mut test_state = build_test_state(4);
+    let (consensus_round, _network_key_bytes, _network_key_id) =
+        create_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+
+    // The key the announcement names: adopted network-wide, but this validator
+    // has no pool for it yet.
+    let late_key_id = ObjectID::random();
+    let demand_id = checkpoint_demand_id(2);
+    let derived_algorithm = demand_id.expected_signature_algorithm();
+    deliver_noa_presign_demand(&mut test_state, &demand_id, late_key_id);
+
+    flow_consensus_rounds(&mut test_state, 3).await;
+    assert_eq!(
+        test_state.epoch_stores[PARK_TEST_TARGET]
+            .noa_presign_demand_resolution(&demand_id)
+            .expect("read resolution"),
+        None,
+        "the demand cannot be resolved before its key's pool exists"
+    );
+
+    // The lag resolves: the key's presign pool fills.
+    const LATE_POOL_MARKER: u8 = 0x7C;
+    test_state.epoch_stores[PARK_TEST_TARGET]
+        .insert_presigns(
+            derived_algorithm,
+            late_key_id,
+            0,
+            SessionIdentifier::new(SessionType::InternalPresign, [LATE_POOL_MARKER; 32]),
+            vec![vec![LATE_POOL_MARKER; 16]],
+        )
+        .expect("seed the late key's presign pool");
+
+    flow_consensus_rounds(&mut test_state, 2).await;
+
+    let (_session_identifier, _blending_index, presign_bytes, assigned_key_id) =
+        expect_assigned_presign(
+            test_state.epoch_stores[PARK_TEST_TARGET]
+                .noa_presign_demand_resolution(&demand_id)
+                .expect("read resolution"),
+            "the parked demand once its key's pool arrives",
+        );
+    assert_eq!(
+        presign_bytes,
+        vec![LATE_POOL_MARKER; 16],
+        "the assignment must draw from the late key's pool"
+    );
+    assert_eq!(
+        assigned_key_id, late_key_id,
+        "the assignment must record the announced key, not a locally resolved one"
+    );
+    assert_eq!(
+        test_state.dwallet_mpc_services[PARK_TEST_TARGET].parked_noa_presign_demand_count(),
+        0,
+        "an assigned demand leaves the queue"
+    );
+}
+
+/// A demand naming a key that never gets a pool is dropped at the park bound —
+/// loudly, counted, and permanently for this epoch.
+///
+/// This is the byzantine case: the consensus dedup key for an announcement is
+/// the demand-id digest alone, so a committee member announcing first pins the
+/// network encryption key for the whole network. Naming a key no validator will
+/// ever adopt would otherwise park the demand for the rest of the epoch and
+/// block that epoch's NOA checkpoint finalization.
+///
+/// The bound is measured in consensus rounds and the test shrinks it, so the
+/// drop is reachable without driving the production ~70k rounds.
+#[tokio::test]
+#[cfg(test)]
+async fn test_noa_presign_demand_is_dropped_at_the_park_bound() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
+
+    let mut test_state = build_test_state(4);
+    let (consensus_round, _network_key_bytes, _network_key_id) =
+        create_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+
+    const PARK_ROUNDS: u64 = 3;
+    test_state.dwallet_mpc_services[PARK_TEST_TARGET]
+        .set_noa_presign_demand_park_rounds_for_testing(PARK_ROUNDS);
+
+    // A key nobody ever adopts, so no pool for it can ever appear.
+    let never_adopted_key_id = ObjectID::random();
+    let demand_id = checkpoint_demand_id(3);
+    let derived_algorithm = demand_id.expected_signature_algorithm();
+    let delivery_round =
+        deliver_noa_presign_demand(&mut test_state, &demand_id, never_adopted_key_id);
+
+    // One more round than the bound, so the drain reaches
+    // `round - delivery_round >= PARK_ROUNDS`.
+    flow_consensus_rounds(&mut test_state, PARK_ROUNDS as usize + 1).await;
+
+    assert_eq!(
+        test_state.dwallet_mpc_services[PARK_TEST_TARGET].parked_noa_presign_demand_count(),
+        0,
+        "the demand must be dropped from the queue once it has been parked for the bound \
+         (delivered at round {delivery_round})"
+    );
+    assert_eq!(
+        test_state.dwallet_mpc_services[PARK_TEST_TARGET]
+            .dwallet_mpc_metrics()
+            .noa_presign_demands_evicted_total
+            .with_label_values(&[&format!("{derived_algorithm:?}")])
+            .get(),
+        1,
+        "the drop must be counted"
+    );
+
+    // A drop is terminal for this epoch, not starvation: a pool appearing for
+    // the announced key AFTER the bound changes nothing, because the demand is
+    // no longer in the queue to be retried.
+    test_state.epoch_stores[PARK_TEST_TARGET]
+        .insert_presigns(
+            derived_algorithm,
+            never_adopted_key_id,
+            0,
+            SessionIdentifier::new(SessionType::InternalPresign, [0x11; 32]),
+            vec![vec![0x11; 16]],
+        )
+        .expect("seed a pool for the dropped demand's key");
+    flow_consensus_rounds(&mut test_state, 3).await;
+    assert_eq!(
+        test_state.epoch_stores[PARK_TEST_TARGET]
+            .noa_presign_demand_resolution(&demand_id)
+            .expect("read resolution"),
+        Some(NoaPresignDemandResolution::Evicted),
+        "a dropped demand must stay dropped — durably — even once a pool for its key exists"
+    );
+    assert_eq!(
+        test_state.epoch_stores[PARK_TEST_TARGET]
+            .presign_pool_size(derived_algorithm, never_adopted_key_id)
+            .expect("pool size"),
+        1,
+        "the dropped demand must not consume the pool that arrived after it"
+    );
+
+    // Local coherence: the sign request behind a dropped demand is released
+    // rather than waiting forever for an assignment nobody will write. It is
+    // sent after the drop because this harness has no consensus dedup — a live
+    // announcement of the same demand would be delivered alongside the planted
+    // one instead of collapsing into it.
+    test_state.network_owned_address_sign_request_senders[PARK_TEST_TARGET]
+        .send(NetworkOwnedAddressSignRequest {
+            message: b"a checkpoint tx whose presign demand was dropped".to_vec(),
+            curve: DWalletCurve::Secp256k1,
+            hash_scheme: DWalletHashScheme::Keccak256,
+            demand_id: demand_id.clone(),
+        })
+        .await
+        .expect("send the sign request behind the dropped demand");
+    // Two rounds: the first drains the request from the channel (the pass that
+    // would announce it, and the pass that releases it), the second gives any
+    // announcement time to be submitted, distributed and drained.
+    flow_consensus_rounds(&mut test_state, 2).await;
+    assert_eq!(
+        test_state.dwallet_mpc_services[PARK_TEST_TARGET]
+            .pending_network_owned_address_sign_request_count(),
+        0,
+        "the pending sign request of a dropped demand must be released"
+    );
+    assert_eq!(
+        test_state.dwallet_mpc_services[PARK_TEST_TARGET].parked_noa_presign_demand_count(),
+        0,
+        "a dropped demand must not be re-announced — a re-announcement would come back \
+         through consensus as a fresh queue entry"
+    );
+    assert_eq!(
+        test_state.epoch_stores[PARK_TEST_TARGET]
+            .noa_presign_demand_resolution(&demand_id)
+            .expect("read resolution"),
+        Some(NoaPresignDemandResolution::Evicted),
+        "nor may a re-announcement quietly assign the dropped demand from the pool that \
+         arrived after it"
+    );
+    assert_eq!(
+        test_state.epoch_stores[PARK_TEST_TARGET]
+            .presign_pool_size(derived_algorithm, never_adopted_key_id)
+            .expect("pool size"),
+        1,
+        "the pool that arrived after the drop must still be untouched"
+    );
+
+    info!(
+        ?derived_algorithm,
+        delivery_round, "the demand was dropped at the park bound"
+    );
+}
+
+/// Builds a test state whose validator 0 can be restarted over its surviving
+/// epoch store, returning the key material a restart has to reuse.
+fn build_restartable_test_state() -> (
+    IntegrationTestState,
+    HashMap<AuthorityName, RootSeed>,
+    OffChainCommitteeBundles,
+) {
+    let (committee, seeds, bundles) = utils::build_committee_with_random_seeds(4);
+    let (
+        dwallet_mpc_services,
+        sui_data_senders,
+        sent_consensus_messages_collectors,
+        epoch_stores,
+        notify_services,
+        network_owned_address_sign_request_senders,
+        network_owned_address_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services_with_committee_and_seeds(
+        committee.clone(),
+        seeds.clone(),
+        bundles.clone(),
+    );
+    let test_state = IntegrationTestState {
+        dwallet_mpc_services,
+        sent_consensus_messages_collectors,
+        epoch_stores,
+        notify_services,
+        crypto_round: 1,
+        consensus_round: 1,
+        committee,
+        sui_data_senders,
+        network_owned_address_sign_request_senders,
+        network_owned_address_sign_output_receivers,
+    };
+    (test_state, seeds, bundles)
+}
+
+/// Replaces the target validator's service with a fresh one over its EXISTING
+/// epoch store — the in-process mid-epoch restart: every in-memory structure
+/// starts empty and the round cursor rewinds, while the store survives to be
+/// replayed.
+fn restart_target_validator(
+    test_state: &mut IntegrationTestState,
+    seeds: &HashMap<AuthorityName, RootSeed>,
+    bundles: &OffChainCommitteeBundles,
+    park_rounds: u64,
+) {
+    let authority = test_state.dwallet_mpc_services[PARK_TEST_TARGET].name;
+    let (service, senders, collector, notify, sign_request_sender, sign_output_receiver) =
+        utils::create_dwallet_mpc_service_over_epoch_store(
+            &authority,
+            test_state.committee.clone(),
+            seeds[&authority].clone(),
+            bundles.clone(),
+            test_state.epoch_stores[PARK_TEST_TARGET].clone(),
+        );
+    test_state.dwallet_mpc_services[PARK_TEST_TARGET] = service;
+    test_state.sui_data_senders[PARK_TEST_TARGET] = senders;
+    test_state.sent_consensus_messages_collectors[PARK_TEST_TARGET] = collector;
+    test_state.notify_services[PARK_TEST_TARGET] = notify;
+    test_state.network_owned_address_sign_request_senders[PARK_TEST_TARGET] = sign_request_sender;
+    test_state.network_owned_address_sign_output_receivers[PARK_TEST_TARGET] = sign_output_receiver;
+    test_state.dwallet_mpc_services[PARK_TEST_TARGET]
+        .dwallet_mpc_manager_mut()
+        .last_session_to_complete_in_current_epoch = 400;
+    test_state.dwallet_mpc_services[PARK_TEST_TARGET]
+        .set_noa_presign_demand_park_rounds_for_testing(park_rounds);
+}
+
+/// A restart must not resurrect a demand the park bound already dropped.
+///
+/// The drain replays every consensus round of the epoch after a restart, and
+/// the presign pool is durable and NOT rewound with it. So a demand dropped at
+/// round R_e, whose announced key's pool only filled at some later round, is
+/// re-read at its delivery round against a pool that now holds a presign — and
+/// a drop recorded only in memory is gone, so the replayed drain would pop.
+/// That validator would then hold an assignment no peer has, and would consume
+/// a presign its peers pair with a DIFFERENT demand, diverging the
+/// demand-to-presign pairing for the rest of the epoch.
+///
+/// Only the honest-lag drop can reach this shape (a key nobody ever adopts
+/// never gets a pool), which is exactly the case the bound deliberately
+/// treats the same as the byzantine one.
+#[tokio::test]
+#[cfg(test)]
+async fn test_restart_does_not_resurrect_a_dropped_noa_presign_demand() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
+
+    let (mut test_state, seeds, bundles) = build_restartable_test_state();
+    let (consensus_round, _network_key_bytes, _network_key_id) =
+        create_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+
+    const PARK_ROUNDS: u64 = 3;
+    test_state.dwallet_mpc_services[PARK_TEST_TARGET]
+        .set_noa_presign_demand_park_rounds_for_testing(PARK_ROUNDS);
+
+    // The announced key is adopted network-wide, but its pool arrives on this
+    // validator only after the bound has already elapsed.
+    let late_key_id = ObjectID::random();
+    let demand_id = checkpoint_demand_id(4);
+    let derived_algorithm = demand_id.expected_signature_algorithm();
+    deliver_noa_presign_demand(&mut test_state, &demand_id, late_key_id);
+
+    flow_consensus_rounds(&mut test_state, PARK_ROUNDS as usize + 1).await;
+    assert_eq!(
+        test_state.dwallet_mpc_services[PARK_TEST_TARGET].parked_noa_presign_demand_count(),
+        0,
+        "the demand must be dropped at the bound before the restart is simulated"
+    );
+
+    // The lag resolves, too late: the key's pool fills AFTER the drop.
+    const LATE_POOL_MARKER: u8 = 0x5E;
+    test_state.epoch_stores[PARK_TEST_TARGET]
+        .insert_presigns(
+            derived_algorithm,
+            late_key_id,
+            0,
+            SessionIdentifier::new(SessionType::InternalPresign, [LATE_POOL_MARKER; 32]),
+            vec![vec![LATE_POOL_MARKER; 16]],
+        )
+        .expect("seed the late key's presign pool");
+
+    // Restart: in-memory state is gone, the epoch store (rounds AND pool)
+    // survives, and the round cursor rewinds so every round is re-drained.
+    restart_target_validator(&mut test_state, &seeds, &bundles, PARK_ROUNDS);
+    flow_consensus_rounds(&mut test_state, 3).await;
+
+    assert_eq!(
+        test_state.epoch_stores[PARK_TEST_TARGET]
+            .noa_presign_demand_resolution(&demand_id)
+            .expect("read resolution"),
+        Some(NoaPresignDemandResolution::Evicted),
+        "the replay must not assign a presign to a demand the bound already dropped"
+    );
+    assert_eq!(
+        test_state.epoch_stores[PARK_TEST_TARGET]
+            .presign_pool_size(derived_algorithm, late_key_id)
+            .expect("pool size"),
+        1,
+        "the replay must not consume the presign that arrived after the drop"
+    );
+    assert_eq!(
+        test_state.dwallet_mpc_services[PARK_TEST_TARGET].parked_noa_presign_demand_count(),
+        0,
+        "the dropped demand must not sit in the rebuilt queue either"
     );
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/noa_signing_key_skew.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/noa_signing_key_skew.rs
@@ -1,0 +1,503 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Investigation harness for issue #2019: can two honest validators
+//! select a DIFFERENT network-encryption key as the
+//! network-owned-address (NOA) signing key at the same moment?
+//!
+//! The selector
+//! (`DWalletMPCManager::network_owned_address_signing_network_encryption_key_id`)
+//! takes the minimum over `adopted_network_key_data`, ordered by
+//! `dkg_at_epoch` then key id. That is a pure function of the ADOPTED
+//! SET, so it is order-independent: two validators can only disagree if
+//! their adopted sets differ at that moment. `adopt_cert_verified_keys`
+//! is a per-tick LOCAL pass over a LOCAL overlay, so the sets diverge
+//! whenever a key is adoptable on one validator and not (yet) on
+//! another.
+//!
+//! These tests drive two managers at the same epoch through the two
+//! per-validator skip paths and compare the selector's answer.
+
+use crate::dwallet_mpc::integration_tests::utils;
+use dwallet_mpc_types::dwallet_mpc::NetworkKeyId;
+use ika_network::mpc_artifacts::mpc_data_blob_hash;
+use ika_types::handoff::{CertifiedHandoffAttestation, HandoffAttestation, HandoffItemKey};
+use ika_types::messages_dwallet_mpc::{
+    DWalletNetworkEncryptionKeyData, DWalletNetworkEncryptionKeyState,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use sui_types::base_types::ObjectID;
+
+/// A network key as the overlay serves it: metadata from chain, blob
+/// bytes from the local producer cache (empty when this validator has
+/// not cached / fetched them yet).
+fn overlay_entry(
+    key_id: ObjectID,
+    current_epoch: u64,
+    dkg_at_epoch: u64,
+    network_dkg_public_output: Vec<u8>,
+    current_reconfiguration_public_output: Vec<u8>,
+) -> DWalletNetworkEncryptionKeyData {
+    DWalletNetworkEncryptionKeyData {
+        id: key_id,
+        current_epoch,
+        dkg_at_epoch,
+        network_dkg_public_output,
+        current_reconfiguration_public_output,
+        state: DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted,
+    }
+}
+
+fn cert_pinning(
+    prior_epoch: u64,
+    keys: &[(NetworkKeyId, &[u8], &[u8])],
+) -> CertifiedHandoffAttestation {
+    // `HandoffItemKey`'s derived `Ord` puts DKG before reconfiguration;
+    // the attestation's items are sorted by key.
+    let mut items: Vec<_> = keys
+        .iter()
+        .flat_map(|(network_key_id, dkg, reconfiguration)| {
+            [
+                (
+                    HandoffItemKey::NetworkDkgOutput {
+                        key_id: *network_key_id,
+                    },
+                    mpc_data_blob_hash(dkg),
+                ),
+                (
+                    HandoffItemKey::NetworkReconfigurationOutput {
+                        key_id: *network_key_id,
+                    },
+                    mpc_data_blob_hash(reconfiguration),
+                ),
+            ]
+        })
+        .collect();
+    items.sort_by(|(a, _), (b, _)| a.cmp(b));
+    CertifiedHandoffAttestation {
+        attestation: HandoffAttestation {
+            epoch: prior_epoch,
+            next_committee_pubkey_set_hash: [0u8; 32],
+            items,
+        },
+        signatures: vec![],
+    }
+}
+
+/// Two ObjectIDs whose ordering is known, with their `NetworkKeyId`
+/// mappings registered (adoption defers any key it cannot map).
+fn two_ordered_keys() -> (ObjectID, ObjectID) {
+    let (low, high) = {
+        let (a, b) = (ObjectID::random(), ObjectID::random());
+        if a < b { (a, b) } else { (b, a) }
+    };
+    // The mapping is a process global; random ObjectIDs keep tests
+    // independent. The NetworkKeyId only has to be unique per key.
+    crate::network_key_id_mapping::register(low, NetworkKeyId(low.into_bytes()));
+    crate::network_key_id_mapping::register(high, NetworkKeyId(high.into_bytes()));
+    (low, high)
+}
+
+/// SKEW MECHANISM 1 — per-key overlay incompleteness.
+///
+/// The syncer merges each key's blob bytes from the LOCAL producer
+/// cache and publishes the overlay even when a key's bytes are still
+/// missing (`overlay_incomplete` in `sui_syncer::sync_network_keys`),
+/// and a per-key chain-read `Err` skips only that key. So one validator
+/// can hold a complete overlay entry for a key while another holds an
+/// empty one. Adoption skips the empty entry
+/// (`network_dkg_public_output.is_empty()` => `continue`), and the
+/// selector's minimum then differs.
+#[tokio::test]
+async fn overlay_incompleteness_on_one_validator_diverges_the_noa_signing_key() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (mut services, _senders, _collectors, epoch_stores, _notify, _req, _out) =
+        utils::create_dwallet_mpc_services(2);
+    let epoch_id = services.first().unwrap().epoch;
+    let prior_epoch = epoch_id - 1;
+
+    let (low_key, high_key) = two_ordered_keys();
+    let low_dkg = b"low key dkg output".to_vec();
+    let low_reconfiguration = b"low key reconfiguration output".to_vec();
+    let high_dkg = b"high key dkg output".to_vec();
+    let high_reconfiguration = b"high key reconfiguration output".to_vec();
+
+    // Both keys are DKG'd in the same (prior) epoch, so the selector's
+    // tie-break is the key id: `low_key` is the NOA key once adopted.
+    let cert = cert_pinning(
+        prior_epoch,
+        &[
+            (
+                NetworkKeyId(low_key.into_bytes()),
+                &low_dkg,
+                &low_reconfiguration,
+            ),
+            (
+                NetworkKeyId(high_key.into_bytes()),
+                &high_dkg,
+                &high_reconfiguration,
+            ),
+        ],
+    );
+    // The cert is network-uniform: BOTH validators are handed the same one.
+    for epoch_store in &epoch_stores {
+        epoch_store
+            .certified_handoff_attestations
+            .lock()
+            .unwrap()
+            .insert(prior_epoch, cert.clone());
+    }
+
+    let complete_overlay = Arc::new(HashMap::from([
+        (
+            low_key,
+            overlay_entry(
+                low_key,
+                epoch_id,
+                0,
+                low_dkg.clone(),
+                low_reconfiguration.clone(),
+            ),
+        ),
+        (
+            high_key,
+            overlay_entry(
+                high_key,
+                epoch_id,
+                0,
+                high_dkg.clone(),
+                high_reconfiguration.clone(),
+            ),
+        ),
+    ]));
+    // Validator two's local producer cache has not yet filled the LOW
+    // key's blobs — the exact shape the syncer publishes as "incomplete".
+    let partial_overlay = Arc::new(HashMap::from([
+        (low_key, overlay_entry(low_key, epoch_id, 0, vec![], vec![])),
+        (
+            high_key,
+            overlay_entry(
+                high_key,
+                epoch_id,
+                0,
+                high_dkg.clone(),
+                high_reconfiguration.clone(),
+            ),
+        ),
+    ]));
+
+    let (first, second) = services.split_at_mut(1);
+    let first = first[0].dwallet_mpc_manager_mut();
+    let second = second[0].dwallet_mpc_manager_mut();
+    first.adopt_cert_verified_keys(&complete_overlay);
+    second.adopt_cert_verified_keys(&partial_overlay);
+
+    let first_selected = first.network_owned_address_signing_network_encryption_key_id();
+    let second_selected = second.network_owned_address_signing_network_encryption_key_id();
+    tracing::info!(
+        ?first_selected,
+        ?second_selected,
+        "selected NOA signing keys"
+    );
+    assert_eq!(
+        first_selected,
+        Some(low_key),
+        "the validator holding both keys must select the lower-id one"
+    );
+    assert_eq!(
+        second_selected,
+        Some(high_key),
+        "the validator whose low-key overlay entry is still empty selects the high key"
+    );
+    assert_ne!(
+        first_selected, second_selected,
+        "SKEW: two honest validators select different NOA signing keys at the same moment"
+    );
+
+    // The window closes when the lagging validator's overlay fills.
+    second.adopt_cert_verified_keys(&complete_overlay);
+    assert_eq!(
+        second.network_owned_address_signing_network_encryption_key_id(),
+        Some(low_key),
+        "the adopted set is monotone, so the laggard converges once its overlay completes"
+    );
+}
+
+/// SKEW MECHANISM 2 — the handoff-cert READ ERROR skip.
+///
+/// A store hiccup makes `adopt_cert_verified_keys` return before
+/// adopting ANYTHING this tick (deliberately: an error is not the same
+/// answer as an absent cert). Everything already adopted stays adopted,
+/// so a validator that adopted the high key in an earlier tick and then
+/// hits the error keeps selecting it while its peers move to the low key.
+///
+/// This is also the harness-capability check for the negative result: it
+/// shows the harness can drive two validators to genuinely different
+/// adopted sets on demand.
+#[tokio::test]
+async fn handoff_cert_read_error_freezes_one_validator_on_a_different_noa_key() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (mut services, _senders, _collectors, epoch_stores, _notify, _req, _out) =
+        utils::create_dwallet_mpc_services(2);
+    let epoch_id = services.first().unwrap().epoch;
+    let prior_epoch = epoch_id - 1;
+
+    let (low_key, high_key) = two_ordered_keys();
+    let low_dkg = b"low key dkg output".to_vec();
+    let low_reconfiguration = b"low key reconfiguration output".to_vec();
+    let high_dkg = b"high key dkg output".to_vec();
+    let high_reconfiguration = b"high key reconfiguration output".to_vec();
+
+    let cert = cert_pinning(
+        prior_epoch,
+        &[
+            (
+                NetworkKeyId(low_key.into_bytes()),
+                &low_dkg,
+                &low_reconfiguration,
+            ),
+            (
+                NetworkKeyId(high_key.into_bytes()),
+                &high_dkg,
+                &high_reconfiguration,
+            ),
+        ],
+    );
+    for epoch_store in &epoch_stores {
+        epoch_store
+            .certified_handoff_attestations
+            .lock()
+            .unwrap()
+            .insert(prior_epoch, cert.clone());
+    }
+
+    let high_only_overlay = Arc::new(HashMap::from([(
+        high_key,
+        overlay_entry(
+            high_key,
+            epoch_id,
+            0,
+            high_dkg.clone(),
+            high_reconfiguration.clone(),
+        ),
+    )]));
+    let both_keys_overlay = Arc::new(HashMap::from([
+        (
+            high_key,
+            overlay_entry(
+                high_key,
+                epoch_id,
+                0,
+                high_dkg.clone(),
+                high_reconfiguration.clone(),
+            ),
+        ),
+        (
+            low_key,
+            overlay_entry(
+                low_key,
+                epoch_id,
+                0,
+                low_dkg.clone(),
+                low_reconfiguration.clone(),
+            ),
+        ),
+    ]));
+
+    let (first, second) = services.split_at_mut(1);
+    let first = first[0].dwallet_mpc_manager_mut();
+    let second = second[0].dwallet_mpc_manager_mut();
+
+    // Tick 1: only the high key is on chain / resolvable anywhere. Both
+    // validators agree.
+    first.adopt_cert_verified_keys(&high_only_overlay);
+    second.adopt_cert_verified_keys(&high_only_overlay);
+    assert_eq!(
+        first.network_owned_address_signing_network_encryption_key_id(),
+        second.network_owned_address_signing_network_encryption_key_id(),
+        "both validators start from the same adopted set"
+    );
+
+    // Tick 2: the low key becomes resolvable for both, but validator
+    // two's handoff-cert read fails, so its whole adoption pass is
+    // skipped while validator one adopts.
+    epoch_stores[1]
+        .fail_certified_handoff_attestation_reads
+        .store(true, Ordering::Relaxed);
+    first.adopt_cert_verified_keys(&both_keys_overlay);
+    second.adopt_cert_verified_keys(&both_keys_overlay);
+
+    let first_selected = first.network_owned_address_signing_network_encryption_key_id();
+    let second_selected = second.network_owned_address_signing_network_encryption_key_id();
+    tracing::info!(
+        ?first_selected,
+        ?second_selected,
+        "selected NOA signing keys"
+    );
+    assert_eq!(first_selected, Some(low_key));
+    assert_eq!(
+        second_selected,
+        Some(high_key),
+        "the cert-read error skipped adoption entirely, freezing the earlier answer"
+    );
+    assert_ne!(
+        first_selected, second_selected,
+        "SKEW: a transient store error diverges the NOA signing key across honest validators"
+    );
+
+    // The skip is per-tick: adoption resumes on the next pass.
+    epoch_stores[1]
+        .fail_certified_handoff_attestation_reads
+        .store(false, Ordering::Relaxed);
+    second.adopt_cert_verified_keys(&both_keys_overlay);
+    assert_eq!(
+        second.network_owned_address_signing_network_encryption_key_id(),
+        Some(low_key),
+        "the pass retries every service iteration, so this window is one tick"
+    );
+}
+
+/// SKEW MECHANISM 3 — the epoch-start fill window, with a SINGLE key.
+///
+/// `adopted_network_key_data` is created empty for every epoch's
+/// manager, so at every epoch start the selector answers `None` until
+/// the first key is adopted. A validator whose overlay resolves a tick
+/// later than its peers' therefore answers `None` while they answer
+/// `Some(key)`. This needs no second key and no error injection, and it
+/// is what makes "reject an announcement that doesn't match my
+/// selection" unsafe even on a one-key network.
+#[tokio::test]
+async fn epoch_start_fill_window_leaves_one_validator_with_no_noa_key() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (mut services, _senders, _collectors, epoch_stores, _notify, _req, _out) =
+        utils::create_dwallet_mpc_services(2);
+    let epoch_id = services.first().unwrap().epoch;
+    let prior_epoch = epoch_id - 1;
+
+    let key_id = ObjectID::random();
+    crate::network_key_id_mapping::register(key_id, NetworkKeyId(key_id.into_bytes()));
+    let dkg = b"the only network key's dkg output".to_vec();
+    let reconfiguration = b"the only network key's reconfiguration output".to_vec();
+    let cert = cert_pinning(
+        prior_epoch,
+        &[(NetworkKeyId(key_id.into_bytes()), &dkg, &reconfiguration)],
+    );
+    for epoch_store in &epoch_stores {
+        epoch_store
+            .certified_handoff_attestations
+            .lock()
+            .unwrap()
+            .insert(prior_epoch, cert.clone());
+    }
+
+    let resolved = Arc::new(HashMap::from([(
+        key_id,
+        overlay_entry(key_id, epoch_id, 0, dkg.clone(), reconfiguration.clone()),
+    )]));
+    // Validator two's overlay entry is still blob-empty this tick.
+    let unresolved = Arc::new(HashMap::from([(
+        key_id,
+        overlay_entry(key_id, epoch_id, 0, vec![], vec![]),
+    )]));
+
+    let (first, second) = services.split_at_mut(1);
+    let first = first[0].dwallet_mpc_manager_mut();
+    let second = second[0].dwallet_mpc_manager_mut();
+    first.adopt_cert_verified_keys(&resolved);
+    second.adopt_cert_verified_keys(&unresolved);
+
+    assert_eq!(
+        first.network_owned_address_signing_network_encryption_key_id(),
+        Some(key_id),
+    );
+    assert_eq!(
+        second.network_owned_address_signing_network_encryption_key_id(),
+        None,
+        "SKEW: validator one would announce a demand carrying a key validator two \
+         has no selection for at all"
+    );
+
+    second.adopt_cert_verified_keys(&resolved);
+    assert_eq!(
+        second.network_owned_address_signing_network_encryption_key_id(),
+        Some(key_id),
+    );
+}
+
+/// CONTROL — the selector is a pure function of the adopted SET, not of
+/// adoption ORDER. Two validators that adopt the same two keys in
+/// opposite orders agree at every point where their sets are equal.
+/// This bounds the claim: order alone never produces skew, so any real
+/// divergence must be a set difference (mechanisms 1-3 above).
+#[tokio::test]
+async fn adoption_order_alone_does_not_diverge_the_noa_signing_key() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (mut services, _senders, _collectors, epoch_stores, _notify, _req, _out) =
+        utils::create_dwallet_mpc_services(2);
+    let epoch_id = services.first().unwrap().epoch;
+    let prior_epoch = epoch_id - 1;
+
+    let (low_key, high_key) = two_ordered_keys();
+    let low_dkg = b"low key dkg output".to_vec();
+    let low_reconfiguration = b"low key reconfiguration output".to_vec();
+    let high_dkg = b"high key dkg output".to_vec();
+    let high_reconfiguration = b"high key reconfiguration output".to_vec();
+    let cert = cert_pinning(
+        prior_epoch,
+        &[
+            (
+                NetworkKeyId(low_key.into_bytes()),
+                &low_dkg,
+                &low_reconfiguration,
+            ),
+            (
+                NetworkKeyId(high_key.into_bytes()),
+                &high_dkg,
+                &high_reconfiguration,
+            ),
+        ],
+    );
+    for epoch_store in &epoch_stores {
+        epoch_store
+            .certified_handoff_attestations
+            .lock()
+            .unwrap()
+            .insert(prior_epoch, cert.clone());
+    }
+
+    let low_entry = overlay_entry(
+        low_key,
+        epoch_id,
+        0,
+        low_dkg.clone(),
+        low_reconfiguration.clone(),
+    );
+    let high_entry = overlay_entry(
+        high_key,
+        epoch_id,
+        0,
+        high_dkg.clone(),
+        high_reconfiguration.clone(),
+    );
+    let both = Arc::new(HashMap::from([
+        (low_key, low_entry.clone()),
+        (high_key, high_entry.clone()),
+    ]));
+
+    let (first, second) = services.split_at_mut(1);
+    let first = first[0].dwallet_mpc_manager_mut();
+    let second = second[0].dwallet_mpc_manager_mut();
+    // Same two adoptions, opposite orders.
+    first.adopt_cert_verified_keys(&Arc::new(HashMap::from([(low_key, low_entry.clone())])));
+    first.adopt_cert_verified_keys(&both);
+    second.adopt_cert_verified_keys(&Arc::new(HashMap::from([(high_key, high_entry.clone())])));
+    second.adopt_cert_verified_keys(&both);
+
+    assert_eq!(
+        first.network_owned_address_signing_network_encryption_key_id(),
+        second.network_owned_address_signing_network_encryption_key_id(),
+        "equal adopted sets must yield the same NOA key regardless of adoption order"
+    );
+}

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -110,6 +110,11 @@ pub(crate) struct TestingAuthorityPerEpochStore {
     /// "cert absent"); tests for the cert-digest gate insert one here.
     pub(crate) certified_handoff_attestations:
         Arc<Mutex<HashMap<EpochId, CertifiedHandoffAttestation>>>,
+    /// When set, every handoff-cert read returns `Err` instead of the map
+    /// contents — the store-hiccup path that makes the adoption pass skip
+    /// the whole tick (as opposed to a genuinely absent cert, which is an
+    /// answer). For tests that need one validator's adoption to stall.
+    pub(crate) fail_certified_handoff_attestation_reads: Arc<AtomicBool>,
     /// Configurable perpetual-tables handle. `None` by default (matching
     /// "nothing recorded"); tests for the produced-this-epoch adoption
     /// guard open real tables in a tempdir and install them here.
@@ -216,6 +221,7 @@ impl TestingAuthorityPerEpochStore {
             presign_private_outputs: Arc::new(Mutex::new(HashMap::new())),
             assigned_presigns: Arc::new(Mutex::new(HashMap::new())),
             certified_handoff_attestations: Arc::new(Mutex::new(HashMap::new())),
+            fail_certified_handoff_attestation_reads: Arc::new(AtomicBool::new(false)),
             perpetual_tables: Arc::new(Mutex::new(None)),
         }
     }
@@ -665,6 +671,14 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
         // Testing impl: serves the configurable in-memory map (empty by
         // default, in which case the cert-verified adoption path behaves
         // as "cert absent" and tests exercise the consensus-voted path).
+        if self
+            .fail_certified_handoff_attestation_reads
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return Err(ika_types::error::IkaError::Storage(
+                "injected handoff-cert read failure".to_string(),
+            ));
+        }
         Ok(self
             .certified_handoff_attestations
             .lock()

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -1,6 +1,7 @@
 use crate::authority::AuthorityStateTrait;
 use crate::authority::authority_per_epoch_store::{
-    AuthorityPerEpochStore, AuthorityPerEpochStoreTrait, NoaAssignedPresign, PresignDemand,
+    AuthorityPerEpochStore, AuthorityPerEpochStoreTrait, NoaPresignDemandResolution,
+    PresignAssignmentOutcome, PresignDemand,
 };
 use crate::dwallet_checkpoints::{DWalletCheckpointServiceNotify, PendingDWalletCheckpoint};
 use crate::dwallet_mpc::dwallet_mpc_service::DWalletMPCService;
@@ -25,7 +26,7 @@ use ika_types::messages_dwallet_mpc::{
     IdleStatusUpdate, SessionIdentifier, SessionType, SuiChainObservationUpdate,
     UserSecretKeyShareEventType,
 };
-use ika_types::noa_checkpoint::CounterpartyChainKind;
+use ika_types::noa_checkpoint::{CounterpartyChainKind, NOAPresignDemandId};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -82,9 +83,13 @@ pub(crate) struct TestingAuthorityPerEpochStore {
     pub(crate) round_to_noa_observations: Arc<Mutex<HashMap<Round, Vec<ConsensusNOAObservation>>>>,
     pub(crate) round_to_noa_presign_demands:
         Arc<Mutex<HashMap<Round, Vec<ConsensusNOAPresignDemand>>>>,
-    /// NOA presigns assigned in consensus order, keyed by demand-id digest.
-    /// Value: (presign session id, blending index, raw presign bytes, network key id).
-    pub(crate) noa_assigned_presigns: Arc<Mutex<HashMap<[u8; 32], NoaAssignedPresign>>>,
+    /// Terminal resolution of each NOA sign demand, keyed by demand-id digest:
+    /// the presign assigned to it in consensus order, or the marker that the
+    /// park bound dropped it. Mirrors the real store's
+    /// `noa_presign_demand_resolutions`, including that it survives a simulated
+    /// restart while the service's in-memory state does not.
+    pub(crate) noa_presign_demand_resolutions:
+        Arc<Mutex<HashMap<[u8; 32], NoaPresignDemandResolution>>>,
     /// Presign served to each global presign request, keyed by the request's
     /// session sequence number. Mirrors the real store's `served_global_presigns`:
     /// a re-seen request is answered from here instead of popping again.
@@ -213,7 +218,7 @@ impl TestingAuthorityPerEpochStore {
             round_to_global_presign_requests: Arc::new(Mutex::new(HashMap::from([(0, vec![])]))),
             round_to_noa_observations: Arc::new(Mutex::new(HashMap::from([(0, vec![])]))),
             round_to_noa_presign_demands: Arc::new(Mutex::new(HashMap::from([(0, vec![])]))),
-            noa_assigned_presigns: Arc::new(Mutex::new(HashMap::new())),
+            noa_presign_demand_resolutions: Arc::new(Mutex::new(HashMap::new())),
             served_global_presigns: Arc::new(Mutex::new(HashMap::new())),
             presign_pools: Arc::new(Mutex::new(Default::default())),
             filled_presign_slot_high_water: Arc::new(Mutex::new(HashMap::new())),
@@ -501,21 +506,35 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
         Ok(store.get(&next).map(|v| (next, v.clone())))
     }
 
-    fn noa_assigned_presign(&self, digest: &[u8; 32]) -> IkaResult<Option<NoaAssignedPresign>> {
+    fn noa_presign_demand_resolution(
+        &self,
+        demand_id: &NOAPresignDemandId,
+    ) -> IkaResult<Option<NoaPresignDemandResolution>> {
         Ok(self
-            .noa_assigned_presigns
+            .noa_presign_demand_resolutions
             .lock()
             .unwrap()
-            .get(digest)
+            .get(&demand_id.digest())
             .cloned())
     }
 
-    fn has_noa_assigned_presign(&self, digest: &[u8; 32]) -> IkaResult<bool> {
-        Ok(self
-            .noa_assigned_presigns
+    fn evict_noa_presign_demand(&self, demand_id: &NOAPresignDemandId) -> IkaResult<()> {
+        // Mirror the real store: never replace an existing resolution.
+        self.noa_presign_demand_resolutions
             .lock()
             .unwrap()
-            .contains_key(digest))
+            .entry(demand_id.digest())
+            .or_insert(NoaPresignDemandResolution::Evicted);
+        Ok(())
+    }
+
+    fn has_noa_presign_demand_resolution(&self, demand_id: &NOAPresignDemandId) -> IkaResult<bool> {
+        let digest = demand_id.digest();
+        Ok(self
+            .noa_presign_demand_resolutions
+            .lock()
+            .unwrap()
+            .contains_key(&digest))
     }
 
     fn assign_presign_for_demand(
@@ -523,38 +542,61 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
         demand: &PresignDemand,
         signature_algorithm: DWalletSignatureAlgorithm,
         dwallet_network_encryption_key_id: ObjectID,
-    ) -> IkaResult<Option<(SessionIdentifier, u16, Vec<u8>)>> {
+    ) -> IkaResult<PresignAssignmentOutcome> {
         match demand {
             PresignDemand::GlobalRequest {
                 session_sequence_number,
             } => {
-                if let Some(served) = self
+                if let Some((session_identifier, blending_index, presign)) = self
                     .served_global_presigns
                     .lock()
                     .unwrap()
                     .get(session_sequence_number)
                     .cloned()
                 {
-                    return Ok(Some(served));
+                    return Ok(PresignAssignmentOutcome::Assigned {
+                        session_identifier,
+                        blending_index,
+                        presign,
+                    });
                 }
             }
+            // Mirror the real store: a NOA demand has ONE terminal resolution,
+            // and a drop recorded by the park bound is as final as an
+            // assignment — including across the simulated restart, which keeps
+            // this store while the service's memory is rebuilt.
             PresignDemand::Noa { demand_id } => {
-                if let Some((session_id, blending_index, presign, _)) = self
-                    .noa_assigned_presigns
+                match self
+                    .noa_presign_demand_resolutions
                     .lock()
                     .unwrap()
                     .get(&demand_id.digest())
                     .cloned()
                 {
-                    return Ok(Some((session_id, blending_index, presign)));
+                    Some(NoaPresignDemandResolution::Assigned {
+                        session_identifier,
+                        blending_index,
+                        presign,
+                        ..
+                    }) => {
+                        return Ok(PresignAssignmentOutcome::Assigned {
+                            session_identifier,
+                            blending_index,
+                            presign,
+                        });
+                    }
+                    Some(NoaPresignDemandResolution::Evicted) => {
+                        return Ok(PresignAssignmentOutcome::Evicted);
+                    }
+                    None => {}
                 }
             }
         }
 
-        let Some((session_id, blending_index, presign)) =
+        let Some((session_identifier, blending_index, presign)) =
             self.pop_presign_for_testing(signature_algorithm, dwallet_network_encryption_key_id)?
         else {
-            return Ok(None);
+            return Ok(PresignAssignmentOutcome::PoolEmpty);
         };
 
         match demand {
@@ -563,28 +605,32 @@ impl AuthorityPerEpochStoreTrait for TestingAuthorityPerEpochStore {
             } => {
                 self.served_global_presigns.lock().unwrap().insert(
                     *session_sequence_number,
-                    (session_id, blending_index, presign.clone()),
+                    (session_identifier, blending_index, presign.clone()),
                 );
             }
             PresignDemand::Noa { demand_id } => {
-                self.noa_assigned_presigns.lock().unwrap().insert(
+                self.noa_presign_demand_resolutions.lock().unwrap().insert(
                     demand_id.digest(),
-                    (
-                        session_id,
+                    NoaPresignDemandResolution::Assigned {
+                        session_identifier,
                         blending_index,
-                        presign.clone(),
-                        dwallet_network_encryption_key_id,
-                    ),
+                        presign: presign.clone(),
+                        network_encryption_key_id: dwallet_network_encryption_key_id,
+                    },
                 );
                 // Mirror the real store: mark the popped presign used at the
                 // point of consumption (the pool pop above).
                 self.used_presigns
                     .lock()
                     .unwrap()
-                    .insert((session_id, blending_index), ());
+                    .insert((session_identifier, blending_index), ());
             }
         }
-        Ok(Some((session_id, blending_index, presign)))
+        Ok(PresignAssignmentOutcome::Assigned {
+            session_identifier,
+            blending_index,
+            presign,
+        })
     }
 
     fn assign_presign(

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -2403,13 +2403,29 @@ impl DWalletMPCManager {
     pub(super) fn network_owned_address_signing_network_encryption_key_id(
         &self,
     ) -> Option<ObjectID> {
-        // Select over the ADOPTED (consensus-agreed) set, not the installed set
+        // Select over the ADOPTED set, not the installed set
         // (`network_keys.network_encryption_keys`): installation completes on
         // wall-clock time per validator, so choosing over it would let two
         // honest validators pick a different NOA key while their installs lag,
         // apply different pool configs (batch sizes), and diverge the
         // internal-presign top-up decision. The adopted set drives the same
-        // top-up loop, so both agree on the NOA key by construction.
+        // top-up loop, so the two stay consistent WITHIN a validator.
+        //
+        // That is the only guarantee here: the answer is NOT uniform across
+        // validators at a given moment. `adopt_cert_verified_keys` is a
+        // per-tick LOCAL pass over a LOCAL overlay — WHICH keys are adoptable
+        // is network-uniform (the handoff cert pins them), but WHEN each
+        // validator adopts is not. The adopted set starts empty every epoch
+        // and fills as each key's blobs become locally resolvable, a key whose
+        // overlay entry is still blob-empty is skipped while its siblings
+        // adopt, and a handoff-cert read error skips the whole pass for a
+        // tick. So this returns `None` on a validator whose peers already
+        // answer `Some`, and with more than one key it can return a different
+        // key than a peer whose adopted set is ahead. The divergence is
+        // transient (the set only grows, so everyone converges on the same
+        // minimum) but not tick-bounded — a stranded key can stay unresolved
+        // for much of an epoch. Callers must not treat a peer's choice that
+        // differs from this one as evidence of misbehavior; see issue #2019.
         self.adopted_network_key_data
             .values()
             .min_by(|a, b| a.dkg_at_epoch.cmp(&b.dkg_at_epoch).then(a.id.cmp(&b.id)))

--- a/dev-docs/specs/internal-presign-pool.md
+++ b/dev-docs/specs/internal-presign-pool.md
@@ -28,7 +28,9 @@ sequence number.
   pool head and puts the presign bytes into a `RespondDWalletPresign`
   checkpoint message;
 - NOA sign demands — each demand is assigned a presign, recorded in
-  `noa_assigned_presigns` and read back at sign-session instantiation.
+  `noa_presign_demand_resolutions` and read back at sign-session
+  instantiation. A demand that stays unassigned for the park bound is recorded
+  in the same table as dropped.
 
 The pool is drained lowest-sequence-number-first, and within a slot in
 blending-index order.
@@ -79,9 +81,184 @@ announced value:
 `network_encryption_key_id` is NOT covered by this reasoning and remains
 announcer-supplied behind the same dedup key: it is frozen at announce time
 on purpose, so the assignment does not depend on the announce-time and
-instantiate-time key resolutions agreeing. Closing that half is issue #2019;
-the shape it wants is park-rather-than-reject, pending the question of
-whether honest validators can transiently hold different adopted key sets.
+instantiate-time key resolutions agreeing. What the drain does with a key it
+does not recognise is the subject of the next section.
+
+## A demand naming a network key with no pool: park, with a bound
+
+A demand carries the network encryption key it was announced under, and pools
+are keyed by that id, so a validator that has no pool for that key cannot
+assign the demand. It **parks**: the demand stays in the queue in
+consensus-delivery order and is retried on every following round. It is
+**not** rejected, and the announced key is **not** validated against the
+validator's own adopted network-key set.
+
+### Why not validate the announced key
+
+Because honest validators genuinely disagree, transiently, about which
+network encryption keys they have adopted — and therefore about the
+network-owned-address signing key derived from that set. Issue #2019
+measured three independent mechanisms in the current code:
+
+- **the epoch-start fill window.** Every epoch's manager starts with an empty
+  adopted-key set and answers "no signing key" until its first
+  blob-complete overlay entry lands. Any stagger between validators — at
+  least one 5s syncer tick at every epoch boundary, longer for a restarting
+  or joining validator — leaves one validator holding a key while a peer
+  holds none. This one needs only a single network key to occur, so it
+  applies to mainnet and testnet as they run today;
+- **per-key overlay incompleteness.** The overlay is assembled per validator
+  from chain metadata plus locally cached blobs. An entry whose blobs are
+  still empty is skipped at adoption, and the recovery path is a chain read
+  with no deadline, so with two or more keys a validator can adopt only the
+  higher key while a peer holding both selects the lower;
+- **a handoff-certificate read error**, which makes a validator skip
+  adoption for that tick entirely and freeze on whatever it had adopted
+  before.
+
+A local equality check against the announced key would convert any of these
+lags into a permanent drop of an honest demand, and the honest duplicate
+announcements are already gone — consensus deduplicates presign-demand
+announcements on the demand-id digest alone, so no corrected announcement can
+follow. Rejecting therefore trades a substitution bug for a stall, exactly as
+in the algorithm case above. Parking fails toward delay instead, which is the
+only direction that is safe here.
+
+### Why the park needs a bound anyway
+
+The same dedup key is what makes an unbounded park exploitable. Whichever
+announcement for a demand is sequenced first supplies the network key for the
+whole network, and demand ids are derivable from public data. A committee
+member that names a key no validator will ever adopt leaves every validator's
+pool lookup empty forever: the demand parks for the rest of the epoch, its
+sign never happens, and the epoch cannot finalize the NOA checkpoint that
+demand belongs to.
+
+So a parked demand is dropped once it has been parked for
+`NOA_PRESIGN_DEMAND_PARK_ROUNDS` consensus rounds
+(`dwallet_mpc_service.rs`). The queue element records the consensus round its
+demand was delivered in; the drain at round *R* drops any still-unassigned
+demand delivered at *R_d* once `R - R_d >= NOA_PRESIGN_DEMAND_PARK_ROUNDS`.
+
+### Why consensus rounds, and not elapsed time
+
+The drop must be **consensus-uniform**: every validator must drop exactly the
+same demands at exactly the same point, or they disagree about which demands
+were assigned a presign — which is the divergence the whole assignment queue
+exists to prevent, reintroduced through the drop path.
+
+Both inputs to the predicate come from the consensus stream and are therefore
+identical everywhere: the delivery round and the round being drained. The
+third input, whether the demand is still unassigned, is a function of the
+presign pool, which is filled from quorum-agreed outputs in round order and
+is likewise uniform per round. Wall-clock time is not: validators observe
+different elapsed times for the same rounds. Neither is the locally adopted
+key set, nor the network-key overlay — the very things the previous section
+showed to differ between honest validators.
+
+The delivery rounds themselves survive a restart for the same reason: the
+round cursor replays the epoch's rounds from the start, so the queue and the
+rounds it measures from rebuild exactly as they were. The *decision*, though,
+must not be recomputed on that replay — see the next section.
+
+### The drop must be recorded durably, or a restart undoes it
+
+The replay runs against a durable pool that was NOT rewound with the rounds.
+That is safe for the park itself — a demand still in the queue means the pool
+for its key was empty, and re-draining it either finds the pool still empty or
+assigns from it, exactly as an uncrashed peer did. It is NOT safe for a drop:
+
+1. demand *D* is parked past the bound and dropped at round *R_e*;
+2. *D*'s network key arrives late and its pool fills at some *R_i > R_e* — the
+   honest-lag case the bound deliberately drops anyway;
+3. the validator restarts. The rounds replay, *D* re-enters the rebuilt queue
+   at its delivery round, and the drain now sees a pool that can serve it.
+
+With the drop held only in process memory, that replay pops a presign for a
+demand the whole committee — including the same validator before the crash —
+had already abandoned. The restarted validator would hold an assignment nobody
+else has, and would consume a presign its peers pair with a DIFFERENT demand,
+diverging the demand-to-presign pairing for every later demand on that pool.
+
+So the drop is written to the SAME durable per-epoch table as the assignment,
+as the second arm of one per-demand resolution
+(`noa_presign_demand_resolutions`, keyed by the demand-id digest):
+
+| resolution | meaning |
+|---|---|
+| `Assigned { … }` | this presign, drawn under this network key, is bound to the demand |
+| `Evicted` | the park bound dropped the demand; it must never be assigned |
+
+Every demand therefore has at most one terminal resolution per epoch, and a
+replayed drain READS it instead of deciding again: an already-dropped demand
+leaves the rebuilt queue without an assignment attempt, without re-logging at
+error level, and without re-counting the metric. The write happens before the
+demand leaves the queue, and a failed write keeps the demand parked for the
+next round — the same posture as a failed assignment.
+
+### The bound drops an honest-lag demand too, deliberately
+
+No consensus-uniform signal distinguishes "a key nobody will ever adopt" from
+"a key still arriving", and any attempt to distinguish them locally breaks
+uniformity. The bound therefore drops both cases alike, and its only defence
+is being generous enough that no honest window comes near it.
+
+`NOA_PRESIGN_DEMAND_PARK_ROUNDS = 70_000` is about an hour of mainnet
+consensus at ~19.5 rounds/s. The honest windows it has to clear are:
+
+- the network-key syncer re-merges the overlay every 5s — ~100 rounds;
+- a restarting or joining validator recovers a stranded key by chain read and
+  then instantiates class groups for it — minutes, so at most low tens of
+  thousands of rounds;
+- a freshly adopted key's presign pool is filled by internal-presign MPC —
+  again minutes.
+
+The ceiling is the epoch: a 24h epoch is ~1.7M rounds, so the bound spends
+~4% of an epoch waiting before giving up, and a demand that is going to be
+dropped is dropped early enough for the epoch to finalize what it can.
+
+The value is a compile-time constant, which is safe only because presign
+demands cannot currently reach the wire at all — announcements are gated on
+the `noa_checkpoints` protocol flag, which is off on every live network, so no
+committee can be split across two values of it. Once that flag is on, the
+number becomes consensus-affecting (validators running different values drop
+different demands) and belongs in `ProtocolConfig`, where a change is
+version-gated rather than binary-driven.
+
+### What a drop means
+
+It is terminal for that demand in that epoch, and durable (above). The drain
+increments `ika_dwallet_mpc_noa_presign_demands_evicted_total` (labeled by
+signature algorithm) and logs an `error!` carrying the demand id and its
+digest, the announced network key id, the announcing authority, the delivery
+round and the round of the drop — including the statement that this demand's
+sign will not happen in this epoch. It is deliberately not reported as an
+internal invariant violation: a byzantine announcer causing it is not a bug in
+our code, and neither is an honest lag that outran the bound. A replay of a
+drop that was already recorded logs at debug and does not touch the counter,
+so the metric counts drops, not restarts.
+
+Two other paths read the same durable resolution rather than any process
+memory, which is what makes them survive a restart as well:
+
+- the **pending sign request** behind a dropped demand is released (it would
+  otherwise wait forever for an assignment nobody will write, feeding the
+  NOA-sign starvation warning). Only the assignment branch of that read needs
+  the signing network key locally; a release must not, or a validator that
+  never adopts the key would hold the request forever;
+- the **announcement** pass skips any demand that already has a resolution, so
+  a dropped demand is not re-announced — a re-announcement would be
+  deduplicated into nothing anyway, the consensus key being the demand-id
+  digest alone.
+
+Recovery, where it exists at all, comes from a HIGHER layer minting a
+**fresh demand id**: a checkpoint demand carries a retry round, so a retry is
+a different demand with a different digest and therefore a different dedup
+key. Today that only happens after an on-chain failure quorum for the
+checkpoint transaction, so a checkpoint sign whose demand was dropped stays
+unsigned for the remainder of the epoch. That is the accepted outcome: a
+bounded, loud, and network-uniform loss of one demand, rather than an
+unbounded park that blocks the epoch's NOA checkpoint finalization.
 
 ## Fills complete out of sequence order
 
@@ -97,7 +274,9 @@ because it is what makes replay unsafe — see below.
 restart.** Its round cursor (`last_read_consensus_round`) is in-memory and
 starts unset, so a restarted validator re-reads the whole per-epoch round
 stream — re-absorbing every internal presign output and re-draining every
-global presign request and NOA demand.
+global presign request and NOA demand. The demand queue and the delivery
+rounds the park bound measures from are rebuilt by that replay, and rebuild
+identically because they are read from the same round stream.
 
 **The pool is NOT reset for that replay.** It is durable per-epoch state, so
 the replay runs against a pool holding whatever survived the crash. That
@@ -131,7 +310,14 @@ and it selects the marker table:
 | `PresignDemand` | idempotency key | marker table |
 |---|---|---|
 | `GlobalRequest { session_sequence_number }` | the request's session sequence number | `served_global_presigns` |
-| `Noa { demand_id }` | `NOAPresignDemandId::digest()` | `noa_assigned_presigns` |
+| `Noa { demand_id }` | `NOAPresignDemandId::digest()` | `noa_presign_demand_resolutions` |
+
+The NOA row's table holds a RESOLUTION, not just an assignment: its value is
+`Assigned { … }` or `Evicted`, the two terminal outcomes a demand can reach.
+That second arm is what `evict_noa_presign_demand` writes when the park bound
+expires, and it is why a drop survives a restart — see "A demand naming a
+network key with no pool" above. A global request has no second arm: it has no
+park bound, so its marker table holds served presigns alone.
 
 There is deliberately no way to drain the pool without naming a demand: a
 consumer that could pop bare would have to know this hazard to avoid it,
@@ -141,8 +327,9 @@ reason — any other 32-byte value would type-check while keying the
 assignment wrong.)
 
 A repeated fill is a no-op. A repeated drain returns the presign it returned
-the first time, without touching the pool. Replay is then a no-op on the pool
-by construction, and the restarted validator's checkpoint messages match its
+the first time — or, for a NOA demand the bound already dropped, reports that
+drop — without touching the pool. Replay is then a no-op on the pool by
+construction, and the restarted validator's checkpoint messages match its
 peers' regardless of where it crashed.
 
 The batching is load-bearing in both directions: a pool mutation that landed


### PR DESCRIPTION
The fix half of #2019, stacked on #2045 (the skew evidence and harness switch). Implemented per the investigation's verdict: **park-with-a-bound**, replacing nothing and rejecting nothing.

## What it does

A NOA presign demand whose announced `network_encryption_key_id` has no presign pool on this validator **parks** in the assignment drain — retained in consensus-delivery order, retried every round. It is deliberately NOT validated against the locally adopted key set: honest validators transiently hold different adopted sets (three measured mechanisms, one of which — the epoch-start fill window — needs only a single network key), so a local reject would permanently drop honest demands whose duplicate announcements consensus already deduplicated away.

The park now has a **bound, counted in consensus rounds**: at round R the drain drops any still-unassigned demand delivered at R_d once `R − R_d ≥ NOA_PRESIGN_DEMAND_PARK_ROUNDS` (70,000 ≈ 1h at mainnet's ~19.5 rounds/s — far above every honest adoption/pool-fill window, ~4% of a 24h epoch). Every predicate input is consensus-uniform (delivery round, drained round, quorum-filled pool state), so every validator drops the same demand at the same round. This closes the byzantine case: an announcer naming a key nobody will ever adopt can no longer park a demand for the whole epoch and block NOA checkpoint finalization.

The drop is **durable**: the per-demand marker table becomes `noa_presign_demand_resolutions`, holding `Assigned { … } | Evicted` — one terminal resolution per demand. Without this, the post-restart round replay would re-read the demand against a pool that is not rewound, and a pool that filled after the drop would let the replaying validator assign a presign every peer abandoned, diverging the demand→presign pairing for the rest of that pool. A restart test written against the pre-tombstone code reproduced exactly that.

Drops are **loud and counted**: `ika_dwallet_mpc_noa_presign_demands_evicted_total` plus an `error!` naming the announcer, key, and rounds. The pending sign request behind a dropped demand is released through the same durable record. Recovery, where it exists, is a higher layer minting a fresh demand id (`retry_round` is part of a checkpoint demand id) — today that fires only after an on-chain failure quorum, so a dropped checkpoint sign stays unsigned for its epoch: the accepted outcome, recorded in the spec.

Builds on #2042's unified `assign_presign_for_demand`: the outcome enum generalizes to `PresignAssignmentOutcome { Assigned{…}, Evicted, PoolEmpty }`, the NOA methods are keyed by `NOAPresignDemandId` per #2042's identity-over-digest argument, and the global drain's unreachable `Evicted` arm is a loud invariant violation rather than a silent catch-all.

`dev-docs/specs/internal-presign-pool.md` gains the full reasoning chain: why parking rather than rejecting, why rounds rather than wall clock, why honest-lag demands drop too (no consensus-uniform signal distinguishes them; the bound's defence is calibration), why the drop must be durable, and what a drop means.

The constant is compile-time only while `noa_checkpoints()` is off everywhere; once that flag ships, the number is consensus-affecting and must move into `ProtocolConfig` (noted in code and spec).

## Tests

Four new integration tests extending the #2039 drain fixture:
- unrecognised key **parks** (production bound, never dropped, never assigned);
- honest lag **resolves** (pool arrives late → assigned from the announced key's pool, announced key recorded);
- never-adopted key **drops at the bound** — loudly and terminally (metric == 1; a pool arriving after the drop is never consumed);
- **restart does not resurrect a dropped demand** (drop → late pool fill → service rebuild + full round replay → still `Evicted`, pool untouched).

Fault-validated per the test-testing playbook, evidence captured for both properties:
- restart test written FIRST against the pre-tombstone code: failed with "the replay must not assign a presign to a demand the bound already dropped";
- drop test against a disabled bound (the pre-fix unbounded park): failed with the demand still in queue and the eviction log absent. Both faults reverted and re-verified.

`cargo test --release -p ika-core dwallet_mpc::integration_tests::network_owned_address_sign -- --test-threads=4`: 18/19 (the one failure is `test_presign_assignment_is_consensus_ordered_not_local`, a pre-existing setup race — its pool-size-2 precondition vs. a wait-helper that returns at pool ≥ 1; it passes alone, and failed identically on the pre-#2042 base). `noa_signing_key_skew`: 4/4. clippy clean, no lint suppressions.

Worth noting: the historical module flake ("exactly one presign from the pre-sign pool snapshot should have been consumed", 5/15 failing on the pre-#2042 base at `--test-threads=4`) did NOT recur on this branch — #2042's identity-keyed idempotent drain appears to have fixed it. The remaining setup race above is separate; a harness fix (wait-helper taking a minimum pool size) can follow independently.

Closes #2019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Kxw9H9dWLZqmQgyEXAHqi
