### PR TITLE
docs(metrics): the round-lag gauge is clamped by the bounded channel and cannot show a replay (#2090)

### DIFF
--- a/crates/ika-core/src/epoch/epoch_metrics.rs
+++ b/crates/ika-core/src/epoch/epoch_metrics.rs
@@ -142,6 +142,16 @@ pub struct EpochMetrics {
     /// to perform. Locally computable on purpose: it needs no peer data and no
     /// fleet context, so it works for anyone running a validator.
     ///
+    /// Bounded in normal operation, and bounded by construction: since #2074
+    /// the fold hands each round to the drain over a blocking channel of
+    /// `DEFAULT_ROUND_CHANNEL_CAPACITY` (`authority::round_transport`), so it
+    /// parks rather than run further than a channel's worth ahead of the
+    /// drain's cursor. Growth past that has one live cause — a drain that has
+    /// EXITED, after which the fold detaches and runs on without it, which is
+    /// exactly the self-stop above. A drain that is merely wedged holds this
+    /// flat near capacity and is `ika_consensus_fold_blocked_seconds_total`'s
+    /// to report.
+    ///
     /// `-1` before the MPC service reports its first round, since round 0 is
     /// a legitimate value.
     pub mpc_consensus_round_lag: IntGauge,
@@ -151,10 +161,14 @@ pub struct EpochMetrics {
     /// transition and so cannot be alerted on continuously.
     ///
     /// This, not a threshold on `mpc_consensus_round_lag`, is the alert
-    /// target: a validator restarted mid-epoch replays every round of the
-    /// epoch so far, and that raw lag legitimately exceeds any stall threshold
-    /// while the node is recovering normally (ika #2036). The gauge already
-    /// accounts for the catch-up the MPC service reports.
+    /// target. A threshold there fired on every restart of every production
+    /// validator while a mid-epoch replay ran (ika #2036); since #2074 it has
+    /// the opposite defect, because the bounded round channel keeps the raw
+    /// lag within a channel's worth of the drain — the drain consumes during
+    /// the boot replay, so no replay ever moves it. The epoch-scale "how far
+    /// behind" is `ika_dwallet_mpc_catchup_gap_rounds`, measured against the
+    /// published consensus-store head. This gauge already accounts for the
+    /// catch-up the MPC service reports.
     pub mpc_stopped_contributing_condition_active: IntGauge,
 
     /// `1` while the MPC service is reporting a catch-up whose consensus-round
@@ -416,7 +430,7 @@ impl EpochMetrics {
             .unwrap(),
             mpc_stopped_contributing_condition_active: register_int_gauge_with_registry!(
                 "ika_mpc_stopped_contributing_condition_active",
-                "1 while this node judges its MPC subsystem to have stopped contributing; alert on this rather than on a threshold over ika_mpc_consensus_round_lag, which a healthy mid-epoch restart legitimately exceeds while it replays",
+                "1 while this node judges its MPC subsystem to have stopped contributing; alert on this rather than on a threshold over ika_mpc_consensus_round_lag, which the bounded round channel holds within a channel's worth of the drain and so cannot show a mid-epoch restart's replay (that is ika_dwallet_mpc_catchup_gap_rounds)",
                 registry,
             )
             .unwrap(),

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -174,7 +174,11 @@ counter. The network-key registry sites are guarded structurally by
 commit path, sampled on every commit. Small and roughly constant in normal
 operation; unbounded growth means MPC has stopped while consensus keeps
 running — the node follows consensus, serves requests, exports every other
-metric, and contributes nothing.
+metric, and contributes nothing. Since #2074 that growth has exactly one live
+cause, because the fold no longer outruns the drain: it blocks on the bounded
+round channel, so the gap opens only once the drain has *exited* and the fold
+detaches from it (`authority::round_transport`), which is the self-stop this
+was built for.
 
 The rule it encodes: **a subsystem cannot report its own stall.** Every path
 that stops the MPC service also stops any check placed inside it — most
@@ -197,10 +201,10 @@ round, since round 0 is a legitimate value.
 **The raw lag is not the alert target** — `ika_mpc_stopped_contributing_condition_active`
 is. Consensus rounds restart at zero each epoch and a restarted node builds a
 fresh epoch store whose cursor starts there too, so a mid-epoch restart's replay
-gap is simply "rounds elapsed this epoch": past the first three quarters of an
-hour of a 24h epoch it exceeds any stall threshold while the node is recovering
-perfectly normally, and the alarm fired on every restart of every production
-validator (#2036).
+gap was simply "rounds elapsed this epoch": past the first three quarters of an
+hour of a 24h epoch it exceeded any stall threshold while the node was
+recovering perfectly normally, and the alarm fired on every restart of every
+production validator (#2036).
 
 Which forces the general rule: **a detector that lives outside a subsystem
 because the subsystem cannot report its own stall must still be told what the
@@ -222,6 +226,18 @@ Suppressing an alarm creates a hole, so it comes with the alarm that covers it:
 stopped reaching new lows, over a bound generous against the observed drain
 rate. Between them, "not contributing" and "not recovering" are both loud, and
 the recovering-normally case is silent.
+
+The suppression outlived the spike it was built for, and that is worth knowing
+before reading the gauge: under the bounded round channel a replay cannot move
+the raw lag at all. The fold parks rather than run more than a channel's worth
+(1,024) ahead, and the drain consumes *during* the boot replay
+([`../specs/event-sourced-epoch.md`](../specs/event-sourced-epoch.md)), so the
+epoch-scale distance behind lives on `ika_dwallet_mpc_catchup_gap_rounds`,
+measured against the published consensus-store head for exactly this reason.
+Nor does the raw lag detect a wedge: a parked fold and a drain that has stopped
+consuming both hold it flat near capacity, and the pair that separates those is
+`ika_consensus_fold_blocked_{seconds,sends}_total` with
+`ika_consensus_round_channel_depth`.
 
 ### Process-wide wire settings need a gauge, not just a log
 

--- a/dev-docs/playbooks/mpc-stall-postmortem.md
+++ b/dev-docs/playbooks/mpc-stall-postmortem.md
@@ -237,11 +237,14 @@ construction; divergence = determinism bug).
   thing eventually happened after the budget expired.
 - **A validator that trails consensus is draining or dead, and the
   difference is whether the gap falls.** A restart refolds the epoch from
-  its first commit and feeds every round to the drain again, so a huge
-  `ika_mpc_consensus_round_lag` right after one is expected, not a stall — the MPC service says so itself
-  (`MPC service entered catch-up mode`), and
-  `ika_dwallet_mpc_catchup_gap_rounds` falls fast while it drains
-  (~40x the tip rate, with computation suppressed). What to act on is
+  its first commit and feeds every round to the drain again, and the gauge
+  that shows it is `ika_dwallet_mpc_catchup_gap_rounds`, never
+  `ika_mpc_consensus_round_lag`: the fold blocks on the bounded round
+  channel, so the raw lag stays within a channel's worth (1,024) of the
+  drain even mid-replay — an unremarkable reading there is not evidence the
+  backlog is small. The MPC service announces the drain itself (`MPC
+  service entered catch-up mode`), and the catch-up gap falls fast while
+  it runs (~40x the tip rate, with computation suppressed). What to act on is
   `ika_mpc_stopped_contributing_condition_active == 1` (nothing is
   draining and MPC has stopped: `MPC subsystem has stopped keeping up
   with consensus`) or `ika_mpc_catch_up_stuck_condition_active == 1`

--- a/dev-docs/playbooks/production-alerts.md
+++ b/dev-docs/playbooks/production-alerts.md
@@ -221,11 +221,19 @@ drain is healthy and this gauge reads 0, so a `1` means the gap went flat or
 started growing and something other than the backlog is holding the service
 up.
 
-**Do not alert on `ika_mpc_consensus_round_lag` directly.** A validator
-restarted mid-epoch refolds the epoch from its first commit, so its raw lag
-legitimately exceeds any stall threshold for as long as that runs. The
-condition gauges above already account for the catch-up the MPC service is
-reporting; the raw lag is a dashboard signal, not a page.
+**Do not alert on `ika_mpc_consensus_round_lag` directly.** It can carry
+neither alert. The fold hands each round to the drain over a bounded blocking
+channel (capacity 1,024) and the drain consumes during the boot replay, so the
+raw lag stays within a channel's worth of the drain's cursor whatever the node
+is doing — a validator refolding a whole epoch after a mid-epoch restart moves
+it no further than a busy one does. Nor is it a wedge detector: a fold parked
+on a full channel and a drain that has stopped consuming both hold it flat near
+capacity, which is why Alert 6 leans on the fold-blocked pair instead. The
+epoch-scale "how far behind" on a restart is
+`ika_dwallet_mpc_catchup_gap_rounds`, measured against the published
+consensus-store head. The condition gauges above already account for the
+catch-up the MPC service is reporting; the raw lag is a dashboard signal, not
+a page.
 
 ## Secondary signals worth dashboarding (no page)
 


### PR DESCRIPTION
## What was stale

Four places told operators that `ika_mpc_consensus_round_lag` spikes during a
mid-epoch restart's replay — "a healthy mid-epoch restart legitimately exceeds
[a threshold] while it replays". That was true before #2074 and cannot happen
now, so a reader goes looking for a replay spike that no longer exists, and can
come away thinking the gauge is a wedge detector. It is neither.

## Why (source lines that establish the clamp)

The gauge is `commit_round - progress.consumed_round`
(`crates/ika-core/src/authority/authority_per_epoch_store.rs:3631`), and
`consumed_round` has exactly one writer: the drain, per payload it consumes
(`record_mpc_consumed_consensus_round`,
`authority_per_epoch_store.rs:665`, called from
`crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs:2107`, at the end of the
loop that pops rounds off the transport, `dwallet_mpc_service.rs:1393-1405`).

The fold hands over every round and BLOCKS when the channel is full
(`authority_per_epoch_store.rs:5149-5152` → `RoundTransportSender::send`,
`crates/ika-core/src/authority/round_transport.rs:214-236`; capacity
`DEFAULT_ROUND_CHANNEL_CAPACITY = 1024`, `round_transport.rs:82`). And the
drain runs during the boot replay rather than after it
(`drain_while_replaying`, `dwallet_mpc_service.rs:625,767`) — deliberately, to
break the circular wait documented at `dwallet_mpc_service.rs:740-766`. So a
replay advances the fold and the drain together and moves the lag no further
than a busy node does.

Two other subsystems already state the same clamp and were built around it: the
catch-up gate measures its gap against the published consensus-store head
because a fold-derived head "would be pinned below the gate's entry threshold"
(`dwallet_mpc_service.rs:1370-1377`, `consensus_handler.rs:232-236,242-252`,
with the property asserted in
`crates/ika-core/src/consensus_manager/boot_replay.rs:940-1035`), and
`dev-docs/specs/event-sourced-epoch.md:298-334` records it as the reason the
head moved off the fold.

Not a wedge detector either: a fold parked on a full channel stops advancing
`commit_round`, and a drain that stopped consuming stops advancing
`consumed_round`, so both hold the gauge flat near capacity — which is why
`ika_consensus_fold_blocked_{seconds,sends}_total` and
`ika_consensus_round_channel_depth` exist (`round_transport.rs:244-262`, and the
test at `round_transport.rs:430-470` asserting the wedge shows up *only* there).

The one path where the lag still grows without bound is a drain that has
**exited** — `send` short-circuits on the `drain_gone` latch
(`round_transport.rs:215-217,239-247`) and the fold detaches and runs on, which
is precisely the self-stop this gauge was built for (#1978, #1980; the call site
says so at `authority_per_epoch_store.rs:5205-5212`). That is captured in the
edits rather than papered over.

## The edits

- `crates/ika-core/src/epoch/epoch_metrics.rs` — the HELP string of
  `ika_mpc_stopped_contributing_condition_active` (the advice to alert here
  rather than on the raw lag is unchanged; the reason is corrected). Also the
  two rustdoc blocks carrying the same stale claim three lines above it, and a
  note on the lag gauge itself that growth past a channel's worth means a
  departed drain, not a wedged one.
- `dev-docs/playbooks/production-alerts.md` — the "do not alert on
  `ika_mpc_consensus_round_lag` directly" paragraph.
- `dev-docs/conventions/metrics.md` — the section intro, the #2036 paragraph
  (now past tense: that alarm did fire on every restart, before the transport
  changed), and one new paragraph for the mechanism.
- `dev-docs/playbooks/mpc-stall-postmortem.md` — the "draining or dead"
  interpretation rule, which told an operator to expect a huge raw lag right
  after a restart.

No metric NAME changes (`./scripts/check-metric-names.sh` passes: 337 literal
names, unchanged), no behaviour change. `cargo fmt --all -- --check` and
`cargo clippy -p ika-core --all-targets --all-features -- -D warnings` are
clean.

Infra side was already corrected in dwallet-labs/infra@76b0a760.

Closes #2090

🤖 Generated with [Claude Code](https://claude.com/claude-code)
