### PR TITLE
fix(ocs): guard the untagged chain mirrors against layout drift at build time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,13 @@ jobs:
         # Every should-never-happen log must increment the fleet-visible
         # invariant violation counter through the shared macro.
         run: ./scripts/check-invariant-violation-markers.sh
+      - name: Chain-mirror layout
+        # The Move structs that Rust mirrors with UNTAGGED structs may not
+        # change shape without the Rust mirror and the version dispatch moving
+        # in the same PR: BCS is positional, so their field order is the wire
+        # format of bytes already on chain, and no OCS proof gate verifies shape.
+        # See dev-docs/conventions/chain-mirror-layout.md.
+        run: ./scripts/check-chain-mirror-layout.sh
       - name: Sui version consistency
         # The Sui pin lives in several places that don't update together;
         # see dev-docs/conventions/sui-version-bump.md.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,15 @@ jobs:
         # format of bytes already on chain, and no OCS proof gate verifies shape.
         # See dev-docs/conventions/chain-mirror-layout.md.
         run: ./scripts/check-chain-mirror-layout.sh
+      - name: Chain-mirror layout (Rust half)
+        # The golden BCS pins beside each mirror are the Rust half of the
+        # check above: the script reads Move declarations and Rust field
+        # NAMES, so a Rust-side retype (u64 -> u32) passes it and only the
+        # pinned length/digest catches it. Nothing else on PR CI executes
+        # ika-types' tests (Cargo Test Check is compile-only), so the pins
+        # must run here or a retype merges green. ika-types has no MPC
+        # crypto, so the debug profile is fine.
+        run: cargo test -p ika-types --lib -- layout_is_pinned variant_indices_are_pinned
       - name: Sui version consistency
         # The Sui pin lives in several places that don't update together;
         # see dev-docs/conventions/sui-version-bump.md.

--- a/crates/ika-core/src/sui_connector/verified_reader.rs
+++ b/crates/ika-core/src/sui_connector/verified_reader.rs
@@ -41,6 +41,7 @@ use ika_network::proof_provider::{
     ProofProvider, VerifiedDynamicFieldsPageRequest, VerifiedObjectResponse,
 };
 
+use ika_types::chain_mirror::{DWALLET_COORDINATOR_INNER_V1, SYSTEM_INNER_V1, decode_chain_mirror};
 use ika_types::sui::system_inner_v1::{DWalletCoordinatorInnerV1, SystemInnerV1};
 use ika_types::sui::{DWalletCoordinator, DWalletCoordinatorInner, System, SystemInner};
 
