### PR TITLE
fix(proxy): compare the Sui chain identifier against Sui's constants, not ika's (#2091)

### DIFF
--- a/crates/ika-proxy/src/lib.rs
+++ b/crates/ika-proxy/src/lib.rs
@@ -10,6 +10,7 @@ pub mod middleware;
 pub mod peers;
 pub mod prom_to_mimir;
 pub mod remote_write;
+pub mod sui_chain;
 
 /// var extracts environment variables at runtime with a default fallback value
 /// if a default is not provided, the value is simply an empty string if not found

--- a/crates/ika-proxy/src/main.rs
+++ b/crates/ika-proxy/src/main.rs
@@ -33,10 +33,10 @@ use ika_proxy::{
     },
     config::load,
     histogram_relay, metrics,
+    sui_chain::check_sui_chain_identifier,
 };
 use ika_sui_client::SuiConnectorClient;
 use ika_sui_client::metrics::SuiClientMetrics;
-use ika_types::digests::{get_mainnet_chain_identifier, get_testnet_chain_identifier};
 use mysten_metrics::RegistryService;
 use prometheus::Registry;
 use std::env;
@@ -158,17 +158,7 @@ async fn validate_sui_chain(
     expected_chain: SuiChainIdentifier,
 ) -> Result<()> {
     let actual_chain = sui_client.get_chain_identifier().await?;
-    let expected_identifier = match expected_chain {
-        SuiChainIdentifier::Mainnet => Some(get_mainnet_chain_identifier().to_string()),
-        SuiChainIdentifier::Testnet => Some(get_testnet_chain_identifier().to_string()),
-        SuiChainIdentifier::Devnet | SuiChainIdentifier::Custom => None,
-    };
-    if expected_identifier
-        .as_ref()
-        .is_some_and(|identifier| identifier != &actual_chain)
-    {
-        anyhow::bail!("expected Sui chain {expected_chain}, but connected to {actual_chain}");
-    }
+    check_sui_chain_identifier(expected_chain, &actual_chain)?;
     info!(%expected_chain, %actual_chain, "connected to Sui gRPC endpoint");
     Ok(())
 }

