### PR TITLE
chore: upgrade Sui to mainnet-v1.77.2

### DIFF
--- a/.github/workflows/system-tests-ci.yaml
+++ b/.github/workflows/system-tests-ci.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install Sui from Github
         run: |
-          curl -L https://github.com/MystenLabs/sui/releases/download/mainnet-v1.76.1/sui-mainnet-v1.76.1-ubuntu-x86_64.tgz > sui.tgz
+          curl -L https://github.com/MystenLabs/sui/releases/download/mainnet-v1.77.2/sui-mainnet-v1.77.2-ubuntu-x86_64.tgz > sui.tgz
           tar -xvzf sui.tgz
           sudo cp ./sui /usr/local/bin/sui
 

--- a/.github/workflows/ts-ci.yaml
+++ b/.github/workflows/ts-ci.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install Sui from Github
         run: |
-          curl -L https://github.com/MystenLabs/sui/releases/download/mainnet-v1.76.1/sui-mainnet-v1.76.1-ubuntu-x86_64.tgz > sui.tgz
+          curl -L https://github.com/MystenLabs/sui/releases/download/mainnet-v1.77.2/sui-mainnet-v1.77.2-ubuntu-x86_64.tgz > sui.tgz
           tar -xvzf sui.tgz
           sudo cp ./sui /usr/local/bin/sui
 

--- a/.github/workflows/ts-integration-tests.yaml
+++ b/.github/workflows/ts-integration-tests.yaml
@@ -122,11 +122,11 @@ jobs:
         with:
           version: "latest"
 
-      # The Cargo workspace pins Sui to mainnet-v1.76.1; a mismatched local
+      # The Cargo workspace pins Sui to mainnet-v1.77.2; a mismatched local
       # sui completes DKG but stalls reconfiguration, so pin the binary too.
-      - name: Install Sui mainnet-v1.76.1
+      - name: Install Sui mainnet-v1.77.2
         run: |
-          curl -L https://github.com/MystenLabs/sui/releases/download/mainnet-v1.76.1/sui-mainnet-v1.76.1-ubuntu-x86_64.tgz > sui.tgz
+          curl -L https://github.com/MystenLabs/sui/releases/download/mainnet-v1.77.2/sui-mainnet-v1.77.2-ubuntu-x86_64.tgz > sui.tgz
           tar -xzf sui.tgz
           mkdir -p "$HOME/.local/bin"
           cp ./sui "$HOME/.local/bin/sui"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ already validated, branch names, and in-flight CI run IDs/URLs.
   at its root) and browsable at github.com/MystenLabs/sui at the pinned
   tag. How to locate it + what to read for what:
   `dev-docs/reference/sui-upstream.md`.
-- **Sui version is pinned in MULTIPLE places** (currently `mainnet-v1.76.1`;
+- **Sui version is pinned in MULTIPLE places** (currently `mainnet-v1.77.2`;
   sometimes a `testnet-v*` tag): when bumping it, bump EVERYWHERE in one
   PR — root `Cargo.toml` (~90 tag pins), excluded wasm workspace locks,
   the sui-binary downloads in the TS CI workflows, this file, and every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,8 +2476,8 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "const-str 0.5.7",
  "git-version",
@@ -3404,7 +3404,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "fastcrypto",
  "mysten-network",
@@ -3416,7 +3416,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "base64 0.21.7",
  "consensus-config",
@@ -4983,7 +4983,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -7481,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "serde",
  "serde_json",
@@ -8626,12 +8626,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 
 [[package]]
 name = "move-abstract-interpreter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-binary-format",
 ]
@@ -8639,17 +8639,17 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 
 [[package]]
 name = "move-analyzer"
 version = "1.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "clap",
