### PR TITLE
fix(logging): stop printing a stack backtrace on every retry tick

### DIFF
--- a/crates/ika-core/src/dwallet_checkpoints/mod.rs
+++ b/crates/ika-core/src/dwallet_checkpoints/mod.rs
@@ -25,7 +25,7 @@ use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 
 use ika_types::crypto::AuthorityStrongQuorumSignInfo;
 use ika_types::digests::DWalletCheckpointMessageDigest;
-use ika_types::error::{IkaError, IkaResult};
+use ika_types::error::{IkaError, IkaResult, error_chain};
 use ika_types::message::DWalletCheckpointMessageKind;
 use ika_types::message_envelope::Message;
 use ika_types::messages_dwallet_checkpoint::{
@@ -503,7 +503,7 @@ impl DWalletCheckpointBuilder {
 
             if let Err(e) = self.make_checkpoint(vec![pending.clone()]).await {
                 error!(
-                    ?e,
+                    error = %error_chain(&e),
                     last_height,
                     ?pending,
                     "Error while making dwallet checkpoint, will retry in 1s",

--- a/crates/ika-core/src/sui_connector/bag_event_pump.rs
+++ b/crates/ika-core/src/sui_connector/bag_event_pump.rs
@@ -33,6 +33,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ika_types::committee::EpochId;
+use ika_types::error::error_chain;
 use ika_types::messages_dwallet_mpc::{DBSuiEvent, IkaNetworkConfig};
 use ika_types::sui::{DWalletCoordinator, DWalletCoordinatorInner};
 use sui_types::TypeTag;
@@ -195,13 +196,17 @@ impl BagEventPump {
                     // outage no longer floods the log at the poll rate.
                     if consecutive_failures >= PUMP_FAILURE_ESCALATION_TICKS {
                         error!(
-                            error = ?e,
+                            error = %error_chain(&e),
                             consecutive_failures,
                             backoff_ms = backoff.as_millis() as u64,
                             "BagEventPump tick failing persistently (relay/proof outage?); backing off"
                         );
                     } else {
-                        warn!(error = ?e, consecutive_failures, "BagEventPump tick failed; will retry with backoff");
+                        warn!(
+                            error = %error_chain(&e),
+                            consecutive_failures,
+                            "BagEventPump tick failed; will retry with backoff"
+                        );
                     }
                 }
             }
@@ -256,7 +261,12 @@ impl BagEventPump {
                     snapshot_requests.push(req);
                 }
                 Ok(None) => {}
-                Err(e) => error!(error=?e, event_type=?ev.type_, ?id, "failed to parse bag entry"),
+                Err(e) => error!(
+                    error = %error_chain(&e),
+                    event_type = ?ev.type_,
+                    ?id,
+                    "failed to parse bag entry"
+                ),
             }
         }
 

--- a/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
+++ b/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
@@ -27,6 +27,7 @@ use fastcrypto::ed25519::Ed25519PublicKey;
 use ika_sui_client::{SuiClient, SuiClientInner};
 use ika_types::committee::{Committee, EpochId, StakeUnit};
 use ika_types::crypto::{AuthorityName, AuthorityPublicKeyBytes};
+use ika_types::error::error_chain;
 use ika_types::sui::{SystemInner, SystemInnerTrait, SystemInnerV1};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, Weak};
