### PR TITLE
fix(metrics): close the default-registry hole in the metric-name ratchet

### DIFF
--- a/crates/ika-proxy/README.md
+++ b/crates/ika-proxy/README.md
@@ -200,8 +200,8 @@ All incoming requests are validated through middleware:
 
 The proxy exposes comprehensive metrics about its operation:
 
-- **`http_handler_hits`**: Request count by handler and peer
-- **`http_handler_duration_seconds`**: Request latency by handler and peer
+- **`ika_proxy_http_handler_hits`**: Request count by handler and peer
+- **`ika_proxy_http_handler_duration_seconds`**: Request latency by handler and peer
 - **`ika_sui_client_sui_rpc_errors`**: Sui gRPC call errors by method
 - **`ika_proxy_uptime`**: Proxy uptime information
 

--- a/crates/ika-proxy/src/consumer.rs
+++ b/crates/ika-proxy/src/consumer.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 use crate::admin::ReqwestClient;
+use crate::metrics::PROXY_REGISTRY;
 use crate::prom_to_mimir::Mimir;
 use crate::remote_write::WriteRequest;
 use anyhow::Result;
@@ -13,42 +14,48 @@ use multiaddr::Multiaddr;
 use once_cell::sync::Lazy;
 use prometheus::proto::{self, MetricFamily};
 use prometheus::{Counter, CounterVec, HistogramVec};
-use prometheus::{register_counter, register_counter_vec, register_histogram_vec};
+use prometheus::{
+    register_counter_vec_with_registry, register_counter_with_registry,
+    register_histogram_vec_with_registry,
+};
 use prost::Message;
 use protobuf::CodedInputStream;
 use std::io::Read;
 use tracing::{debug, error};
 
 static CONSUMER_OPS_SUBMITTED: Lazy<Counter> = Lazy::new(|| {
-    register_counter!(
-        "consumer_operations_submitted",
+    register_counter_with_registry!(
+        "ika_proxy_consumer_operations_submitted",
         "Operations counter for the number of metric family types we submit, excluding histograms, and not the discrete timeseries counts.",
+        PROXY_REGISTRY
     )
     .unwrap()
 });
 static CONSUMER_OPS: Lazy<CounterVec> = Lazy::new(|| {
-    register_counter_vec!(
-        "consumer_operations",
+    register_counter_vec_with_registry!(
+        "ika_proxy_consumer_operations",
         "Operations counters and status from operations performed in the consumer.",
-        &["operation", "status"]
+        &["operation", "status"],
+        PROXY_REGISTRY
     )
     .unwrap()
 });
 static CONSUMER_ENCODE_COMPRESS_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        "protobuf_compression_seconds",
+    register_histogram_vec_with_registry!(
+        "ika_proxy_protobuf_compression_seconds",
         "The time it takes to compress a remote_write payload in seconds.",
         &["operation"],
         vec![
             1e-08, 2e-08, 4e-08, 8e-08, 1.6e-07, 3.2e-07, 6.4e-07, 1.28e-06, 2.56e-06, 5.12e-06,
             1.024e-05, 2.048e-05, 4.096e-05, 8.192e-05
         ],
+        PROXY_REGISTRY
     )
     .unwrap()
 });
 static CONSUMER_OPERATION_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        "consumer_operations_duration_seconds",
+    register_histogram_vec_with_registry!(
+        "ika_proxy_consumer_operations_duration_seconds",
         "The time it takes to perform various consumer operations in seconds.",
         &["operation"],
         vec![
@@ -62,6 +69,7 @@ static CONSUMER_OPERATION_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
             22.25, 22.5, 22.75, 23.0, 23.25, 23.5, 23.75, 24.0, 24.25, 24.5, 24.75, 25.0, 26.0,
             27.0, 28.0, 29.0, 30.0
         ],
+        PROXY_REGISTRY
     )
     .unwrap()
 });

--- a/crates/ika-proxy/src/handlers.rs
+++ b/crates/ika-proxy/src/handlers.rs
@@ -3,6 +3,7 @@
 use crate::admin::{Labels, ReqwestClient};
 use crate::consumer::{NodeMetric, convert_to_remote_write, populate_labels};
 use crate::histogram_relay::HistogramRelay;
