### PR TITLE
fix(release): bump the Docker builders to rust:1.97 and pin them to rust-toolchain.toml in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,6 +124,11 @@ jobs:
         # The Sui pin lives in several places that don't update together;
         # see dev-docs/conventions/sui-version-bump.md.
         run: ./scripts/check-sui-version-consistency.sh
+      - name: Rust toolchain consistency
+        # rust-toolchain.toml and the Docker builders' `FROM rust:` image are
+        # separate pins, and only release tags build the Dockerfiles — the
+        # v1.4.0 release build failed on exactly this drift.
+        run: ./scripts/check-rust-toolchain-consistency.sh
 
       - name: Workspace version consistency (standalone lockfiles)
         # Standalone lockfiles (sdk/ika-wasm) pin root-workspace crates and

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -4,7 +4,7 @@
 # Usage:
 #   Linux x64 (default):  docker build --output type=local,dest=out .
 #   Linux arm64:          docker build --build-arg TARGET=aarch64-unknown-linux-gnu --output type=local,dest=out .
-FROM rust:1.94-bookworm AS builder
+FROM rust:1.97-bookworm AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION=unknown

--- a/docker/ika-node/Dockerfile
+++ b/docker/ika-node/Dockerfile
@@ -1,7 +1,7 @@
 # ==========================
 # Build stage
 # ==========================
-FROM rust:1.94-bookworm AS builder
+FROM rust:1.97-bookworm AS builder
 
 # Arguments
 ARG PROFILE=release

--- a/docker/ika-proxy/Dockerfile
+++ b/docker/ika-proxy/Dockerfile
@@ -1,7 +1,7 @@
 # ==========================
 # Build stage
 # ==========================
-FROM rust:1.94-bookworm AS builder
+FROM rust:1.97-bookworm AS builder
 
 # Arguments
 ARG PROFILE=release

--- a/scripts/check-rust-toolchain-consistency.sh
+++ b/scripts/check-rust-toolchain-consistency.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# The Rust version is pinned in two places that do not update together:
+# rust-toolchain.toml (what every developer, PR CI job, and the macOS/Windows
+# release builds use via rustup) and the `FROM rust:<ver>-bookworm` base image
+# of the Docker builders (what the Linux release binaries and the node/proxy
+# images are built with). Nothing on PR CI builds those Dockerfiles, so a
+# drift between the two only surfaces when a release tag is pushed — which is
+# how the v1.4.0 release build failed: a dependency refresh raised the MSRV
+# past the Docker image's rustc while rust-toolchain.toml was already ahead.
+#
+# The Docker tag carries major.minor (rust:1.97-bookworm tracks the latest
+# 1.97.x), so that is the granularity compared.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+want=$(sed -nE 's/^channel = "([0-9]+\.[0-9]+)(\.[0-9]+)?"$/\1/p' rust-toolchain.toml)
+[ -n "$want" ] || { echo "ERROR: could not read the channel from rust-toolchain.toml"; exit 1; }
+
+status=0
+for f in docker/builder/Dockerfile docker/ika-node/Dockerfile docker/ika-proxy/Dockerfile; do
+  got=$(sed -nE 's/^FROM rust:([0-9]+\.[0-9]+)(\.[0-9]+)?-bookworm AS builder$/\1/p' "$f")
+  if [ -z "$got" ]; then
+    echo "ERROR: $f: no 'FROM rust:<major.minor>-bookworm AS builder' line found"; status=1
+  elif [ "$got" != "$want" ]; then
+    echo "ERROR: $f pins rust:$got but rust-toolchain.toml is $want — bump the FROM line (the Linux release build compiles with the image's rustc, and the lockfile's MSRV already assumes $want)"; status=1
+  fi
+done
+[ $status -eq 0 ] && echo "rust toolchain pins consistent ($want): rust-toolchain.toml + 3 Dockerfiles"
+exit $status


### PR DESCRIPTION
## What broke

Both v1.4.0 release builds ([mainnet](https://github.com/dwallet-labs/ika/actions/runs/32519628898), [testnet](https://github.com/dwallet-labs/ika/actions/runs/32519628772)) failed on `linux-x64` and `linux-arm64`:

```
error: rustc 1.94.1 is not supported by the following package:
  sysinfo@0.39.6 requires rustc 1.95
```

`docker/builder/Dockerfile` pulls `rust:1.94-bookworm`; `rust-toolchain.toml` has been `1.97.1`; #2059 raised `sysinfo` to 0.39.6 (MSRV 1.95). Cargo refuses before compiling. macOS/Windows passed because they build on the runner via rustup + the toolchain file. No PR CI job builds the Dockerfiles, so the drift only surfaces on a release tag.

## Fix

- `docker/builder/Dockerfile`, `docker/ika-node/Dockerfile`, `docker/ika-proxy/Dockerfile`: `FROM rust:1.97-bookworm` (image tag verified on Docker Hub).
- `scripts/check-rust-toolchain-consistency.sh` + a CI step next to the Sui one: fails when any of the three `FROM rust:` pins disagrees with `rust-toolchain.toml` on major.minor. Passes on this branch; would have failed on main since #2059.

## Verification

Cannot reproduce the Docker build locally (it needs the `inkrypto` deploy key), but the failure is a pure MSRV gate ahead of compilation, and this lockfile compiles on 1.97.1 in every CI job. The proof is the release re-run: after merge, the `release/*-v1.4.0` tags move onto this commit and the workflow re-triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)