@@ -1095,10 +1096,9 @@ impl OcsVerifiedReader {
                 let child_id = derive_versioned_child_id(coordinator_id, outer.version)?;
                 let child_obj = self.verified_anchor_object(child_id).await?;
                 let child_bcs = move_object_contents(&child_obj.object)?;
-                let field: Field<u64, DWalletCoordinatorInnerV1> = bcs::from_bytes(child_bcs)
-                    .map_err(|e| {
-                        ReaderError::Decode(format!("Field<u64, DWalletCoordinatorInnerV1>: {e}"))
-                    })?;
+                let field: Field<u64, DWalletCoordinatorInnerV1> =
+                    decode_chain_mirror(child_bcs, DWALLET_COORDINATOR_INNER_V1)
+                        .map_err(ReaderError::Decode)?;
                 Ok((outer, DWalletCoordinatorInner::V1(field.value)))
             }
             v => Err(ReaderError::UnsupportedVersion {
@@ -1131,8 +1131,8 @@ impl OcsVerifiedReader {
                 let child_id = derive_versioned_child_id(system_id, outer.version)?;
                 let child_obj = self.verified_anchor_object(child_id).await?;
                 let child_bcs = move_object_contents(&child_obj.object)?;
-                let field: Field<u64, SystemInnerV1> = bcs::from_bytes(child_bcs)
-                    .map_err(|e| ReaderError::Decode(format!("Field<u64, SystemInnerV1>: {e}")))?;
+                let field: Field<u64, SystemInnerV1> =
+                    decode_chain_mirror(child_bcs, SYSTEM_INNER_V1).map_err(ReaderError::Decode)?;
                 Ok((outer, SystemInner::V1(field.value)))
             }
             v => Err(ReaderError::UnsupportedVersion {

--- a/crates/ika-sui-client/src/grpc_backend.rs
+++ b/crates/ika-sui-client/src/grpc_backend.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use dwallet_mpc_types::dwallet_mpc::VersionedMPCData;
 use ika_config::node::SuiGrpcHeaders;
+use ika_types::chain_mirror::{DWALLET_NETWORK_ENCRYPTION_KEY, decode_chain_mirror};
 use ika_types::error::IkaError;
 use ika_types::messages_consensus::MovePackageDigest;
 use ika_types::messages_dwallet_mpc::{
@@ -347,8 +348,9 @@ impl SuiClientInner for GrpcSuiClient {
         self.for_each_dynamic_child(
             dwallet_coordinator_inner.dwallet_network_encryption_keys.id,
             |object_id, contents| {
-                let value = bcs::from_bytes::<DWalletNetworkEncryptionKey>(&contents)
-                    .map_err(GrpcSuiClientError::decode)?;
+                let value: DWalletNetworkEncryptionKey =
+                    decode_chain_mirror(&contents, DWALLET_NETWORK_ENCRYPTION_KEY)
+                        .map_err(GrpcSuiClientError::Decode)?;
                 network_encryption_keys.insert(object_id, value);
                 Ok(())
             },

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use core::panic;
 use dwallet_mpc_types::dwallet_mpc::VersionedMPCData;
 use ika_config::node::SuiGrpcHeaders;
+use ika_types::chain_mirror::{DWALLET_COORDINATOR_INNER_V1, SYSTEM_INNER_V1, decode_chain_mirror};
 use ika_types::error::{IkaError, IkaResult};
 use ika_types::messages_consensus::MovePackageDigest;
 use ika_types::messages_dwallet_mpc::{
@@ -262,14 +263,9 @@ where
                             "Can't get DWalletCoordinatorInner v1: {e}"
                         ))
                     })?;
-                let dynamic_field_inner = bcs::from_bytes::<Field<u64, DWalletCoordinatorInnerV1>>(
-                    &result,
-                )
-                .map_err(|e| {
-                    IkaError::SuiClientSerializationError(format!(
-                        "Can't serialize DWalletCoordinatorInner v1: {e}"
-                    ))
-                })?;
+                let dynamic_field_inner: Field<u64, DWalletCoordinatorInnerV1> =
+                    decode_chain_mirror(&result, DWALLET_COORDINATOR_INNER_V1)
+                        .map_err(IkaError::SuiClientSerializationError)?;
                 let ika_system_state_inner = dynamic_field_inner.value;
 
                 Ok((wrapper, DWalletCoordinatorInner::V1(ika_system_state_inner)))
@@ -303,12 +299,9 @@ where
                     .map_err(|e| {
                         IkaError::SuiClientInternalError(format!("Can't get SystemInner v1: {e}"))
                     })?;
-                let dynamic_field_inner = bcs::from_bytes::<Field<u64, SystemInnerV1>>(&result)
-                    .map_err(|e| {
-                        IkaError::SuiClientSerializationError(format!(
-                            "Can't serialize SystemInner v1: {e}"
-                        ))
-                    })?;
+                let dynamic_field_inner: Field<u64, SystemInnerV1> =
+                    decode_chain_mirror(&result, SYSTEM_INNER_V1)
+                        .map_err(IkaError::SuiClientSerializationError)?;
                 let ika_system_state_inner = dynamic_field_inner.value;
 
                 Ok((wrapper, SystemInner::V1(ika_system_state_inner)))

--- a/crates/ika-types/src/chain_mirror.rs
+++ b/crates/ika-types/src/chain_mirror.rs
@@ -150,7 +150,8 @@ pub(crate) mod test_support {
              format of bytes a deployed package already wrote, and nothing in those bytes \
              identifies which layout produced them, so a change here re-interprets live chain \
              state instead of failing closed.\n\n\
-             A pure rename is safe — BCS is positional — and only the pin needs updating. An \
+             A pure rename is safe — BCS is positional, so the pinned bytes don't change; \
+             update the field name in this test's struct literal (and the layout manifest). An \
              add, remove, reorder, or retype is not: the Move struct has to have changed to \
              match, and it cannot change in place, because Sui's compatible-policy upgrade \
              checker rejects datatype layout changes. Such a change reaches chain only through \

--- a/crates/ika-types/src/chain_mirror.rs
+++ b/crates/ika-types/src/chain_mirror.rs
@@ -1,0 +1,234 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Decoding of Rust structs that mirror deployed Move struct layouts.
+//!
+//! A few Rust types — `DWalletCoordinatorInnerV1`, `SystemInnerV1`,
+//! `DWalletNetworkEncryptionKey` — are plain untagged `#[derive(Deserialize)]`
+//! structs whose field order must match, byte for byte, the layout of a Move
+//! struct already deployed on chain. Nothing in the bytes says which layout
+//! produced them: the OCS proof chain (committee BLS → artifacts digest →
+//! Merkle inclusion → id binding → currency) authenticates *provenance* — that
+//! these bytes are the chain's — and never *shape*. A tagged type like
+//! `VersionedMPCData` fails closed on an unknown variant; these cannot.
+//!
+//! Decoding here is already as strict as BCS allows. `bcs::from_bytes` runs the
+//! deserializer to `end()` and rejects residue, every one of these mirrors is
+//! the last value in its byte stream, and each terminates in a fixed-width tail
+//! (`extra_fields: Bag` is 40 bytes; the fieldless `state` enum is one). So a
+//! layout change that alters the encoded length does surface. What it surfaces
+//! as is the problem: a bare `remaining input`, or an `unexpected end of input`
+//! raised several fields past the one that actually moved. That error names the
+//! wrong place, and has already cost this repo multiple CI cycles of hunting in
+//! the wrong struct (`dev-docs/learnings/pitfalls.md`, "Sui types & encoding").
+//!
+//! [`decode_chain_mirror`] is the decode entry point for these types. It adds
+//! nothing to the strictness — that was already maximal — and everything to the
+//! attribution of the failure.
+//!
+//! Drift is *prevented*, rather than merely diagnosed, at build time by two
+//! guards that have to be updated together:
+//! `scripts/check-chain-mirror-layout.sh` ties the Move declarations to the Rust
+//! mirrors, and a golden layout test sits beside each mirror. Neither can act at
+//! runtime; see `dev-docs/conventions/chain-mirror-layout.md` for what that does
+//! and does not buy.
+
+use serde::de::DeserializeOwned;
+
+/// A Rust struct mirroring a deployed Move struct layout, paired with the Move
+/// declaration it must stay identical to.
+///
+/// Exists only to build the message of a failed decode: it names the Move source
+/// the reader's expectation came from, so a drift points at the two files that
+/// have to agree rather than at the byte offset where the mis-parse ran out.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct ChainMirror {
+    /// The Rust type being decoded, spelled as it is at the call site —
+    /// `Field<u64, DWalletCoordinatorInnerV1>` for a mirror read out of a
+    /// versioned dynamic field, since that whole wrapper is what BCS consumes.
+    pub rust_type: &'static str,
+    /// The Move struct whose on-chain layout `rust_type` mirrors.
+    pub move_struct: &'static str,
+    /// Repo-root-relative path of the Move source declaring `move_struct`.
+    pub move_source: &'static str,
+}
+
+/// The coordinator inner state, read out of the `Field<u64, _>` dynamic field
+/// that the `DWalletCoordinator` outer object stores it under.
+pub const DWALLET_COORDINATOR_INNER_V1: ChainMirror = ChainMirror {
+    rust_type: "Field<u64, DWalletCoordinatorInnerV1>",
+    move_struct: "DWalletCoordinatorInner",
+    move_source: "contracts/ika_dwallet_2pc_mpc/sources/coordinator_inner.move",
+};
+
+/// The system inner state, read out of the `Field<u64, _>` dynamic field that
+/// the `System` outer object stores it under.
+pub const SYSTEM_INNER_V1: ChainMirror = ChainMirror {
+    rust_type: "Field<u64, SystemInnerV1>",
+    move_struct: "SystemInner",
+    move_source: "contracts/ika_system/sources/system/system_inner.move",
+};
+
+/// A network encryption key. Unlike the two inners this is a `key` object read
+/// directly, so its Move `id: UID` is the mirror's leading `ObjectID` and there
+/// is no version wrapper in front of it at all.
+pub const DWALLET_NETWORK_ENCRYPTION_KEY: ChainMirror = ChainMirror {
+    rust_type: "DWalletNetworkEncryptionKey",
+    move_struct: "DWalletNetworkEncryptionKey",
+    move_source: "contracts/ika_dwallet_2pc_mpc/sources/coordinator_inner.move",
+};
+
+/// BCS-decode on-chain bytes into an untagged Rust mirror of a Move struct,
+/// attributing a failure to the layout drift that is one of its causes.
+///
+/// Identical to `bcs::from_bytes` on the success path, including its exhaustion
+/// check. On the error path it returns [`decode_error_message`].
+pub fn decode_chain_mirror<T: DeserializeOwned>(
+    bytes: &[u8],
+    mirror: ChainMirror,
+) -> Result<T, String> {
+    bcs::from_bytes(bytes).map_err(|e| decode_error_message(bytes.len(), mirror, &e.to_string()))
+}
+
+/// The attributed message [`decode_chain_mirror`] produces on failure.
+///
+/// Split out so a test can assert on it without having to synthesise bytes that
+/// fail to decode as every mirror.
+fn decode_error_message(byte_len: usize, mirror: ChainMirror, cause: &str) -> String {
+    let ChainMirror {
+        rust_type,
+        move_struct,
+        move_source,
+    } = mirror;
+    format!(
+        "failed to BCS-decode {byte_len} on-chain bytes as `{rust_type}`: {cause}. \
+         `{rust_type}` is an UNTAGGED mirror of Move `{move_struct}` \
+         ({move_source}), so this is as plausibly a LAYOUT DRIFT — the deployed \
+         Move struct no longer matching the Rust mirror — as it is a corrupt or \
+         truncated read, and a verified read does not rule that out: the proof \
+         chain authenticates where the bytes came from, never what shape they \
+         are. Diff the Move declaration against the Rust struct field by field \
+         before debugging the field this decode died in. \
+         See dev-docs/conventions/chain-mirror-layout.md"
+    )
+}
+
+/// Shared assertion for the golden layout pins that sit beside each mirror.
+///
+/// The pins themselves live next to the structs they pin (`mod tests` in
+/// `sui/system_inner_v1.rs` and in `messages_dwallet_mpc.rs`), because the
+/// struct literal that populates a mirror is half the guard: with every field
+/// written out and no `..Default::default()`, an added or removed field fails to
+/// compile there. Only the assertion is shared.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::ChainMirror;
+    use fastcrypto::hash::{Blake2b256, HashFunction};
+    use serde::Serialize;
+
+    /// Assert a mirror's BCS encoding against its pin, and say what to do about
+    /// a mismatch rather than only that two values differ.
+    ///
+    /// Callers must pass a FULLY-POPULATED value: every field distinct, every
+    /// collection non-empty, every `Option` `Some`. Zeroes everywhere would let
+    /// a swap of two same-width fields encode identically, and an empty `Vec` or
+    /// a `None` hides the shape of what it contains — which is the shape being
+    /// pinned.
+    pub(crate) fn assert_pinned_layout<T: Serialize>(
+        mirror: ChainMirror,
+        value: &T,
+        pinned_len: usize,
+        pinned_digest: &str,
+    ) {
+        let bytes = bcs::to_bytes(value).expect("a chain mirror must BCS-encode");
+        let digest = hex::encode(Blake2b256::digest(&bytes).digest);
+
+        let guidance = format!(
+            "\n\nThe BCS layout of `{}` changed (pinned {pinned_len} bytes / {pinned_digest}, \
+             got {} bytes / {digest}).\n\n\
+             This struct is an UNTAGGED mirror of Move `{}` ({}). Its field order is the wire \
+             format of bytes a deployed package already wrote, and nothing in those bytes \
+             identifies which layout produced them, so a change here re-interprets live chain \
+             state instead of failing closed.\n\n\
+             A pure rename is safe — BCS is positional — and only the pin needs updating. An \
+             add, remove, reorder, or retype is not: the Move struct has to have changed to \
+             match, and it cannot change in place, because Sui's compatible-policy upgrade \
+             checker rejects datatype layout changes. Such a change reaches chain only through \
+             a `VERSION` bump plus `migrate()`, or a fresh package publish — and either way the \
+             arm that maps chain versions onto this struct (`match wrapper.version {{ 1 | 2 => \
+             .. }}`, in ika-sui-client/src/lib.rs and \
+             ika-core/src/sui_connector/verified_reader.rs) must stop claiming those versions \
+             share one layout. Update `scripts/chain-mirror-layout.txt` in the same change.\n\n\
+             See dev-docs/conventions/chain-mirror-layout.md.\n",
+            mirror.rust_type,
+            bytes.len(),
+            mirror.move_struct,
+            mirror.move_source,
+        );
+
+        // Length first: it is the half a human can act on directly, and an
+        // added or removed field moves it.
+        assert_eq!(bytes.len(), pinned_len, "{guidance}");
+        assert_eq!(digest, pinned_digest, "{guidance}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The failure this helper exists for is a human reading a log line at
+    /// 3am, so assert on the parts that redirect them: the underlying bcs
+    /// cause is preserved, and the Move source and the drift hypothesis are
+    /// both named.
+    #[test]
+    fn decode_error_names_the_move_source_and_the_drift_hypothesis() {
+        let message = decode_error_message(41, DWALLET_NETWORK_ENCRYPTION_KEY, "remaining input");
+
+        assert!(message.contains("remaining input"), "{message}");
+        assert!(message.contains("41 on-chain bytes"), "{message}");
+        assert!(message.contains("DWalletNetworkEncryptionKey"), "{message}");
+        assert!(
+            message.contains("contracts/ika_dwallet_2pc_mpc/sources/coordinator_inner.move"),
+            "{message}"
+        );
+        assert!(message.contains("LAYOUT DRIFT"), "{message}");
+    }
+
+    /// A mirror read through a versioned dynamic field is decoded as the whole
+    /// `Field<u64, _>`, and the message must say so — a reader told only
+    /// "DWalletCoordinatorInnerV1" would not think to check the 40-byte
+    /// `Field` header that precedes it.
+    #[test]
+    fn versioned_inner_mirrors_name_the_field_wrapper_they_decode_through() {
+        assert_eq!(
+            DWALLET_COORDINATOR_INNER_V1.rust_type,
+            "Field<u64, DWalletCoordinatorInnerV1>"
+        );
+        assert_eq!(SYSTEM_INNER_V1.rust_type, "Field<u64, SystemInnerV1>");
+    }
+
+    /// The success path must stay byte-identical to `bcs::from_bytes`,
+    /// exhaustion check included — the helper is attribution, not a relaxation.
+    #[test]
+    fn decode_matches_bcs_from_bytes_including_the_exhaustion_check() {
+        let bytes = bcs::to_bytes(&(7u64, 9u64)).unwrap();
+
+        let decoded: (u64, u64) =
+            decode_chain_mirror(&bytes, DWALLET_NETWORK_ENCRYPTION_KEY).unwrap();
+        assert_eq!(decoded, (7, 9));
+
+        // One trailing byte, exactly what an appended Move field looks like.
+        let with_residue = [bytes.as_slice(), &[0u8]].concat();
+        let error =
+            decode_chain_mirror::<(u64, u64)>(&with_residue, DWALLET_NETWORK_ENCRYPTION_KEY)
+                .unwrap_err();
+        assert!(error.contains("LAYOUT DRIFT"), "{error}");
+
+        // One byte short, what an inserted Move field looks like from here.
+        let truncated = &bytes[..bytes.len() - 1];
+        let error = decode_chain_mirror::<(u64, u64)>(truncated, DWALLET_NETWORK_ENCRYPTION_KEY)
+            .unwrap_err();
+        assert!(error.contains("LAYOUT DRIFT"), "{error}");
+    }
+}

--- a/crates/ika-types/src/lib.rs
+++ b/crates/ika-types/src/lib.rs
@@ -9,6 +9,7 @@
 
 #[macro_use]
 pub mod error;
+pub mod chain_mirror;
 pub mod committee;
 pub mod crypto;
 pub mod digests;

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -1246,3 +1246,88 @@ mod session_identifier_tests {
         assert!(low < high, "digest order must dominate type and preimage");
     }
 }
+
+// === Layout pin for the untagged chain mirror ===
+//
+// `DWalletNetworkEncryptionKey` carries no version tag: its field order IS the
+// wire format of a `key` object a deployed Move package already wrote, and
+// nothing in those bytes identifies which layout produced them
+// (`crate::chain_mirror`). Changing it does not fail closed anywhere — it
+// silently re-interprets live chain state.
+//
+// The struct literal below is half the guard: every field is written out with
+// no `..Default::default()`, so adding or removing a Rust field fails to
+// COMPILE here. The digest covers what compilation cannot see, a reorder or a
+// retype, which is why every field gets a distinct value.
+//
+// This is the Rust half; the Move half is
+// `scripts/check-chain-mirror-layout.sh`, and both must move together.
+// See dev-docs/conventions/chain-mirror-layout.md.
+#[cfg(test)]
+mod chain_mirror_layout_tests {
+    use super::*;
+    use crate::chain_mirror::DWALLET_NETWORK_ENCRYPTION_KEY;
+    use crate::chain_mirror::test_support::assert_pinned_layout;
+
+    /// Fully populated: every field distinct, every collection non-empty, and a
+    /// deliberately NON-zero `state` variant so a reordering of the state enum
+    /// shows up here too.
+    fn populated_network_encryption_key() -> DWalletNetworkEncryptionKey {
+        DWalletNetworkEncryptionKey {
+            id: ObjectID::new([1; 32]),
+            dkg_at_epoch: 2,
+            network_dkg_public_output: TableVec {
+                contents: Table {
+                    id: ObjectID::new([3; 32]),
+                    size: 4,
+                },
+            },
+            reconfiguration_public_outputs: Table {
+                id: ObjectID::new([5; 32]),
+                size: 6,
+            },
+            dkg_params_for_network: vec![7, 8, 9],
+            supported_curves: vec![10, 11],
+            state: DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted,
+        }
+    }
+
+    #[test]
+    fn dwallet_network_encryption_key_layout_is_pinned() {
+        assert_pinned_layout(
+            DWALLET_NETWORK_ENCRYPTION_KEY,
+            &populated_network_encryption_key(),
+            134,
+            "605dd15140b1c6c2e2437a8f8269d733407771d6288d9941ad162c996b765f55",
+        );
+    }
+
+    /// The state enum's variant INDEX is its wire discriminant, so the order of
+    /// the variant list is layout, not documentation. A single populated value
+    /// pins only the variant it happens to use; this pins all four.
+    #[test]
+    fn dwallet_network_encryption_key_state_variant_indices_are_pinned() {
+        for (variant, index) in [
+            (DWalletNetworkEncryptionKeyState::AwaitingNetworkDKG, 0u8),
+            (DWalletNetworkEncryptionKeyState::NetworkDKGCompleted, 1),
+            (
+                DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration,
+                2,
+            ),
+            (
+                DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted,
+                3,
+            ),
+        ] {
+            assert_eq!(
+                bcs::to_bytes(&variant).unwrap(),
+                vec![index],
+                "{variant:?} moved to a different BCS discriminant. This enum mirrors Move \
+                 `DWalletNetworkEncryptionKeyState` \
+                 (contracts/ika_dwallet_2pc_mpc/sources/coordinator_inner.move); reordering \
+                 its variants re-interprets the state of every network encryption key already \
+                 on chain. See dev-docs/conventions/chain-mirror-layout.md."
+            );
+        }
+    }
+}

--- a/crates/ika-types/src/sui/system_inner_v1.rs
+++ b/crates/ika-types/src/sui/system_inner_v1.rs
@@ -400,4 +400,243 @@ mod tests {
         // No sessions at all in a freshly-locked epoch → trivially ready.
         assert!(sessions_manager(true, 0, 0, 0, 0).all_current_epoch_sessions_completed());
     }
+
+    // === Layout pins for the untagged chain mirrors ===
+    //
+    // `DWalletCoordinatorInnerV1` and `SystemInnerV1` carry no version tag: their
+    // field order IS the wire format of bytes a deployed Move package already
+    // wrote, and nothing in those bytes identifies the layout that produced them
+    // (`crate::chain_mirror`). Changing either struct does not fail closed
+    // anywhere — it silently re-interprets live chain state.
+    //
+    // Two things pin them, and the cheaper one is the struct literal itself:
+    // every field is written out, with no `..Default::default()`, so adding or
+    // removing a Rust field fails to COMPILE here. The digest assertion covers
+    // what compilation cannot see — a reorder or a retype — which is why every
+    // field gets a distinct value: with zeroes everywhere, swapping two `u64`s
+    // would encode identically and slip through.
+    //
+    // These are the Rust half of the guard. The Move half is
+    // `scripts/check-chain-mirror-layout.sh`, and the two must be updated in the
+    // same change, because either side moving alone is exactly the drift.
+    // Rationale and the update procedure: dev-docs/conventions/chain-mirror-layout.md.
+
+    use crate::chain_mirror::test_support::assert_pinned_layout;
+    use crate::chain_mirror::{DWALLET_COORDINATOR_INNER_V1, SYSTEM_INNER_V1};
+    use sui_types::balance::Supply;
+    use sui_types::collection_types::Entry;
+    use sui_types::id::UID;
+
+    /// A distinct 32-byte id per seed, so a reordered pair of `ObjectID` fields
+    /// changes the encoding.
+    fn oid(seed: u8) -> ObjectID {
+        ObjectID::new([seed; 32])
+    }
+
+    fn table(seed: u8) -> Table {
+        Table {
+            id: oid(seed),
+            size: u64::from(seed),
+        }
+    }
+
+    fn bag(seed: u8) -> Bag {
+        Bag {
+            id: UID::new(oid(seed)),
+            size: u64::from(seed),
+        }
+    }
+
+    fn element(seed: u8) -> Element {
+        Element {
+            bytes: vec![seed, seed.wrapping_add(1)],
+        }
+    }
+
+    fn bls_committee(seed: u8) -> BlsCommittee {
+        BlsCommittee {
+            members: vec![BlsCommitteeMember {
+                validator_id: oid(seed),
+                protocol_pubkey: element(seed.wrapping_add(1)),
+            }],
+            aggregated_protocol_pubkey: element(seed.wrapping_add(2)),
+            quorum_threshold: u64::from(seed) + 300,
+            validity_threshold: u64::from(seed) + 400,
+        }
+    }
+
+    fn pricing_info(seed: u8) -> PricingInfo {
+        PricingInfo {
+            pricing_map: VecMap {
+                contents: vec![Entry {
+                    key: PricingInfoKey {
+                        curve: u32::from(seed) + 1,
+                        signature_algorithm: Some(u32::from(seed) + 2),
+                        protocol: u32::from(seed) + 3,
+                    },
+                    value: PricingInfoValue {
+                        fee_ika: u64::from(seed) + 4,
+                        gas_fee_reimbursement_sui: u64::from(seed) + 5,
+                        gas_fee_reimbursement_sui_for_system_calls: u64::from(seed) + 6,
+                    },
+                }],
+            },
+        }
+    }
+
+    fn sessions_keeper_populated(seed: u8) -> SessionsKeeper {
+        SessionsKeeper {
+            sessions: table(seed),
+            session_events: bag(seed.wrapping_add(1)),
+            started_sessions_count: u64::from(seed) + 10,
+            completed_sessions_count: u64::from(seed) + 20,
+            next_session_sequence_number: u64::from(seed) + 30,
+        }
+    }
+
+    /// A fully-populated coordinator inner: every field distinct, every
+    /// collection non-empty, every `Option` `Some`. An empty `Vec` or a `None`
+    /// hides the shape of what it contains, and the shape of what it contains is
+    /// what is being pinned.
+    fn populated_coordinator_inner() -> DWalletCoordinatorInnerV1 {
+        DWalletCoordinatorInnerV1 {
+            current_epoch: 1,
+            sessions_manager: SessionsManager {
+                registered_user_session_identifiers: table(2),
+                user_sessions_keeper: sessions_keeper_populated(3),
+                system_sessions_keeper: sessions_keeper_populated(5),
+                last_user_initiated_session_to_complete_in_current_epoch: 7,
+                locked_last_user_initiated_session_to_complete_in_current_epoch: true,
+                max_active_sessions_buffer: 8,
+            },
+            dwallets: table(9),
+            dwallet_network_encryption_keys: table(10),
+            epoch_dwallet_network_encryption_keys_reconfiguration_completed: 11,
+            encryption_keys: table(12),
+            presigns: table(13),
+            partial_centralized_signed_messages: table(14),
+            pricing_and_fee_management: PricingAndFeeManagement {
+                current: pricing_info(15),
+                default: pricing_info(16),
+                validator_votes: table(17),
+                calculation_votes: Some(PricingInfoCalculationVotes {
+                    bls_committee: bls_committee(18),
+                    default_pricing: pricing_info(21),
+                    working_pricing: pricing_info(22),
+                }),
+                gas_fee_reimbursement_sui_system_call_value: 23,
+                gas_fee_reimbursement_sui_system_call_balance: Balance::new(24),
+                fee_charged_ika: Balance::new(25),
+            },
+            active_committee: bls_committee(26),
+            next_epoch_active_committee: Some(bls_committee(29)),
+            total_messages_processed: 32,
+            last_processed_checkpoint_sequence_number: 33,
+            previous_epoch_last_checkpoint_sequence_number: 34,
+            support_config: SupportConfig {
+                supported_curves_to_signature_algorithms_to_hash_schemes: VecMap {
+                    contents: vec![Entry {
+                        key: 35,
+                        value: VecMap {
+                            contents: vec![Entry {
+                                key: 36,
+                                value: vec![37, 38],
+                            }],
+                        },
+                    }],
+                },
+                paused_curves: vec![39],
+                paused_signature_algorithms: vec![40],
+                paused_hash_schemes: vec![41],
+                signature_algorithms_allowed_global_presign: vec![42],
+            },
+            received_end_of_publish: true,
+            extra_fields: bag(43),
+        }
+    }
+
+    /// A fully-populated system inner; same construction rules as
+    /// [`populated_coordinator_inner`].
+    fn populated_system_inner() -> SystemInnerV1 {
+        SystemInnerV1 {
+            epoch: 1,
+            epoch_start_tx_digest: vec![2, 3, 4],
+            system_object_cap: SystemObjectCap { id: oid(5) },
+            protocol_version: 6,
+            next_protocol_version: Some(7),
+            upgrade_caps: vec![UpgradeCap {
+                id: oid(8),
+                package: oid(9),
+                version: 10,
+                policy: 11,
+            }],
+            approved_upgrades: VecMap {
+                contents: vec![Entry {
+                    key: oid(12),
+                    value: vec![13, 14],
+                }],
+            },
+            validator_set: ValidatorSetV1 {
+                total_stake: 15,
+                reward_slashing_rate: 16,
+                validators: table(17),
+                active_committee: bls_committee(18),
+                next_epoch_committee: Some(bls_committee(21)),
+                previous_committee: bls_committee(24),
+                pending_active_set: ExtendedField { id: oid(27) },
+                validator_report_records: VecMap {
+                    contents: vec![Entry {
+                        key: oid(28),
+                        value: VecSet {
+                            contents: vec![oid(29)],
+                        },
+                    }],
+                },
+                extra_fields: bag(30),
+            },
+            epoch_duration_ms: 31,
+            stake_subsidy_start_epoch: 32,
+            protocol_treasury: ProtocolTreasuryV1 {
+                treasury_cap: TreasuryCap {
+                    id: UID::new(oid(33)),
+                    total_supply: Supply { value: 34 },
+                },
+                stake_subsidy_distribution_counter: 35,
+                stake_subsidy_rate: 36,
+                stake_subsidy_amount_per_distribution: 37,
+                stake_subsidy_period_length: 38,
+                total_supply_at_period_start: 39,
+                extra_fields: bag(40),
+            },
+            epoch_start_timestamp_ms: 41,
+            last_processed_checkpoint_sequence_number: 42,
+            previous_epoch_last_checkpoint_sequence_number: 43,
+            total_messages_processed: 44,
+            remaining_rewards: Balance::new(45),
+            authorized_protocol_cap_ids: vec![oid(46)],
+            witness_approving_advance_epoch: vec!["witness".to_string()],
+            received_end_of_publish: true,
+            extra_fields: bag(47),
+        }
+    }
+
+    #[test]
+    fn dwallet_coordinator_inner_v1_layout_is_pinned() {
+        assert_pinned_layout(
+            DWALLET_COORDINATOR_INNER_V1,
+            &populated_coordinator_inner(),
+            968,
+            "ef75b1f13bb56bde94de39667e2b1881a626779169d45bc98aa71512148d6a5b",
+        );
+    }
+
+    #[test]
+    fn system_inner_v1_layout_is_pinned() {
+        assert_pinned_layout(
+            SYSTEM_INNER_V1,
+            &populated_system_inner(),
+            778,
+            "b68ac624de60d0f14c7842af6e2bb205e8b4a7f94ce8d77f03d292b7b20d7382",
+        );
+    }
 }

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -158,6 +158,12 @@ them has a bug — determine which before changing either.
   reason its consumers survive that); the reader-side rule that #1917 was
   actually born on, and the one table whose argument does not close.
   CI-enforced via `scripts/check-epoch-table-write-discipline.sh`.
+- [`conventions/chain-mirror-layout.md`](conventions/chain-mirror-layout.md)
+  — the three Rust structs that are UNTAGGED mirrors of deployed Move
+  structs, why a verified read proves provenance but never shape, and the
+  six things that move together when one of them changes. CI-enforced via
+  `scripts/check-chain-mirror-layout.sh` plus golden layout tests in
+  `ika-types`.
 - [`conventions/logging.md`](conventions/logging.md) — the `tracing`
   log-level discipline: hot MPC paths are `debug!`, once-per-epoch
   lifecycle events are `info!`; why an `info!` on the per-computation

--- a/dev-docs/conventions/chain-mirror-layout.md
+++ b/dev-docs/conventions/chain-mirror-layout.md
@@ -1,0 +1,147 @@
+# Chain-mirror layout discipline
+
+Three Rust structs are **untagged mirrors** of Move structs deployed on
+mainnet and testnet:
+
+| Rust | Move |
+|---|---|
+| `DWalletCoordinatorInnerV1` (`crates/ika-types/src/sui/system_inner_v1.rs`) | `DWalletCoordinatorInner` (`contracts/ika_dwallet_2pc_mpc/sources/coordinator_inner.move`) |
+| `SystemInnerV1` (`crates/ika-types/src/sui/system_inner_v1.rs`) | `SystemInner` (`contracts/ika_system/sources/system/system_inner.move`) |
+| `DWalletNetworkEncryptionKey` (`crates/ika-types/src/messages_dwallet_mpc.rs`) | `DWalletNetworkEncryptionKey` (`contracts/ika_dwallet_2pc_mpc/sources/coordinator_inner.move`) |
+
+BCS is positional and these types carry no version tag, so **their field
+order is the wire format** of bytes a deployed package has already
+written. Nothing in those bytes identifies the layout that produced them.
+
+## Why this needs a guard at all
+
+A verified read proves *provenance*, never *shape*. The OCS trust chain —
+committee BLS → artifacts digest → Merkle inclusion → id binding →
+changeset currency — establishes that these bytes are the chain's. Not one
+of those gates establishes that the reader's struct still describes them.
+A tagged type like `VersionedMPCData` fails closed on an unknown variant;
+these cannot, because there is no tag to be unknown.
+
+Two things are already true and are **not** what the guard is for:
+
+- **Decoding is as strict as BCS allows.** Every decode goes through
+  `bcs::from_bytes`, which runs the deserializer to `end()` and rejects
+  residue. There is no reader-style partial decode anywhere in the repo.
+- **Most drift therefore fails loudly.** Each mirror is the last value in
+  its byte stream and ends in a fixed-width tail (`extra_fields: Bag` is
+  40 bytes; the fieldless `state` enum is one), so a length-changing
+  field-add trips `remaining input`, or dies earlier on a strict `bool` or
+  an unknown enum variant.
+
+What is left is narrow but real, and it is two things:
+
+1. **A same-total-length reshuffle decodes silently.** Remove a field and
+   add one of equal encoded width, or retype `u64` → `u64`, and every byte
+   still parses. Nothing anywhere notices.
+2. **When it does fail, it fails in the wrong place.** A bare
+   `unexpected end of input` raised several fields past the one that
+   actually moved sends the reader hunting in the wrong struct — that has
+   already cost this repo multiple CI cycles (see
+   `dev-docs/learnings/pitfalls.md`, "Sui types & encoding").
+
+## Why the guard is build-time, not runtime
+
+An in-place field-add cannot reach mainnet or testnet: Sui's
+compatible-policy upgrade checker rejects datatype layout changes, so
+there is no same-version path to chain. Drift arrives one of two ways,
+and both pass through this repo:
+
+- a `const VERSION` bump plus `migrate()`, which installs the inner under
+  a new dynamic-field key — this is the *intended*, upgrade-legal way a
+  layout change ships; or
+- a fresh package publish (a localnet, devnet, or testnet redeploy).
+
+A red build is the cheapest possible signal for both.
+
+## The trap the version wrapper is currently not catching
+
+Both outer objects carry a `u64 version` (`VERSION = 2` today in
+`coordinator.move` and `system.move`), and `migrate()` exists precisely so
+a layout change can ship under a new version. **Rust does not use that
+seam.** Both readers do:
+
+```rust
+match wrapper.version {
+    1 | 2 => { /* decode as ...V1 */ }
+```
+
+in `crates/ika-sui-client/src/lib.rs` and
+`crates/ika-core/src/sui_connector/verified_reader.rs`. That is an
+assertion that versions 1 and 2 share one layout. It happens to be true —
+the Move struct is a single unsuffixed declaration and the bump carried no
+layout change — but nothing tested it and nothing forces the next bump to
+revisit it.
+
+Deliberately **not** fixed by splitting the arm: the two versions really
+do share a layout today, so separate types would fabricate a distinction
+the bytes do not have. The `VERSION` value is pinned in the manifest
+instead, so the next bump fails the build and lands in front of a human.
+
+## The guard, in two halves
+
+Both halves must move together. Either side moving alone is exactly the
+drift being guarded against.
+
+- **Move half** — `scripts/check-chain-mirror-layout.sh`, run in CI,
+  pinned by `scripts/chain-mirror-layout.txt`. Extracts each Move struct's
+  ordered `(name, type)` list, each Rust mirror's ordered field names, and
+  each `const VERSION`, and diffs them against the manifest. The manifest
+  maps Move field → Rust field **explicitly**, because the names genuinely
+  differ in places (`presign_sessions` → `presigns`,
+  `pricing_and_fee_manager` → `pricing_and_fee_management`,
+  `witnesses_approving_advance_epoch` → `witness_approving_advance_epoch`);
+  a name-equality check would be a lie.
+- **Rust half** — the golden layout tests beside each mirror
+  (`cargo test --release -p ika-types layout_is_pinned`). Each builds a
+  fully-populated value and pins its encoded length and Blake2b digest.
+  The struct literal is itself half of this: every field is written out
+  with no `..Default::default()`, so an added or removed Rust field fails
+  to **compile**. The digest covers what compilation cannot see — a
+  reorder or a retype — which is why every field gets a distinct value:
+  with zeroes everywhere, swapping two `u64`s would encode identically.
+
+Runtime keeps one thing, and it is diagnosis only:
+`ika_types::chain_mirror::decode_chain_mirror` wraps `bcs::from_bytes` at
+every leaf decode site. It changes nothing about strictness and names the
+Move source plus the layout-drift hypothesis in the error.
+
+## Changing a mirrored struct
+
+All of these move in the same PR:
+
+1. The Move struct and the Rust mirror.
+2. The version dispatch: a layout change means versions 1 and 2 no longer
+   share a layout, so the `1 | 2 =>` arm must stop claiming they do.
+3. The `const VERSION` bump plus `migrate()` that carries old state
+   across.
+4. The golden tests: `cargo test --release -p ika-types layout_is_pinned`.
+5. The Residuals section of `dev-docs/specs/ocs-verified-sui-reads.md`.
+6. The manifest: `./scripts/check-chain-mirror-layout.sh --write`.
+
+Run `--write` only after a deliberate change, never to turn a red build
+green.
+
+## What this does not buy
+
+- **Nothing here authenticates shape at runtime.** A node reading a chain
+  whose layout drifted still depends on `bcs::from_bytes` exhaustion to
+  notice, and a same-total-length reshuffle still mis-decodes silently.
+- **The guards bind this repo's releases only.** They are build-time, so
+  they say nothing about a node pointed at a foreign or hand-patched
+  package, or a redeploy built from a different source tree.
+- **The Move half proves agreement, not correctness.** It proves the Move
+  declaration has not moved since a human last checked it against the Rust
+  mirror. It cannot prove the mirror was right in the first place — the
+  Move and Rust type vocabularies do not correspond mechanically
+  (`VecMap<ID, vector<u8>>` vs `VecMap<ObjectID, Vec<u8>>`), so types are
+  pinned as text on the Move side and only names and order are tied across.
+
+The only true runtime fix is a version tag inside the Move struct, which
+is a Move change plus a protocol version bump. Given that the upgrade
+checker already blocks the in-place case, that has not been judged worth
+its cost.

--- a/dev-docs/learnings/pitfalls.md
+++ b/dev-docs/learnings/pitfalls.md
@@ -474,6 +474,25 @@ rule, not the instance.
   reports "unexpected end of input", suspect a too-short *header* (off-by-a-name)
   before re-checking the value struct.
 
+- **A bcs error on an UNTAGGED chain mirror is a layout-drift suspect, not
+  just a corrupt read.** `DWalletCoordinatorInnerV1`, `SystemInnerV1`, and
+  `DWalletNetworkEncryptionKey` mirror deployed Move structs with no version
+  tag, so their field order IS the wire format and a verified read proves
+  nothing about it — every OCS gate authenticates the bytes' provenance, none
+  their shape. `bcs::from_bytes` is exhausting, so a length-changing drift does
+  surface, but it surfaces as a bare `remaining input` / `unexpected end of
+  input` raised wherever the mis-parse happened to run out — which is the same
+  wrong-place symptom as the entry above, one level up. The decode sites now go
+  through `ika_types::chain_mirror::decode_chain_mirror`, which names the Move
+  source and the drift hypothesis in the error; drift itself is caught earlier
+  by `scripts/check-chain-mirror-layout.sh` and the `ika-types` layout pins.
+  → Rule: on a decode failure in one of these types, diff the Move declaration
+  against the Rust struct field by field BEFORE debugging the field the decode
+  died in. Note what stays uncovered: a same-total-length reshuffle (a field
+  swapped for one of equal encoded width) decodes silently, and the guards are
+  build-time — they bind this repo's releases, not a node run against a foreign
+  package. See `dev-docs/conventions/chain-mirror-layout.md`.
+
 ## Sui reads & submission
 
 - **Re-reading mutable state from a lagging fullnode between serial

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -1237,16 +1237,48 @@ because the bytes came from a peer's disk rather than its fullnode.
   and withholding — the relay's already-documented privilege — never
   forgery.
 - **The proof chain does not authenticate a struct's SHAPE, only its
-  bytes.** `DWalletCoordinatorInnerV1` and `DWalletNetworkEncryptionKey`
-  are plain `#[derive(Serialize, Deserialize)]` structs with no version
-  tag. A Move field-add WITHIN the same version therefore mis-decodes
-  while passing every gate above — committee BLS, artifacts digest,
-  Merkle inclusion, id-binding, currency — because every one of those
-  proves the bytes are the chain's, and none proves the reader's struct
-  still matches them. Contrast `VersionedMPCData`, a tagged enum that
-  fails closed on an unknown variant. Treat "it verified" as a statement
-  about provenance, never about well-formedness, and give any new leaf
-  type read through this path a version tag.
+  bytes.** `DWalletCoordinatorInnerV1`, `SystemInnerV1`, and
+  `DWalletNetworkEncryptionKey` are plain `#[derive(Serialize,
+  Deserialize)]` structs with no version tag, so no gate above —
+  committee BLS, artifacts digest, Merkle inclusion, id-binding,
+  currency — says anything about whether the reader's struct still
+  describes the bytes: every one of them proves the bytes are the
+  chain's. Contrast `VersionedMPCData`, a tagged enum that fails closed
+  on an unknown variant. Treat "it verified" as a statement about
+  provenance, never about well-formedness, and give any new leaf type
+  read through this path a version tag.
+
+  **Scoped precisely** (the residual is narrower than "a field-add
+  mis-decodes", and the guards are build-time):
+  - Decoding is already maximally strict — every leaf site uses
+    exhausting `bcs::from_bytes`, which runs to `end()` and rejects
+    residue; there is no partial-read decoder in the repo. Each mirror is
+    also the last value in its byte stream and ends in a fixed-width tail
+    (`extra_fields: Bag` is 40 bytes, the fieldless `state` enum one), so
+    a length-changing field-add trips `remaining input` or dies on a
+    strict `bool`/unknown variant. **The silent case is a same-total-length
+    reshuffle** — a removed field replaced by one of equal encoded width,
+    or a same-width retype. That still mis-decodes with no signal.
+  - An in-place field-add cannot reach mainnet/testnet at all: Sui's
+    compatible-policy upgrade checker rejects datatype layout changes.
+    Drift arrives via a `const VERSION` bump plus `migrate()`, or a fresh
+    package publish — which is why the guards live at build time
+    (`scripts/check-chain-mirror-layout.sh`, golden layout tests in
+    `ika-types`, and an attributed decode error naming the Move source).
+  - **Those guards bind this repo's releases, not a running node.** They
+    say nothing about a node pointed at a foreign or hand-patched package,
+    or a redeploy built from a different source tree; and the Move-side
+    check proves only that the Move declaration has not moved since a human
+    last checked it against the Rust mirror, not that the mirror was ever
+    right. Nothing authenticates shape at runtime.
+  - Related, still open: the version dispatch (`match wrapper.version { 1
+    | 2 => .. }`, in `ika-sui-client/src/lib.rs` and
+    `verified_reader.rs`) asserts that chain versions 1 and 2 share one
+    layout. True today, and now pinned by the `const VERSION` value in
+    `scripts/chain-mirror-layout.txt` so the next bump fails the build —
+    but the arm is not split, because the two versions really do share a
+    layout and separate types would fabricate a distinction the bytes do
+    not have. See `dev-docs/conventions/chain-mirror-layout.md`.
 - **`OBJECT_DIGEST_CANCELLED` is bucketed as `Modified -> Current`** in
   the changeset fold. A cancelled transaction's object entry is not a
   real modification, so folding it as one attributes a currency claim to

--- a/scripts/chain-mirror-layout.txt
+++ b/scripts/chain-mirror-layout.txt
@@ -1,0 +1,85 @@
+# Frozen layout of the Move structs that Rust mirrors with untagged
+# `#[derive(Deserialize)]` types.
+#
+# Each block pins one Move struct's field list, in declaration order, and names
+# the Rust field each Move field decodes into. BCS is positional, so this order
+# IS the wire format of bytes that deployed packages have already written. The
+# names on the two sides genuinely differ in places (`presign_sessions` ->
+# `presigns`, `witnesses_approving_advance_epoch` ->
+# `witness_approving_advance_epoch`), which is exactly why the mapping is
+# written out instead of assumed.
+#
+# `scripts/check-chain-mirror-layout.sh` re-extracts both sides from source and
+# fails if either has moved. Regenerate with `--write` after a DELIBERATE change,
+# never to make a red build green.
+#
+# Full rationale and update procedure: dev-docs/conventions/chain-mirror-layout.md
+
+[mirror]
+move-source = contracts/ika_dwallet_2pc_mpc/sources/coordinator_inner.move
+move-struct = DWalletCoordinatorInner
+rust-source = crates/ika-types/src/sui/system_inner_v1.rs
+rust-struct = DWalletCoordinatorInnerV1
+version-source = contracts/ika_dwallet_2pc_mpc/sources/coordinator.move
+version-value = 2
+fields =
+  current_epoch: u64 -> current_epoch
+  sessions_manager: SessionsManager -> sessions_manager
+  dwallets: ObjectTable<ID, DWallet> -> dwallets
+  dwallet_network_encryption_keys: ObjectTable<ID, DWalletNetworkEncryptionKey> -> dwallet_network_encryption_keys
+  epoch_dwallet_network_encryption_keys_reconfiguration_completed: u64 -> epoch_dwallet_network_encryption_keys_reconfiguration_completed
+  encryption_keys: ObjectTable<address, EncryptionKey> -> encryption_keys
+  presign_sessions: ObjectTable<ID, PresignSession> -> presigns
+  partial_centralized_signed_messages: ObjectTable<ID, PartialUserSignature> -> partial_centralized_signed_messages
+  pricing_and_fee_manager: PricingAndFeeManager -> pricing_and_fee_management
+  active_committee: BlsCommittee -> active_committee
+  next_epoch_active_committee: Option<BlsCommittee> -> next_epoch_active_committee
+  total_messages_processed: u64 -> total_messages_processed
+  last_processed_checkpoint_sequence_number: u64 -> last_processed_checkpoint_sequence_number
+  previous_epoch_last_checkpoint_sequence_number: u64 -> previous_epoch_last_checkpoint_sequence_number
+  support_config: SupportConfig -> support_config
+  received_end_of_publish: bool -> received_end_of_publish
+  extra_fields: Bag -> extra_fields
+
+[mirror]
+move-source = contracts/ika_dwallet_2pc_mpc/sources/coordinator_inner.move
+move-struct = DWalletNetworkEncryptionKey
+rust-source = crates/ika-types/src/messages_dwallet_mpc.rs
+rust-struct = DWalletNetworkEncryptionKey
+fields =
+  id: UID -> id
+  dkg_at_epoch: u64 -> dkg_at_epoch
+  network_dkg_public_output: TableVec<vector<u8>> -> network_dkg_public_output
+  reconfiguration_public_outputs: Table<u64, TableVec<vector<u8>>> -> reconfiguration_public_outputs
+  dkg_params_for_network: vector<u8> -> dkg_params_for_network
+  supported_curves: vector<u32> -> supported_curves
+  state: DWalletNetworkEncryptionKeyState -> state
+
+[mirror]
+move-source = contracts/ika_system/sources/system/system_inner.move
+move-struct = SystemInner
+rust-source = crates/ika-types/src/sui/system_inner_v1.rs
+rust-struct = SystemInnerV1
+version-source = contracts/ika_system/sources/system.move
+version-value = 2
+fields =
+  epoch: u64 -> epoch
+  epoch_start_tx_digest: vector<u8> -> epoch_start_tx_digest
+  system_object_cap: SystemObjectCap -> system_object_cap
+  protocol_version: u64 -> protocol_version
+  next_protocol_version: Option<u64> -> next_protocol_version
+  upgrade_caps: vector<UpgradeCap> -> upgrade_caps
+  approved_upgrades: VecMap<ID, vector<u8>> -> approved_upgrades
+  validator_set: ValidatorSet -> validator_set
+  epoch_duration_ms: u64 -> epoch_duration_ms
+  stake_subsidy_start_epoch: u64 -> stake_subsidy_start_epoch
+  protocol_treasury: ProtocolTreasury -> protocol_treasury
+  epoch_start_timestamp_ms: u64 -> epoch_start_timestamp_ms
+  last_processed_checkpoint_sequence_number: u64 -> last_processed_checkpoint_sequence_number
+  previous_epoch_last_checkpoint_sequence_number: u64 -> previous_epoch_last_checkpoint_sequence_number
+  total_messages_processed: u64 -> total_messages_processed
+  remaining_rewards: Balance<IKA> -> remaining_rewards
+  authorized_protocol_cap_ids: vector<ID> -> authorized_protocol_cap_ids
+  witnesses_approving_advance_epoch: vector<String> -> witness_approving_advance_epoch
+  received_end_of_publish: bool -> received_end_of_publish
+  extra_fields: Bag -> extra_fields

--- a/scripts/check-chain-mirror-layout.sh
+++ b/scripts/check-chain-mirror-layout.sh
@@ -85,7 +85,7 @@ def move_fields(path, struct):
     fields = []
     for raw in struct_body(lines, f"struct {struct} ", path):
         line = strip_comment(raw)
-        if not line.strip() or line.strip().startswith("///"):
+        if not line.strip():
             continue
         match = MOVE_FIELD.match(line)
         if match:
@@ -101,7 +101,7 @@ def rust_fields(path, struct):
     names = []
     for raw in struct_body(lines, f"pub struct {struct} ", path):
         line = strip_comment(raw)
-        if not line.strip() or line.strip().startswith(("///", "#[")):
+        if not line.strip() or line.strip().startswith("#["):
             continue
         match = RUST_FIELD.match(line)
         if match:

--- a/scripts/check-chain-mirror-layout.sh
+++ b/scripts/check-chain-mirror-layout.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# Chain-mirror layout ratchet: the Move structs that Rust mirrors with untagged
+# `#[derive(Deserialize)]` types may not change shape without the Rust mirror,
+# the version dispatch, and the docs changing in the same PR.
+#
+# Why a check and not just review: `DWalletCoordinatorInner`, `SystemInner`, and
+# `DWalletNetworkEncryptionKey` are read from chain into Rust structs that carry
+# NO version tag. BCS is positional, so their field order is the wire format of
+# bytes deployed packages have already written, and nothing in those bytes
+# identifies which layout produced them. Every OCS proof gate — committee BLS,
+# artifacts digest, Merkle inclusion, id binding, currency — verifies the bytes'
+# PROVENANCE and none verifies their SHAPE, so a drifted layout passes all of
+# them and surfaces, at best, as a bare bcs error pointing at the wrong field.
+#
+# The check is build-time on purpose. An in-place field-add cannot reach
+# mainnet/testnet anyway (Sui's compatible-policy upgrade checker rejects
+# datatype layout changes); drift arrives through a `VERSION` bump plus
+# `migrate()`, or a fresh package publish — both of which pass through this repo,
+# where a red build is the cheapest possible signal.
+#
+# The Rust half of the guard is the golden layout tests beside each mirror
+# (`cargo test --release -p ika-types layout_is_pinned`); this script is the
+# Move half plus the mapping between them.
+#
+# Convention: dev-docs/conventions/chain-mirror-layout.md
+#
+# Usage:
+#   check-chain-mirror-layout.sh           # validate (CI)
+#   check-chain-mirror-layout.sh --list    # print each mirror's extracted layout
+#   check-chain-mirror-layout.sh --write   # regenerate the manifest after a
+#                                          # DELIBERATE change
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+python3 - "$@" <<'EOF'
+import pathlib
+import re
+import sys
+
+MANIFEST = pathlib.Path("scripts/chain-mirror-layout.txt")
+SPEC = "dev-docs/specs/ocs-verified-sui-reads.md"
+CONVENTION = "dev-docs/conventions/chain-mirror-layout.md"
+
+# A Move field line inside a struct body: `name: Type,`. Types can carry nested
+# generics and commas, so take everything up to the LAST comma.
+MOVE_FIELD = re.compile(r"^\s{4}(?P<name>[a-z_][A-Za-z0-9_]*)\s*:\s*(?P<type>.+?),?\s*$")
+# A Rust field line at struct indentation: `pub name: Type,`.
+RUST_FIELD = re.compile(r"^    pub\s+(?P<name>[a-z_][A-Za-z0-9_]*)\s*:")
+MOVE_VERSION = re.compile(r"^const VERSION:\s*u64\s*=\s*(?P<value>\d+)\s*;")
+
+
+def fail(message):
+    sys.exit(f"ERROR: {message}")
+
+
+def read_lines(path):
+    source = pathlib.Path(path)
+    if not source.is_file():
+        fail(f"{path} not found — update this script alongside the move/rename.")
+    return source.read_text().splitlines()
+
+
+def strip_comment(line):
+    """Drop a trailing `//` comment, which Move field lines carry freely."""
+    return line.split("//", 1)[0].rstrip()
+
+
+def struct_body(lines, header, path):
+    """The lines between a `... struct NAME ... {` header and its closing `}`."""
+    starts = [i for i, line in enumerate(lines) if line.rstrip().endswith("{") and header in line]
+    if not starts:
+        fail(f"`{header}` not found in {path} — update this script alongside the rename.")
+    if len(starts) > 1:
+        fail(f"`{header}` is declared {len(starts)} times in {path}; the extractor needs one.")
+    start = starts[0] + 1
+    ends = [i for i in range(start, len(lines)) if lines[i].rstrip() == "}"]
+    if not ends:
+        fail(f"`{header}` in {path} has no closing brace at column 0.")
+    return lines[start:ends[0]]
+
+
+def move_fields(path, struct):
+    """Ordered `(name, type)` of a Move struct, comments and blank lines dropped."""
+    lines = read_lines(path)
+    fields = []
+    for raw in struct_body(lines, f"struct {struct} ", path):
+        line = strip_comment(raw)
+        if not line.strip() or line.strip().startswith("///"):
+            continue
+        match = MOVE_FIELD.match(line)
+        if match:
+            fields.append((match.group("name"), match.group("type").strip()))
+    if not fields:
+        fail(f"extracted no fields from Move `{struct}` in {path}.")
+    return fields
+
+
+def rust_fields(path, struct):
+    """Ordered field names of an all-`pub` Rust struct."""
+    lines = read_lines(path)
+    names = []
+    for raw in struct_body(lines, f"pub struct {struct} ", path):
+        line = strip_comment(raw)
+        if not line.strip() or line.strip().startswith(("///", "#[")):
+            continue
+        match = RUST_FIELD.match(line)
+        if match:
+            names.append(match.group("name"))
+    if not names:
+        fail(f"extracted no fields from Rust `{struct}` in {path}.")
+    return names
+
+
+def move_version(path):
+    for line in read_lines(path):
+        match = MOVE_VERSION.match(line.strip())
+        if match:
+            return match.group("value")
+    fail(f"`const VERSION: u64` not found in {path}.")
+
+
+def parse_manifest():
+    """Blocks of `key = value`, with `fields` taking indented continuation lines."""
+    blocks = []
+    block = None
+    key = None
+    for raw in MANIFEST.read_text().splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        if raw.strip() == "[mirror]":
+            block = {"fields": []}
+            blocks.append(block)
+            key = None
+            continue
+        if block is None:
+            fail(f"{MANIFEST}: content before the first [mirror] block.")
+        if raw.startswith((" ", "\t")):
+            if key != "fields":
+                fail(f"{MANIFEST}: indented line outside `fields =`: {raw!r}")
+            move_side, _, rust_name = raw.strip().partition("->")
+            move_name, _, move_type = move_side.partition(":")
+            block["fields"].append(
+                (move_name.strip(), move_type.strip(), rust_name.strip())
+            )
+            continue
+        key, _, value = raw.partition("=")
+        key, value = key.strip(), value.strip()
+        # `fields =` opens the indented list parsed above; it has no value of
+        # its own and must not overwrite the list already sitting there.
+        if key != "fields":
+            block[key] = value
+    return blocks
+
+
+def render(block, fields):
+    lines = ["[mirror]"]
+    for key in ("move-source", "move-struct", "rust-source", "rust-struct"):
+        lines.append(f"{key} = {block[key]}")
+    if "version-source" in block:
+        lines.append(f"version-source = {block['version-source']}")
+        lines.append(f"version-value = {block['version-value']}")
+    lines.append("fields =")
+    for move_name, move_type, rust_name in fields:
+        lines.append(f"  {move_name}: {move_type} -> {rust_name}")
+    return "\n".join(lines)
+
+
+def extract(block):
+    """The live layout, as manifest-shaped `(move_name, move_type, rust_name)`."""
+    move = move_fields(block["move-source"], block["move-struct"])
+    rust = rust_fields(block["rust-source"], block["rust-struct"])
+    if len(move) != len(rust):
+        fail(
+            f"Move `{block['move-struct']}` has {len(move)} fields but Rust "
+            f"`{block['rust-struct']}` has {len(rust)}.\n\n"
+            f"  Move: {block['move-source']}\n"
+            f"  Rust: {block['rust-source']}\n\n"
+            "These must agree field for field: the Rust struct is an UNTAGGED mirror, so its\n"
+            "field order is the wire format of bytes already on chain. Fix the mismatch, then\n"
+            f"regenerate with `./scripts/check-chain-mirror-layout.sh --write`.\n\n"
+            f"See {CONVENTION}."
+        )
+    return [(name, type_, rust_name) for (name, type_), rust_name in zip(move, rust)]
+
+
+blocks = parse_manifest()
+
+if "--list" in sys.argv:
+    for block in blocks:
+        print(render(block, extract(block)))
+        print()
+    sys.exit(0)
+
+if "--write" in sys.argv:
+    header = []
+    for line in MANIFEST.read_text().splitlines():
+        if line.strip() == "[mirror]":
+            break
+        header.append(line)
+    body = "\n\n".join(render(block, extract(block)) for block in blocks)
+    MANIFEST.write_text("\n".join(header) + body + "\n")
+    print(f"wrote {MANIFEST}")
+    sys.exit(0)
+
+problems = []
+for block in blocks:
+    live = extract(block)
+    pinned = block["fields"]
+    if live != pinned:
+        detail = [f"Move `{block['move-struct']}` <-> Rust `{block['rust-struct']}`:"]
+        for index in range(max(len(live), len(pinned))):
+            got = live[index] if index < len(live) else None
+            want = pinned[index] if index < len(pinned) else None
+            if got != want:
+                detail.append(f"    field {index}: pinned {want} but source has {got}")
+        problems.append("\n".join(detail))
+    if "version-source" in block:
+        version = move_version(block["version-source"])
+        if version != block["version-value"]:
+            problems.append(
+                f"Move `{block['move-struct']}`: {block['version-source']} declares "
+                f"VERSION = {version}, manifest pins {block['version-value']}."
+            )
+
+if problems:
+    sys.exit(
+        "ERROR: a chain-mirror layout drifted from its pin.\n\n"
+        + "\n\n".join(problems)
+        + "\n\n"
+        "These Rust structs are UNTAGGED mirrors of deployed Move structs. BCS is\n"
+        "positional, so their field order is the wire format of bytes already written on\n"
+        "chain, and nothing in those bytes says which layout produced them: every OCS proof\n"
+        "gate verifies the bytes' provenance, none verifies their shape. A drift here does\n"
+        "not fail closed at runtime — it re-interprets live chain state.\n\n"
+        "If this change is deliberate, ALL of the following move together:\n"
+        "  1. the Move struct and the Rust mirror,\n"
+        "  2. the version dispatch — `match wrapper.version { 1 | 2 => .. }` in\n"
+        "     crates/ika-sui-client/src/lib.rs and\n"
+        "     crates/ika-core/src/sui_connector/verified_reader.rs — which today asserts,\n"
+        "     untested, that versions 1 and 2 share one layout. A layout change means they\n"
+        "     no longer do, and the arm must stop claiming it,\n"
+        "  3. the `const VERSION` bump plus `migrate()` that carries old state across (an\n"
+        "     in-place field-add is rejected by Sui's compatible-policy upgrade checker, so\n"
+        "     there is no same-version path to chain),\n"
+        "  4. the golden layout tests: cargo test --release -p ika-types layout_is_pinned,\n"
+        f"  5. the Residuals section of {SPEC},\n"
+        "  6. this manifest: ./scripts/check-chain-mirror-layout.sh --write\n\n"
+        f"See {CONVENTION}."
+    )
+EOF


### PR DESCRIPTION
Closes the untagged-leaf-struct decode non-guarantee found during the dev-docs reconciliation (#2079): `DWalletCoordinatorInnerV1`, `SystemInnerV1`, and `DWalletNetworkEncryptionKey` are plain untagged deserialize structs mirroring deployed Move layouts, and every OCS proof gate verifies **bytes, not shape** — so layout drift between the Move source and the Rust mirror passes all gates and surfaces, at best, as an unattributed bcs error (a trap that has already cost three CI cycles per the pitfalls record).

## What re-verification narrowed before designing

- Decode strictness already holds: every leaf site uses exhausting `bcs::from_bytes` (verified against bcs-0.1.6 — residue is a hard `RemainingInput`). Length-changing drift fails loudly today.
- Both mirrors end in fixed-width tails, so the genuinely silent runtime case is a **same-total-length reshuffle**, not a field-add.
- The real structural hole: Move's coordinator/system are at `const VERSION = 2` with a single unsuffixed inner struct, and both Rust readers match `1 | 2 =>` onto one mirror — an untested, uncommented assertion that two versions share a layout. Mainnet's `compatible` upgrade policy already blocks in-place field-adds, so real drift arrives via VERSION-bump + `migrate()` or fresh publishes — which is why this fix is **build/CI-time prevention**, not runtime defense.

## The three guards

1. **`scripts/check-chain-mirror-layout.sh` + `scripts/chain-mirror-layout.txt`** (CI-wired beside its five sibling checks, with `--list`/`--write` modes): extracts the Move field lists, the Rust mirror field order, and both `const VERSION`s, and diffs them against a committed manifest. The manifest maps Move→Rust **explicitly** — three real name divergences exist (`presign_sessions`→`presigns`, `pricing_and_fee_manager`→`pricing_and_fee_management`, `witnesses_approving_advance_epoch`→`witness_approving_advance_epoch`), so name-equality would have been a lie. Any Move field add/remove/reorder/retype or a VERSION bump fails CI naming everything that must move together, including the spec.
2. **Golden BCS pins** beside each mirror: length + Blake2b digest over a fully-populated value with every field distinct, plus a pin on all four `DWalletNetworkEncryptionKeyState` variant indices (the variant index is the wire discriminant). The struct literal uses no `..Default::default()`, so a Rust field add/remove is a *compile* error before the digest even runs.
3. **Decode-error attribution**: a `map_err`-only wrapper at all five leaf sites that names the Move source struct and states layout drift as a candidate cause — converting "hunt in the wrong struct" into a pointed failure. Strictness untouched.

Deliberately NOT done: splitting the `1 | 2 =>` arm into separate types — an ungated live-path behavior change fabricating a distinction the layouts don't have. The VERSION tripwire is what forces the layout question when the arm is next widened.

## Fault-injection evidence (per `dev-docs/playbooks/test-testing.md`; all injected, caught, reverted, re-greened)

| injected drift | caught by |
|---|---|
| Move field-add | script: field-count mismatch naming both sides |
| Move+Rust coordinated add (counts match) | script: per-field diff naming the exact field |
| Rust-only field-add | compile error (no-default struct literal) |
| `const VERSION` 2→3 | script: version pin (honest note: runtime already fails closed on a `3`; the tripwire's value is forcing the layout question when the arm is widened) |
| Rust retype `u64`→`u32` | digest ONLY — the script reads names, proving the two halves aren't redundant |
| **same-width field swap in `SystemInnerV1` (778 bytes → 778 bytes)** | **both build-time halves — the exact case runtime `bcs::from_bytes` would have accepted silently** |

## What this does NOT guarantee (also in the spec's Residuals and the new convention doc)

Nothing here authenticates shape at runtime — the proof chain proves provenance, never well-formedness, and a same-total-length reshuffle still mis-decodes silently on a running node. The guards bind this repo's releases at build time, not a node pointed at a foreign or hand-patched package. The script proves the Move declaration hasn't moved since a human last checked it against the mirror, not that the mirror was ever correct: the Move and Rust type vocabularies don't correspond mechanically, so Move types are pinned as text and only names and order are tied across. The only true runtime fix is a version tag inside the Move struct — a Move change plus protocol version bump, judged not worth its cost while the upgrade checker blocks the in-place case.

Docs in the same PR: new `dev-docs/conventions/chain-mirror-layout.md`, README index entry, rewritten spec Residuals, pitfalls entry.

Gates: workspace `cargo check --release` clean; clippy `-D warnings` exit 0, no `#[allow]`; `ika-types` 43/43, `ika-sui-client` 39/39, `verified_reader` 45/45; fmt zero unrelated churn; no Move files in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Kxw9H9dWLZqmQgyEXAHqi