+use crate::metrics::PROXY_REGISTRY;
 use crate::middleware::LenDelimProtobuf;
 use crate::peers::AllowedPeer;
 use axum::{
@@ -13,29 +14,31 @@ use hex;
 use multiaddr::Multiaddr;
 use once_cell::sync::Lazy;
 use prometheus::{CounterVec, HistogramVec};
-use prometheus::{register_counter_vec, register_histogram_vec};
+use prometheus::{register_counter_vec_with_registry, register_histogram_vec_with_registry};
 use std::env;
 use std::net::SocketAddr;
 use tracing::{debug, info};
 
 static HANDLER_HITS: Lazy<CounterVec> = Lazy::new(|| {
-    register_counter_vec!(
-        "http_handler_hits",
+    register_counter_vec_with_registry!(
+        "ika_proxy_http_handler_hits",
         "Number of HTTP requests made.",
-        &["handler", "remote"]
+        &["handler", "remote"],
+        PROXY_REGISTRY
     )
     .unwrap()
 });
 
 static HTTP_HANDLER_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        "http_handler_duration_seconds",
+    register_histogram_vec_with_registry!(
+        "ika_proxy_http_handler_duration_seconds",
         "The HTTP request latencies in seconds.",
         &["handler", "remote"],
         vec![
             1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0, 3.25, 3.5, 3.75, 4.0, 4.25, 4.5, 4.75,
             5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0
         ],
+        PROXY_REGISTRY
     )
     .unwrap()
 });

--- a/crates/ika-proxy/src/histogram_relay.rs
+++ b/crates/ika-proxy/src/histogram_relay.rs
@@ -5,7 +5,7 @@ use axum::{Router, extract::Extension, http::StatusCode, routing::get};
 use once_cell::sync::Lazy;
 use prometheus::proto::{Metric, MetricFamily};
 use prometheus::{CounterVec, HistogramVec};
-use prometheus::{register_counter_vec, register_histogram_vec};
+use prometheus::{register_counter_vec_with_registry, register_histogram_vec_with_registry};
 use std::net::TcpListener;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
@@ -17,27 +17,30 @@ use tower_http::LatencyUnit;
 use tower_http::trace::{DefaultOnResponse, TraceLayer};
 use tracing::{Level, info};
 
+use crate::metrics::PROXY_REGISTRY;
 use crate::var;
 
 const METRICS_ROUTE: &str = "/metrics";
 
 static RELAY_PRESSURE: Lazy<CounterVec> = Lazy::new(|| {
-    register_counter_vec!(
-        "relay_pressure",
+    register_counter_vec_with_registry!(
+        "ika_proxy_relay_pressure",
         "HistogramRelay's number of metric families submitted, exported, overflowed to/from the queue.",
-        &["histogram_relay"]
+        &["histogram_relay"],
+        PROXY_REGISTRY
     )
     .unwrap()
 });
 static RELAY_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        "relay_duration_seconds",
+    register_histogram_vec_with_registry!(
+        "ika_proxy_relay_duration_seconds",
         "HistogramRelay's submit/export fn latencies in seconds.",
         &["histogram_relay"],
         vec![
             0.0008, 0.0016, 0.0032, 0.0064, 0.0128, 0.0256, 0.0512, 0.1024, 0.2048, 0.4096, 0.8192,
             1.0, 1.25, 1.5, 1.75, 2.0, 4.0, 8.0, 10.0, 12.5, 15.0
         ],
+        PROXY_REGISTRY
     )
     .unwrap()
 });

--- a/crates/ika-proxy/src/metrics.rs
+++ b/crates/ika-proxy/src/metrics.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 use axum::{Router, extract::Extension, http::StatusCode, routing::get};
 use mysten_metrics::RegistryService;
-use prometheus::TextEncoder;
+use once_cell::sync::Lazy;
+use prometheus::{Registry, TextEncoder};
 use std::net::TcpListener;
 use std::sync::{Arc, RwLock};
 use tower::ServiceBuilder;
@@ -13,12 +14,27 @@ use tracing::Level;
 const METRICS_ROUTE: &str = "/metrics";
 const POD_HEALTH_ROUTE: &str = "/pod_health";
 
