### PR TITLE
fix(system-checkpoints): SetRewardSlashingRate is u16, matching the Move peel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,6 +120,14 @@ jobs:
         # must run here or a retype merges green. ika-types has no MPC
         # crypto, so the debug profile is fine.
         run: cargo test -p ika-types --lib -- layout_is_pinned variant_indices_are_pinned
+      - name: System checkpoint message widths
+        # Move peels a checkpoint's whole message vector as one flat BCS stream,
+        # with no per-message length prefix to resynchronize on, so a Rust
+        # payload whose width no longer matches its `peel_*` call desynchronizes
+        # every message after it in the same checkpoint. The pins live in
+        # ika-types' tests, which PR CI otherwise never executes (Cargo Test
+        # Check is compile-only), so they must be named here to run at all.
+        run: cargo test -p ika-types --lib -- variant_encodings_are_pinned_to_the_move_peel_widths
       - name: Sui version consistency
         # The Sui pin lives in several places that don't update together;
         # see dev-docs/conventions/sui-version-bump.md.

--- a/crates/ika-types/src/messages_system_checkpoints.rs
+++ b/crates/ika-types/src/messages_system_checkpoints.rs
@@ -44,7 +44,7 @@ pub enum SystemCheckpointMessageKind {
     /// Set a new maximum number of validators that can change in a single epoch.
     SetMaxValidatorChangeCount(u64),
     /// Set a new rate at which rewards are slashed in basis points (1/100th of a percent).
-    SetRewardSlashingRate(u64),
+    SetRewardSlashingRate(u16),
     /// Marks the final checkpoint message for an epoch.
     /// Once the Sui smart contract processes this message, it recognizes that no further
     /// system checkpoints will be created in the current epoch, enabling external calls
@@ -210,5 +210,128 @@ impl SystemCheckpointSignatureMessage {
     pub fn verify(&self, committee: &Committee) -> IkaResult {
         self.checkpoint_message
             .verify_authority_signatures(committee)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SystemCheckpointMessageKind::*;
+    use super::*;
+
+    /// Compile-time guard: a new variant of the enum has to be named here, which
+    /// is the reminder that it also needs a row in the table below and an arm in
+    /// the Move dispatch.
+    fn assert_variant_is_covered(kind: &SystemCheckpointMessageKind) {
+        match kind {
+            SetNextConfigVersion(_)
+            | SetEpochDurationMs(_)
+            | SetStakeSubsidyStartEpoch(_)
+            | SetStakeSubsidyRate(_)
+            | SetStakeSubsidyPeriodLength(_)
+            | SetMinValidatorCount(_)
+            | SetMaxValidatorCount(_)
+            | SetMinValidatorJoiningStake(_)
+            | SetMaxValidatorChangeCount(_)
+            | SetRewardSlashingRate(_)
+            | EndOfPublish
+            | SetApprovedUpgrade { .. }
+            | SetOrRemoveWitnessApprovingAdvanceEpochMessageType { .. } => {}
+        }
+    }
+
+    /// Move reads a checkpoint's whole message vector as one flat BCS stream: per
+    /// element it peels the enum tag and then peels exactly the fields that tag's
+    /// arm names, with no per-message length prefix to resynchronize on. So a Rust
+    /// payload wider or narrower than the matching `peel_*` call does not merely
+    /// corrupt its own message — it leaves the reader mid-value, and every message
+    /// after it in the same checkpoint is decoded from the wrong offset.
+    ///
+    /// Each row pins one variant's complete BCS encoding against the arm that
+    /// consumes it in the `message_data_enum_tag` match of
+    /// `process_checkpoint_message_by_quorum`
+    /// (`contracts/ika_system/sources/system/system_inner.move`): the leading byte
+    /// is the tag the arm's `*_MESSAGE_TYPE` constant matches, and the remaining
+    /// bytes are what that arm's `peel_*` sequence consumes.
+    #[test]
+    fn variant_encodings_are_pinned_to_the_move_peel_widths() {
+        // Payloads chosen so the encoded width is legible in the expected bytes:
+        // little-endian 0x0807060504030201 is `01..08`, and 0x0201 is `01 02`.
+        let eight_bytes = 0x0807_0605_0403_0201u64;
+        let two_bytes = 0x0201u16;
+
+        for (kind, move_peels, expected) in [
+            (
+                SetNextConfigVersion(ProtocolVersion::new(eight_bytes)),
+                "peel_u64",
+                vec![0, 1, 2, 3, 4, 5, 6, 7, 8],
+            ),
+            (
+                SetEpochDurationMs(eight_bytes),
+                "peel_u64",
+                vec![1, 1, 2, 3, 4, 5, 6, 7, 8],
+            ),
+            (
+                SetStakeSubsidyStartEpoch(eight_bytes),
+                "peel_u64",
+                vec![2, 1, 2, 3, 4, 5, 6, 7, 8],
+            ),
+            (SetStakeSubsidyRate(two_bytes), "peel_u16", vec![3, 1, 2]),
+            (
+                SetStakeSubsidyPeriodLength(eight_bytes),
+                "peel_u64",
+                vec![4, 1, 2, 3, 4, 5, 6, 7, 8],
+            ),
+            (
+                SetMinValidatorCount(eight_bytes),
+                "peel_u64",
+                vec![5, 1, 2, 3, 4, 5, 6, 7, 8],
+            ),
+            (
+                SetMaxValidatorCount(eight_bytes),
+                "peel_u64",
+                vec![6, 1, 2, 3, 4, 5, 6, 7, 8],
+            ),
+            (
+                SetMinValidatorJoiningStake(eight_bytes),
+                "peel_u64",
+                vec![7, 1, 2, 3, 4, 5, 6, 7, 8],
+            ),
+            (
+                SetMaxValidatorChangeCount(eight_bytes),
+                "peel_u64",
+                vec![8, 1, 2, 3, 4, 5, 6, 7, 8],
+            ),
+            (SetRewardSlashingRate(two_bytes), "peel_u16", vec![9, 1, 2]),
+            (EndOfPublish, "(no payload)", vec![10]),
+            (
+                SetApprovedUpgrade {
+                    package_id: vec![1, 2, 3],
+                    digest: Some(vec![4, 5]),
+                },
+                "peel_vec_u8, peel_option!(peel_vec_u8)",
+                vec![11, 3, 1, 2, 3, 1, 2, 4, 5],
+            ),
+            (
+                SetOrRemoveWitnessApprovingAdvanceEpochMessageType {
+                    witness_type: "ab".to_string(),
+                    remove: true,
+                },
+                "peel_vec_u8, peel_bool",
+                vec![12, 2, b'a', b'b', 1],
+            ),
+        ] {
+            assert_variant_is_covered(&kind);
+            assert_eq!(
+                bcs::to_bytes(&kind).unwrap(),
+                expected,
+                "{kind:?} no longer encodes as the Move dispatch reads it (tag {} then {move_peels}, \
+                 in `process_checkpoint_message_by_quorum` in \
+                 contracts/ika_system/sources/system/system_inner.move). Move peels the \
+                 checkpoint's messages as one flat stream, so a width or tag change here \
+                 desynchronizes every message that follows it in the same checkpoint. Change the \
+                 Move arm in the same commit, or restore the encoding.",
+                expected[0],
+            );
+        }
     }
 }


### PR DESCRIPTION
`SystemCheckpointMessageKind::SetRewardSlashingRate` carried a `u64`, but the Move arm that consumes it peels a `u16`, and so does the setter it forwards to (`validator_set::set_reward_slashing_rate`). Its correctly-paired sibling `SetStakeSubsidyRate(u16)` ↔ `peel_u16()` shows the intended shape.

Move is the authoritative half here, not just in `contracts/`: both `deployed_contracts/mainnet` and `deployed_contracts/testnet` peel `u16` too, so the Rust side was the one out of step.

## Why six bytes break more than one message

Move reads a checkpoint's message vector as **one flat BCS stream**. Per element it peels the enum tag and then exactly the fields that tag's arm names — there is no per-message length prefix to resynchronize on:

```move
let len = bcs_body.peel_vec_length();
while (i < len) {
    let message_data_enum_tag = bcs_body.peel_enum_tag();
    match (message_data_enum_tag) { ... }
}
```

So a payload wider than its `peel_*` call does not merely corrupt its own message — it leaves the reader mid-value, and **every message after it in the same checkpoint is decoded from the wrong offset**. Encoding `SetRewardSlashingRate(1000)` both ways makes the cascade concrete:

| | bytes | Move consumes | left over |
|---|---|---|---|
| before (`u64`) | `[9, 232, 3, 0, 0, 0, 0, 0, 0]` | tag `9`, then `u16` = `1000` | **6 zero bytes** |
| after (`u16`) | `[9, 232, 3]` | tag `9`, then `u16` = `1000` | none |

The next `peel_enum_tag` then reads the u64's zero padding as tag `0` — `SET_NEXT_PROTOCOL_VERSION` — and applies a garbage protocol version, followed by whatever the remaining misaligned bytes decode to.

## Why this is wire-safe

The variant has **never been emitted**: the sole producer of checkpoint messages (`authority_per_epoch_store.rs`) does not construct it. Narrowing the type therefore changes no bytes any node has ever written, and no on-chain state was produced under the old width. Nothing else in the tree constructs the variant either, so there were no `u64` literals to update — the type change is the whole fix.

No Move changes: the Move side was already correct.

## What the new test guards

`variant_encodings_are_pinned_to_the_move_peel_widths` pins the **complete BCS encoding of all 13 variants** — tag byte plus payload — against the widths the Move dispatch consumes, with each row annotated by the `peel_*` sequence of its arm so the table can be read side by side with `system_inner.move`. Variant order and count were already documented as load-bearing on both sides; the widths were unchecked until now, which is how this drifted.

It follows the `layout_is_pinned` / `variant_indices_are_pinned` tests added in #2083. A compile-time exhaustiveness guard (`assert_variant_is_covered`) makes a newly added variant fail to build until it is given a row, so the table cannot silently fall behind the enum.

## The pin had to be wired into CI to run at all

Worth flagging for reviewers: adding the test was not sufficient. `Cargo Test Check` is **compile-only**, so ika-types' pins reach PR CI solely through the explicitly named filters in the lint job:

```
cargo test -p ika-types --lib -- layout_is_pinned variant_indices_are_pinned
```

A new test whose name matches neither filter gets compiled and **never run**, and `cargo test` exits 0 when a filter selects nothing — so the guard would have been green and vacuous, which is the same "a retype merges green" hole the adjacent step's comment warns about. The second commit adds a step that names the new pin.

Verified while writing it that every **other** variant already agrees: the `*_MESSAGE_TYPE` constants are `0..=12` and map exactly onto the Rust variant order, `ProtocolVersion`/`EpochId`/the six counters pair with `peel_u64`, `Vec<u8>` and `String` with `peel_vec_u8`, `Option<Vec<u8>>` with `peel_option!`, `bool` with `peel_bool`, and `EndOfPublish` peels nothing. **Index 9 was the only mismatch.**

Fixes #2094

🤖 Generated with [Claude Code](https://claude.com/claude-code)
