### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-classgroups-types"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "bcs 0.2.1",
  "class_groups",
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bcs 0.2.1",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bcs 0.2.1",
@@ -5081,7 +5081,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-rng"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "commitment",
  "fastcrypto",
@@ -6871,7 +6871,7 @@ dependencies = [
 
 [[package]]
 name = "ika"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -6915,7 +6915,7 @@ dependencies = [
 
 [[package]]
 name = "ika-archival"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -7086,7 +7086,7 @@ dependencies = [
 
 [[package]]
 name = "ika-node"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7157,7 +7157,7 @@ dependencies = [
 
 [[package]]
 name = "ika-proxy"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -7310,7 +7310,7 @@ dependencies = [
 
 [[package]]
 name = "ika-test-cluster"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -7392,7 +7392,7 @@ dependencies = [
 
 [[package]]
 name = "ika-upgrade-test"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bcs 0.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 [workspace.package]
 # This version string will be inherited by ika-core, ika-node, ika-tools, and ika crates.
-version = "1.3.1"
+version = "1.4.0"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/sdk/ika-wasm/Cargo.lock
+++ b/sdk/ika-wasm/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bcs 0.2.1",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bcs 0.2.1",


### PR DESCRIPTION
Version bump for the v1.4.0 release — the commit the \`release/testnet-v1.4.0\` and \`release/mainnet-v1.4.0\` tags go on, same as #2034 did for 1.3.1.

Minor (not patch) because the release changes the node's storage/restart model (event-sourced epoch, #2074: derived epoch state held in memory and rebuilt by replay; per-round MPC tables removed), crash behaviour (#2054: the commit-liveness watchdog exits the process), and adds twelve metrics plus the shared Sui rate-limit gate (#2071). Protocol version is unchanged (7); mid-epoch rollback to v1.3.1 is tested (#2077).

Merge only after the full battery dispatched on \`3af21bf07d\` (integration, cluster, TS, simtest, upgrade-test \`all\`) is green — this commit adds nothing but the version on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)