@@ -338,14 +339,14 @@ where
                 Err(err) => {
                     if consecutive_refresh_failures.is_multiple_of(12) {
                         warn!(
-                            error=?err,
+                            error = %error_chain(&err),
                             label = self.label,
                             consecutive_failures = consecutive_refresh_failures,
                             "pubkey provider refresh failed; will retry"
                         );
                     } else {
                         debug!(
-                            error=?err,
+                            error = %error_chain(&err),
                             label = self.label,
                             consecutive_failures = consecutive_refresh_failures,
                             "pubkey provider refresh failed; will retry"

--- a/crates/ika-core/src/sui_connector/push_worker.rs
+++ b/crates/ika-core/src/sui_connector/push_worker.rs
@@ -23,6 +23,7 @@ use std::time::{Duration, Instant};
 use ika_network::proof_provider::VerifiedObjectEntry;
 use ika_sui_client::archive::CheckpointArchive;
 use ika_sui_client::transport::SuiTransport;
+use ika_types::error::error_chain;
 use ika_types::messages_dwallet_mpc::IkaPackageConfig;
 use sui_light_client::proof::ocs::ModifiedObjectTree;
 use sui_types::TypeTag;
@@ -200,7 +201,10 @@ impl IkaCheckpointPusher {
         loop {
             tick.tick().await;
             if let Err(e) = self.advance().await {
-                warn!(error = ?e, "checkpoint pusher tick failed; will retry");
+                warn!(
+                    error = %error_chain(&e),
+                    "checkpoint pusher tick failed; will retry"
+                );
             }
         }
     }
@@ -541,7 +545,11 @@ impl IkaCheckpointPusher {
                         );
                     }
                     Err(e) => {
-                        warn!(seq, error = ?e, "gap checkpoint fetched but failed to fold — will retry");
+                        warn!(
+                            seq,
+                            error = %error_chain(&e),
+                            "gap checkpoint fetched but failed to fold — will retry"
+                        );
                     }
                 },
                 Err(fullnode_error) => {
@@ -625,7 +633,11 @@ impl IkaCheckpointPusher {
                     Err(e) => {
                         // Same transient-vs-deterministic ambiguity as the
                         // fullnode fold path; the caller's deadline bounds it.
-                        warn!(seq, error = ?e, "archive checkpoint fetched but failed to fold — will retry");
+                        warn!(
+                            seq,
+                            error = %error_chain(&e),
+                            "archive checkpoint fetched but failed to fold — will retry"
+                        );
                         false
                     }
                 }

--- a/crates/ika-core/src/system_checkpoints/mod.rs
+++ b/crates/ika-core/src/system_checkpoints/mod.rs
@@ -23,7 +23,7 @@ use sui_types::base_types::ConciseableName;
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use ika_types::crypto::AuthorityStrongQuorumSignInfo;
-use ika_types::error::{IkaError, IkaResult};
+use ika_types::error::{IkaError, IkaResult, error_chain};
 use ika_types::message_envelope::Message;
 use ika_types::messages_system_checkpoints::{
     CertifiedSystemCheckpointMessage, SignedSystemCheckpointMessage, SystemCheckpointMessage,
@@ -492,7 +492,7 @@ impl SystemCheckpointBuilder {
 
             if let Err(e) = self.make_checkpoint(vec![pending.clone()]).await {
                 error!(
-                    ?e,
+                    error = %error_chain(&e),
                     last_height,
                     ?pending,
                     "Error while making system checkpoint, will retry in 1s"

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -45,6 +45,9 @@ pub mod ika_validator_transactions;
 pub mod metrics;
 pub mod transport;
 pub use transport::{SubmittedTransaction, SuiFundsBreakdown};
+// Re-exported so `retry_with_max_elapsed_time!` can reach it as `$crate::error_chain`
+// from any expansion site, without requiring the caller to depend on ika-types.
+pub use ika_types::error::error_chain;
 
 #[macro_export]
 macro_rules! retry_with_max_elapsed_time {
@@ -68,7 +71,7 @@ macro_rules! retry_with_max_elapsed_time {
                     }
                     Err(err) => {
           // For simplicity we treat every error as transient so we can retry until max_elapsed_time
-          warn!(error=?err, "retrying with max elapsed time");
+          warn!(error = %$crate::error_chain(&err), "retrying with max elapsed time");
                         return Err(backoff::Error::transient(err));
                     }
                 }

--- a/crates/ika-types/src/error.rs
+++ b/crates/ika-types/src/error.rs
@@ -33,6 +33,60 @@ macro_rules! fp_ensure {
 use crate::dwallet_mpc_error::DwalletMPCError;
 use sui_types::error::SuiError;
 
+/// One-line, backtrace-free rendering of an error **and its full context
+/// chain**, for logging on paths that will retry.
+///
+/// # Why this exists
+///
+/// The obvious way to log an error under `tracing` is `error = ?e`, and for a
+/// plain `#[derive(Debug)]` error enum that is fine. For an [`anyhow::Error`]
+/// it is not: `anyhow`'s `Debug` impl prints the message, then each `Caused
+/// by:` line, then — when the binary captures backtraces, which ika's do — the
+/// **entire captured stack backtrace**. On a path that logs once per retry
+/// tick that turns the log into mostly backtrace by volume, and the one line an
+/// operator actually needs (the underlying cause) is buried in frames that are
+/// identical on every tick and say nothing the log line's own message didn't.
+///
+/// The naive fix, `error = %e`, is worse than it looks: `anyhow`'s plain
+/// `Display` prints **only the outermost context**. A tick that failed with
+/// `.context("bag walk failed")` over a transport error would log exactly
+/// `bag walk failed` and drop the actual reason.
+///
+/// `anyhow`'s *alternate* `Display` (`{:#}`) is the one that renders the whole
+/// chain, on a single line, with no backtrace — which is precisely what a
+/// retry-path log wants. This wrapper is that formatting, made greppable and
+/// usable from a `tracing` field (the macros have sigils for `Display` and
+/// `Debug`, but no sigil for alternate-`Display`).
+///
+/// It is generic over `Display`, not specific to `anyhow`: for a typed error
+/// enum `{:#}` is identical to `{}`, so the same call site stays correct if the
+/// error type changes.
+///
+/// Fatal and non-retryable paths should keep `?e` — a backtrace logged once,
+/// where the process is about to stop or a decision is final, is worth having.
+///
+/// ```ignore
+/// warn!(error = %error_chain(&e), "checkpoint pusher tick failed; will retry");
+/// ```
+pub struct ErrorChain<E>(E);
+
+impl<E: std::fmt::Display> std::fmt::Display for ErrorChain<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:#}", self.0)
+    }
+}
+
+impl<E: std::fmt::Display> std::fmt::Debug for ErrorChain<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
+/// See [`ErrorChain`].
+pub fn error_chain<E: std::fmt::Display>(error: E) -> ErrorChain<E> {
+    ErrorChain(error)
+}
+
 #[macro_export]
 macro_rules! exit_main {
     ($result:expr_2021) => {
@@ -370,5 +424,74 @@ impl Ord for IkaError {
 impl PartialOrd for IkaError {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+#[cfg(test)]
+mod error_chain_tests {
+    use super::error_chain;
+
+    fn nested() -> anyhow::Error {
+        anyhow::anyhow!("transport: code 'Unavailable', message: \"grpc-status header missing\"")
+            .context("verified_dynamic_fields_page failed")
+            .context("bag walk failed")
+    }
+
+    /// The whole point: one line, the full cause chain, no backtrace.
+    #[test]
+    fn renders_the_full_chain_on_one_line() {
+        let rendered = format!("{}", error_chain(&nested()));
+        assert!(
+            !rendered.contains('\n'),
+            "a retry-path log line must stay one line, got:\n{rendered}"
+        );
+        for fragment in [
+            "bag walk failed",
+            "verified_dynamic_fields_page failed",
+            "grpc-status header missing",
+        ] {
+            assert!(
+                rendered.contains(fragment),
+                "the chain must survive; {fragment:?} missing from {rendered:?}"
+            );
+        }
+        assert!(
+            !rendered.contains("Stack backtrace"),
+            "a retry-path log line must not carry a backtrace: {rendered}"
+        );
+    }
+
+    /// What `error = ?e` does instead, and why it is wrong here: `Debug` on an
+    /// `anyhow::Error` is multi-line before a backtrace is even captured, and
+    /// with `RUST_BACKTRACE` set (which ika's binaries enable) it appends the
+    /// whole stack — once per retry tick.
+    #[test]
+    fn debug_formatting_is_the_multi_line_shape_this_replaces() {
+        assert!(
+            format!("{:?}", nested()).contains('\n'),
+            "if anyhow's Debug ever became single-line this fix would be moot"
+        );
+    }
+
+    /// The naive one-line alternative, `error = %e`, silently drops every
+    /// cause — which is exactly the information a retry-path log exists to
+    /// carry.
+    #[test]
+    fn plain_display_would_drop_the_causes() {
+        let plain = format!("{}", nested());
+        assert_eq!(plain, "bag walk failed");
+        assert!(!plain.contains("grpc-status header missing"));
+    }
+
+    /// Generic over `Display`, so a call site stays correct if its error type
+    /// is a plain enum rather than `anyhow::Error` (`{:#}` == `{}` there).
+    #[test]
+    fn typed_errors_render_unchanged() {
+        let typed = crate::error::IkaError::TooManyRequests;
+        assert_eq!(
+            format!("{}", error_chain(&typed)),
+            format!("{typed}"),
+            "a non-anyhow error must render exactly as it always did"
+        );
     }
 }


### PR DESCRIPTION
Fixes #2069.

Logging only. No retry behavior changes anywhere in this PR, so it stays independently revertable from the 429-backoff work (#2068).

## Before / after

One log line, from a real run of the exact formatting change (`anyhow` with `backtrace`, `RUST_BACKTRACE=1`, `tracing_subscriber::fmt`):

**Before** — `warn!(error = ?e, "checkpoint pusher tick failed; will retry")`:

```
 WARN ika_core::sui_connector::push_worker: checkpoint pusher tick failed; will retry error=probe latest checkpoint sequence

Caused by:
    transport: code: 'Unavailable', message: "grpc-status header missing, mapped from HTTP status code 429"

Stack backtrace:
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/…/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/…/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14
   2: std::backtrace::Backtrace::create
             at /rustc/…/library/std/src/backtrace.rs:331:13
   3: anyhow::error::<impl anyhow::Error>::msg
             at …/anyhow-1.0.104/src/backtrace.rs:10:14
   4: anyhow::__private::format_err
             at …/anyhow-1.0.104/src/lib.rs:687:13
   5: ika_core::sui_connector::push_worker::…::advance::{{closure}}
   … 16 more frames …
  21: _main
```

**After** — `warn!(error = %error_chain(&e), "checkpoint pusher tick failed; will retry")`:

```
 WARN ika_core::sui_connector::push_worker: checkpoint pusher tick failed; will retry error=probe latest checkpoint sequence: transport: code: 'Unavailable', message: "grpc-status header missing, mapped from HTTP status code 429"
```

45 lines → 1, and the underlying cause moves from the middle of the block to the end of the line. (That capture is from a toy 8-frame-deep program; inside the node's tokio runtime the frame count — and therefore the ratio — is considerably worse. In one operator's production log excerpt this pattern was roughly 80% of total volume.)

## Why `%e` is not the fix

Worth stating explicitly, because it is the change a reviewer would expect and it is wrong here.

`anyhow`'s plain `Display` prints **only the outermost context**. The same line under `error = %e` would be:

```
 WARN …: checkpoint pusher tick failed; will retry error=probe latest checkpoint sequence
```

— the 429 is gone. That trades a log that is 80% noise for one that is 100% useless. `anyhow`'s *alternate* `Display` (`{:#}`) is the one that renders the full chain on a single line with no backtrace.

`tracing`'s macros have sigils for `Display` (`%`) and `Debug` (`?`) but none for alternate-`Display`, so this PR adds `ika_types::error::error_chain` — a zero-allocation `Display` wrapper that formats its inner value with `{:#}`. It is generic over `Display`, not tied to `anyhow`: for a typed error enum `{:#}` is identical to `{}`, so a call site stays correct if its error type later changes.

## What changed

Retryable paths only, and only where the error is genuinely an `anyhow::Error`:

- `sui_connector/push_worker.rs` — the pusher tick, the gap-fold retry, the archive-fold retry
- `sui_connector/bag_event_pump.rs` — the per-tick `warn!`, the sustained-failure `error!` (which fires on *every* tick past the escalation threshold, not once), and `"failed to parse bag entry"` (re-logged on every ~50ms bag walk for as long as the bad entry sits in the bag)
- `sui_connector/pubkey_provider_updater.rs` — both the `warn!` and `debug!` refresh arms
- `dwallet_checkpoints/mod.rs`, `system_checkpoints/mod.rs` — the `"will retry in 1s"` loops
- `ika-sui-client/src/lib.rs` — `retry_with_max_elapsed_time!`. Highest volume of the lot: `max_elapsed_time` is one hour, and two `sui_executor` call sites (`request_mid_epoch_reconfiguration`, `calculate_protocols_pricing`) pass it an `anyhow::Error`, so every backoff attempt for an hour printed a full backtrace. The macro's other five call sites pass `IkaResult`, for which the change is a no-op.

## What deliberately did not change

**Non-retryable and fatal paths keep `?e`.** A backtrace logged once, where a decision is final, is worth having:

- `push_worker.rs` — `"gap checkpoint kept failing to fold until the retry deadline — dropping"`: fires once per dropped gap and is terminal for that checkpoint. Its per-tick sibling three lines up *is* changed, so the flood stops while the one-shot detail survives.
- `sui_connector/mod.rs` — the one-shot gas-coin sweep warning at notifier setup.

**Sites whose error is not `anyhow`.** I resolved the concrete type at every remaining `?e`/`?err` log site in `ika-core`; the rest are plain `#[derive(Debug)]` / `thiserror` enums (`IkaError`, `DwalletMPCError`, `TransportError`, `ReaderError`, `ChangesetError`, `CommitteeTransitionError`, `ProofError`, `TypedStoreError`, `watch::error::SendError`, …). None captures a backtrace, so `{:?}` on them is already one line — changing them would be churn that also loses structured field rendering.

One near-miss worth flagging so it does not get "fixed" later: `sui_connector/changeset_receiver.rs` — `"ChangesetReceiver tick failed; will retry"` looks exactly like the anyhow pattern and *is* retryable, but its error is `ChangesetError`. Left alone on purpose.

## Tests

`crates/ika-types/src/error.rs`, module `error_chain_tests`:

- `renders_the_full_chain_on_one_line` — asserts no newline, every link of the chain present, no `"Stack backtrace"`
- `debug_formatting_is_the_multi_line_shape_this_replaces` — pins the thing being fixed, so if `anyhow`'s `Debug` ever became single-line this PR's premise is flagged rather than silently stale
- `plain_display_would_drop_the_causes` — pins why `%e` is not the fix
- `typed_errors_render_unchanged` — the generic case is a no-op for non-`anyhow` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
