### PR TITLE
chore(upgrade-test): retarget the cross-binary gate to v1.4.0

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -9,18 +9,18 @@ name: Upgrade Test
 # dev-docs/specs/cross-binary-upgrade.md).
 #
 # Manual dispatch can run any scenario. Relevant pull requests run only
-# `v131_rollout`, avoiding the full expensive matrix on unrelated changes.
+# `v140_rollout`, avoiding the full expensive matrix on unrelated changes.
 # (The v3/v4-era rehearsals — cross_binary, v118_*, v121_rollout — were
-# retired when protocol v3/v4 support was removed; v131_rollout is their
-# successor against the current v1.3.1 release.) Pick the scenario with
+# retired when protocol v3/v4 support was removed; v140_rollout is their
+# successor against the current v1.4.0 release.) Pick the scenario with
 # the `test` input:
 #
 #   smoke        — go/no-go plumbing: 4 same-binary processes reach epoch 2.
 #                  Needs only the current build. Fastest.
 #   workload     — full user DKG -> Presign -> Sign on-chain at genesis
 #                  protocol v7. Current build only.
-#   v131_rollout — the deployed-release compatibility gate: boot the literal
-#                  v1.3.1 release (deployed on mainnet AND testnet, which run
+#   v140_rollout — the deployed-release compatibility gate: boot the literal
+#                  v1.4.0 release (deployed on mainnet AND testnet, which run
 #                  protocol v7 — the only version either binary supports, so
 #                  the run genesises there),
 #                  upgrade exactly one validator to the current build,
@@ -28,18 +28,21 @@ name: Upgrade Test
 #                  zero malicious reports and per-authority output
 #                  byte-equality, then swap the rest and converge again — a
 #                  pure binary swap, no protocol transition. Defaults to
-#                  old_ref=release/mainnet-v1.3.1, old_bin_name=ika-validator.
-#   v131_churn   — v131_rollout's churn counterpart: full sequential swap
-#                  over the literal v1.3.1 committee, then a mirrored OCS
-#                  joiner folds into the reshared v1.3.1-origin key (4→5)
+#                  old_ref=release/mainnet-v1.4.0, old_bin_name=ika-validator.
+#                  v1.4.0 is post-#2074, so unlike the v1.3.1-based gate this
+#                  mixed committee shares ONE storage model; crossing the
+#                  event-sourcing change is mid_epoch_rollback's job.
+#   v140_churn   — v140_rollout's churn counterpart: full sequential swap
+#                  over the literal v1.4.0 committee, then a mirrored OCS
+#                  joiner folds into the reshared v1.4.0-origin key (4→5)
 #                  and a shrink reshare removes an original (5→4). Same OLD
-#                  defaults as v131_rollout.
-#   malicious_v131 — test-testing counterpart: honest literal-v1.3.1
+#                  defaults as v140_rollout.
+#   malicious_v140 — test-testing counterpart: honest literal-v1.4.0
 #                  committee + ONE current validator built with the
 #                  test-testing reconfiguration-message fault; honest
 #                  validators must convict it and reshare without it
-#                  (committee dips to 3). Green = the v131 gates are not
-#                  vacuous. Same OLD defaults as v131_rollout.
+#                  (committee dips to 3). Green = the v140 gates are not
+#                  vacuous. Same OLD defaults as v140_rollout.
 #   restart_spectator — the #1952 mid-epoch-restart gate: one validator is
 #                  restarted (same binary) far from an epoch boundary, in an
 #                  epoch with an established network key and ongoing
@@ -56,19 +59,24 @@ name: Upgrade Test
 #                  the already-settled work it re-sends (measured at the peers,
 #                  against a control window of ordinary traffic), and that a
 #                  peer witnesses it contributing MPC output again before the
-#                  boundary. Same OLD defaults as v131_rollout; needs a long
-#                  epoch so the whole experiment fits inside one.
+#                  boundary. Deliberately NOT retargeted with the rest of the
+#                  family: it stays on old_ref=release/mainnet-v1.3.1, the last
+#                  release that reopens an epoch store expecting its own fold's
+#                  tables to be there. Against v1.4.0 (post-#2074) there would
+#                  be no empty fold-side tables to re-derive against and the
+#                  scenario would assert nothing. Needs a long epoch so the
+#                  whole experiment fits inside one.
 #
 # Each scenario binds the fixed Sui localnet ports (9000/9123) and chdirs the
 # process during publish, so only ONE runs per job — `--test-threads=1`, one
 # `--test` target.
 #
-# The OLD binary for v131_rollout is built from `old_ref` in an isolated
+# The OLD binary for v140_rollout is built from `old_ref` in an isolated
 # `git worktree`, at that ref's OWN pinned toolchain (rustup honors the
 # worktree's rust-toolchain.toml). All binaries build with default features —
 # enforcement (enforce-minimum-cpu) is runtime-gated to validators on the ika
 # testnet/mainnet networks, so it is inert on the CI localnet (its ika
-# system object maps to Chain::Unknown), and v1.3.1 already carries the
+# system object maps to Chain::Unknown), and v1.4.0 already carries the
 # runtime gate.
 
 on:
@@ -116,7 +124,7 @@ on:
         description: "Scenario or comma-separated scenarios"
         type: string
         required: false
-        default: "v131_rollout"
+        default: "v140_rollout"
       candidate_sha:
         description: "Exact release-candidate commit SHA to check out and test"
         type: string
@@ -150,7 +158,7 @@ on:
         required: false
         default: false
       test_testing_fault:
-        description: "TEST ONLY: build a deliberately divergent candidate for v131_rollout"
+        description: "TEST ONLY: build a deliberately divergent candidate for v140_rollout"
         type: boolean
         required: false
         default: false
@@ -170,7 +178,7 @@ on:
         required: false
         default: ""
       old_ref:
-        description: "Git ref/tag/sha for the OLD binary (empty = per-scenario default; v131_rollout uses release/mainnet-v1.3.1)"
+        description: "Git ref/tag/sha for the OLD binary (empty = per-scenario default; v140_rollout uses release/mainnet-v1.4.0)"
         type: string
         required: false
         default: ""
@@ -180,7 +188,7 @@ on:
         required: false
         default: ""
       epoch_duration_ms:
-        description: "Override ika genesis epoch duration in ms (v131_rollout requires >=480000; empty = scenario default)"
+        description: "Override ika genesis epoch duration in ms (v140_rollout requires >=480000; empty = scenario default)"
         type: string
         required: false
         default: ""
@@ -205,7 +213,7 @@ on:
         required: false
         default: false
       test_testing_fault:
-        description: "TEST ONLY: build the current validator with the test-testing reconfiguration-message fault and run v131_rollout; the zero-malicious/convergence gate must fail."
+        description: "TEST ONLY: build the current validator with the test-testing reconfiguration-message fault and run v140_rollout; the zero-malicious/convergence gate must fail."
         type: boolean
         required: false
         default: false
@@ -244,10 +252,10 @@ jobs:
         env:
           # The default is the deployed-release compatibility gate, the one
           # scenario every relevant pull request and release candidate runs.
-          TEST: ${{ inputs.test || 'v131_rollout' }}
+          TEST: ${{ inputs.test || 'v140_rollout' }}
         run: |
           set -euo pipefail
-          ALL="smoke workload v131_rollout v131_churn malicious_v131 restart_spectator mid_epoch_rollback"
+          ALL="smoke workload v140_rollout v140_churn malicious_v140 restart_spectator mid_epoch_rollback"
           if [ "$TEST" = "all" ]; then
             SELECTED="$ALL"
           else
@@ -283,7 +291,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           # Full history + tags: the OLD binary is built from an arbitrary
-          # ref (e.g. the release/mainnet-v1.3.1 tag) via `git worktree add`.
+          # ref (e.g. the release/mainnet-v1.4.0 tag) via `git worktree add`.
           fetch-depth: 0
           # Resolve once at trigger time; never rebuild a moving branch head.
           ref: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
@@ -360,11 +368,11 @@ jobs:
           case "$TEST" in
             smoke)        RUN_FLAG=RUN_UPGRADE_SMOKE ;;
             workload)     RUN_FLAG=RUN_WORKLOAD_TEST ;;
-            v131_churn)   RUN_FLAG=RUN_V131_CHURN ;;
-            malicious_v131) RUN_FLAG=RUN_MALICIOUS_V131 ;;
+            v140_churn)   RUN_FLAG=RUN_V140_CHURN ;;
+            malicious_v140) RUN_FLAG=RUN_MALICIOUS_V140 ;;
             restart_spectator) RUN_FLAG=RUN_RESTART_SPECTATOR ;;
             mid_epoch_rollback) RUN_FLAG=RUN_MID_EPOCH_ROLLBACK ;;
