### PR TITLE
docs: correct a phantom metric name in the wedged-drain alert and its prose

### DIFF
--- a/crates/ika-core/src/authority/round_transport.rs
+++ b/crates/ika-core/src/authority/round_transport.rs
@@ -251,7 +251,7 @@ impl RoundTransportSender {
     /// (a parked fold is not an isolated node), so a drain that stops
     /// consuming entirely holds the watchdog indefinitely and correctly —
     /// isolation is not what has gone wrong. This climbing while
-    /// `ika_dwallet_mpc_consumed_round` is flat is that failure, and it is
+    /// `ika_last_process_mpc_consensus_round` is flat is that failure, and it is
     /// the only place it shows.
     ///
     /// Which is exactly why the park in progress has to count. Accruing only

--- a/crates/ika-core/src/consensus_handler.rs
+++ b/crates/ika-core/src/consensus_handler.rs
@@ -69,7 +69,7 @@ use tracing::{debug, error, instrument, trace_span, warn};
 /// watchdog, because commits keep arriving. That case is covered by
 /// observability rather than by self-exit: `ika_consensus_round_channel_depth`
 /// pinned at capacity together with `ika_consensus_fold_blocked_seconds_total`
-/// climbing while `ika_dwallet_mpc_consumed_round` is flat is a wedged drain,
+/// climbing while `ika_last_process_mpc_consensus_round` is flat is a wedged drain,
 /// and the MPC lag alarm fires on it. Do not "fix" this by moving the call
 /// back after the boundary.
 ///

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -635,7 +635,7 @@ impl DWalletMPCMetrics {
             fold_blocked_seconds_total: register_int_counter_with_registry!(
                 "ika_consensus_fold_blocked_seconds_total",
                 "Cumulative seconds the consensus fold spent waiting for room in the MPC \
-                 round channel. Climbing while ika_dwallet_mpc_consumed_round is flat is a \
+                 round channel. Climbing while ika_last_process_mpc_consensus_round is flat is a \
                  wedged drain — the commit-liveness watchdog deliberately does NOT catch \
                  that, because a waiting fold is not an isolated node",
                 registry

--- a/dev-docs/playbooks/mpc-stall-postmortem.md
+++ b/dev-docs/playbooks/mpc-stall-postmortem.md
@@ -253,7 +253,7 @@ construction; divergence = determinism bug).
   while the fold waits, because a node holding a commit it received is not
   isolated. So a wedged drain produces no exit and no silence alarm. Its
   signature is `ika_consensus_fold_blocked_seconds_total` climbing while
-  `ika_dwallet_mpc_consumed_round` is flat and
+  `ika_last_process_mpc_consensus_round` is flat and
   `ika_consensus_round_channel_depth` sits at capacity. Check that pair
   before concluding the node is healthy because nothing alarmed.
   `ika_consensus_fold_blocked_sends_total` tells a wedge from a merely

--- a/dev-docs/playbooks/production-alerts.md
+++ b/dev-docs/playbooks/production-alerts.md
@@ -177,7 +177,7 @@ increase(ika_consensus_fold_blocked_seconds_total[10m]) > 300
 # still. Capacity is `DEFAULT_ROUND_CHANNEL_CAPACITY` (1024) unless a node
 # overrides it.
 ika_consensus_round_channel_depth >= 1024
-  and increase(ika_dwallet_mpc_consumed_round[10m]) == 0
+  and increase(ika_last_process_mpc_consensus_round[10m]) == 0
 # for: 10m
 ```
 


### PR DESCRIPTION
The wedged-drain corroboration expression in `production-alerts.md` — and four doc-comment/playbook sites echoing it — named `ika_dwallet_mpc_consumed_round`, which was never registered. The exported metric is `ika_last_process_mpc_consensus_round` (same value, set in the drain the line before `record_mpc_consumed_consensus_round`). An alert written from the playbook as-is would silently never fire — the exact failure class it exists to catch, one level up. Found by infra's `check-dashboard-queries.py` while implementing #2064's alerts; the infra rules are being written with the correct name and a comment noting the substitution. Five prose sites corrected, no code paths touched. PR CI's compile jobs cover the doc-comment edits.

Refs #2064.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Kxw9H9dWLZqmQgyEXAHqi