### PR TITLE
fix(mpc-data): make the pre-freeze wait legible; warn on undecodable blobs; memoize decode verdicts (#2080)

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -1248,6 +1248,21 @@ pub struct AuthorityPerEpochStore {
     /// The `own_mpc_data_blob_unhealthy` gauge carries the ongoing state.
     self_blob_unhealthy_warned: AtomicBool,
 
+    /// Memoized decode verdicts for announced mpc_data blobs, keyed by
+    /// the content digest they are stored under. The emit gate re-runs
+    /// `compute_locally_validated_peers` on every ~2s tick and each run
+    /// used to BCS-decode every announced ~72KB class-groups bundle
+    /// again for an answer that cannot change (issue #2080). Per-epoch
+    /// lifetime, so it is bounded by the epoch's distinct announced
+    /// digests and drops at the boundary.
+    mpc_data_decode_cache: crate::validator_metadata::MpcDataDecodeCache,
+
+    /// `(announcer, digest)` pairs already warned about for a locally-held
+    /// but undecodable mpc_data blob. Dedupes what would otherwise be the
+    /// same warn on every emit-gate tick; bounded by the epoch's distinct
+    /// announced digests, like the cache above.
+    invalid_peer_blob_warned: parking_lot::Mutex<HashSet<(AuthorityName, [u8; 32])>>,
+
     /// Running max of `commit_timestamp_ms` over every consensus commit
     /// this validator has processed this epoch — the epoch's consensus
     /// clock. In-memory only: it starts at 0 on (re)open and restores
@@ -2322,6 +2337,8 @@ impl AuthorityPerEpochStore {
             handoff_aggregator: parking_lot::Mutex::new(None),
             perpetual_tables_for_handoff: ArcSwapOption::empty(),
             self_blob_unhealthy_warned: AtomicBool::new(false),
+            mpc_data_decode_cache: crate::validator_metadata::MpcDataDecodeCache::new(),
+            invalid_peer_blob_warned: parking_lot::Mutex::new(HashSet::new()),
             max_processed_commit_timestamp_ms: AtomicU64::new(0),
             round_transport: ArcSwapOption::empty(),
             observed_consensus_head_round: AtomicU64::new(0),
@@ -4041,14 +4058,41 @@ impl AuthorityPerEpochStore {
             self.name,
             announcements,
             |digest| {
-                perpetual
-                    .get_mpc_artifact_blob(digest)
-                    .ok()
-                    .flatten()
-                    .map(|bytes| crate::validator_metadata::blob_decodes_to_valid_mpc_data(&bytes))
-                    .unwrap_or(false)
+                self.mpc_data_decode_cache.verdict(digest, || {
+                    perpetual.get_mpc_artifact_blob(digest).ok().flatten()
+                })
             },
         );
+        // A blob that IS held locally but doesn't decode is a fault with
+        // no in-epoch self-heal (the digest names exactly one byte string),
+        // and it silently costs the announcer its place in this validator's
+        // attestation. Before #2080 it was dropped without a word, which is
+        // what made a stalled off-chain plane unreadable from the logs.
+        // Once per (announcer, digest) — the emit gate re-evaluates every
+        // ~2s tick. Self has its own warn plus a gauge just below, so it is
+        // not repeated here.
+        for (authority, digest) in &decision.invalid_blobs {
+            if *authority == self.name {
+                continue;
+            }
+            // Take and drop the dedupe lock before logging — never hold a
+            // mutex across a `tracing` call.
+            let first_sighting = self
+                .invalid_peer_blob_warned
+                .lock()
+                .insert((*authority, *digest));
+            if first_sighting {
+                warn!(
+                    validator = ?authority,
+                    blob_digest = ?digest,
+                    epoch = self.epoch(),
+                    "announced mpc_data blob is held locally but fails the decode gate; \
+                     excluding this validator from our locally-validated set until it \
+                     announces a different blob (its bytes cannot become valid — the \
+                     blob store is content-addressed)"
+                );
+            }
+        }
         if decision.self_blob_unhealthy {
             // Own announcement is in the table but the corresponding
             // perpetual blob is missing or fails decode. Attesting

--- a/crates/ika-core/src/epoch_tasks/mpc_data_announcement_sender.rs
+++ b/crates/ika-core/src/epoch_tasks/mpc_data_announcement_sender.rs
@@ -54,13 +54,51 @@ use std::time::Duration;
 use tokio::sync::watch::Receiver;
 use tracing::{debug, info, warn};
 
+/// Why the emit gate is still waiting, carried on
+/// [`ReadyToFinalize::NotYet`] so the caller can say so out loud.
+///
+/// Before #2080 the gate returned a bare "not yet" and the caller
+/// logged one `debug!` line, so the single longest wait in the
+/// protocol — a fresh network sitting until mid-epoch reconfiguration
+/// publishes `V_{e+1}`, which is HALF THE EPOCH after genesis — was
+/// invisible at the default log level. That silence is what made a
+/// correctly-waiting 4-validator network read as a hang for three
+/// hours.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadySignalWait {
+    /// Whether `V_{e+1}` has been published on chain yet. `false` is
+    /// the mid-epoch-reconfiguration wait: nothing this validator
+    /// does can shorten it, and on a fresh network with a long
+    /// genesis epoch it dominates everything else.
+    pub next_committee_published: bool,
+    /// Next-epoch members that are neither locally validated nor
+    /// carried forward by the freeze. Empty while
+    /// `next_committee_published` is false (the member list is not
+    /// known yet).
+    pub uncovered: Vec<AuthorityName>,
+    /// The epoch's consensus clock at evaluation time, and the
+    /// consensus-clock deadline after which the gate emits anyway.
+    /// `deadline_ms == u64::MAX` means no deadline is armed yet (no
+    /// consensus commit processed this epoch).
+    pub now_ms: u64,
+    pub deadline_ms: u64,
+}
+
+impl ReadySignalWait {
+    /// Seconds of consensus clock left before the liveness backstop
+    /// forces an emit; `None` when no deadline is armed.
+    pub fn seconds_until_deadline(&self) -> Option<u64> {
+        (self.deadline_ms != u64::MAX).then(|| self.deadline_ms.saturating_sub(self.now_ms) / 1000)
+    }
+}
+
 /// Outcome of the ready-signal emit gate ([`decide_ready_to_finalize`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReadyToFinalize {
     /// Don't emit yet — keep waiting (V_{e+1} unpublished, or some of
     /// its members neither validated nor carry-forward-covered, and
-    /// the deadline hasn't passed).
-    NotYet,
+    /// the deadline hasn't passed). Carries why, for the operator log.
+    NotYet(ReadySignalWait),
     /// Emit: the next-epoch committee is published and every member is
     /// covered — its blob locally validated, or carried forward by the
     /// freeze (in the prior epoch's handoff cert AND in the current
@@ -134,7 +172,12 @@ fn decide_ready_to_finalize(
     if now_ms >= deadline_ms {
         return ReadyToFinalize::ReadyViaDeadlineMissing(missing);
     }
-    ReadyToFinalize::NotYet
+    ReadyToFinalize::NotYet(ReadySignalWait {
+        next_committee_published: next_published,
+        uncovered: missing,
+        now_ms,
+        deadline_ms,
+    })
 }
 
 /// Post-publication grace bounds for [`ready_signal_deadline_ms`]:
@@ -146,6 +189,16 @@ fn decide_ready_to_finalize(
 /// runway loss.
 const POST_PUBLICATION_GRACE_MIN_MS: u64 = 30_000;
 const POST_PUBLICATION_GRACE_MAX_MS: u64 = 3_600_000;
+
+/// Log the ready-signal emit gate's reason for waiting on the first
+/// deferral and every Nth thereafter. The poll interval is pinned at
+/// 2s ([`crate::validator_metadata::epoch_scaled_poll_interval`]
+/// clamps to it), so this is one line per five minutes per validator:
+/// dense enough that any five-minute window of log answers "why has
+/// MPC not started?", sparse enough that the wait this exists to
+/// document — half an epoch, twelve hours under a 24h mainnet epoch —
+/// costs ~150 lines rather than ~4,000.
+const READY_SIGNAL_DEFERRAL_LOG_EVERY: u64 = 150;
 
 /// The deadline after which the emit gate stops waiting for uncovered
 /// next-epoch members, denominated in the epoch's CONSENSUS clock (max
@@ -260,6 +313,11 @@ pub struct MpcDataAnnouncementSender {
     /// thereafter, so a sequencing stall still surfaces) logs at
     /// info, re-submissions in between at debug.
     announcement_submit_attempts: AtomicU64,
+    /// Number of ticks that fell through the ready-signal emit gate
+    /// without emitting. Bounds the operator-facing "still waiting,
+    /// and here is what for" log to the first such tick and every
+    /// [`READY_SIGNAL_DEFERRAL_LOG_EVERY`]th afterwards.
+    ready_signal_deferrals: AtomicU64,
     /// Consensus-clock ms (the epoch store's max processed commit
     /// timestamp) at which this validator FIRST observed the
     /// next-epoch committee published on the watch channel, or `0`
@@ -333,6 +391,7 @@ impl MpcDataAnnouncementSender {
             ),
             next_sequence_number: std::sync::atomic::AtomicU64::new(next_sequence_number),
             announcement_submit_attempts: AtomicU64::new(0),
+            ready_signal_deferrals: AtomicU64::new(0),
             next_committee_first_seen_ms: AtomicU64::new(0),
         }
     }
@@ -438,6 +497,23 @@ impl MpcDataAnnouncementSender {
         Ok(recorded
             .map(|r| r.timestamp_ms == cached.timestamp_ms && r.blob_hash == cached.blob_hash)
             .unwrap_or(false))
+    }
+
+    /// Runs `log` on the first emit-gate deferral of the epoch and
+    /// every [`READY_SIGNAL_DEFERRAL_LOG_EVERY`]th one after it.
+    ///
+    /// The gate legitimately defers for hours on a fresh network —
+    /// until mid-epoch reconfiguration publishes `V_{e+1}` — and
+    /// before #2080 said so only at `debug!`, so at the default level
+    /// a correctly-waiting validator and a wedged one produced the
+    /// same output: none. Rate-limiting rather than latching keeps
+    /// the state visible from anywhere in the log, not just from
+    /// whoever happened to catch the first line.
+    fn log_ready_signal_deferral(&self, log: impl FnOnce()) {
+        let deferrals = self.ready_signal_deferrals.fetch_add(1, Ordering::Relaxed);
+        if deferrals.is_multiple_of(READY_SIGNAL_DEFERRAL_LOG_EVERY) {
+            log();
+        }
     }
 
     fn epoch_store(&self) -> DwalletMPCResult<Arc<AuthorityPerEpochStore>> {
@@ -760,11 +836,17 @@ impl MpcDataAnnouncementSender {
             .local_blob_coverage_meets_quorum()
             .map_err(DwalletMPCError::IkaError)?
         {
-            debug!(
-                epoch = self.epoch_id,
-                "deferring EpochMpcDataReadySignal: \
-                 local blob coverage below stake-quorum"
-            );
+            self.log_ready_signal_deferral(|| {
+                info!(
+                    epoch = self.epoch_id,
+                    reason = "local_blob_coverage_below_quorum",
+                    "not emitting EpochMpcDataReadySignal yet: fewer than a stake \
+                     quorum of peer mpc_data blobs are locally held and decode-valid. \
+                     Waiting for P2P propagation; the mpc_data freeze (and with it \
+                     network DKG / reconfiguration) cannot start until a quorum of \
+                     validators emit this signal"
+                );
+            });
             return Ok(());
         }
         // Carry the blob hash we validated for each peer, so the
@@ -791,12 +873,40 @@ impl MpcDataAnnouncementSender {
         // validator emits; the freeze snapshot itself is still computed
         // deterministically at the consensus-ordered quorum point.
         let deadline_missing = match self.ready_to_finalize(&epoch_store, &validated_names) {
-            ReadyToFinalize::NotYet => {
-                debug!(
-                    epoch = self.epoch_id,
-                    "deferring EpochMpcDataReadySignal: \
-                     next-epoch committee not yet fully validated"
-                );
+            ReadyToFinalize::NotYet(wait) => {
+                self.log_ready_signal_deferral(|| {
+                    if wait.next_committee_published {
+                        info!(
+                            epoch = self.epoch_id,
+                            reason = "next_epoch_members_uncovered",
+                            uncovered_count = wait.uncovered.len(),
+                            uncovered = ?wait.uncovered,
+                            seconds_until_deadline = ?wait.seconds_until_deadline(),
+                            "not emitting EpochMpcDataReadySignal yet: the next-epoch \
+                             committee is published but some of its members are neither \
+                             locally validated nor carried forward by the freeze. \
+                             Emitting anyway once the announcement deadline elapses"
+                        );
+                    } else {
+                        // The long pole, and the one that reads as a hang:
+                        // `V_{e+1}` is published by mid-epoch reconfiguration,
+                        // which the chain refuses before
+                        // `epoch_start + epoch_duration / 2`. On a fresh network
+                        // with a long genesis epoch that is hours of correct,
+                        // silent waiting (issue #2080).
+                        info!(
+                            epoch = self.epoch_id,
+                            reason = "next_epoch_committee_unpublished",
+                            seconds_until_deadline = ?wait.seconds_until_deadline(),
+                            "not emitting EpochMpcDataReadySignal yet: the next-epoch \
+                             committee (V_e+1) has not been published on chain — \
+                             mid-epoch reconfiguration has not run, and it cannot run \
+                             before half the epoch duration has elapsed. The mpc_data \
+                             freeze, and with it network DKG / reconfiguration, waits \
+                             for this; nothing is stuck"
+                        );
+                    }
+                });
                 return Ok(());
             }
             ReadyToFinalize::Ready => Vec::new(),
@@ -926,6 +1036,133 @@ mod tests {
         AuthorityName([n; 32])
     }
 
+    /// Expected `NotYet` with its wait reason spelled out. The reason
+    /// is what the operator log prints (#2080), so the gate tests pin
+    /// it rather than accepting any old "not yet".
+    fn not_yet(
+        next_committee_published: bool,
+        uncovered: Vec<AuthorityName>,
+        now_ms: u64,
+        deadline_ms: u64,
+    ) -> ReadyToFinalize {
+        ReadyToFinalize::NotYet(ReadySignalWait {
+            next_committee_published,
+            uncovered,
+            now_ms,
+            deadline_ms,
+        })
+    }
+
+    /// The emit gate's "still waiting, here is why" line must be
+    /// rate-limited, NOT latched to the first occurrence: the wait can
+    /// last hours (issue #2080), and an operator who attaches to the
+    /// log mid-wait — or greps a window of it — has to be able to find
+    /// out why MPC has not started without hunting for one line emitted
+    /// at process start.
+    // `test_sender` opens perpetual tables, whose typed-store metrics
+    // need a Tokio reactor — hence async, like the other sender tests.
+    #[tokio::test]
+    async fn ready_signal_deferral_logging_repeats_on_a_bounded_cadence() {
+        let sender = test_sender();
+        let mut logged = 0usize;
+        let ticks = READY_SIGNAL_DEFERRAL_LOG_EVERY * 3;
+        for _ in 0..ticks {
+            sender.log_ready_signal_deferral(|| logged += 1);
+        }
+        assert_eq!(
+            logged, 3,
+            "expected one line on the first deferral and every {READY_SIGNAL_DEFERRAL_LOG_EVERY}th after"
+        );
+        assert!(
+            logged > 1,
+            "a latched one-shot would leave a multi-hour wait undocumented"
+        );
+    }
+
+    /// Regression for issue #2080. A fresh network spends the first
+    /// half of its genesis epoch waiting for mid-epoch reconfiguration
+    /// to publish `V_{e+1}` — the chain refuses the call before
+    /// `epoch_start + epoch_duration / 2` — and only then can the
+    /// mpc_data freeze fire and network DKG start. With a 6-hour
+    /// genesis epoch that is a three-hour wait during which the gate
+    /// said nothing, and a correctly-waiting validator was
+    /// indistinguishable from a wedged one.
+    ///
+    /// The gate must therefore report WHICH wait it is in, and how
+    /// long the liveness backstop still has to run, so the caller can
+    /// print it. Distinguishing the two waits is the whole point: one
+    /// is "the chain has not reached mid-epoch yet, nothing you can
+    /// do", the other is "these named members still owe us a blob".
+    #[test]
+    fn ready_to_finalize_names_the_wait_it_is_in() {
+        let a = name(1);
+        let b = name(2);
+        let joiner = name(3);
+        let no_prior_cert = HashSet::new();
+        let current: HashSet<AuthorityName> = [a, b].into_iter().collect();
+
+        // Genesis-epoch wait: V_{e+1} unpublished (chain shows epoch 5,
+        // we want 6). Everything local is validated; the gate is
+        // blocked purely on mid-epoch reconfiguration.
+        let waiting_for_chain = decide_ready_to_finalize(
+            1_000_000,
+            11_800_000,
+            5,
+            6,
+            &[a, b],
+            &[a, b],
+            &no_prior_cert,
+            &current,
+        );
+        let ReadyToFinalize::NotYet(wait) = waiting_for_chain else {
+            panic!("expected NotYet while V_e+1 is unpublished");
+        };
+        assert!(
+            !wait.next_committee_published,
+            "the mid-epoch-reconfiguration wait must be identified as such"
+        );
+        assert!(
+            wait.uncovered.is_empty(),
+            "no member list is known before publication, so none can be blamed"
+        );
+        assert_eq!(wait.seconds_until_deadline(), Some(10_800));
+
+        // Post-publication wait: the joiner owes us a blob. Same
+        // `NotYet`, different — and nameable — cause.
+        let waiting_for_peer = decide_ready_to_finalize(
+            1_000_000,
+            11_800_000,
+            6,
+            6,
+            &[a, b, joiner],
+            &[a, b],
+            &no_prior_cert,
+            &current,
+        );
+        let ReadyToFinalize::NotYet(wait) = waiting_for_peer else {
+            panic!("expected NotYet while the joiner is uncovered");
+        };
+        assert!(wait.next_committee_published);
+        assert_eq!(wait.uncovered, vec![joiner]);
+
+        // No consensus commit processed yet: the deadline is inert and
+        // must be reported as absent rather than as a bogus countdown.
+        let no_clock = decide_ready_to_finalize(
+            0,
+            u64::MAX,
+            5,
+            6,
+            &[a, b],
+            &[a, b],
+            &no_prior_cert,
+            &current,
+        );
+        let ReadyToFinalize::NotYet(wait) = no_clock else {
+            panic!("expected NotYet with no consensus clock");
+        };
+        assert_eq!(wait.seconds_until_deadline(), None);
+    }
+
     #[test]
     fn ready_to_finalize_waits_for_next_committee_then_emits() {
         let a = name(1);
@@ -937,7 +1174,7 @@ mod tests {
         // not 6): not ready, even with everything validated.
         assert_eq!(
             decide_ready_to_finalize(100, 1000, 5, 6, &[a, b], &[a, b], &no_prior_cert, &current),
-            ReadyToFinalize::NotYet
+            not_yet(false, vec![], 100, 1000)
         );
         // V_{e+1} published (epoch 6) but the joiner isn't validated
         // yet: not ready.
@@ -952,7 +1189,7 @@ mod tests {
                 &no_prior_cert,
                 &current
             ),
-            ReadyToFinalize::NotYet
+            not_yet(true, vec![joiner], 100, 1000)
         );
         // V_{e+1} published AND all its members validated: ready.
         assert_eq!(
@@ -1052,7 +1289,7 @@ mod tests {
                 &prior_cert,
                 &current
             ),
-            ReadyToFinalize::NotYet
+            not_yet(false, vec![], 100, 1000)
         );
     }
 
@@ -1091,7 +1328,7 @@ mod tests {
                 &prior_cert,
                 &current
             ),
-            ReadyToFinalize::NotYet
+            not_yet(true, vec![rejoiner], 100, 1000)
         );
         // Once it validates, the gate opens immediately.
         assert_eq!(
@@ -1147,7 +1384,7 @@ mod tests {
                 &prior_cert,
                 &current
             ),
-            ReadyToFinalize::NotYet
+            not_yet(true, vec![never_alive], 100, 1000)
         );
         // At the deadline, only the uncovered member is reported.
         assert_eq!(

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -1224,6 +1224,34 @@ where
     AssemblyInputDecision::Pairs(pairs)
 }
 
+/// What a local lookup of an announced blob found. Distinguishing
+/// "not here yet" from "here but garbage" is what lets the caller
+/// warn about the second without drowning in the first: an absent
+/// blob is the ordinary pre-propagation state on every epoch start,
+/// while a present-but-undecodable blob is a real fault that has no
+/// in-epoch self-heal and used to be indistinguishable from it
+/// (issue #2080 — three hours of silence while the operator could
+/// not tell a wait from a fault).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalBlobVerdict {
+    /// Bytes are held locally and decode into valid mpc_data.
+    Valid,
+    /// Bytes are held locally but fail
+    /// [`blob_decodes_to_valid_mpc_data`]. Content-addressed
+    /// storage makes this a stable property of the digest, so it
+    /// will not fix itself by re-reading.
+    Invalid,
+    /// No bytes held locally for this digest yet. Benign and
+    /// expected until P2P propagation delivers them.
+    Absent,
+}
+
+impl LocalBlobVerdict {
+    fn is_valid(self) -> bool {
+        matches!(self, LocalBlobVerdict::Valid)
+    }
+}
+
 /// Decision returned by [`decide_locally_validated_peers`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatedPeersDecision {
@@ -1238,6 +1266,15 @@ pub struct ValidatedPeersDecision {
     /// caller is expected to emit a `warn!` when this is true so
     /// operators notice the persist failure.
     pub self_blob_unhealthy: bool,
+    /// Announcers (self included) whose blob IS held locally but
+    /// fails the decode gate, paired with the digest they announced.
+    /// Held-but-invalid is a fault, not a wait: the bytes under a
+    /// digest can never change (the perpetual table rejects an
+    /// insert whose digest doesn't match `Blake2b256(bytes)`), so
+    /// re-reading will never turn this into `Valid`. The caller
+    /// warns once per pair so the validator and digest are named
+    /// in the log instead of being dropped silently.
+    pub invalid_blobs: Vec<(AuthorityName, [u8; 32])>,
 }
 
 /// Builds the locally-validated-peers set from a stream of
@@ -1253,21 +1290,26 @@ pub struct ValidatedPeersDecision {
 pub fn decide_locally_validated_peers<F>(
     self_authority: AuthorityName,
     announcements: impl IntoIterator<Item = (AuthorityName, [u8; 32])>,
-    blob_valid_for_digest: F,
+    blob_verdict_for_digest: F,
 ) -> ValidatedPeersDecision
 where
-    F: Fn(&[u8; 32]) -> bool,
+    F: Fn(&[u8; 32]) -> LocalBlobVerdict,
 {
     let mut validated: std::collections::BTreeSet<AuthorityName> =
         std::collections::BTreeSet::new();
     let mut self_announcement_seen = false;
     let mut self_blob_unhealthy = false;
+    let mut invalid_blobs: Vec<(AuthorityName, [u8; 32])> = Vec::new();
     for (authority, digest) in announcements {
         let is_self = authority == self_authority;
         if is_self {
             self_announcement_seen = true;
         }
-        if blob_valid_for_digest(&digest) {
+        let verdict = blob_verdict_for_digest(&digest);
+        if verdict == LocalBlobVerdict::Invalid {
+            invalid_blobs.push((authority, digest));
+        }
+        if verdict.is_valid() {
             validated.insert(authority);
         } else if is_self {
             self_blob_unhealthy = true;
@@ -1283,6 +1325,77 @@ where
     ValidatedPeersDecision {
         validated,
         self_blob_unhealthy,
+        invalid_blobs,
+    }
+}
+
+/// Memoizes [`blob_decodes_to_valid_mpc_data`] by blob digest.
+///
+/// The decode gate runs on every emit-gate poll — one to two times
+/// per ~2s tick, over every announced digest — and each call BCS-
+/// decodes a ~72KB class-groups bundle that has already been decoded
+/// on every previous tick with the identical answer. Nothing about
+/// that answer can change: `AuthorityPerpetualTables::
+/// insert_mpc_artifact_blob` refuses any insert whose digest is not
+/// `Blake2b256(bytes)`, so a digest names exactly one byte string
+/// for the life of the store, and the decode of that byte string is
+/// a pure function. Caching the verdict is therefore observationally
+/// equivalent to recomputing it, and turns a per-tick O(committee ×
+/// blob size) decode into one decode per distinct digest per epoch
+/// (issue #2080).
+///
+/// An `Absent` lookup is deliberately NOT cached: the blob has not
+/// arrived yet and the very next tick may find it, which is the
+/// whole point of the poll.
+///
+/// Lifetime is the per-epoch store's, so the map is bounded by the
+/// number of distinct digests announced in one epoch (committee
+/// scale) and is dropped at the epoch boundary.
+#[derive(Default)]
+pub struct MpcDataDecodeCache {
+    verdicts: parking_lot::RwLock<HashMap<[u8; 32], bool>>,
+}
+
+impl MpcDataDecodeCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The verdict for `digest`, decoding at most once per digest.
+    /// `load_bytes` is called only on a miss and may return `None`
+    /// to mean "not held locally", which stays uncached.
+    pub fn verdict<F>(&self, digest: &[u8; 32], load_bytes: F) -> LocalBlobVerdict
+    where
+        F: FnOnce() -> Option<Vec<u8>>,
+    {
+        if let Some(valid) = self.verdicts.read().get(digest).copied() {
+            return if valid {
+                LocalBlobVerdict::Valid
+            } else {
+                LocalBlobVerdict::Invalid
+            };
+        }
+        let Some(bytes) = load_bytes() else {
+            return LocalBlobVerdict::Absent;
+        };
+        let valid = blob_decodes_to_valid_mpc_data(&bytes);
+        // A concurrent decoder may have raced us to the same answer;
+        // both wrote the same value, so last-writer-wins is fine.
+        self.verdicts.write().insert(*digest, valid);
+        if valid {
+            LocalBlobVerdict::Valid
+        } else {
+            LocalBlobVerdict::Invalid
+        }
+    }
+
+    /// Number of memoized verdicts. Test-facing.
+    pub fn len(&self) -> usize {
+        self.verdicts.read().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }
 
@@ -2704,7 +2817,9 @@ mod tests {
         let b = auth(0xBB);
         // Input only has B; self's announcement hasn't landed yet.
         let decision =
-            decide_locally_validated_peers(self_authority, vec![(b, [0xBB; 32])], |_| true);
+            decide_locally_validated_peers(self_authority, vec![(b, [0xBB; 32])], |_| {
+                LocalBlobVerdict::Valid
+            });
         assert!(decision.validated.contains(&self_authority));
         assert!(decision.validated.contains(&b));
         assert!(!decision.self_blob_unhealthy);
@@ -2720,7 +2835,7 @@ mod tests {
         let decision = decide_locally_validated_peers(
             self_authority,
             vec![(self_authority, [0xAA; 32]), (b, [0xBB; 32])],
-            |_| true,
+            |_| LocalBlobVerdict::Valid,
         );
         assert!(decision.validated.contains(&self_authority));
         assert!(decision.validated.contains(&b));
@@ -2741,7 +2856,14 @@ mod tests {
         let decision = decide_locally_validated_peers(
             self_authority,
             vec![(self_authority, self_digest), (b, [0xBB; 32])],
-            |digest| *digest != self_digest, // self's blob fails, B's passes
+            // Self's blob is held but garbage; B's is fine.
+            |digest| {
+                if *digest == self_digest {
+                    LocalBlobVerdict::Invalid
+                } else {
+                    LocalBlobVerdict::Valid
+                }
+            },
         );
         assert!(
             !decision.validated.contains(&self_authority),
@@ -2762,7 +2884,13 @@ mod tests {
         let decision = decide_locally_validated_peers(
             self_authority,
             vec![(b, bad_digest), (c, [0xCC; 32])],
-            |digest| *digest != bad_digest,
+            |digest| {
+                if *digest == bad_digest {
+                    LocalBlobVerdict::Invalid
+                } else {
+                    LocalBlobVerdict::Valid
+                }
+            },
         );
         // Self is inserted optimistically (no self announcement in input).
         assert!(decision.validated.contains(&self_authority));
@@ -2777,7 +2905,9 @@ mod tests {
     #[test]
     fn decide_locally_validated_peers_empty_input_inserts_self() {
         let self_authority = auth(0xAA);
-        let decision = decide_locally_validated_peers(self_authority, std::iter::empty(), |_| true);
+        let decision = decide_locally_validated_peers(self_authority, std::iter::empty(), |_| {
+            LocalBlobVerdict::Valid
+        });
         assert_eq!(decision.validated.len(), 1);
         assert!(decision.validated.contains(&self_authority));
         assert!(!decision.self_blob_unhealthy);
@@ -3309,6 +3439,121 @@ mod tests {
         let seed = RootSeed::new([7u8; 32]);
         let blob = derive_mpc_data_blob(&seed).expect("derive");
         assert!(blob_decodes_to_valid_mpc_data(&blob));
+    }
+
+    /// The emit gate re-runs on every ~2s poll tick for as long as the
+    /// freeze is pending — hours, on a fresh network waiting for
+    /// mid-epoch reconfiguration (issue #2080). The cache must decode
+    /// each real ~72KB class-groups blob exactly once no matter how
+    /// many ticks ask, and must return the same verdict every time.
+    #[test]
+    fn decode_cache_decodes_a_real_blob_once_across_many_polls() {
+        let blob = derive_mpc_data_blob(&RootSeed::new([7u8; 32])).expect("derive");
+        let digest = ika_network::mpc_artifacts::mpc_data_blob_hash(&blob);
+        let cache = MpcDataDecodeCache::new();
+        let loads = std::sync::atomic::AtomicUsize::new(0);
+        for _ in 0..50 {
+            let verdict = cache.verdict(&digest, || {
+                loads.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                Some(blob.clone())
+            });
+            assert_eq!(verdict, LocalBlobVerdict::Valid);
+        }
+        assert_eq!(
+            loads.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "the blob must be read + decoded once, not once per poll tick"
+        );
+        assert_eq!(cache.len(), 1);
+    }
+
+    /// A held-but-undecodable blob is cached too: the perpetual table
+    /// refuses any insert whose digest isn't `Blake2b256(bytes)`, so
+    /// the bytes under a digest — and therefore the verdict — can
+    /// never change. Re-decoding it every tick would be the same
+    /// wasted work as the valid case, on the path that matters most
+    /// (a validator excluded from every attestation).
+    #[test]
+    fn decode_cache_memoizes_the_invalid_verdict_too() {
+        let garbage: Vec<u8> = (0u32..512).map(|i| (i % 251) as u8).collect();
+        let digest = ika_network::mpc_artifacts::mpc_data_blob_hash(&garbage);
+        let cache = MpcDataDecodeCache::new();
+        let loads = std::sync::atomic::AtomicUsize::new(0);
+        for _ in 0..5 {
+            let verdict = cache.verdict(&digest, || {
+                loads.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                Some(garbage.clone())
+            });
+            assert_eq!(verdict, LocalBlobVerdict::Invalid);
+        }
+        assert_eq!(loads.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    /// An absent blob must NOT be cached: it is the ordinary state
+    /// until P2P propagation delivers the bytes, and caching it would
+    /// pin the announcer out of the validated set for the whole epoch.
+    /// The loader is re-consulted every tick until it produces bytes,
+    /// and the tick that does flips the verdict.
+    #[test]
+    fn decode_cache_never_caches_absence_and_flips_when_the_blob_lands() {
+        let blob = derive_mpc_data_blob(&RootSeed::new([11u8; 32])).expect("derive");
+        let digest = ika_network::mpc_artifacts::mpc_data_blob_hash(&blob);
+        let cache = MpcDataDecodeCache::new();
+        for _ in 0..3 {
+            assert_eq!(
+                cache.verdict(&digest, || None),
+                LocalBlobVerdict::Absent,
+                "absence must stay re-checkable"
+            );
+        }
+        assert!(cache.is_empty(), "absence must not be memoized");
+        // The blob lands.
+        assert_eq!(
+            cache.verdict(&digest, || Some(blob.clone())),
+            LocalBlobVerdict::Valid
+        );
+        assert_eq!(cache.len(), 1);
+    }
+
+    /// A locally-held but undecodable blob must be reported to the
+    /// caller with the announcer and the digest, so it can be named in
+    /// a `warn!` instead of being dropped silently — three hours of
+    /// exactly that silence is what made #2080 expensive to diagnose.
+    /// An ABSENT blob must not be reported: that is the ordinary
+    /// pre-propagation state and would be pure noise.
+    #[test]
+    fn decide_locally_validated_peers_reports_held_but_undecodable_blobs() {
+        let self_authority = auth(0xAA);
+        let corrupt = auth(0xBB);
+        let not_yet_fetched = auth(0xCC);
+        let healthy = auth(0xDD);
+        let corrupt_digest = [0xBB; 32];
+        let absent_digest = [0xCC; 32];
+        let decision = decide_locally_validated_peers(
+            self_authority,
+            vec![
+                (corrupt, corrupt_digest),
+                (not_yet_fetched, absent_digest),
+                (healthy, [0xDD; 32]),
+            ],
+            |digest| {
+                if *digest == corrupt_digest {
+                    LocalBlobVerdict::Invalid
+                } else if *digest == absent_digest {
+                    LocalBlobVerdict::Absent
+                } else {
+                    LocalBlobVerdict::Valid
+                }
+            },
+        );
+        assert_eq!(
+            decision.invalid_blobs,
+            vec![(corrupt, corrupt_digest)],
+            "only the held-but-undecodable blob is reported, with its digest"
+        );
+        assert!(!decision.validated.contains(&corrupt));
+        assert!(!decision.validated.contains(&not_yet_fetched));
+        assert!(decision.validated.contains(&healthy));
     }
 
     // -------- compute_freeze_partition byzantine scenarios --------


### PR DESCRIPTION
# Root cause for #2080: not a race — a legitimate mid-epoch wait, killed ~2 minutes early

**Both hypotheses in the issue are wrong, and so is the "spin" framing.** There is no
race, no torn read, no lost wakeup, and nothing was pinning a core. The 4-validator
network in the wedged run was waiting — correctly, and exactly as designed — for
mid-epoch reconfiguration to publish `V_{e+1}`, and the run was killed **~2 minutes
before that was due**. This PR therefore does not fix a product bug. It fixes the
reason three hours of correct waiting were indistinguishable from a hang, and lands
the two hardening items the issue called for regardless of root cause.

## What actually happened

The mpc_data freeze — and with it network DKG — cannot start until the next-epoch
committee is published on chain. `decide_ready_to_finalize` returns `NotYet` until
`V_{e+1}` is published (or the 3/4-epoch liveness backstop elapses), and `V_{e+1}` is
published by `process_mid_epoch()`, which `system_inner.move::assert_mid_epoch_time`
refuses before `epoch_start_timestamp_ms + epoch_duration_ms / 2`.

The two runs were **not** the same flow. From the launch commands:

| | smoke (succeeded) | full (reported as wedged) |
|---|---|---|
| `EPOCH_DURATION_MS` | `3_600_000` (1 h) | `21_600_000` (6 h) |
| epoch 1 start | ~14:27:00 UTC | ≤ 15:04:39 UTC |
| mid-epoch due | 14:57:00 | **~18:04:30** |
| `Calling process_mid_epoch()` | **14:57:00.032** | never — run killed 18:02:00 |
| freeze | 14:57:09 | — |
| network DKG output | 14:58:04 | — |

The model predicts the smoke run to within 30 ms. For the full run it predicts
mid-epoch at ~18:04:30 against a kill at 18:02:00. The bound is not sensitive to the
exact genesis instant: even taking the earliest conceivable epoch start — 15:03:30,
the moment the Sui localnet came up, before the packages were even published —
mid-epoch reconfiguration was still due 90 seconds *after* the run was killed.

Corroborating, from the evidence bundle:

- `Calling process_mid_epoch()` (INFO, notifier) appears in the smoke notifier log and
  **never** in the wedged one; the wedged notifier's only `sui_executor` line is its
  startup line, which is also all the smoke notifier had before *its* mid-epoch fired.
- Every wedged `end-of-publish gate not yet satisfied` line, for three hours, reports
  `next_epoch_committee_exists=false` — the chain agrees `V_{e+1}` was never created.
- The smoke run's own first MPC activity is at 14:57:14, i.e. **28½ minutes after its
  first consensus commit** and 5 s after its freeze. Its "network DKG in ~30 minutes"
  was itself almost entirely this same wait, just a 1-hour-epoch-sized one.

## Why the stack samples are not a spin

The samples attached to the issue refute hypothesis 1 outright and refute the
"one core pinned at 100%" reading:

- `wedged-v0-sample2.txt` contains **both** `local_blob_coverage_meets_quorum`
  (`authority_per_epoch_store.rs:4135`) and `validated_peers_with_hashes`
  (`:4098`) above `compute_locally_validated_peers`. `validated_peers_with_hashes`
  is only reached *after* `local_blob_coverage_meets_quorum` returns **true** — so
  local blob coverage met the stake quorum. No blob was silently failing to decode.
- The sample is 146,747 thread-samples over a 2.36 s window; **146,513 of them are
  parked** in `__psynch_cvwait`/`kevent`/`__semwait_signal`. The whole process used
  ~234 ms of CPU in 2.36 s (≈0.1 of one core), and the decode path accounts for 5 of
  those samples — about **0.2 % of one core**, not 100 %.

What the frames actually show is the announcement sender's healthy 2 s poll tick
(`mpc_data_announcement_sender.rs::run`, `tokio::time::sleep(2s)` per iteration)
being caught mid-tick, twice, because it is one of the few things still doing any
work at all on an idle-but-waiting node.

## What this PR changes

**1. The emit gate says which wait it is in, at INFO (the actual remedy).**
`ReadyToFinalize::NotYet` now carries a `ReadySignalWait` — is `V_{e+1}` published,
which next-epoch members are uncovered, and how long the liveness backstop still has
to run — and the caller logs it. Previously this was one `debug!` line, so at the
default log level a validator waiting hours for mid-epoch reconfiguration and a
genuinely wedged one produced identical output: none.

Rate-limited to one line per five minutes per validator (first deferral, then every
150th tick), deliberately **not** latched: an operator who attaches mid-wait, or greps
a window of log, has to be able to find out why MPC has not started without hunting
for a line emitted at process start. Half a 24 h mainnet epoch costs ~150 lines.
The below-quorum-coverage branch is promoted from `debug!` to the same rate-limited
INFO for the same reason.

**2. A locally-held but undecodable announcement blob is named at WARN.**
`decide_locally_validated_peers` now takes a tri-state `LocalBlobVerdict`
(`Valid`/`Invalid`/`Absent`) instead of a bool, so the caller can tell "not here yet"
(ordinary, silent) from "here and garbage" (a fault) and reports the latter as
`invalid_blobs`. `compute_locally_validated_peers` warns once per `(announcer,
digest)` with both named. Held-but-invalid has no in-epoch self-heal — the perpetual
table rejects any insert whose digest is not `Blake2b256(bytes)`, so the bytes under a
digest can never change — and it silently costs the announcer its place in this
validator's attestation, which is precisely the failure the issue feared and could not
have seen.

**3. Decode verdicts are memoized by content digest.**
New `MpcDataDecodeCache` on the per-epoch store. The emit gate re-ran
`blob_decodes_to_valid_mpc_data` over every announced ~72 KB class-groups bundle one
to two times per 2 s tick for the entire pre-freeze window, always with the same
answer. Content-addressing makes the verdict a pure function of the digest, so this is
observationally equivalent and turns O(committee × blob size) per tick into one decode
per distinct digest per epoch. `Absent` is deliberately not cached — the blob may
arrive on the next tick, which is the point of the poll. Per-epoch lifetime, so the
map is committee-scale and drops at the boundary.

## Does this bite at epoch boundaries on a live network?

**No — nothing is broken, so nothing can bite.** The gate behaved correctly.

The *legibility* problem, however, recurs at **every** epoch, not just at genesis: the
`NotYet(next_committee_unpublished)` window runs from epoch start to mid-epoch, which
under a 24 h mainnet epoch is a **twelve-hour silent window per epoch, per validator**
during which the off-chain plane looks identical whether it is waiting or wedged. That
is the argument for landing this, and it is an observability argument only.

**This does not block the release.** #2080 should be reclassified from "v-next blocker
/ genesis-start race that silently disables MPC" to "observability gap".

The harness side needs a fix of its own, and it is the reason this looked
nondeterministic. `expect_network_dkg_output_version_at_least` waits `epoch_timeout`
(3 h in the RSS test) from the moment flow 3 starts, while the event it is waiting on
lands `epoch_duration_ms / 2` (3 h) after `system::initialize` — which is ~2 minutes
*earlier*. Network DKG is therefore given only about two minutes of budget after
mid-epoch reconfiguration finally fires, against the 64 seconds the smoke run took to
get from `process_mid_epoch()` to a persisted DKG output. That is a coin flip on a
loaded machine, and the reported run was manually killed at 18:02:00 while its own
flow-3 deadline still had until 18:06:21. Either raise `epoch_timeout` well above
`epoch_duration_ms / 2` or lower `EPOCH_DURATION_MS`.

## Tests

New, all `-p ika-core --release`:

- `validator_metadata::tests::decode_cache_decodes_a_real_blob_once_across_many_polls`
- `validator_metadata::tests::decode_cache_memoizes_the_invalid_verdict_too`
- `validator_metadata::tests::decode_cache_never_caches_absence_and_flips_when_the_blob_lands`
- `validator_metadata::tests::decide_locally_validated_peers_reports_held_but_undecodable_blobs`
- `epoch_tasks::mpc_data_announcement_sender::tests::ready_to_finalize_names_the_wait_it_is_in`
- `epoch_tasks::mpc_data_announcement_sender::tests::ready_signal_deferral_logging_repeats_on_a_bounded_cadence`

The five existing `decide_ready_to_finalize` gate tests now pin the wait reason rather
than accepting any `NotYet`.

**Fault-validated.** Each of the four protected properties was reverted to its pre-fix
behaviour — memoization removed from `MpcDataDecodeCache::verdict`; `invalid_blobs`
left unpopulated; `next_committee_published` hard-coded to `true`; the rate limit
degenerated to a one-shot `deferrals == 0` latch — and the suite re-run: **8 failed,
88 passed**, covering all four targeted tests plus four gate tests that also detect
the wait-reason revert (e.g. `decode_cache_decodes_a_real_blob_once_across_many_polls`
failed with `left: 50` against an expected 1 decode). Restoring the fix returns the
suite to **96 passed, 0 failed**.

`cargo clippy --all-targets --all-features -- -D warnings` and
`cargo simtest clippy --all-targets --all-features -- -D warnings` (the msim
compilation universe) are both clean, as are `cargo fmt -- --check` and the six
repo guard scripts CI runs.

Closes #2080.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