-            v131_rollout)   RUN_FLAG=RUN_V131_ROLLOUT ;;
+            v140_rollout)   RUN_FLAG=RUN_V140_ROLLOUT ;;
             *) echo "unknown test: $TEST" >&2; exit 1 ;;
           esac
           # Per-scenario OLD-binary defaults; explicit inputs override (an
@@ -372,21 +380,26 @@ jobs:
           OLD_REF="$IN_OLD_REF"
           OLD_BIN_NAME="$IN_OLD_BIN_NAME"
           case "$TEST" in
-            v131_churn | malicious_v131)
-              : "${OLD_REF:=release/mainnet-v1.3.1}"
+            v140_churn | malicious_v140)
+              : "${OLD_REF:=release/mainnet-v1.4.0}"
               : "${OLD_BIN_NAME:=ika-validator}"
               ;;
             mid_epoch_rollback)
-              # Same release, opposite direction: OLD is what the node is
-              # rolled BACK to after the candidate has been writing its stores.
+              # NOT the deployed release, and deliberately left behind when the
+              # rest of the family retargeted to v1.4.0. This scenario's whole
+              # subject is an old binary reopening an epoch store that an
+              # event-sourcing binary has been writing — it needs the last
+              # release from BEFORE #2074, which is v1.3.1. v1.4.0 is
+              # post-#2074 and would find its own fold's tables exactly where
+              # it expects them, leaving nothing to re-derive.
               : "${OLD_REF:=release/mainnet-v1.3.1}"
               : "${OLD_BIN_NAME:=ika-validator}"
               ;;
-            v131_rollout)
+            v140_rollout)
               # OLD is the release the fleet is running; NEW is the candidate.
               # Both support protocol v7 only, so the boundary under test is a
               # pure binary swap.
-              : "${OLD_REF:=release/mainnet-v1.3.1}"
+              : "${OLD_REF:=release/mainnet-v1.4.0}"
               : "${OLD_BIN_NAME:=ika-validator}"
               ;;
           esac
@@ -422,7 +435,7 @@ jobs:
           # exists again — it is the run standing behind a version flip on a
           # live network, which is where mocked agreement is most misleading.
           case "$TEST_NAME" in
-            v131_rollout|v131_churn|malicious_v131|mid_epoch_rollback)
+            v140_rollout|v140_churn|malicious_v140|mid_epoch_rollback)
               if [ "$USE_MOCKS" = "true" ]; then
                 echo "$TEST_NAME is a cross-binary gate and must use real cryptography" >&2
                 exit 1
@@ -431,12 +444,12 @@ jobs:
           esac
           # ONE scenario, deliberately. The two rollout gates this condition
           # was originally written for are now a single one, and
-          # malicious_v131 is NOT a third: it builds its own faulty validator
+          # malicious_v140 is NOT a third: it builds its own faulty validator
           # (below) rather than taking it from this input, and it is expected
           # to PASS — the honest committee convicts the fault — whereas this
           # input is expected to make its run FAIL CLOSED.
-          if [ "$TEST_TESTING_FAULT" = "true" ] && [ "$TEST_NAME" != "v131_rollout" ]; then
-            echo "test_testing_fault is only supported by v131_rollout" >&2
+          if [ "$TEST_TESTING_FAULT" = "true" ] && [ "$TEST_NAME" != "v140_rollout" ]; then
+            echo "test_testing_fault is only supported by v140_rollout" >&2
             exit 1
           fi
           if [ "$TEST_TESTING_FAULT" = "true" ]; then
@@ -460,11 +473,11 @@ jobs:
           # testnet/mainnet networks, so it never fires on this localnet.
           cargo build --release $NODE_FEATURES $NODE_FAULT_FEATURES -p ika-node --bin ika-validator --bin ika-notifier
           cargo build --release -p ika --bin ika $IKA_FEATURES
-          if [ "$TEST_NAME" = "malicious_v131" ]; then
+          if [ "$TEST_NAME" = "malicious_v140" ]; then
             # The deliberately-faulty validator: current source with the
             # feature-gated reconfiguration-message fault compiled IN. Built
             # after the normal binaries and copied aside (the feature build
-            # overwrites target/release/ika-validator; malicious_v131 never
+            # overwrites target/release/ika-validator; malicious_v140 never
             # reads the honest current validator, so the overwrite is inert).
             cargo build --release --features test-testing -p ika-node --bin ika-validator
             cp target/release/ika-validator "$GITHUB_WORKSPACE/ika-validator-faulty"
@@ -473,7 +486,7 @@ jobs:
           cargo test --no-run --release -p ika-upgrade-test --test "$TEST_NAME"
 
       - name: Build OLD binary from ${{ env.OLD_REF }}
-        if: ${{ matrix.test == 'v131_rollout' || matrix.test == 'v131_churn' || matrix.test == 'malicious_v131' || matrix.test == 'mid_epoch_rollback' }}
+        if: ${{ matrix.test == 'v140_rollout' || matrix.test == 'v140_churn' || matrix.test == 'malicious_v140' || matrix.test == 'mid_epoch_rollback' }}
         run: |
           set -euo pipefail
           WT="$GITHUB_WORKSPACE/old-build"
@@ -495,7 +508,7 @@ jobs:
           echo "resolved OLD_REF=$OLD_REF to immutable commit $OLD_COMMIT"
           git worktree add --force --detach "$WT" "$OLD_COMMIT"
           # Build at the OLD ref's own toolchain (rustup reads the worktree's
-          # rust-toolchain.toml). Default features: v1.3.1's
+          # rust-toolchain.toml). Default features: v1.4.0's
           # enforce-minimum-cpu is runtime-gated (inert on the CI localnet),
           # matching its production build.
           ( cd "$WT" && cargo build --release -p ika-node --bin "$OLD_BIN_NAME" )
@@ -507,7 +520,7 @@ jobs:
       - name: Run ${{ matrix.test }}
         env:
           # smoke/workload read IKA_VALIDATOR_BIN/
-          # IKA_NOTIFIER_BIN/IKA_BIN; v131_rollout reads NEW_BIN/NOTIFIER_BIN/
+          # IKA_NOTIFIER_BIN/IKA_BIN; v140_rollout reads NEW_BIN/NOTIFIER_BIN/
           # OLD_BIN/IKA_BIN (OLD_BIN comes from the build step via
           # $GITHUB_ENV; unset for the others, which ignore it). Setting both
           # naming sets is harmless — each test reads only its own.
@@ -562,7 +575,7 @@ jobs:
           # quiet top-up loop can't prove resumption). The reduced-pool
           # override remains a resource concession for the lighter scenarios,
           # not compatibility evidence.
-          if [ "$TEST_NAME" = "v131_rollout" ] || [ "$TEST_NAME" = "restart_spectator" ]; then
+          if [ "$TEST_NAME" = "v140_rollout" ] || [ "$TEST_NAME" = "restart_spectator" ]; then
             unset IKA_ENABLE_SMALL_PRESIGN_POOLS
           fi
           mkdir -p "$UPGRADE_TEST_DIR"

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -902,7 +902,7 @@ async fn this_epoch_reconfiguration_output_is_skipped_and_current_epoch_output_r
 /// validators, so without intervention the key is never adopted. Adoption
 /// must flag it for the syncer's stranded-key chain read — the recovery that
 /// the removed v3→v4 chain-read fallback used to provide implicitly (caught