@@ -8681,7 +8681,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -8697,12 +8697,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8718,7 +8718,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -8731,7 +8731,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -8748,7 +8748,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -8758,7 +8758,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -8788,7 +8788,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -8803,7 +8803,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -8820,7 +8820,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "clap",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "clap",
@@ -8880,7 +8880,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8900,7 +8900,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8936,7 +8936,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8958,7 +8958,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8984,7 +8984,7 @@ dependencies = [
 [[package]]
 name = "move-decompiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "clap",
@@ -9024,7 +9024,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "clap",
@@ -9043,7 +9043,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -9061,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "hex",
@@ -9074,7 +9074,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -9084,31 +9084,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "move-model"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
-dependencies = [
- "anyhow",
- "codespan",
- "codespan-reporting",
- "itertools 0.10.5",
- "log",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-command-line-common",
- "move-compiler",
- "move-core-types",
- "move-disassembler",
- "move-ir-types",
- "move-symbol-pool",
- "num",
- "serde",
-]
-
-[[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -9125,7 +9103,7 @@ dependencies = [
 [[package]]
 name = "move-package-alt"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -9166,7 +9144,7 @@ dependencies = [
 [[package]]
 name = "move-package-alt-compilation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "clap",
@@ -9193,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "enum-compat-util",
  "quote",
@@ -9203,7 +9181,7 @@ dependencies = [
 [[package]]
 name = "move-regex-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "indexmap 2.9.0",
  "move-binary-format",
@@ -9213,30 +9191,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "move-stackless-bytecode"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
-dependencies = [
- "codespan",
- "codespan-reporting",
- "ethnum",
- "im",
- "itertools 0.10.5",
- "log",
- "move-binary-format",
- "move-command-line-common",
- "move-compiler",
- "move-core-types",
- "move-model",
- "num",
- "petgraph 0.8.2",
- "serde",
-]
-
-[[package]]
 name = "move-stackless-bytecode-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "move-abstract-interpreter",
@@ -9246,7 +9203,6 @@ dependencies = [
  "move-model-2",
  "move-package-alt",
  "move-package-alt-compilation",
- "move-stackless-bytecode",
  "move-symbol-pool",
  "tempfile",
 ]
@@ -9254,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "hex",
@@ -9270,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v0"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -9285,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v1"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -9300,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v2"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -9315,7 +9271,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v3"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -9330,7 +9286,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "phf",
  "serde",
@@ -9339,7 +9295,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -9351,7 +9307,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9375,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-binary-format",
 ]
@@ -9383,7 +9339,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-trace-format",
  "move-vm-config",
@@ -9395,7 +9351,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9425,7 +9381,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "better_any",
  "fail",
@@ -9443,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "better_any",
  "fail",
@@ -9461,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "better_any",
  "fail",
@@ -9479,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "better_any",
  "fail",
@@ -9497,7 +9453,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9509,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9521,7 +9477,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9533,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9576,7 +9532,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6#2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=6b8e1e8cdce408e73d46538773fc85a56c082db7#6b8e1e8cdce408e73d46538773fc85a56c082db7"
 dependencies = [
  "ahash 0.7.8",
  "async-task",
@@ -9605,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6#2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=6b8e1e8cdce408e73d46538773fc85a56c082db7#6b8e1e8cdce408e73d46538773fc85a56c082db7"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -9679,7 +9635,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "mysten-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "antithesis_sdk",
  "either",
@@ -9700,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "async-trait",
  "axum 0.8.8",
@@ -9721,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -9760,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "mysten-service"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11215,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13037,7 +12993,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "eyre",
@@ -13481,8 +13437,8 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sui"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anemo",
  "anyhow",
@@ -13562,7 +13518,7 @@ dependencies = [
  "sui-rpc",
  "sui-rpc-api",
  "sui-sdk",
- "sui-source-validation",
+ "sui-source-verification",
  "sui-swarm",
  "sui-swarm-config",
  "sui-transaction-builder",
@@ -13583,7 +13539,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13618,7 +13574,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13646,7 +13602,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13673,7 +13629,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13700,7 +13656,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13735,7 +13691,7 @@ dependencies = [
 [[package]]
 name = "sui-authority-aggregation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "futures",
  "mysten-metrics",
@@ -13746,8 +13702,8 @@ dependencies = [
 
 [[package]]
 name = "sui-bridge"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "alloy",
  "alloy-multiprovider-strategy",
@@ -13803,7 +13759,7 @@ dependencies = [
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anemo",
  "anyhow",
@@ -13834,8 +13790,8 @@ dependencies = [
 
 [[package]]
 name = "sui-consistent-store"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13871,7 +13827,7 @@ dependencies = [
 [[package]]
 name = "sui-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anemo",
  "antithesis_sdk",
@@ -13970,8 +13926,8 @@ dependencies = [
 
 [[package]]
 name = "sui-crypto"
-version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d8643443b523fb14873c3ea566a7b7f8146b34e8#d8643443b523fb14873c3ea566a7b7f8146b34e8"
+version = "0.3.1"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8#5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",
@@ -13997,7 +13953,7 @@ dependencies = [
 [[package]]
 name = "sui-data-store"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14017,8 +13973,8 @@ dependencies = [
 
 [[package]]
 name = "sui-display"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14041,7 +13997,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -14049,7 +14005,7 @@ dependencies = [
 [[package]]
 name = "sui-execution"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-interpreter-v2",
@@ -14096,8 +14052,8 @@ dependencies = [
 
 [[package]]
 name = "sui-faucet"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -14123,16 +14079,16 @@ dependencies = [
 
 [[package]]
 name = "sui-field-count"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "sui-field-count-derive",
 ]
 
 [[package]]
 name = "sui-field-count-derive"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -14141,7 +14097,7 @@ dependencies = [
 [[package]]
 name = "sui-framework"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -14153,8 +14109,8 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14168,8 +14124,8 @@ dependencies = [
 
 [[package]]
 name = "sui-futures"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "futures",
@@ -14182,7 +14138,7 @@ dependencies = [
 [[package]]
 name = "sui-genesis-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14231,8 +14187,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14260,8 +14216,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-consistent-api"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
@@ -14271,8 +14227,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-consistent-store"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14323,8 +14279,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14369,8 +14325,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework-store-traits"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14380,8 +14336,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-graphql"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -14446,8 +14402,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-metrics"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -14462,8 +14418,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-reader"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -14500,8 +14456,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-schema"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14517,8 +14473,8 @@ dependencies = [
 
 [[package]]
 name = "sui-inverted-index"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -14534,7 +14490,7 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14551,7 +14507,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -14606,7 +14562,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14626,7 +14582,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14661,7 +14617,7 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14688,8 +14644,8 @@ dependencies = [
 
 [[package]]
 name = "sui-kvstore"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -14733,8 +14689,8 @@ dependencies = [
 
 [[package]]
 name = "sui-light-client"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14775,7 +14731,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "futures",
  "once_cell",
@@ -14786,7 +14742,7 @@ dependencies = [
 [[package]]
 name = "sui-metrics-push-client"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14802,8 +14758,8 @@ dependencies = [
 
 [[package]]
 name = "sui-move"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -14843,8 +14799,8 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14870,7 +14826,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "better_any",
@@ -14891,7 +14847,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "better_any",
@@ -14912,7 +14868,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "better_any",
@@ -14933,7 +14889,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "better_any",
@@ -14954,7 +14910,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "better_any",
@@ -14976,8 +14932,8 @@ dependencies = [
 
 [[package]]
 name = "sui-name-service"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -14989,7 +14945,7 @@ dependencies = [
 [[package]]
 name = "sui-network"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -15042,8 +14998,8 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -15103,8 +15059,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "schemars 0.8.21",
@@ -15116,7 +15072,7 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -15128,8 +15084,8 @@ dependencies = [
 
 [[package]]
 name = "sui-package-alt"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15147,8 +15103,8 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "sui-framework-snapshot",
@@ -15160,7 +15116,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "async-trait",
  "bcs",
@@ -15176,8 +15132,8 @@ dependencies = [
 
 [[package]]
 name = "sui-pg-db"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15206,7 +15162,7 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -15217,8 +15173,8 @@ dependencies = [
 
 [[package]]
 name = "sui-prompt"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "clap",
@@ -15229,7 +15185,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "clap",
  "fastcrypto",
@@ -15250,7 +15206,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15260,7 +15216,7 @@ dependencies = [
 [[package]]
 name = "sui-replay-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -15298,8 +15254,8 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc"
-version = "0.3.1"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d8643443b523fb14873c3ea566a7b7f8146b34e8#d8643443b523fb14873c3ea566a7b7f8146b34e8"
+version = "0.3.2"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8#5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -15324,7 +15280,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -15377,7 +15333,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc-cursor"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bytes",
@@ -15386,8 +15342,8 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc-store"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15417,8 +15373,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15453,8 +15409,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk-types"
-version = "0.3.1"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d8643443b523fb14873c3ea566a7b7f8146b34e8#d8643443b523fb14873c3ea566a7b7f8146b34e8"
+version = "0.3.2"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8#5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8"
 dependencies = [
  "base64ct",
  "bcs",
@@ -15475,7 +15431,7 @@ dependencies = [
 [[package]]
 name = "sui-simulator"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -15500,7 +15456,7 @@ dependencies = [
 [[package]]
 name = "sui-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -15526,12 +15482,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sui-source-validation"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+name = "sui-source-verification"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "colored 2.2.0",
+ "dirs 4.0.0",
+ "fastcrypto",
  "flate2",
  "futures",
  "move-binary-format",
@@ -15545,6 +15503,7 @@ dependencies = [
  "msim",
  "mysten-common",
  "serde",
+ "serde_json",
  "sui-move-build",
  "sui-package-alt",
  "sui-package-management",
@@ -15561,8 +15520,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sql-macro"
-version = "1.76.1"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+version = "1.77.2"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -15572,7 +15531,7 @@ dependencies = [
 [[package]]
 name = "sui-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15625,7 +15584,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "futures",
@@ -15652,7 +15611,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anemo",
  "anyhow",
@@ -15678,7 +15637,7 @@ dependencies = [
 [[package]]
 name = "sui-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "reqwest",
  "serde",
@@ -15689,7 +15648,7 @@ dependencies = [
 [[package]]
 name = "sui-test-transaction-builder"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -15705,7 +15664,7 @@ dependencies = [
 [[package]]
 name = "sui-tls"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -15727,7 +15686,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15743,7 +15702,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-checks"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "fastcrypto-zkp",
  "sui-config",
@@ -15757,7 +15716,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anemo",
  "anyhow",
@@ -15832,7 +15791,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -15849,7 +15808,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -15865,7 +15824,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -15880,7 +15839,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -15896,7 +15855,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v3"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -16048,7 +16007,7 @@ dependencies = [
 [[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -16188,7 +16147,7 @@ dependencies = [
 [[package]]
 name = "test-cluster"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "bcs",
@@ -17210,7 +17169,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "anyhow",
  "backoff",
@@ -17239,7 +17198,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -17250,7 +17209,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.76.1#433212f8f2768ac22dd412229c970b8a5281d4e5"
+source = "git+https://github.com/MystenLabs/sui?tag=mainnet-v1.77.2#51d177ad7d65102fc368b582408f466d97b31548"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ moka = { version = "0.12", default-features = false, features = [
     "atomic64",
 ] }
 more-asserts = "0.3.1"
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "6b8e1e8cdce408e73d46538773fc85a56c082db7", package = "msim" }
 multiaddr = "0.18.2"
 nonempty = "0.12.0"
 num-bigint = "0.4.6"
@@ -283,13 +283,13 @@ shlex = "1.3.0"
 lazy_static = "1.5.0"
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-move-bytecode-utils = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-move-compiler = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-move-package = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-move-package-alt-compilation = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-move-symbol-pool = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+move-binary-format = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+move-bytecode-utils = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+move-compiler = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+move-package = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+move-package-alt-compilation = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+move-symbol-pool = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
 
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "3273734b9791df0c3d1655509476e10a49978528" }
@@ -302,48 +302,48 @@ anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "68adc31d
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "68adc31d4ea1f4573f08c2c75317fcb205b823de" }
 
 ### Sui Members ###
-bin-version =  { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-mysten-common = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-mysten-network = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-mysten-service = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-shared-crypto = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-faucet = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-indexer = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-json = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-light-client = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-metrics-push-client = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-move = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-protocol-config-macros = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+bin-version =  { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+mysten-common = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+mysten-network = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+mysten-service = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+shared-crypto = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-faucet = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-indexer = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-json = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-light-client = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-metrics-push-client = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-move = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-protocol-config-macros = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
 # Proto/BCS type conversions (e.g. ValidatorAggregatedSignature) used by the
-# OCS gRPC read layer. Pinned to the sui-rust-sdk rev that sui@mainnet-v1.76.1
+# OCS gRPC read layer. Pinned to the sui-rust-sdk rev that sui@mainnet-v1.77.2
 # itself depends on, so there's exactly one sui-sdk-types in the tree.
-sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "d8643443b523fb14873c3ea566a7b7f8146b34e8" }
-sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-swarm = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-swarm-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-test-transaction-builder = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-tls = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-transaction-checks = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-typed-store = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-typed-store-error = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8" }
+sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-swarm = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-swarm-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-test-transaction-builder = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-tls = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-transaction-checks = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+sui-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+typed-store = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+typed-store-error = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
 
-consensus-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-consensus-core = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
-consensus-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.76.1" }
+consensus-config = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+consensus-core = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
+consensus-types = { git = "https://github.com/MystenLabs/sui", tag = "mainnet-v1.77.2" }
 
 ### Workspace Members ###
 dwallet-rng = { path = "crates/dwallet-rng" }

--- a/crates/ika-core/src/consensus_manager/mod.rs
+++ b/crates/ika-core/src/consensus_manager/mod.rs
@@ -75,7 +75,7 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
         config.mysticeti_num_leaders_per_round(),
         config.consensus_bad_nodes_stake_threshold(),
         // `enable_v3`: hardcoded `false` to match upstream exactly. At the
-        // pinned mainnet-v1.76.1, Sui's own `to_consensus_protocol_config` also
+        // pinned mainnet-v1.77.2, Sui's own `to_consensus_protocol_config` also
         // hardcodes `/* enable_v3 */ false` — it is NOT yet exposed by
         // `sui_protocol_config::ProtocolConfig`, so there is no version-gated
         // getter to source it from. When Sui gates it behind the protocol config
@@ -86,7 +86,7 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
         false,
         // `leader_schedule_window_size` / `leader_schedule_update_interval`:
         // hardcoded to match upstream's `to_consensus_protocol_config` at the
-        // pinned mainnet-v1.76.1 (300 / 12). These only take effect under the
+        // pinned mainnet-v1.77.2 (300 / 12). These only take effect under the
         // Mysticeti v3 leader schedule, which is gated off above (`enable_v3 =
         // false`), so they are inert today; mirror upstream exactly so enabling
         // v3 later (via a version-gated getter) does not silently fork.
@@ -270,6 +270,9 @@ impl ConsensusManager {
             self.network_keypair.clone(),
             Arc::new(Clock::default()),
             Arc::new(tx_validator.clone()),
+            // ika submits via `TransactionClient`; it has no in-process pool to
+            // feed the proposer. `None` means fall back to the client path.
+            None,
             commit_consumer,
             registry.clone(),
             *boot_counter,

--- a/dev-docs/conventions/sui-version-bump.md
+++ b/dev-docs/conventions/sui-version-bump.md
@@ -26,9 +26,10 @@ the locations below and runs in CI; it fails the build on drift.
    ```
 3. **CI workflows that download the `sui` binary** — the release URL
    embeds the version twice:
-   - `.github/workflows/ts-integration-tests.yaml`
-   - `.github/workflows/ts-ci.yaml`
-4. **`CLAUDE.md`** — the pinned-version line in Gotchas.
+    - `.github/workflows/ts-integration-tests.yaml`
+    - `.github/workflows/ts-ci.yaml`
+    - `.github/workflows/system-tests-ci.yaml`
+  4. **`CLAUDE.md`** — the pinned-version line in Gotchas.
 5. **msim / simtest rev** — `scripts/simtest/cargo-simtest` **and**
    `scripts/simtest/config-patch` (the coverage path in
    `scripts/simtest/codecov.sh` applies the same patch as a real diff,

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -55,12 +55,12 @@ else
   # mysten-sim rev — MUST match the msim/sui-simulator rev the pinned Sui
   # version uses (see Sui's own scripts/simtest/cargo-simtest at the tag),
   # else simtest links two mysten-sim copies and panics "no reactor running".
-  # Bump together with the Sui tag in root Cargo.toml. (mainnet-v1.76.1 -> 2c2ec3ff)
+  # Bump together with the Sui tag in root Cargo.toml. (mainnet-v1.77.2 -> 6b8e1e8c)
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6"'
+    --config 'patch.crates-io.tokio.rev = "6b8e1e8cdce408e73d46538773fc85a56c082db7"'
     --config 'patch.crates-io.futures-timer.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.futures-timer.rev = "2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6"'
+    --config 'patch.crates-io.futures-timer.rev = "6b8e1e8cdce408e73d46538773fc85a56c082db7"'
   )
 fi
 

--- a/scripts/simtest/config-patch
+++ b/scripts/simtest/config-patch
@@ -19,5 +19,5 @@ index 20f92df9df..0d76a5c962 100644
  async-graphql = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18-graphiql-4" }
  async-graphql-axum = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18-graphiql-4" }
  async-graphql-value = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18-graphiql-4" }
-+tokio = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6" }
-+futures-timer = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6" }
++tokio = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "6b8e1e8cdce408e73d46538773fc85a56c082db7" }
++futures-timer = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "6b8e1e8cdce408e73d46538773fc85a56c082db7" }


### PR DESCRIPTION
## Description

Upgrade the Sui pin from `mainnet-v1.76.1` to `mainnet-v1.77.2`, everywhere it
lives in one PR:

- **`Cargo.toml`** — 45 Sui git-dep tags -> `mainnet-v1.77.2`.
- **`sui-rust-sdk` rev** — `sui-sdk-types`/`sui-crypto`/`sui-rpc` rev bumped to
  `5781b718`, the rev Sui 1.77.2 itself pins. Leaving the old rev would put two
  `sui-sdk-types` in the graph (one per git source) and fail type unification.
- **msim simtest rev** — `2c2ec3ff` -> `6b8e1e8c` (the rev Sui 1.77.2's own
  simtest uses). The `tokio` exact pin stays `=1.52.1`: verified both Sui 1.77.2
  and that mysten-sim rev still ship `msim-tokio 1.52.1`, so the
  `[patch.crates-io.tokio]` stays effective.
- **`consensus_manager`** — Sui 1.77.2 added a required
  `transaction_pool: Option<Arc<dyn TransactionPool>>` param to
  `ConsensusAuthority::start`; ika has no in-process pool (it submits via
  `TransactionClient`), so pass `None`. Verified 1.77.2's upstream
  `to_consensus_protocol_config` still hardcodes `enable_v3=false` and
  `300/12`, so ika's mirrored constants hold.
- **CI sui-binary URLs** (`ts-ci`, `ts-integration-tests`,
  `system-tests-ci`), **`CLAUDE.md`** gotcha, **`Cargo.lock`** (surgical — only
  the Sui git revs and their sui-rust-sdk transitives move; no unrelated
  registry drift).

> [!important]
> Developers running localnets must update the local `sui` binary to
> `mainnet-v1.77.2` — a mismatched binary completes DKG but silently stalls
> reconfiguration (see `dev-docs/playbooks/localnet.md`).

## Test plan

- `./scripts/check-sui-version-consistency.sh` passes.
- `cargo build --release` passes.
- Dispatched `integration-tests-ci`, `test-cluster`, and
  `ts-integration-tests` on the branch for real-crypto / epoch-boundary
  validation (watching to verdict).