+/// The registry ika-proxy registers its OWN metrics in.
+///
+/// It exists so those metrics are registered with an explicit registry rather
+/// than prometheus's process-global default one. That is not a style
+/// preference: `scripts/check-metric-names.sh` extracts metric names from
+/// `register_*_with_registry!` call sites, so a metric registered with the bare
+/// `register_*!` form is invisible to the `ika_` naming ratchet and to the
+/// generated inventory in `dev-docs/conventions/metrics.md` — which is exactly
+/// how the proxy's nine metrics stayed unprefixed while every other crate was
+/// renamed at the 1.2.0 boundary.
+///
+/// The proxy's own metrics are unrelated to the node metrics it relays, which
+/// pass through as payloads and are never registered here.
+pub static PROXY_REGISTRY: Lazy<Registry> = Lazy::new(Registry::new);
+
 type HealthCheckMetrics = Arc<RwLock<HealthCheck>>;
 
 /// Do not access struct members without using HealthCheckMetrics to arc+mutex
 #[derive(Debug)]
 struct HealthCheck {
-    // eg; consumer_operations_submitted{...}
+    // eg; ika_proxy_consumer_operations_submitted{...}
     consumer_operations_submitted: f64,
 }
 
@@ -71,12 +87,17 @@ async fn metrics(
     Extension(pod_health): Extension<HealthCheckMetrics>,
 ) -> (StatusCode, String) {
     let mut metric_families = registry_service.gather_all();
+    metric_families.extend(PROXY_REGISTRY.gather());
+    // ika-proxy registers nothing in prometheus's default registry any more,
+    // but the prometheus crate itself installs a process collector there
+    // (`process_cpu_seconds_total`, `process_resident_memory_bytes`, …).
+    // Keep gathering it so that telemetry stays on the endpoint.
     metric_families.extend(prometheus::gather());
 
     if let Some(consumer_operations_submitted) = metric_families
         .iter()
         .filter_map(|v| {
-            if v.name() == "consumer_operations_submitted" {
+            if v.name() == "ika_proxy_consumer_operations_submitted" {
                 // Expecting one metric, so return the first one, as it is the only one
                 v.get_metric().first().map(|m| m.counter.value())
             } else {

--- a/crates/ika-proxy/src/middleware.rs
+++ b/crates/ika-proxy/src/middleware.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
-use crate::{consumer::ProtobufDecoder, peers::SuiNodeProvider};
+use crate::{consumer::ProtobufDecoder, metrics::PROXY_REGISTRY, peers::SuiNodeProvider};
 use axum::{
     body::Body,
     body::Bytes,
@@ -14,17 +14,18 @@ use axum_extra::typed_header::TypedHeader;
 use bytes::Buf;
 use hyper::header::CONTENT_ENCODING;
 use once_cell::sync::Lazy;
-use prometheus::{CounterVec, proto::MetricFamily, register_counter_vec};
+use prometheus::{CounterVec, proto::MetricFamily, register_counter_vec_with_registry};
 use std::env;
 use std::sync::Arc;
 use sui_tls::TlsConnectionInfo;
 use tracing::{debug, error};
 
 static MIDDLEWARE_OPS: Lazy<CounterVec> = Lazy::new(|| {
-    register_counter_vec!(
-        "middleware_operations",
+    register_counter_vec_with_registry!(
+        "ika_proxy_middleware_operations",
         "Operations counters and status for axum middleware.",
-        &["operation", "status"]
+        &["operation", "status"],
+        PROXY_REGISTRY
     )
     .unwrap()
 });

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -44,15 +44,20 @@ parts:
   without anybody remembering to update anything — which was the failure
   mode of every list-based version of this rule.
 
-  **The check has one blind spot, and it is worth knowing before you
-  trust a green run.** Its extractor matches `register_*_with_registry!`
-  only, so a metric registered on prometheus's *default* registry with the
-  bare `register_*!` form is neither validated nor inventoried. `ika-proxy`
-  registers nine that way and they ARE exported — `ika-proxy/src/metrics.rs`
-  gathers the default registry onto its `/metrics` — so ika's binaries do
-  in practice export a handful of unprefixed names. Treat rules 1 and 2 as
-  binding on everything the extractor can see, and register new metrics
-  with an explicit registry so they stay in scope.
+  **Register with an explicit registry, never the bare macro.** The
+  extractor reads `register_*_with_registry!` call sites, so the bare
+  `register_*!` forms — which write to prometheus's process-global default
+  registry — used to be outside every rule above: not prefix-checked, not
+  inventoried, and still exported. That was not hypothetical. `ika-proxy`
+  carried nine such metrics (`consumer_operations`, `relay_pressure`,
+  `http_handler_hits` and friends) straight through the 1.2.0 rename,
+  gathered onto its `/metrics` by `ika-proxy/src/metrics.rs` under
+  unprefixed names that no dashboard author could have found here. They are
+  now `ika_proxy_*` in `metrics::PROXY_REGISTRY`, and the checker **rejects
+  the bare form outright** as its third rule, so the blind spot cannot
+  reopen. A new metric therefore needs a registry the endpoint gathers; if a
+  crate has none, give it one static registry rather than reaching for the
+  default.
 
   Note that `ika_consensus_*` **is** ika's to use — those are ika's own
   consensus-handling metrics (`ika_consensus_handler_processed` and
@@ -346,20 +351,20 @@ ika_consensus_boot_replay_target_commit_index
 ika_consensus_calculated_throughput
 ika_consensus_calculated_throughput_profile
 ika_consensus_commit_silence_seconds
-ika_consensus_fold_blocked_seconds_total
-ika_consensus_fold_blocked_sends_total
 ika_consensus_committed_messages
 ika_consensus_committed_subdags
 ika_consensus_committed_user_transactions
+ika_consensus_fold_blocked_seconds_total
+ika_consensus_fold_blocked_sends_total
 ika_consensus_handler_cancelled_transactions
 ika_consensus_handler_num_low_scoring_authorities
 ika_consensus_handler_processed
-ika_consensus_round_channel_depth
 ika_consensus_handler_scores
 ika_consensus_handler_transaction_sizes
 ika_consensus_last_committed_timestamp_seconds
 ika_consensus_manager_shutdown_latency
 ika_consensus_manager_start_latency
+ika_consensus_round_channel_depth
 ika_current_epoch
 ika_current_protocol_version
 ika_current_voting_right
@@ -564,6 +569,15 @@ ika_off_chain_assembly_wedged
 ika_own_mpc_data_blob_unhealthy
 ika_protocol_upgrade_effective_threshold
 ika_protocol_upgrade_supporting_stake
+ika_proxy_consumer_operations
+ika_proxy_consumer_operations_duration_seconds
+ika_proxy_consumer_operations_submitted
+ika_proxy_http_handler_duration_seconds
+ika_proxy_http_handler_hits
+ika_proxy_middleware_operations
+ika_proxy_protobuf_compression_seconds
+ika_proxy_relay_duration_seconds
+ika_proxy_relay_pressure
 ika_reconfig_phase
 ika_remote_dwallet_checkpoint_forks
 ika_remote_system_checkpoint_forks
@@ -661,6 +675,31 @@ ika_validator_temperature_celsius
 ika_validator_temperature_critical_celsius
 ika_validator_up
 ```
+
+## ika-proxy rename table (legacy → current)
+
+The proxy's own nine metrics — the ones the default-registry blind spot hid
+from the 1.2.0 rename — moved to `ika_proxy_*` and into
+`ika_proxy::metrics::PROXY_REGISTRY`. Types, help strings, buckets and label
+sets are unchanged, so a dashboard or alert needs only the name substituted.
+
+| legacy | current |
+|---|---|
+| `consumer_operations` | `ika_proxy_consumer_operations` |
+| `consumer_operations_duration_seconds` | `ika_proxy_consumer_operations_duration_seconds` |
+| `consumer_operations_submitted` | `ika_proxy_consumer_operations_submitted` |
+| `http_handler_duration_seconds` | `ika_proxy_http_handler_duration_seconds` |
+| `http_handler_hits` | `ika_proxy_http_handler_hits` |
+| `middleware_operations` | `ika_proxy_middleware_operations` |
+| `protobuf_compression_seconds` | `ika_proxy_protobuf_compression_seconds` |
+| `relay_duration_seconds` | `ika_proxy_relay_duration_seconds` |
+| `relay_pressure` | `ika_proxy_relay_pressure` |
+
+The proxy's `/metrics` still gathers prometheus's default registry, but only
+because the prometheus crate installs its own process collector there
+(`process_cpu_seconds_total`, `process_resident_memory_bytes`, …). Those are
+upstream's names in upstream's namespace; ika registers nothing on that
+registry, and CI now rejects any attempt to.
 
 ## 1.2.0 rename table (legacy → current)
 

--- a/scripts/check-metric-names.sh
+++ b/scripts/check-metric-names.sh
@@ -1,13 +1,28 @@
 #!/usr/bin/env bash
-# Metric-name ratchet, two halves of one rule: ika owns `ika_*` and nothing
+# Metric-name ratchet, three halves of one rule: ika owns `ika_*` and nothing
 # else owns any of it.
 #   1. every metric registered with a literal name uses the `ika_` prefix (or
 #      appears in scripts/metric-name-allowlist.txt, the frozen legacy set —
 #      never add to it; rename or prefix new metrics instead);
 #   2. no prefixed registry re-exports someone else's metrics under a prefix
-#      starting with `ika`.
+#      starting with `ika`;
+#   3. every metric is registered with an EXPLICIT registry —
+#      `register_*_with_registry!`, never the bare `register_*!` form that
+#      writes to prometheus's process-global default registry.
 # Together those make an ika name and a vendored name unable to occupy the
 # same string, whatever upstream adds (ika #2022).
+#
+# Rule 3 is what makes rule 1 total rather than best-effort. The extractor can
+# only see names passed to `register_*_with_registry!`, so a metric registered
+# on the default registry is exported by the binary and invisible to every
+# check here — unvalidated, uninventoried, and undiscoverable by anyone writing
+# a dashboard. ika-proxy shipped nine such metrics (`consumer_operations`,
+# `relay_pressure`, `http_handler_hits`, …) straight through the 1.2.0
+# `ika_` rename because of exactly that blind spot: they were gathered onto
+# /metrics by `ika-proxy/src/metrics.rs` while no rule could reach them.
+# Rejecting the bare form is preferred over teaching the extractor to read it,
+# because an explicit registry is the workspace convention anyway
+# (dev-docs/conventions/metrics.md) and rejection needs no per-macro upkeep.
 #
 # Names built dynamically (format!) cannot be validated statically and
 # are skipped; keep those few call sites' generated names in the
@@ -29,21 +44,59 @@ MACRO = re.compile(
     re.S,
 )
 
+# Any `register_*!` invocation. The ones ending in `_with_registry` name a
+# registry explicitly; every other one writes to prometheus's default registry.
+# Deliberately not restricted to today's prometheus macro list, so a metric
+# family the crate adds later is covered without anyone editing this file. The
+# cost is that an unrelated `register_*!` macro would be flagged — a loud,
+# one-line-to-diagnose false positive, which is the failure direction to prefer
+# over silently missing a real default-registry registration.
+ANY_MACRO = re.compile(r'\bregister_(?P<kind>[a-z_]+)!')
+
+sources = sorted(pathlib.Path("crates").rglob("*.rs"))
+
 names = set()
 dynamic_sites = 0
-for path in pathlib.Path("crates").rglob("*.rs"):
+default_registry_sites = []
+for path in sources:
     text = path.read_text(errors="replace")
     for m in MACRO.finditer(text):
         if m.group("name"):
             names.add(m.group("name"))
         else:
             dynamic_sites += 1
+    for m in ANY_MACRO.finditer(text):
+        if m.group("kind").endswith("_with_registry"):
+            continue
+        line = text.count("\n", 0, m.start()) + 1
+        default_registry_sites.append((str(path), line, m.group(0).rstrip("!")))
 
 if "--list" in sys.argv:
     for n in sorted(names):
         print(n)
     print(f"# {len(names)} literal names; {dynamic_sites} dynamic (format!-built) sites not listed", file=sys.stderr)
     sys.exit(0)
+
+# Rule 3, checked BEFORE the name rules: a metric on the default registry is
+# one the name rules cannot see at all, so a green prefix check over the rest
+# means nothing while such a site exists.
+if default_registry_sites:
+    print(
+        "ERROR: prometheus metrics must be registered with an EXPLICIT registry.\n"
+        "These call sites use the bare macro, which registers on prometheus's\n"
+        "process-global default registry — invisible to the `ika_` prefix rule\n"
+        "and missing from the generated inventory, while still being exported:",
+        file=sys.stderr,
+    )
+    for f, line, macro in default_registry_sites:
+        print(f"  {f}:{line}: {macro}!", file=sys.stderr)
+    print(
+        "Use the `_with_registry` form and pass the registry the endpoint\n"
+        "gathers (e.g. `register_counter_vec_with_registry!(name, help, labels,\n"
+        "registry)`). Convention: dev-docs/conventions/metrics.md",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 allowlist_path = pathlib.Path("scripts/metric-name-allowlist.txt")
 allowlist = {
@@ -155,6 +208,7 @@ print(
     f"metric names OK ({len(names)} literal, {dynamic_sites} dynamic sites skipped; "
     f"{len(vendored)} prefixed registr{'y' if len(vendored) == 1 else 'ies'} "
     f"({', '.join(sorted(vendored)) or 'none'}), none under `ika`; "
-    f"{test_scoped} test-scoped skipped)"
+    f"{test_scoped} test-scoped skipped); "
+    f"{len(sources)} source files, no default-registry registration"
 )
 EOF


### PR DESCRIPTION
Closes the enforcement hole found during the dev-docs reconciliation (#2079): `ika-proxy` registered **9 metrics on prometheus's default registry** with bare `register_*!` forms, all unprefixed, all exported on `/metrics` — and `scripts/check-metric-names.sh` only matched `register_*_with_registry!`, so they escaped the `ika_` naming ratchet entirely.

## The fix, both halves in one commit (either half alone leaves the tree red)

- **The 9 metrics renamed with the `ika_proxy_` prefix** and moved onto a crate-owned explicit registry (`metrics::PROXY_REGISTRY`) that the `/metrics` handler gathers. Types, help strings, buckets, and label sets unchanged — a naming/registration change only. `ika_proxy_` was chosen because the crate had no pre-existing prefixed metric of its own. The handler still gathers the default registry deliberately: prometheus's process collector (`process_cpu_seconds_total`, …) lives there, and dropping it would silently delete that telemetry; ika now registers nothing on it.
- **The ratchet now REJECTS default-registry registration outright** (rule runs before the prefix rules — a green prefix check is meaningless while a metric exists that the extractor cannot see). Rejection over regex-widening: `dev-docs/conventions/metrics.md` makes explicit-registry the convention, and rejection needs no upkeep as prometheus adds macro families. The generated inventory block in that doc is regenerated via the script's own `--list`.

One subtle catch folded in: `/pod_health` matched the literal string `"consumer_operations_submitted"` — a missed rename there would have reported the pod permanently unhealthy with nothing failing. Renamed in the same commit.

## Fault validation (per `dev-docs/playbooks/test-testing.md`)

Two bare `register_counter!` sites injected — one unprefixed, one already `ika_proxy_`-prefixed (the second is the case a merely-widened extractor would wave through). The **baseline script from origin/main run against the faulted tree exits 0** — the hole, reproduced. The widened script fails the same tree naming both sites and exits 1. Both injections reverted.

## Dashboard impact: all 9 renames are free

Every reference to the old names in the infra repo sits in `archive/` (two identical retired pre-rebrand dashboards still scoped to `sui-proxy`); three of the nine have zero references even there. **Zero live dashboards or alert rules name any of the nine** — the live `metrics_source="ika-proxy"` occurrences are a label on relayed validator series, unrelated. Follow-up after merge: regenerate the infra repo's `metric-inventory.txt` so `check-dashboard-queries.py` can validate the new names (infra-side, non-blocking).

## Gates

`check-metric-names.sh` green (337 names, no default-registry registration); `cargo check --release -p ika-proxy --all-targets`; workspace clippy `-D warnings` exit 0; `cargo test --release -p ika-proxy` 9/9; `cargo fmt --all` zero churn; no `#[allow]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Kxw9H9dWLZqmQgyEXAHqi