-/// live by the `v131_churn` scenario's mirrored joiner). A key DKG'd THIS
+/// live by the `v140_churn` scenario's mirrored joiner). A key DKG'd THIS
 /// epoch must NOT be flagged: that is the healthy fresh-key bootstrap window.
 #[tokio::test]
 async fn empty_overlay_for_prior_epoch_key_flags_stranded() {

--- a/crates/ika-swarm-config/src/sui_client.rs
+++ b/crates/ika-swarm-config/src/sui_client.rs
@@ -139,7 +139,7 @@ pub async fn fund_address_from_faucet(
 /// the faucet executes its transfer asynchronously ("It can take up to 1
 /// minute to get the coin"), and a long-lived payer can arrive at a step
 /// with its earlier grants already burned down to dust (seen live in
-/// v131_churn: the publisher entered the join step with 0.199 SUI total
+/// v140_churn: the publisher entered the join step with 0.199 SUI total
 /// against a 5 SUI budget). Polling the summed gas-coin balance covers
 /// both.
 pub async fn ensure_sui_balance_from_faucet(

--- a/crates/ika-upgrade-test/src/bin/upgrade-test.rs
+++ b/crates/ika-upgrade-test/src/bin/upgrade-test.rs
@@ -3,7 +3,7 @@
 
 //! CLI entry point for the cross-binary upgrade test harness.
 //!
-//! `dev` vs `tag:release/mainnet-v1.3.1` is the default example, not a baked-in constant —
+//! `dev` vs `tag:release/mainnet-v1.4.0` is the default example, not a baked-in constant —
 //! both sides are `--old` / `--new` binary specs (`path:` / `tag:` / `sha:` /
 //! `branch:`, or a bare value the resolver classifies).
 
@@ -22,7 +22,7 @@ struct Args {
     #[arg(long, default_value_t = 4)]
     validators: usize,
 
-    /// Old binary spec, e.g. `tag:release/mainnet-v1.3.1`.
+    /// Old binary spec, e.g. `tag:release/mainnet-v1.4.0`.
     #[arg(long)]
     old: String,
 
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
     let scenario = match args.scenario.as_str() {
         "rolling_majority_then_minority" => {
             // Proven-good config (originally from the retired
-            // `tests/cross_binary.rs`; `tests/v131_rollout.rs` uses the same
+            // `tests/cross_binary.rs`; `tests/v140_rollout.rs` uses the same
             // shape): long (10-min) epochs avoid the short-epoch sui_executor
             // wedge, the timeout covers a full long epoch per
             // `wait_for_epoch`, and the `set_buffer_stake(0)` before the

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -2123,7 +2123,7 @@ impl ClusterOfProcesses {
         .context("faucet-fund joiner")?;
 
         // The publisher signs `stake_ika` below, and by this point in a long
-        // scenario its bootstrap grants can be burned down to dust (v131_churn
+        // scenario its bootstrap grants can be burned down to dust (v140_churn
         // reached this step with 0.199 SUI total against the 5 SUI budget).
         // Top it up and wait for the grant to land before signing.
         ensure_sui_balance_from_faucet(

--- a/crates/ika-upgrade-test/src/lib.rs
+++ b/crates/ika-upgrade-test/src/lib.rs
@@ -4,7 +4,7 @@
 //! Out-of-process cross-binary upgrade test harness.
 //!
 //! Runs an Ika cluster on one machine with validators executing *real,
-//! separately-compiled* `ika-validator` binaries (e.g. `release/mainnet-v1.3.1` vs
+//! separately-compiled* `ika-validator` binaries (e.g. `release/mainnet-v1.4.0` vs
 //! `dev`), drives them across epoch boundaries, swaps binaries on individual
 //! validators mid-run, and asserts the upgrade invariants (protocol-version
 //! vote, reconfiguration MPC, session lifecycle, wire compat, on-disk compat).

--- a/crates/ika-upgrade-test/tests/malicious_v140.rs
+++ b/crates/ika-upgrade-test/tests/malicious_v140.rs
@@ -4,7 +4,7 @@
 //! Cross-binary **malicious-party detection** rehearsal (test-testing) —
 //! the successor to the retired `malicious_cross_binary`.
 //!
-//! Boots a 4-validator committee on the HONEST literal v1.3.1 release
+//! Boots a 4-validator committee on the HONEST literal v1.4.0 release
 //! (deployed on both networks, protocol v7), lets it complete the genesis
 //! network DKG, then swaps **one** validator to a deliberately-FAULTY
 //! current build (`FAULTY_BIN`) that corrupts its outgoing reconfiguration
@@ -17,7 +17,7 @@
 //! --bin ika-validator --features test-testing`). The fault is compiled
 //! out of every normal build, so a plain release can never carry it.
 //!
-//! Expectation: the honest v1.3.1 validators must identify the faulty one as
+//! Expectation: the honest v1.4.0 validators must identify the faulty one as
 //! a malicious actor and reconfigure without it (committee dips to 3), so
 //! the network still reaches epoch 3. Detection is asserted
 //! **programmatically** by scraping the
@@ -26,24 +26,24 @@
 //! code alone is not the assertion: the network could reach epoch 3 without
 //! flagging anyone, which is exactly the vacuous-pass this guards against. A
 //! green run proves mixed-committee malicious detection against the deployed
-//! release is not vacuous — i.e. `v131_rollout`'s zero-malicious gate would
+//! release is not vacuous — i.e. `v140_rollout`'s zero-malicious gate would
 //! actually fire on a real divergence. This is NOT a production test; it
 //! validates the test infrastructure (see `.claude/skills/test-testing`).
 //!
-//! Opt-in, via `RUN_MALICIOUS_V131=1`:
+//! Opt-in, via `RUN_MALICIOUS_V140=1`:
 //!
 //! ```bash
 //! # Build the faulty binary via the feature (no source edit):
 //! cargo build --release -p ika-node --bin ika-validator --features test-testing
 //! cp target/release/ika-validator /tmp/ika-validator-FAULTY-RECONFIG
 //! # then run:
-//! RUN_MALICIOUS_V131=1 \
-//!   OLD_BIN=/path/to/ika-validator-v1.3.1 \
+//! RUN_MALICIOUS_V140=1 \
+//!   OLD_BIN=/path/to/ika-validator-v1.4.0 \
 //!   FAULTY_BIN=/tmp/ika-validator-FAULTY-RECONFIG \
 //!   NOTIFIER_BIN=target/release/ika-notifier \
 //!   IKA_BIN=target/release/ika \
 //!   SUI_BIN=$(which sui) \
-//!   cargo test --release -p ika-upgrade-test --test malicious_v131 -- --nocapture
+//!   cargo test --release -p ika-upgrade-test --test malicious_v140 -- --nocapture
 //! ```
 
 use std::path::PathBuf;
@@ -60,9 +60,9 @@ fn bin_from_env(var: &str, default: &str) -> PathBuf {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn honest_committee_marks_faulty_current_validator_malicious() {
-    if std::env::var("RUN_MALICIOUS_V131").is_err() {
+    if std::env::var("RUN_MALICIOUS_V140").is_err() {
         eprintln!(
-            "skipping: set RUN_MALICIOUS_V131=1 (needs OLD_BIN/FAULTY_BIN/NOTIFIER_BIN/IKA_BIN/SUI_BIN)"
+            "skipping: set RUN_MALICIOUS_V140=1 (needs OLD_BIN/FAULTY_BIN/NOTIFIER_BIN/IKA_BIN/SUI_BIN)"
         );
         return;
     }
@@ -71,10 +71,10 @@ async fn honest_committee_marks_faulty_current_validator_malicious() {
         .with_env()
         .init();
 
-    // Honest reference binary: the literal v1.3.1 ika-validator.
+    // Honest reference binary: the literal v1.4.0 ika-validator.
     let honest = BinarySpec::Path(bin_from_env(
         "OLD_BIN",
-        "/tmp/ika-v131/target/release/ika-validator",
+        "/tmp/ika-v140/target/release/ika-validator",
     ));
     // Deliberately-faulty current build (corrupts its reshare message),
     // produced by `cargo build --bin ika-validator --features test-testing`.
@@ -93,7 +93,7 @@ async fn honest_committee_marks_faulty_current_validator_malicious() {
         .to_path_buf();
 
     let base = PathBuf::from(
-        std::env::var("UPGRADE_TEST_DIR").unwrap_or_else(|_| "/tmp/ika-malicious-v131".to_string()),
+        std::env::var("UPGRADE_TEST_DIR").unwrap_or_else(|_| "/tmp/ika-malicious-v140".to_string()),
     );
     let _ = std::fs::remove_dir_all(&base);
 
@@ -118,7 +118,7 @@ async fn honest_committee_marks_faulty_current_validator_malicious() {
         .with_min_validator_count(3)
         .with_ika_cli(ika_cli)
         .with_genesis_global_presign_config(GenesisGlobalPresignConfig::Empty)
-        // Genesis network DKG on the all-honest v1.3.1 committee at v7.
+        // Genesis network DKG on the all-honest v1.4.0 committee at v7.
         .start_all(honest)
         .wait_for_epoch(2)
         // Swap ONE validator to the faulty current build — a mixed committee.
@@ -131,10 +131,10 @@ async fn honest_committee_marks_faulty_current_validator_malicious() {
         .expect_malicious_actors_at_least(&[3], 1)
         .run()
         .await
-        .expect("honest v1.3.1 committee should reconfigure past a faulty current validator");
+        .expect("honest v1.4.0 committee should reconfigure past a faulty current validator");
 
     tracing::info!(
-        "malicious-v131 PASSED: honest v1.3.1 committee reached epoch 3 AND recorded the \
+        "malicious-v140 PASSED: honest v1.4.0 committee reached epoch 3 AND recorded the \
          faulty current validator as malicious (asserted via the \
          ika_dwallet_mpc_malicious_actors_count gauge)"
     );

--- a/crates/ika-upgrade-test/tests/restart_spectator.rs
+++ b/crates/ika-upgrade-test/tests/restart_spectator.rs
@@ -9,7 +9,7 @@
 //! window — not merely stay consensus-healthy while peers absorb every
 //! session.
 //!
-//! This is the ingredient `v131_rollout` lacks: its binary swaps land minutes
+//! This is the ingredient `v140_rollout` lacks: its binary swaps land minutes
 //! from an epoch boundary and none of its gates assert per-validator top-up
 //! participation, so a restarted validator that silently re-mints
 //! already-completed internal-presign ordinals (the in-memory

--- a/crates/ika-upgrade-test/tests/v140_churn.rs
+++ b/crates/ika-upgrade-test/tests/v140_churn.rs
@@ -1,15 +1,15 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-//! Literal v1.3.1 upgrade rehearsal **with post-upgrade committee churn** —
+//! Literal v1.4.0 upgrade rehearsal **with post-upgrade committee churn** —
 //! the successor to the retired `v118_churn`/`cross_binary` churn coverage.
 //!
-//! Boot a 4-validator committee on the actual v1.3.1 release (deployed on
+//! Boot a 4-validator committee on the actual v1.4.0 release (deployed on
 //! mainnet AND testnet, protocol v7), sequentially swap **all validators** to
 //! the current build — then, on the now all-current committee:
 //!
 //! - **join a brand-new validator** (candidate → stake → activate) so the
-//!   next reshare encrypts the network key (originally DKG'd by v1.3.1's
+//!   next reshare encrypts the network key (originally DKG'd by v1.4.0's
 //!   binary) to a 5-member committee that includes a party which never held
 //!   it. The joiner boots peer-only `SuiStateMirrored`, reading verified Sui
 //!   state through the direct relay validators — the OCS joiner
@@ -20,21 +20,21 @@
 //!   retired `cross_binary` exercised).
 //!
 //! The sequential replacement has transient mixed states but intentionally
-//! avoids an MPC boundary; real mixed-committee MPC is `v131_rollout`'s job.
+//! avoids an MPC boundary; real mixed-committee MPC is `v140_rollout`'s job.
 //! The OCS read topology splits at the swap: validators 0 and 1 stay direct
 //! (serving the relay), 2 and 3 flip to peer-only mirrored, and the joiner
 //! comes up mirrored — the topology the retired `cross_binary` exercised.
 //!
-//! Opt-in, via `RUN_V131_CHURN=1` (same binaries as `v131_rollout`):
+//! Opt-in, via `RUN_V140_CHURN=1` (same binaries as `v140_rollout`):
 //!
 //! ```bash
-//! RUN_V131_CHURN=1 \
-//!   OLD_BIN=/path/to/ika-validator-v1.3.1 \
+//! RUN_V140_CHURN=1 \
+//!   OLD_BIN=/path/to/ika-validator-v1.4.0 \
 //!   NEW_BIN=target/release/ika-validator \
 //!   NOTIFIER_BIN=target/release/ika-notifier \
 //!   IKA_BIN=target/release/ika \
 //!   SUI_BIN=$(which sui) \
-//!   cargo test --release -p ika-upgrade-test --test v131_churn -- --nocapture
+//!   cargo test --release -p ika-upgrade-test --test v140_churn -- --nocapture
 //! ```
 
 use std::path::PathBuf;
@@ -50,10 +50,10 @@ fn bin_from_env(var: &str, default: &str) -> PathBuf {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn v131_full_swap_then_committee_churn() {
-    if std::env::var("RUN_V131_CHURN").is_err() {
+async fn v140_full_swap_then_committee_churn() {
+    if std::env::var("RUN_V140_CHURN").is_err() {
         eprintln!(
-            "skipping: set RUN_V131_CHURN=1 \
+            "skipping: set RUN_V140_CHURN=1 \
              (needs OLD_BIN/NEW_BIN/NOTIFIER_BIN/IKA_BIN/SUI_BIN)"
         );
         return;
@@ -65,7 +65,7 @@ async fn v131_full_swap_then_committee_churn() {
 
     let old = BinarySpec::Path(bin_from_env(
         "OLD_BIN",
-        "/tmp/ika-v131/target/release/ika-validator",
+        "/tmp/ika-v140/target/release/ika-validator",
     ));
     let current = BinarySpec::Path(bin_from_env("NEW_BIN", "target/release/ika-validator"));
     let notifier = bin_from_env("NOTIFIER_BIN", "target/release/ika-notifier");
@@ -79,7 +79,7 @@ async fn v131_full_swap_then_committee_churn() {
         .to_path_buf();
     let base = PathBuf::from(
         std::env::var("UPGRADE_TEST_DIR")
-            .unwrap_or_else(|_| "/mnt/nvme0n1p1/tmp/ika-v131-churn".to_string()),
+            .unwrap_or_else(|_| "/mnt/nvme0n1p1/tmp/ika-v140-churn".to_string()),
     );
     let _ = std::fs::remove_dir_all(&base);
     let epoch_duration_ms = std::env::var("EPOCH_DURATION_MS")
@@ -88,7 +88,7 @@ async fn v131_full_swap_then_committee_churn() {
         .unwrap_or(600_000);
     assert!(
         epoch_duration_ms >= 480_000,
-        "the v1.3.1 churn scenario requires an epoch of at least 480000ms so the bounded sequential \
+        "the v1.4.0 churn scenario requires an epoch of at least 480000ms so the bounded sequential \
          restarts complete before the mid-epoch reconfiguration"
     );
 
@@ -109,13 +109,13 @@ async fn v131_full_swap_then_committee_churn() {
         .with_epoch_timeout(Duration::from_secs(1200))
         // OCS read topology: 0 and 1 stay direct (relay servers); 2, 3 and
         // the joiner run peer-only SuiStateMirrored through them. The split
-        // materializes at the swap; the v1.3.1 boot phase is all-direct.
+        // materializes at the swap; the v1.4.0 boot phase is all-direct.
         .with_direct_validators(&[0, 1])
         .with_ika_cli(ika_cli)
         // Deployed-faithful on-chain state (populated global-presign config).
         .with_genesis_global_presign_config(GenesisGlobalPresignConfig::Full)
-        // Boot the literal v1.3.1 committee at protocol v7; epoch 2
-        // guarantees the genesis network DKG (v1.3.1 binary) completed
+        // Boot the literal v1.4.0 committee at protocol v7; epoch 2
+        // guarantees the genesis network DKG (v1.4.0 binary) completed
         // before the swap.
         .start_all(old)
         .wait_for_epoch(2)
@@ -124,8 +124,12 @@ async fn v131_full_swap_then_committee_churn() {
         .expect_committee_size(4)
         .expect_protocol_version_at_least(7)
         // Sequentially swap every validator to the current build. The
-        // current binaries inherit the v1.3.1-written RocksDB state and
-        // reshare the v1.3.1-DKG'd network key.
+        // current binaries inherit the v1.4.0-written RocksDB state and
+        // reshare the v1.4.0-DKG'd network key. v1.4.0 is post-#2074, so
+        // that inheritance is now within ONE storage model — the durable
+        // tables both binaries keep, not a fold-side set one writes and the
+        // other does not. Crossing the event-sourcing change is
+        // `mid_epoch_rollback`'s job, and it stays pinned at v1.3.1 for it.
         .stop_and_swap(&[0, 1, 2, 3], current.clone())
         .expect_all_validators_healthy()
         .wait_for_epoch(3)
@@ -133,7 +137,7 @@ async fn v131_full_swap_then_committee_churn() {
         .expect_all_validators_healthy()
         .expect_committee_size(4)
         // ── Churn 1: grow 4 → 5 with a mirrored joiner. ────────────────────
-        // The reshare encrypts the v1.3.1-origin key to a committee
+        // The reshare encrypts the v1.4.0-origin key to a committee
         // including a party that never held it; the joiner installs the key
         // by the cert-pinned digest over the OCS mirrored path.
         .join_validator_mirrored(current)
@@ -156,7 +160,7 @@ async fn v131_full_swap_then_committee_churn() {
         .expect_network_key_output_converged(&current_observer)
         .expect_malicious_actors_exactly(&current_observer, 0)
         // The 5-member committee runs a full lifecycle against the reshared
-        // v1.3.1-origin network key.
+        // v1.4.0-origin network key.
         .run_workload("v7-with-joiner")
         .record_mpc_timings("v7-with-joiner")
         // ── Churn 2: shrink 5 → 4 by removing an original validator. ──────
@@ -185,11 +189,11 @@ async fn v131_full_swap_then_committee_churn() {
         .expect_log_line_absent("failed to submit an MPC output message to consensus")
         .run()
         .await
-        .expect("v1.3.1 -> current full-committee upgrade + committee churn in both directions");
+        .expect("v1.4.0 -> current full-committee upgrade + committee churn in both directions");
 
     tracing::info!(
-        "v1.3.1 churn PASSED: full binary swap over v1.3.1 state, a mirrored joiner folded \
-         into the reshared v1.3.1-origin key (4→5), and a shrink reshare (5→4) all converged \
+        "v1.4.0 churn PASSED: full binary swap over v1.4.0 state, a mirrored joiner folded \
+         into the reshared v1.4.0-origin key (4→5), and a shrink reshare (5→4) all converged \
          while serving a full user lifecycle"
     );
 }

--- a/crates/ika-upgrade-test/tests/v140_rollout.rs
+++ b/crates/ika-upgrade-test/tests/v140_rollout.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 //! Deployed-release rolling-upgrade rehearsal at protocol v7: the literal
-//! v1.3.1 release against the candidate build.
+//! v1.4.0 release against the candidate build.
 //!
-//! - **OLD** = the v1.3.1 `ika-validator` (built from the
-//!   `release/mainnet-v1.3.1` tag, deployed on mainnet AND testnet).
+//! - **OLD** = the v1.4.0 `ika-validator` (built from the
+//!   `release/mainnet-v1.4.0` tag, deployed on mainnet AND testnet).
 //! - **NEW** = the candidate build.
 //!
 //! `MIN_PROTOCOL_VERSION = MAX_PROTOCOL_VERSION = 7`, so both binaries support
@@ -18,17 +18,32 @@
 //! Sign lifecycle across two reshares and a full binary swap. That is the
 //! wire-no-op every candidate must be against the release the fleet is running.
 //!
-//! Opt-in (real binaries + long-running), via `RUN_V131_ROLLOUT=1`:
+//! **What the storage model does to this gate's reach.** Against v1.3.1 the
+//! mixed phase also straddled the event-sourcing change (#2074): the OLD
+//! validators wrote per-round MPC tables and a `last_consensus_stats`
+//! watermark, the NEW ones kept that state in memory, and a green run said
+//! something about two committee members disagreeing about what is durable.
+//! v1.4.0 is post-#2074, so both sides of this scenario now share one storage
+//! model and that ingredient is GONE from here — the assertions below are
+//! unchanged and still gate wire and MPC-output agreement, but they no longer
+//! stand behind any claim about mixed storage models. The one scenario that
+//! still crosses the boundary is `mid_epoch_rollback`, which is deliberately
+//! NOT retargeted with this family: it stays pinned to `release/mainnet-v1.3.1`
+//! because v1.3.1 is the last release that reopens an epoch store expecting its
+//! own fold's tables to be there, and retargeting it to v1.4.0 would leave it
+//! asserting nothing.
+//!
+//! Opt-in (real binaries + long-running), via `RUN_V140_ROLLOUT=1`:
 //!
 //! ```bash
-//! # OLD_BIN: the v1.3.1 ika-validator; NEW_BIN: the candidate
-//! RUN_V131_ROLLOUT=1 \
-//!   OLD_BIN=/path/to/ika-validator-v1.3.1 \
+//! # OLD_BIN: the v1.4.0 ika-validator; NEW_BIN: the candidate
+//! RUN_V140_ROLLOUT=1 \
+//!   OLD_BIN=/path/to/ika-validator-v1.4.0 \
 //!   NEW_BIN=target/release/ika-validator \
 //!   NOTIFIER_BIN=target/release/ika-notifier \
 //!   IKA_BIN=target/release/ika \
 //!   SUI_BIN=$(which sui) \
-//!   cargo test --release -p ika-upgrade-test --test v131_rollout -- --nocapture
+//!   cargo test --release -p ika-upgrade-test --test v140_rollout -- --nocapture
 //! ```
 
 use std::path::PathBuf;
@@ -45,10 +60,10 @@ fn bin_from_env(var: &str, default: &str) -> PathBuf {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn v131_rollout_converges_across_binary_swap_at_v7() {
-    if std::env::var("RUN_V131_ROLLOUT").is_err() {
+async fn v140_rollout_converges_across_binary_swap_at_v7() {
+    if std::env::var("RUN_V140_ROLLOUT").is_err() {
         eprintln!(
-            "skipping: set RUN_V131_ROLLOUT=1 \
+            "skipping: set RUN_V140_ROLLOUT=1 \
              (needs OLD_BIN/NEW_BIN/NOTIFIER_BIN/IKA_BIN/SUI_BIN)"
         );
         return;
@@ -60,7 +75,7 @@ async fn v131_rollout_converges_across_binary_swap_at_v7() {
 
     let old = BinarySpec::Path(bin_from_env(
         "OLD_BIN",
-        "/mnt/nvme0n1p1/v131-bins/ika-validator",
+        "/mnt/nvme0n1p1/v140-bins/ika-validator",
     ));
     let current = BinarySpec::Path(bin_from_env("NEW_BIN", "target/release/ika-validator"));
     let notifier = bin_from_env("NOTIFIER_BIN", "target/release/ika-notifier");
@@ -74,7 +89,7 @@ async fn v131_rollout_converges_across_binary_swap_at_v7() {
         .to_path_buf();
     let base = PathBuf::from(
         std::env::var("UPGRADE_TEST_DIR")
-            .unwrap_or_else(|_| "/mnt/nvme0n1p1/tmp/ika-v131-rollout".to_string()),
+            .unwrap_or_else(|_| "/mnt/nvme0n1p1/tmp/ika-v140-rollout".to_string()),
     );
     let _ = std::fs::remove_dir_all(&base);
     let epoch_duration_ms = std::env::var("EPOCH_DURATION_MS")
@@ -83,7 +98,7 @@ async fn v131_rollout_converges_across_binary_swap_at_v7() {
         .unwrap_or(600_000);
     assert!(
         epoch_duration_ms >= 480_000,
-        "the v1.3.1 rollout requires an epoch of at least 480000ms so the bounded sequential \
+        "the v1.4.0 rollout requires an epoch of at least 480000ms so the bounded sequential \
          restarts complete before the mid-epoch reconfiguration"
     );
 
@@ -185,12 +200,12 @@ async fn v131_rollout_converges_across_binary_swap_at_v7() {
         .run()
         .await
         .expect(
-            "v1.3.1/candidate committee must converge across the mixed phase and the full binary \
+            "v1.4.0/candidate committee must converge across the mixed phase and the full binary \
              swap at protocol v7",
         );
 
     tracing::info!(
-        "v1.3.1 rollout PASSED: the mixed v1.3.1/candidate committee converged across two \
+        "v1.4.0 rollout PASSED: the mixed v1.4.0/candidate committee converged across two \
          reshares at v7, and the fully-upgraded committee converged and kept serving a full \
          user lifecycle at each stage"
     );

--- a/dev-docs/plans/archive/cross-binary-upgrade-testing.md
+++ b/dev-docs/plans/archive/cross-binary-upgrade-testing.md
@@ -2,8 +2,8 @@
 
 > ARCHIVED PLAN — built by #1727, then superseded. **The two tests its results
 > table names, `tests/cross_binary.rs` and `tests/v118_upgrade.rs`, were deleted
-> in #1895** (`0f2679799f`); the current scenarios are `v131_rollout`,
-> `v131_churn`, `malicious_v131`, `mid_epoch_rollback`, `restart_spectator`,
+> in #1895** (`0f2679799f`); the current scenarios are `v140_rollout`,
+> `v140_churn`, `malicious_v140`, `mid_epoch_rollback`, `restart_spectator`,
 > `smoke` and `workload`. The contract is
 > [`../../specs/cross-binary-upgrade.md`](../../specs/cross-binary-upgrade.md)
 > and the running procedure is

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -65,7 +65,7 @@ gh run download <run-id> -n <artifact>   # localnet-logs / cluster-tests-log-<at
 child processes against an external `sui` localnet. Manual dispatch remains
 available. Pull requests that touch `ika-core/src`, `ika-types`,
 `ika-network`, the MPC or crypto crates, protocol configuration, the upgrade
-harness, or `Cargo.lock` automatically run the `v131_rollout` deployed-release
+harness, or `Cargo.lock` automatically run the `v140_rollout` deployed-release
 gate rather than the entire matrix. Those are whole-crate globs on purpose:
 the filter previously listed individual modules and silently stopped covering
 code three separate times as modules were added or split out — if you are
@@ -84,7 +84,7 @@ v5 -> v6 flavor was retired at MIN = 6 and resurrected for v6 -> v7.
 > #1891).** It previously called this workflow with the candidate SHA and
 > blocked tag publication on `v118_mixed_rollout`; that job was removed, so
 > a release tag now builds, uploads and drafts **unconditionally**.
-> Validating a release candidate is a manual step: dispatch `v131_rollout`
+> Validating a release candidate is a manual step: dispatch `v140_rollout`
 > (the deployed-release compatibility gate) plus the cluster and
 > Rust-integration suites against the exact tagged SHA and record the runs
 > in the draft's Validation section (the notes scaffold prompts for it). A
@@ -105,21 +105,38 @@ version-transition gates, which were retargeted rather than dropped:
 (`v127_v7_upgrade` and the `protocol_version_transition` cluster test) —
 retired outright this time rather than retargeted, because MIN = MAX = 7
 leaves no boundary; see the note above on resurrecting them at v8. Their
-successors are `v131_rollout`/`v131_churn`/`malicious_v131`
+successors are `v140_rollout`/`v140_churn`/`malicious_v140`
 (below), which play the same mixed-committee gate against the CURRENTLY
-deployed release (v1.3.1, both networks, protocol v7) — a pure binary swap
+deployed release (v1.4.0, both networks, protocol v7) — a pure binary swap
 with no protocol transition. (Historical `cross_binary` 96 GiB runner-OOM
 forensics and its infra fix: this playbook's pre-#1751 history.)
 
 **Retarget the `v1XY_*` family whenever the deployed release moves.** The
 scenario names carry the OLD BINARY's release, not the protocol version,
 so that this maintenance is visible rather than silent: the set was
-`v125_*` against v1.2.5, then `v127_*`, then `v128_*`, and is now
-`v131_*` with `old_ref=release/mainnet-v1.3.1`. A retarget renames all of
+`v125_*` against v1.2.5, then `v127_*`, then `v128_*`, then `v131_*`, and is
+now `v140_*` with `old_ref=release/mainnet-v1.4.0`. A retarget renames all of
 it in one change — the three test files, their `RUN_*` opt-in env gates,
 the workflow's scenario names, `RUN_FLAG` mapping, `old_ref` defaults and
 both guard lists below, plus this playbook and the spec. Leaving any of
 them behind is the failure the convention exists to make visible.
+
+`mid_epoch_rollback` is the one scenario the family sweep must NOT carry
+along, and the v1.3.1 → v1.4.0 retarget is where that first mattered. Its
+subject is an old binary reopening an epoch store that an event-sourcing
+binary has been writing, so it needs the last release from BEFORE #2074 —
+v1.3.1 — and it keeps `old_ref=release/mainnet-v1.3.1` while everything
+else moves. Renaming it forward would have left it booting a post-#2074
+binary that finds its own fold's tables exactly where it expects them, with
+nothing to re-derive and three assertions that pass for free. When a
+scenario's OLD side is pinned to a specific capability rather than to
+"whatever is deployed", say so at the pin and leave it there.
+
+Retargeting also costs the gate whatever the OLD side happened to bring
+beyond its version. The v1.3.1-based gate straddled the event-sourcing
+change by accident of timing; the v1.4.0-based one does not, because both
+sides are post-#2074. That is not a regression to fix in the gate — it is
+the reason the backward scenario is pinned separately.
 Naming a gate after the protocol version instead is what
 produced the incomplete rename this convention now guards against: a
 scenario briefly called `v6_rollout` left the workflow's real-crypto and
@@ -129,8 +146,10 @@ superficially correct while the thing it tests changes underneath is
 worse than one that visibly goes stale.
 
 **Which gates must refuse mocks.** Every gate whose evidence is
-cross-binary agreement: `v131_rollout`, `v131_churn` and `malicious_v131` —
-plus any transition gate, the moment one exists again. Mocked cryptography is deterministic, so two
+cross-binary agreement: `v140_rollout`, `v140_churn`, `malicious_v140` and
+`mid_epoch_rollback` — plus any transition gate, the moment one exists
+again. (The workflow has guarded all four since `mid_epoch_rollback`
+landed; this list had not caught up.) Mocked cryptography is deterministic, so two
 binaries agree under it for reasons that say nothing about whether they
 agree in production — a green run on mocks is not weaker evidence of the
 same claim, it is evidence of a different one. Retarget this list with
@@ -157,11 +176,11 @@ gh workflow run upgrade-test.yaml --ref <branch> -f test=smoke
 gh workflow run upgrade-test.yaml --ref <branch> -f test=workload
 
 # THE DEPLOYED-RELEASE GATE (also the PR default, and the scenario to run
-# by hand on every release tag): boot the literal v1.3.1 release, upgrade
+# by hand on every release tag): boot the literal v1.4.0 release, upgrade
 # one validator to current, converge two mixed aggregated reshares
 # (per-authority byte-equality, zero malicious), then swap the rest.
-gh workflow run upgrade-test.yaml --ref <branch> -f test=v131_rollout
-#   override the old side:  -f old_ref=release/mainnet-v1.3.1 -f old_bin_name=ika-validator
+gh workflow run upgrade-test.yaml --ref <branch> -f test=v140_rollout
+#   override the old side:  -f old_ref=release/mainnet-v1.4.0 -f old_bin_name=ika-validator
 
 # THE PROTOCOL-UPGRADE GATE: none exists right now. MIN = MAX = 7, so there
 # is no boundary to cross, and both transition gates were retired with the v6
@@ -176,18 +195,18 @@ gh workflow run upgrade-test.yaml --ref <branch> -f test=v131_rollout
 # Test-test the gate with the compiled-in, feature-gated one-validator
 # reconfiguration-message fault. This run is expected to fail; its logs must
 # show the exact zero-malicious or output-convergence assertion firing.
-gh workflow run upgrade-test.yaml --ref <branch> -f test=v131_rollout -f test_testing_fault=true
+gh workflow run upgrade-test.yaml --ref <branch> -f test=v140_rollout -f test_testing_fault=true
 
 # The standalone test-testing counterpart (green = detection works): honest
-# v1.3.1 committee + one faulty current validator (built in-workflow with
+# v1.4.0 committee + one faulty current validator (built in-workflow with
 # --features test-testing); honest validators must convict it and reshare
 # without it (committee dips to 3).
-gh workflow run upgrade-test.yaml --ref <branch> -f test=malicious_v131
+gh workflow run upgrade-test.yaml --ref <branch> -f test=malicious_v140
 
-# v131_rollout's churn counterpart: full swap, then a mirrored OCS joiner
-# folds into the reshared v1.3.1-origin key (4→5) and a shrink reshare
+# v140_rollout's churn counterpart: full swap, then a mirrored OCS joiner
+# folds into the reshared v1.4.0-origin key (4→5) and a shrink reshare
 # removes an original validator (5→4).
-gh workflow run upgrade-test.yaml --ref <branch> -f test=v131_churn
+gh workflow run upgrade-test.yaml --ref <branch> -f test=v140_churn
 
 # THE ROLLBACK GATE, and the only backward direction in the matrix: the
 # candidate runs the network, then the v1.3.1 release is put BACK on one
@@ -197,6 +216,9 @@ gh workflow run upgrade-test.yaml --ref <branch> -f test=v131_churn
 # window; the number is the operator-facing "mid-epoch rollback re-emits"
 # figure, printed by the step as `re_submitted_consensus_transactions`), and
 # that a peer witnesses it authoring MPC output again before the boundary.
+# Its OLD side stays v1.3.1 while the rest of the family moved to v1.4.0:
+# v1.3.1 is the last release from before #2074, and a post-#2074 old binary
+# would find its own fold's tables intact and re-derive nothing.
 gh workflow run upgrade-test.yaml --ref <branch> -f test=mid_epoch_rollback
 #   the whole experiment must fit inside ONE epoch (the boundary hands the
 #   node a fresh epoch store and ends it), so give a loaded runner more room
@@ -220,9 +242,9 @@ notifier + a validator committee:
 |---|---|---|
 | `smoke` | current only | process harness reaches epoch 2 |
 | `workload` | current only | user DKG → Presign → Sign completes on-chain |
-| `v131_rollout` | **one current + three literal v1.3.1**, then all swapped | mixed aggregated reshares converge byte-identically with zero malicious reports; the fully-swapped committee converges and keeps serving |
-| `v131_churn` | all swapped, then a mirrored joiner (4→5) and a removal (5→4) | the v1.3.1-origin key reshares to a party that never held it (OCS joiner trust-anchor path) and back down |
-| `malicious_v131` | three literal v1.3.1 + one FAULTY current (test-testing build) | honest committee convicts the faulty validator and reshares without it — detection is not vacuous |
+| `v140_rollout` | **one current + three literal v1.4.0**, then all swapped | mixed aggregated reshares converge byte-identically with zero malicious reports; the fully-swapped committee converges and keeps serving |
+| `v140_churn` | all swapped, then a mirrored joiner (4→5) and a removal (5→4) | the v1.4.0-origin key reshares to a party that never held it (OCS joiner trust-anchor path) and back down |
+| `malicious_v140` | three literal v1.4.0 + one FAULTY current (test-testing build) | honest committee convicts the faulty validator and reshares without it — detection is not vacuous |
 
 ### CI runner resources
 
@@ -231,8 +253,8 @@ quota, a **96 GiB pod memory limit**, and no swap. Each idle `ika-validator`
 runs ≈7.5–8 GB RSS, so co-locating many validators approaches the pod limit —
 the deleted `cross_binary` scenario (5–6 validators) reproducibly OOM-killed
 the runner at that limit (`OOMKilled`/137; forensics in this playbook's
-pre-#1751 history). `v131_rollout` is 4-validator and fits comfortably;
-`v131_churn` peaks at 5 validators during its joiner phase — the same peak
+pre-#1751 history). `v140_rollout` is 4-validator and fits comfortably;
+`v140_churn` peaks at 5 validators during its joiner phase — the same peak
 as the retired `v118_churn`, which passed on these runners (the OOM death
 was specific to `cross_binary`'s heavier 5–6-validator multi-lifecycle
 profile).

--- a/dev-docs/playbooks/test-testing.md
+++ b/dev-docs/playbooks/test-testing.md
@@ -66,7 +66,7 @@ conclude from pass/fail alone.
 
 4. **Build only the binary that carries the fault, and name it.** A
    reference binary you can't edit (a fixed release like the literal
-   v1.3.1 build) cannot carry a producer fault — put the fault in the
+   v1.4.0 build) cannot carry a producer fault — put the fault in the
    **local** build and run it as the minority in an otherwise-honest
    committee. Build to a clearly-named artifact (`…-FAULTED` / `…-FAULTY-*`)
    so it's never mistaken for a real binary.
@@ -119,14 +119,14 @@ Property: in a mixed-binary committee, honest validators identify a
 validator that broadcasts a malformed contribution and reconfigure without
 it.
 
-Harness: `crates/ika-upgrade-test/tests/malicious_v131.rs`. It boots a
-4-validator committee on the HONEST literal v1.3.1 release, lets the genesis
+Harness: `crates/ika-upgrade-test/tests/malicious_v140.rs`. It boots a
+4-validator committee on the HONEST literal v1.4.0 release, lets the genesis
 network DKG finish, then swaps ONE validator to the `--features test-testing`
 build so it corrupts its outgoing reconfiguration message at the next epoch
 boundary.
 
 ```bash
-gh workflow run upgrade-test.yaml --ref <branch> -f test=malicious_v131
+gh workflow run upgrade-test.yaml --ref <branch> -f test=malicious_v140
 ```
 
 Outcome shape: **recoverable** — the honest validators exclude the faulty
@@ -146,8 +146,8 @@ wire incompatibility would have failed every cross-binary message and never
 reached quorum; had a *clean* swapped validator also been flagged, you would
 be measuring incompatibility, not detection.
 
-What a green `malicious_v131` buys you is the right to trust a different
-run: it shows `v131_rollout`'s zero-malicious gate would actually fire on a
+What a green `malicious_v140` buys you is the right to trust a different
+run: it shows `v140_rollout`'s zero-malicious gate would actually fire on a
 real divergence, rather than reading zero because nothing ever checks.
 
 ## Worked example — hard-fail: running the fault through the gate itself
@@ -157,10 +157,10 @@ detection test, inverts the outcome shape:
 
 ```bash
 gh workflow run upgrade-test.yaml --ref <branch> \
-  -f test=v131_rollout -f test_testing_fault=true
+  -f test=v140_rollout -f test_testing_fault=true
 ```
 
-`v131_rollout` requires mixed reshares to converge byte-identically with
+`v140_rollout` requires mixed reshares to converge byte-identically with
 ZERO malicious reports, so a faulty validator must break it. **This run is
 expected to FAIL**, and its logs must show the specific zero-malicious or
 output-convergence assertion firing. A green run here is the red flag: it

--- a/dev-docs/specs/cross-binary-upgrade.md
+++ b/dev-docs/specs/cross-binary-upgrade.md
@@ -187,12 +187,25 @@ of those rollouts completed on the deployed networks.
 
 Beyond the MIN-driven retirements, the mixed-committee family is retargeted
 whenever the DEPLOYED release moves — the scenario names carry the old
-binary's release (`v125_*` → `v127_*` → `v128_*` → `v131_*`), so the
-maintenance is visible rather than silent. The current deployed-release gate
-is `tests/v131_rollout.rs`: the one-upgraded-validator mixed topology against
-the literal **v1.3.1** release at protocol v7. Both sides support v7 and only
-v7, so the boundary under test is a pure binary swap. It is the PR-gating
-scenario and the one a release manager dispatches against every release tag.
+binary's release (`v125_*` → `v127_*` → `v128_*` → `v131_*` → `v140_*`), so
+the maintenance is visible rather than silent. The current deployed-release
+gate is `tests/v140_rollout.rs`: the one-upgraded-validator mixed topology
+against the literal **v1.4.0** release at protocol v7. Both sides support v7
+and only v7, so the boundary under test is a pure binary swap. It is the
+PR-gating scenario and the one a release manager dispatches against every
+release tag.
+
+`tests/mid_epoch_rollback.rs` is deliberately NOT part of that sweep. It is
+pinned to **v1.3.1**, the last release from before the epoch was
+event-sourced (#2074), because its subject is precisely an old binary
+reopening an epoch store whose fold-side tables it expects and does not
+find. Every other member of the family follows the deployed release; this
+one follows a capability, and moving it to v1.4.0 would leave it asserting
+nothing. Note what that costs the forward gate: the v1.3.1-based
+`v131_rollout` straddled the storage-model change by accident of timing,
+while `v140_rollout` has both sides post-#2074 and stands behind wire and
+MPC-output agreement only. Nothing in it was weakened to get there — the
+ingredient simply moved to the scenario that is pinned for it.
 
 ## How this is verified
 
@@ -204,8 +217,8 @@ drives them across epochs. The surviving scenarios (current build only):
   epoch 2 on the genesis epoch cadence.
 - `tests/workload.rs` — the session-lifecycle invariant: a full user
   DKG → Presign → Sign completing on-chain at genesis protocol v7.
-- `tests/v131_rollout.rs` — the current deployed-release compatibility gate:
-  boot the literal v1.3.1 release at genesis protocol v7, upgrade exactly one
+- `tests/v140_rollout.rs` — the current deployed-release compatibility gate:
+  boot the literal v1.4.0 release at genesis protocol v7, upgrade exactly one
   of four validators to the candidate, require two mixed
   network-key reshares to converge byte-identically with zero malicious
   reports and a served user lifecycle after each, then swap the remaining
@@ -222,23 +235,25 @@ drives them across epochs. The surviving scenarios (current build only):
   it independently the way a fleet does, while the in-process cluster test
   shares one such global across all four simulated validators and can only
   gate the vote arithmetic and the cross-epoch handoff path.
-- `tests/v131_churn.rs` — the churn counterpart: full sequential swap over
-  the literal v1.3.1 committee (on-disk RocksDB continuity), then a
-  peer-only-mirrored joiner folds into the reshared v1.3.1-origin key
+- `tests/v140_churn.rs` — the churn counterpart: full sequential swap over
+  the literal v1.4.0 committee (on-disk RocksDB continuity), then a
+  peer-only-mirrored joiner folds into the reshared v1.4.0-origin key
   (4→5, the OCS joiner trust-anchor path) and a shrink reshare removes an
   original validator (5→4).
-- `tests/malicious_v131.rs` — the test-testing counterpart: an honest
-  literal-v1.3.1 committee plus ONE current-build validator carrying the
+- `tests/malicious_v140.rs` — the test-testing counterpart: an honest
+  literal-v1.4.0 committee plus ONE current-build validator carrying the
   `test-testing`-gated reconfiguration-message fault (the hook lives in
   the main reconfiguration advance path in
   `crytographic_computation/mpc_computations.rs`); honest validators must
   convict it and reshare without it, asserted via the malicious-actors
   gauge. Green = the compatibility gates above are not vacuous. The
   workflow's `test_testing_fault` input runs the same fault through
-  `v131_rollout` itself (that run must fail closed); `malicious_v131` is
+  `v140_rollout` itself (that run must fail closed); `malicious_v140` is
   also directly dispatchable (the workflow builds the faulty binary).
 - `tests/mid_epoch_rollback.rs` — the only BACKWARD direction in the
-  matrix: the candidate runs the network, then the v1.3.1 release is put
+  matrix, and the only scenario whose OLD side is pinned to a capability
+  rather than to the deployed release: the candidate runs the network, then
+  the **v1.3.1** release — the last one from before #2074 — is put
   back on one validator MID-EPOCH, on stores the candidate has been
   writing. It asserts that the old binary re-derives the epoch against
   empty fold-side tables, counts the already-settled work it re-sends at

--- a/dev-docs/specs/event-sourced-epoch.md
+++ b/dev-docs/specs/event-sourced-epoch.md
@@ -856,12 +856,24 @@ What in-process coverage cannot reach, and belongs on CI or a cluster:
   reachable, and the one place a traced "bounded blast radius" should be
   replaced by a measurement.
 - **Mixed old/new binaries sharing an epoch** (`ika-upgrade-test`). The
-  forward direction is covered by `v131_rollout` / `v131_churn`; the BACKWARD
-  direction — the rollback section above — is `mid_epoch_rollback`, which puts
-  the v1.3.1 release back on one validator mid-epoch and asserts the
-  re-derivation reaches the peers' consumed round, counts the already-settled
-  work it re-sends, and requires a peer to witness it authoring MPC output
-  again inside the same epoch.
+  BACKWARD direction — the rollback section above — is `mid_epoch_rollback`,
+  which puts the v1.3.1 release back on one validator mid-epoch and asserts
+  the re-derivation reaches the peers' consumed round, counts the
+  already-settled work it re-sends, and requires a peer to witness it
+  authoring MPC output again inside the same epoch. It is pinned to v1.3.1
+  and does NOT move with the deployed release: v1.3.1 is the last binary that
+  expects its own fold's tables to be in the epoch store, and that expectation
+  is the whole experiment.
+
+  The FORWARD direction across this change was covered by `v131_rollout` /
+  `v131_churn` while v1.3.1 was the deployed release. Their successors
+  `v140_rollout` / `v140_churn` boot v1.4.0, which is itself post-#2074, so
+  they no longer put two storage models in one committee — they gate wire and
+  MPC-output agreement between two event-sourced binaries. **Nothing now
+  exercises a pre-#2074 binary sharing an epoch with a current one in the
+  forward direction**, and nothing will again: the fleet is past it. If that
+  coverage is wanted as a regression record rather than as a live gate, it has
+  to be a separately-pinned scenario, the way the backward one is.
 - **Upstream queue bytes under a real burst** (REQUIRED): throttle the drain
   on a live cluster and record `ika_consensus_round_channel_depth`, RSS and
   the commit-channel backlog. This closes both directions the local harness

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -335,7 +335,7 @@ next epoch inherits.
      flags the key for the syncer's chain-sourced read instead of
      skipping it forever. (Until issue #1751 removed the migration
      chain-read fallback, that fallback covered this shape implicitly;
-     the `v131_churn` scenario's mirrored joiner caught the regression.)
+     the `v140_churn` scenario's mirrored joiner caught the regression.)
      A key DKG'd THIS epoch is excluded — the healthy fresh-key
      bootstrap window. Second (mid-epoch restart, issue #1852). Once this
      epoch's reconfiguration completes, the off-chain copy of a key's


### PR DESCRIPTION
Retargets the cross-binary upgrade suite's OLD baseline from the v1.3.1 release to **v1.4.0** (`release/mainnet-v1.4.0` = `release/testnet-v1.4.0` = `ae91dc24bf`, released 2026-08-24 and rolling out across the fleet now): scenario files/gates renamed `v131_*` → `v140_*`, workflow `old_ref` defaults, RUN-flag mapping, must-refuse-mocks and fault-injection guard lists, dev-machine `OLD_BIN` defaults, and the ci-suites playbook + cross-binary-upgrade spec + test-testing playbook in the same change.

Follows the precedent of #2040 ("retarget the cross-binary baseline to the v1.3.1 release") exactly: same rename surface, same one-change-renames-everything discipline the playbook spells out, and the same old-binary mechanism — the harness **builds** the old binary from the git tag in an isolated `git worktree` at that ref's own pinned toolchain. It does not download a release asset, so the only artifact requirement is that the tag exists (verified: both network tags resolve to `ae91dc24bf`, and v1.4.0 pins the same `1.97.1` toolchain as main).

## `mid_epoch_rollback` is deliberately left at v1.3.1

This is the one place this retarget is not a mechanical rename, and it is new since #2040.

`mid_epoch_rollback` (#2077) runs the candidate first and puts the **old** release back on one validator mid-epoch. Its whole subject is an old binary reopening an epoch store in which everything its own fold writes is empty — it asserts the re-derivation through the table-writing path, measures the already-settled work it re-emits, and requires a peer to witness it authoring MPC output again.

v1.4.0 is post-#2074: the event-sourcing change landed in `927f0b3af9`, before the `1.4.0` version bump (#2088) and before the tag. So a v1.4.0 old binary would find its own fold's tables exactly where it expects them, re-derive nothing, and pass all three assertions for free. **Retargeting it would have silently emptied it**, which is precisely what "do not weaken an assertion" rules out. It keeps `old_ref=release/mainnet-v1.3.1` — the last release from before #2074 — and the pin now carries that reasoning at the site, in the workflow, the spec and the playbook.

The general rule is now written down: this scenario's OLD side is pinned to a **capability**, not to "whatever is deployed", and the family sweep must skip it.

## What the retarget costs the forward gate (recorded, not papered over)

The v1.3.1-based `v131_rollout` straddled the storage-model change by accident of timing: three OLD validators writing per-round MPC tables and a `last_consensus_stats` watermark, one NEW validator keeping that state in memory. `v140_rollout` has both sides post-#2074, so that ingredient is gone from it and it stands behind wire and MPC-output agreement only.

No assertion was changed, removed or relaxed anywhere — the assertion lists in all three renamed scenarios are byte-identical modulo the rename. What changed is the prose in `v140_rollout.rs`, `v140_churn.rs`, the workflow header, `ci-suites.md`, `cross-binary-upgrade.md` and `event-sourced-epoch.md`, which now say what the gate does and does not cover. `event-sourced-epoch.md` also records the honest consequence: **nothing exercises a pre-#2074 binary sharing an epoch with a current one in the forward direction any more, and nothing will again** — the fleet is past it, and if that is wanted as a regression record it needs its own pinned scenario.

## Protocol versions

Unaffected. v1.4.0 and main are both `MIN_PROTOCOL_VERSION = MAX_PROTOCOL_VERSION = 7`, so there is no version delta for the scenario to assume: it stays a pure binary swap and the `SupportedProtocolVersions::new_for_testing(7, 7)` pins and `expect_protocol_version_at_*(7)` assertions are unchanged.

## Also fixed in passing

`ci-suites.md`'s must-refuse-mocks list had never picked up `mid_epoch_rollback`, which the workflow has guarded since it landed. That is exactly the drift the list warns about, so it is corrected here rather than left for the next retarget.

## Validation

- `cargo check -p ika-upgrade-test --tests` clean; `cargo fmt --all -- --check` clean; `cargo clippy -p ika-upgrade-test --all-targets --all-features -- -D warnings` clean.
- **The retargeted gate was dispatched for real against the published v1.4.0 assets** and is the evidence for this PR, not a proxy for it: https://github.com/dwallet-labs/ika/actions/runs/32729477864 — **success**.
  The run resolved `old_ref=release/mainnet-v1.4.0` to the immutable commit `ae91dc24bf235fa7d8b5aaca2acf1db9f1ce178f`, built the old validator from it, and logged `v1.4.0 rollout PASSED` after all 62 flow steps — including three real DKG → Presign → Sign lifecycles (`mixed-v7-after-first-reshare`, `mixed-v7-after-second-reshare`, `all-new-v7-after-full-swap`). The workflow's false-green guard (`test result: ok. 1 passed`) is satisfied, so the gate ran rather than skipping.
- This PR's paths auto-trigger `v140_rollout` on the PR itself; that run is also **green** (2957s), resolving the same v1.4.0 commit. All other PR checks pass.

## For the repo admin — required status check

The job name is the check name, so this PR renames the status check that appears on every PR:

| | |
|---|---|
| **old check name** | `v131_rollout` |
| **new check name** | `v140_rollout` |

**Checked, and no branch-protection change is needed.** `main`'s classic protection has both `required_status_checks.contexts` and `required_status_checks.checks` **empty**, and the repo has **no rulesets**, so no check is pinned by name and nothing breaks on merge. (This PR shows as `BLOCKED` only because `main` requires 2 approving reviews.)

Worth knowing anyway if anyone has the old name saved outside branch protection — dashboards, `gh` filters, saved searches, or a personal required-check list. Nothing here touches branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