--- a/crates/ika-proxy/src/sui_chain.rs
+++ b/crates/ika-proxy/src/sui_chain.rs
@@ -1,0 +1,134 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Validation of the **Sui** chain a proxy instance is pointed at.
+//!
+//! The proxy resolves ika's on-chain IDs over a Sui gRPC endpoint, so a
+//! misconfigured endpoint (mainnet config against a testnet fullnode) must fail
+//! the boot loudly. The comparison lives here — separated from the client call
+//! in `main.rs` — so it can be unit tested without a live Sui endpoint; the
+//! proxy's `SuiConnectorClient` is a concrete type alias with no trait seam to
+//! mock.
+//!
+//! The identifiers below MUST come from [`sui_types::digests`]. `ika_types`
+//! exports functions with the very same names that return **ika's** chain
+//! identifiers; comparing a Sui chain identifier against those can never match,
+//! which is what crash-looped `ika-proxy` v1.4.0 (#2091).
+
+use anyhow::Result;
+use ika_config::node::SuiChainIdentifier;
+use sui_types::digests::{get_mainnet_chain_identifier, get_testnet_chain_identifier};
+
+/// The Sui chain identifier a proxy configured for `chain` must observe, or
+/// `None` when the chain is not a well-known public one and therefore cannot be
+/// pinned to a compiled-in expectation.
+pub fn expected_sui_chain_identifier(chain: SuiChainIdentifier) -> Option<String> {
+    match chain {
+        SuiChainIdentifier::Mainnet => Some(get_mainnet_chain_identifier().to_string()),
+        SuiChainIdentifier::Testnet => Some(get_testnet_chain_identifier().to_string()),
+        SuiChainIdentifier::Devnet | SuiChainIdentifier::Custom => None,
+    }
+}
+
+/// Compare the chain identifier reported by the configured gRPC endpoint against
+/// the compiled-in expectation for `expected_chain`. Devnet/Custom always pass.
+pub fn check_sui_chain_identifier(
+    expected_chain: SuiChainIdentifier,
+    actual_chain: &str,
+) -> Result<()> {
+    let Some(expected_identifier) = expected_sui_chain_identifier(expected_chain) else {
+        return Ok(());
+    };
+    if expected_identifier != actual_chain {
+        anyhow::bail!(
+            "expected Sui chain {expected_chain} ({expected_identifier}), \
+             but connected to {actual_chain}"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The public Sui chain identifiers, as reported by a fullnode's
+    /// `getChainIdentifier` and logged by `ika_sui_client` on connect.
+    const SUI_MAINNET: &str = "35834a8a";
+    const SUI_TESTNET: &str = "4c78adac";
+
+    /// The regression guard for #2091: the proxy's expectations must be **Sui's**
+    /// chain identifiers, never ika's namesake constants from `ika_types::digests`.
+    /// Pre-fix these expectations were ika's own chain IDs, so every Mainnet- or
+    /// Testnet-configured proxy rejected the legitimate chain it had just
+    /// connected to and exited non-zero.
+    #[test]
+    fn expectations_are_sui_chain_ids_not_ika_ones() {
+        let mainnet = expected_sui_chain_identifier(SuiChainIdentifier::Mainnet).unwrap();
+        let testnet = expected_sui_chain_identifier(SuiChainIdentifier::Testnet).unwrap();
+
+        assert_eq!(
+            mainnet,
+            sui_types::digests::get_mainnet_chain_identifier().to_string(),
+            "the Mainnet expectation must be Sui's mainnet chain identifier"
+        );
+        assert_eq!(
+            testnet,
+            sui_types::digests::get_testnet_chain_identifier().to_string(),
+            "the Testnet expectation must be Sui's testnet chain identifier"
+        );
+        assert_eq!(mainnet, SUI_MAINNET);
+        assert_eq!(testnet, SUI_TESTNET);
+
+        assert_ne!(
+            mainnet,
+            ika_types::digests::get_ika_mainnet_chain_identifier().to_string(),
+            "ika's own mainnet chain identifier is NOT a Sui chain identifier"
+        );
+        assert_ne!(
+            testnet,
+            ika_types::digests::get_ika_testnet_chain_identifier().to_string(),
+            "ika's own testnet chain identifier is NOT a Sui chain identifier"
+        );
+    }
+
+    /// Devnet and Custom have no compiled-in expectation, so any chain passes.
+    #[test]
+    fn unpinned_chains_have_no_expectation() {
+        assert!(expected_sui_chain_identifier(SuiChainIdentifier::Devnet).is_none());
+        assert!(expected_sui_chain_identifier(SuiChainIdentifier::Custom).is_none());
+        check_sui_chain_identifier(SuiChainIdentifier::Devnet, "deadbeef").unwrap();
+        check_sui_chain_identifier(SuiChainIdentifier::Custom, "deadbeef").unwrap();
+    }
+
+    /// The exact reproduction from #2091: a Testnet-configured proxy pointed at
+    /// `https://fullnode.testnet.sui.io:443`, which reports `4c78adac`.
+    #[test]
+    fn public_sui_chains_are_accepted() {
+        check_sui_chain_identifier(SuiChainIdentifier::Testnet, SUI_TESTNET)
+            .expect("a Testnet-configured proxy must accept Sui testnet");
+        check_sui_chain_identifier(SuiChainIdentifier::Mainnet, SUI_MAINNET)
+            .expect("a Mainnet-configured proxy must accept Sui mainnet");
+    }
+
+    /// A genuinely wrong endpoint must still fail the boot, and the message must
+    /// name the expected identifier — printing only the chain *name* is what made
+    /// #2091 read as "Testnet != 4c78adac" and hid the real cause.
+    #[test]
+    fn crossed_chains_are_rejected_with_the_expected_identifier() {
+        let err = check_sui_chain_identifier(SuiChainIdentifier::Mainnet, SUI_TESTNET)
+            .expect_err("a Mainnet-configured proxy must reject Sui testnet");
+        let msg = err.to_string();
+        assert_eq!(
+            msg,
+            format!("expected Sui chain Mainnet ({SUI_MAINNET}), but connected to {SUI_TESTNET}")
+        );
+
+        let err = check_sui_chain_identifier(SuiChainIdentifier::Testnet, SUI_MAINNET)
+            .expect_err("a Testnet-configured proxy must reject Sui mainnet");
+        assert_eq!(
+            err.to_string(),
+            format!("expected Sui chain Testnet ({SUI_TESTNET}), but connected to {SUI_MAINNET}")
+        );
+    }
+}

--- a/crates/ika-sui-client/src/genesis.rs
+++ b/crates/ika-sui-client/src/genesis.rs
@@ -369,12 +369,12 @@ mod tests {
         );
         assert_ne!(
             mainnet,
-            ika_types::digests::get_mainnet_chain_identifier(),
+            ika_types::digests::get_ika_mainnet_chain_identifier(),
             "the ika mainnet chain identifier (system object ID) is NOT a Sui genesis digest"
         );
         assert_ne!(
             testnet,
-            ika_types::digests::get_testnet_chain_identifier(),
+            ika_types::digests::get_ika_testnet_chain_identifier(),
             "the ika testnet chain identifier (system object ID) is NOT a Sui genesis digest"
         );
         assert!(matches!(

--- a/crates/ika-types/src/digests.rs
+++ b/crates/ika-types/src/digests.rs
@@ -155,11 +155,25 @@ impl Default for ChainIdentifier {
     }
 }
 
-pub const MAINNET_CHAIN_IDENTIFIER_BASE58: &str = "3FFWaJu1SeurUdyLuWbhc7xE7ThvVqfHkjopBge3vLVu";
-pub const TESTNET_CHAIN_IDENTIFIER_BASE58: &str = "3FZxkWnWSKp64iY6h6GrBuW3CKxxpBDcnfEVyTZ8EZnV";
+/// **ika**'s own chain identifier for its mainnet deployment — NOT Sui's.
+///
+/// `sui_types::digests` exports a `MAINNET_CHAIN_IDENTIFIER_BASE58` too, and it
+/// is a completely different value (the Sui genesis checkpoint digest, short id
+/// `35834a8a`). The `IKA_` prefix here exists so the two can never be confused
+/// at a `use` site: comparing a *Sui* chain identifier against this constant
+/// can never match, which is exactly the bug that crash-looped `ika-proxy`
+/// v1.4.0 (#2091) and, before it, the gRPC genesis verifier.
+pub const IKA_MAINNET_CHAIN_IDENTIFIER_BASE58: &str =
+    "3FFWaJu1SeurUdyLuWbhc7xE7ThvVqfHkjopBge3vLVu";
+/// **ika**'s own chain identifier for its testnet deployment — NOT Sui's.
+///
+/// See [`IKA_MAINNET_CHAIN_IDENTIFIER_BASE58`] for why this carries an `IKA_`
+/// prefix. Sui testnet's identifier has the short id `4c78adac`.
+pub const IKA_TESTNET_CHAIN_IDENTIFIER_BASE58: &str =
+    "3FZxkWnWSKp64iY6h6GrBuW3CKxxpBDcnfEVyTZ8EZnV";
 
-pub static MAINNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
-pub static TESTNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
+pub static IKA_MAINNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
+pub static IKA_TESTNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
 
 /// For testing purposes or bootstrapping chain reconfiguration, you can set
 /// this environment variable to force protocol config to use a specific Chain.
@@ -183,24 +197,24 @@ impl ChainIdentifier {
     /// take a short 4 byte identifier and convert it into a ChainIdentifier
     /// short ids come from the JSON RPC getChainIdentifier and are encoded in hex
     pub fn from_chain_short_id(short_id: &String) -> Option<Self> {
-        if Hex::from_bytes(&Base58::decode(MAINNET_CHAIN_IDENTIFIER_BASE58).ok()?)
+        if Hex::from_bytes(&Base58::decode(IKA_MAINNET_CHAIN_IDENTIFIER_BASE58).ok()?)
             .encoded_with_format()
             .starts_with(&format!("0x{short_id}"))
         {
-            Some(get_mainnet_chain_identifier())
-        } else if Hex::from_bytes(&Base58::decode(TESTNET_CHAIN_IDENTIFIER_BASE58).ok()?)
+            Some(get_ika_mainnet_chain_identifier())
+        } else if Hex::from_bytes(&Base58::decode(IKA_TESTNET_CHAIN_IDENTIFIER_BASE58).ok()?)
             .encoded_with_format()
             .starts_with(&format!("0x{short_id}"))
         {
-            Some(get_testnet_chain_identifier())
+            Some(get_ika_testnet_chain_identifier())
         } else {
             None
         }
     }
 
     pub fn chain(&self) -> Chain {
-        let mainnet_id = get_mainnet_chain_identifier();
-        let testnet_id = get_testnet_chain_identifier();
+        let mainnet_id = get_ika_mainnet_chain_identifier();
+        let testnet_id = get_ika_testnet_chain_identifier();
 
         let chain = match self {
             id if *id == mainnet_id => Chain::Mainnet,
@@ -222,26 +236,30 @@ impl ChainIdentifier {
     }
 }
 
-pub fn get_mainnet_chain_identifier() -> ChainIdentifier {
-    let object_id = MAINNET_CHAIN_IDENTIFIER.get_or_init(|| {
+/// ika's mainnet chain identifier. To validate a connection to *Sui* mainnet,
+/// use [`sui_types::digests::get_mainnet_chain_identifier`] instead.
+pub fn get_ika_mainnet_chain_identifier() -> ChainIdentifier {
+    let object_id = IKA_MAINNET_CHAIN_IDENTIFIER.get_or_init(|| {
         let object_id = ObjectID::new(
-            Base58::decode(MAINNET_CHAIN_IDENTIFIER_BASE58)
-                .expect("mainnet genesis checkpoint digest literal is invalid")
+            Base58::decode(IKA_MAINNET_CHAIN_IDENTIFIER_BASE58)
+                .expect("ika mainnet chain identifier literal is invalid")
                 .try_into()
-                .expect("Mainnet genesis checkpoint digest literal has incorrect length"),
+                .expect("ika mainnet chain identifier literal has incorrect length"),
         );
         ChainIdentifier::from(object_id)
     });
     *object_id
 }
 
-pub fn get_testnet_chain_identifier() -> ChainIdentifier {
-    let object_id = TESTNET_CHAIN_IDENTIFIER.get_or_init(|| {
+/// ika's testnet chain identifier. To validate a connection to *Sui* testnet,
+/// use [`sui_types::digests::get_testnet_chain_identifier`] instead.
+pub fn get_ika_testnet_chain_identifier() -> ChainIdentifier {
+    let object_id = IKA_TESTNET_CHAIN_IDENTIFIER.get_or_init(|| {
         let object_id = ObjectID::new(
-            Base58::decode(TESTNET_CHAIN_IDENTIFIER_BASE58)
-                .expect("testnet genesis checkpoint digest literal is invalid")
+            Base58::decode(IKA_TESTNET_CHAIN_IDENTIFIER_BASE58)
+                .expect("ika testnet chain identifier literal is invalid")
                 .try_into()
-                .expect("Testnet genesis checkpoint digest literal has incorrect length"),
+                .expect("ika testnet chain identifier literal has incorrect length"),
         );
         ChainIdentifier::from(object_id)
     });


### PR DESCRIPTION
## What broke

`ika-proxy`'s startup validation compared the **Sui** chain identifier returned by the configured gRPC endpoint against **ika's own** chain identifiers. `crates/ika-proxy/src/main.rs` imported

```rust
use ika_types::digests::{get_mainnet_chain_identifier, get_testnet_chain_identifier};
```

when it needed the identically-named functions from Sui:

```rust
use sui_types::digests::{get_mainnet_chain_identifier, get_testnet_chain_identifier};
```

The two crates hold completely disjoint values — `ika_types::digests` has ika's own deployment identifiers (the ika system object IDs), `sui_types::digests` has Sui's genesis checkpoint digests:

| constant | base58 | short id (what gets compared) |
| --- | --- | --- |
| `ika_types` mainnet | `3FFWaJu1…` | `215de95d` |
| `ika_types` testnet | `3FZxkWnW…` | `2172c648` |
| `sui_types` mainnet | `4btiuiMP…` | **`35834a8a`** |
| `sui_types` testnet | `69WiPg3D…` | **`4c78adac`** |

So a Testnet-configured proxy was asking whether `4c78adac == 2172c648`. That can never hold, and **every** proxy configured for `Mainnet` or `Testnet` rejected the legitimate chain it had just successfully connected to and exited non-zero:

```
INFO ika_sui_client: SuiClient is connected to chain 4c78adac, current checkpoint sequence number: 374686336
Error: expected Sui chain Testnet, but connected to 4c78adac
```

Only `Devnet`/`Custom` — which have no compiled-in expectation — could boot.

## Why it shipped

Introduced by #2056 (`refactor(proxy): use chain-resolved Ika IDs over gRPC`) and released in v1.4.0. Two things let it through:

- **Nothing tests the proxy's startup validation.** `ika-proxy` had no coverage of `validate_sui_chain` at all, and the failure only reproduces against a live public Sui endpoint, so no unit or integration test could have caught it.
- **The namesake trap.** `ika_types::digests` and `sui_types::digests` export functions and constants with byte-identical names but different meanings. The import line reads perfectly at review; only the crate prefix distinguishes correct from catastrophic. The node's own connector (`crates/ika-core/src/sui_connector/mod.rs`) gets it right, so the two spellings sit side by side in the tree.

This is the *second* time this exact confusion shipped: `crates/ika-sui-client/src/genesis.rs` carries a regression test (`compiled_in_identifiers_are_sui_genesis_digests_not_ika_object_ids`) written after the v1.2.1 gRPC-path boot failure, which was the same mix-up in the genesis verifier. The guard was crate-local, so it did nothing for the proxy.

## The fix

`crates/ika-proxy/src/main.rs` now uses Sui's constants, and the bail message prints the **expected identifier** alongside the chain name:

```
expected Sui chain Testnet (4c78adac), but connected to 35834a8a
```

The original message (`expected Sui chain Testnet, but connected to 4c78adac`) compared a name against a hex id and read as a config error, which is exactly what made #2091 hard to diagnose from the log alone.

The comparison moved out of the binary into `crates/ika-proxy/src/sui_chain.rs` as two pure functions — `expected_sui_chain_identifier(SuiChainIdentifier) -> Option<String>` and `check_sui_chain_identifier(SuiChainIdentifier, &str) -> Result<()>`. `SuiConnectorClient` is a concrete type alias (`SuiClient<SuiBackend>`) with no trait seam to mock, so extracting the pure logic is what makes the validation testable without a live endpoint. `validate_sui_chain` keeps its signature and just fetches the identifier and delegates.

## Guard against recurrence

I took **both** options from the issue triage — the rename *and* the test — because the call-site count made the rename cheap:

**(a) Renamed ika's namesakes** so no `use` site can be ambiguous again:

| before (`ika_types::digests`) | after |
| --- | --- |
| `get_mainnet_chain_identifier` | `get_ika_mainnet_chain_identifier` |
| `get_testnet_chain_identifier` | `get_ika_testnet_chain_identifier` |
| `MAINNET_CHAIN_IDENTIFIER_BASE58` | `IKA_MAINNET_CHAIN_IDENTIFIER_BASE58` |
| `TESTNET_CHAIN_IDENTIFIER_BASE58` | `IKA_TESTNET_CHAIN_IDENTIFIER_BASE58` |
| `MAINNET_CHAIN_IDENTIFIER` | `IKA_MAINNET_CHAIN_IDENTIFIER` |
| `TESTNET_CHAIN_IDENTIFIER` | `IKA_TESTNET_CHAIN_IDENTIFIER` |

Total call sites outside `digests.rs`: **two**, both in the `genesis.rs` test above. The constants and `OnceCell`s were used only inside `digests.rs`. `ika-core` is untouched — it already imported Sui's versions, and those keep their upstream names. Post-rename, `sui_types::digests::get_mainnet_chain_identifier` and `ika_types::digests::get_ika_mainnet_chain_identifier` cannot be swapped by a stray crate prefix. Doc comments on each now state which chain they identify and point at the other crate's function for the opposite case; the `expect` strings (which claimed "mainnet genesis checkpoint digest") were corrected too — ika's identifiers are system object IDs, not checkpoint digests.

**(b) Added the assertion test** regardless, so the guard survives even if the names ever converge again. `expectations_are_sui_chain_ids_not_ika_ones` asserts the proxy's expectations equal `sui_types::digests::get_*_chain_identifier().to_string()` and are `assert_ne!` against `ika_types::digests::get_ika_*_chain_identifier().to_string()`.

## Other call sites audited

`grep`ed every `get_*_chain_identifier` / `*_CHAIN_IDENTIFIER*` reference repo-wide (all file types, not just `.rs`). Three comparison sites exist; `ika-proxy` was the only wrong one:

- `crates/ika-core/src/sui_connector/mod.rs:31-33` — imports from `sui_types::digests`. **Correct**, unchanged. This is why validators boot fine on v1.4.0 and only the proxy crash-loops.
- `crates/ika-sui-client/src/genesis.rs:38-41` — imports Sui's constants, aliased to `SUI_*_GENESIS_DIGEST_BASE58` at the `use` site. **Correct**, only its two test call sites updated for the rename.
- `crates/ika-types/src/digests.rs` — `ChainIdentifier::from_chain_short_id` and `::chain()` resolve **ika's** chain from **ika's** identifiers. Correct by construction (both sides are ika's); renamed for consistency.

No other crate imports these symbols, and the TypeScript SDK does not reference them.

## Test plan

```
cargo fmt --all
cargo clippy --all-targets --all-features -- -D warnings
cargo test --release -p ika-proxy
cargo check -p ika-core --features test-utils --tests
cargo test -p ika-types --lib -- layout_is_pinned variant_indices_are_pinned
cargo test --release -p ika-sui-client genesis
```

All green locally (aarch64-darwin, toolchain 1.97.1 per `rust-toolchain.toml`):

| command | result |
| --- | --- |
| `cargo fmt -- --check` | clean |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean, no diagnostics |
| `cargo test --release -p ika-proxy` | **13 passed, 0 failed** (9 pre-existing + 4 new) |
| `cargo check -p ika-core --features test-utils --tests` | clean |
| `cargo test -p ika-types --lib -- layout_is_pinned variant_indices_are_pinned` | 4 passed (the rename does not disturb the pinned layouts) |
| `cargo test --release -p ika-sui-client genesis` | 9 passed, incl. the pre-existing `compiled_in_identifiers_are_sui_genesis_digests_not_ika_object_ids` guard |

New tests in `crates/ika-proxy/src/sui_chain.rs`:

- `expectations_are_sui_chain_ids_not_ika_ones` — the #2091 regression guard (Sui's ids, not ika's).
- `public_sui_chains_are_accepted` — the exact reproduction from the issue: `Testnet` config + `4c78adac` passes, `Mainnet` + `35834a8a` passes. **Fails on `main`.**
- `crossed_chains_are_rejected_with_the_expected_identifier` — a genuinely wrong endpoint still bails, and the message string is asserted verbatim so the expected identifier cannot silently drop back out.
- `unpinned_chains_have_no_expectation` — `Devnet`/`Custom` accept any chain.

No metric names touched, so `./scripts/check-metric-names.sh` is not applicable.

## Release note

**This needs a v1.4.1 release for the proxy binary.** Operators cannot run the v1.4.0 proxy at all on mainnet or testnet — it is `CrashLoopBackOff` on every start, not a degraded mode. Our own cluster currently has the proxies pinned to `v1.3.1` as the workaround, with the validators on v1.4.0; that pin can be lifted once v1.4.1 ships. Validators and other binaries are unaffected.

Closes #2091

🤖 Generated with [Claude Code](https://claude.com/claude-code)
