### PR TITLE
fix(metrics): register metric families by NodeMode, not unconditionally

### DIFF
--- a/crates/ika-core/src/authority.rs
+++ b/crates/ika-core/src/authority.rs
@@ -4,7 +4,7 @@
 
 use arc_swap::{ArcSwap, Guard};
 use chrono::prelude::*;
-use ika_config::NodeConfig;
+use ika_config::{NodeConfig, NodeMode};
 use ika_types::messages_consensus::{AuthorityCapabilitiesV1, MovePackageDigest};
 use itertools::Itertools;
 use parking_lot::Mutex;
@@ -109,6 +109,23 @@ const POSITIVE_INT_BUCKETS: &[f64] = &[
 pub const DEV_INSPECT_GAS_COIN_VALUE: u64 = 1_000_000_000_000;
 
 impl AuthorityMetrics {
+    /// Registers into `registry` only if `mode` runs the consensus handler.
+    ///
+    /// Every family in this struct is written from the consensus commit path,
+    /// so on a fullnode or notifier they would export constant zeros — an
+    /// idle-but-healthy validator's reading. Registering them into a
+    /// role-local registry no endpoint gathers keeps them off that process's
+    /// `/metrics` entirely (ika #2051).
+    pub fn new_for_mode(mode: NodeMode, registry: &prometheus::Registry) -> AuthorityMetrics {
+        let unexported = prometheus::Registry::new();
+        Self::new(if mode.is_validator() {
+            registry
+        } else {
+            &unexported
+        })
+    }
+
+    /// Registers the whole set — the composition a validator process gets.
     pub fn new(registry: &prometheus::Registry) -> AuthorityMetrics {
         Self {
             skipped_consensus_txns: register_int_counter_with_registry!(
@@ -337,6 +354,7 @@ impl AuthorityState {
         committee_store: Arc<CommitteeStore>,
         checkpoint_store: Arc<DWalletCheckpointStore>,
         prometheus_registry: &Registry,
+        mode: NodeMode,
         config: NodeConfig,
     ) -> Arc<Self> {
         // The advertised capability range is constant for the process; export
@@ -352,7 +370,7 @@ impl AuthorityState {
             .set(supported_protocol_versions.max.as_u64() as i64);
         Self::check_protocol_version(supported_protocol_versions, epoch_store.protocol_version());
 
-        let metrics = Arc::new(AuthorityMetrics::new(prometheus_registry));
+        let metrics = Arc::new(AuthorityMetrics::new_for_mode(mode, prometheus_registry));
 
         let epoch = epoch_store.epoch();
 

--- a/crates/ika-core/src/epoch/epoch_metrics.rs
+++ b/crates/ika-core/src/epoch/epoch_metrics.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
+use ika_config::node::NodeMode;
 use prometheus::{
     Histogram, IntCounterVec, IntGauge, Registry, register_histogram_with_registry,
     register_int_counter_vec_with_registry, register_int_gauge_with_registry,
@@ -293,7 +294,32 @@ pub struct EpochMetrics {
 }
 
 impl EpochMetrics {
+    /// Registers the whole set — the composition a validator process gets.
     pub fn new(registry: &Registry) -> Arc<Self> {
+        Self::new_for_mode(NodeMode::Validator, registry)
+    }
+
+    /// Registers into `registry` only the families whose writers run in
+    /// `mode`.
+    ///
+    /// The epoch store is opened by every mode, but most of what it measures
+    /// is written from the consensus, MPC and checkpoint paths that only a
+    /// validator runs. Those families are registered into a role-local
+    /// registry that no endpoint gathers, so a fullnode or notifier does not
+    /// export them at all: absence is the honest signal for "this process has
+    /// no such subsystem", where the constant zero or `-1` sentinel it used
+    /// to serve was indistinguishable from a real reading (ika #2051).
+    ///
+    /// The handles themselves are always constructed, so the write sites stay
+    /// unconditional and a mis-classified family costs a lost observation on
+    /// one role rather than a panic.
+    pub fn new_for_mode(mode: NodeMode, registry: &Registry) -> Arc<Self> {
+        let unexported = Registry::new();
+        let validator_registry = if mode.is_validator() {
+            registry
+        } else {
+            &unexported
+        };
         let this = Self {
             current_epoch: register_int_gauge_with_registry!(
                 "ika_current_epoch",
@@ -310,7 +336,7 @@ impl EpochMetrics {
                     65536.0, 131072.0, 262144.0, 524288.0, 1048576.0, 2097152.0, 4194304.0,
                     8388608.0, 16777216.0, 33554432.0
                 ],
-                registry
+                validator_registry
             )
             .unwrap(),
             current_voting_right: register_int_gauge_with_registry!(
@@ -327,7 +353,7 @@ impl EpochMetrics {
             epoch_total_computation_reward: register_int_gauge_with_registry!(
                 "ika_epoch_total_computation_reward",
                 "Total amount of computation rewards in the epoch",
-                registry
+                validator_registry
             ).unwrap(),
             epoch_reconfig_start_time_since_epoch_close_ms: register_int_gauge_with_registry!(
                 "ika_epoch_reconfig_start_time_since_epoch_close_ms",
@@ -342,12 +368,12 @@ impl EpochMetrics {
             epoch_first_checkpoint_created_time_since_epoch_begin_ms: register_int_gauge_with_registry!(
                 "ika_epoch_first_checkpoint_created_time_since_epoch_begin_ms",
                 "Time interval from when the epoch opens at new epoch to the first checkpoint is created locally",
-                registry
+                validator_registry
             ).unwrap(),
             epoch_first_system_checkpoint_created_time_since_epoch_begin_ms: register_int_gauge_with_registry!(
                 "ika_epoch_first_system_checkpoint_created_time_since_epoch_begin_ms",
                 "Time interval from when the epoch opens at new epoch to the first params message is created locally",
-                registry
+                validator_registry
             ).unwrap(),
             effective_buffer_stake: register_int_gauge_with_registry!(
                 "ika_effective_buffer_stake",
@@ -357,7 +383,7 @@ impl EpochMetrics {
             dwallet_mpc_data_freeze_epoch: register_int_gauge_with_registry!(
                 "ika_dwallet_mpc_data_freeze_epoch",
                 "Epoch of the most recent mpc_data freeze observed locally",
-                registry
+                validator_registry
             )
             .unwrap(),
             committee_quorum_threshold: register_int_gauge_with_registry!(
@@ -405,58 +431,58 @@ impl EpochMetrics {
             dwallet_mpc_data_excluded_validators: register_int_gauge_with_registry!(
                 "ika_dwallet_mpc_data_excluded_validators",
                 "Number of validators the mpc_data freeze partition excluded this epoch",
-                registry
+                validator_registry
             )
             .unwrap(),
             dwallet_mpc_data_ready_quorum_round: register_int_gauge_with_registry!(
                 "ika_dwallet_mpc_data_ready_quorum_round",
                 "Leader round where the mpc_data ready-signal stake quorum was first observed \
                  (freeze-grace anchor); -1 before quorum",
-                registry
+                validator_registry
             )
             .unwrap(),
             last_committed_leader_consensus_round: register_int_gauge_with_registry!(
                 "ika_last_committed_leader_consensus_round",
                 "Leader round of the latest consensus commit processed at the commit boundary \
                  (the freeze-grace round domain); -1 before the epoch's first commit",
-                registry
+                validator_registry
             )
             .unwrap(),
             mpc_consensus_round_lag: register_int_gauge_with_registry!(
                 "ika_mpc_consensus_round_lag",
                 "Consensus rounds the MPC service trails the consensus commit path by; unbounded growth means MPC has stopped while consensus keeps running (-1 before the MPC service reports its first round)",
-                registry,
+                validator_registry,
             )
             .unwrap(),
             mpc_stopped_contributing_condition_active: register_int_gauge_with_registry!(
                 "ika_mpc_stopped_contributing_condition_active",
                 "1 while this node judges its MPC subsystem to have stopped contributing; alert on this rather than on a threshold over ika_mpc_consensus_round_lag, which the bounded round channel holds within a channel's worth of the drain and so cannot show a mid-epoch restart's replay (that is ika_dwallet_mpc_catchup_gap_rounds)",
-                registry,
+                validator_registry,
             )
             .unwrap(),
             mpc_catch_up_stuck_condition_active: register_int_gauge_with_registry!(
                 "ika_mpc_catch_up_stuck_condition_active",
                 "1 while the MPC service reports a catch-up whose consensus-round gap has stopped closing (a drain that is still closing its gap is healthy and sets this to 0)",
-                registry,
+                validator_registry,
             )
             .unwrap(),
             consensus_last_committed_timestamp_seconds: register_int_gauge_with_registry!(
                 "ika_consensus_last_committed_timestamp_seconds",
                 "Consensus timestamp in unix seconds of the latest commit processed at the Ika commit boundary; 0 until this process handles its first commit",
-                registry
+                validator_registry
             )
             .unwrap(),
             dwallet_mpc_data_freeze_grace_rounds: register_int_gauge_with_registry!(
                 "ika_dwallet_mpc_data_freeze_grace_rounds",
                 "Configured mpc_data_freeze_grace_rounds for the current protocol version; \
                  -1 when the freeze feature is disabled or the value is undefined",
-                registry
+                validator_registry
             )
             .unwrap(),
             dwallet_mpc_data_freeze_round: register_int_gauge_with_registry!(
                 "ika_dwallet_mpc_data_freeze_round",
                 "Leader round where the mpc_data input set was frozen; -1 until the freeze",
-                registry
+                validator_registry
             )
             .unwrap(),
             dwallet_mpc_data_ready_signal_deadline_timestamp_seconds: register_int_gauge_with_registry!(
@@ -464,98 +490,98 @@ impl EpochMetrics {
                 "Ready-signal emit deadline on the epoch's consensus clock (leader-proposed \
                  commit timestamps, unix seconds scale, NOT local wall clock); -1 while not \
                  yet computable",
-                registry
+                validator_registry
             )
             .unwrap(),
             dwallet_mpc_data_ready_signals: register_int_gauge_with_registry!(
                 "ika_dwallet_mpc_data_ready_signals",
                 "Number of distinct EpochMpcDataReadySignal signers recorded this epoch",
-                registry
+                validator_registry
             )
             .unwrap(),
             dwallet_mpc_data_ready_signal_stake: register_int_gauge_with_registry!(
                 "ika_dwallet_mpc_data_ready_signal_stake",
                 "Stake attested by the recorded mpc_data ready signals this epoch",
-                registry
+                validator_registry
             )
             .unwrap(),
             dwallet_mpc_data_locally_validated_peers: register_int_gauge_with_registry!(
                 "ika_dwallet_mpc_data_locally_validated_peers",
                 "This validator's locally-validated mpc_data peer count",
-                registry
+                validator_registry
             )
             .unwrap(),
             dwallet_mpc_data_announcements_received: register_int_gauge_with_registry!(
                 "ika_dwallet_mpc_data_announcements_received",
                 "Number of validator mpc_data announcements recorded this epoch",
-                registry
+                validator_registry
             )
             .unwrap(),
             dwallet_handoff_cert_epoch: register_int_gauge_with_registry!(
                 "ika_dwallet_handoff_cert_epoch",
                 "Epoch of the most recent certified handoff attestation formed locally",
-                registry
+                validator_registry
             )
             .unwrap(),
             dwallet_handoff_signatures_collected: register_int_gauge_with_registry!(
                 "ika_dwallet_handoff_signatures_collected",
                 "Number of distinct verified handoff signatures aggregated this epoch",
-                registry
+                validator_registry
             )
             .unwrap(),
             dwallet_handoff_signatures_stake: register_int_gauge_with_registry!(
                 "ika_dwallet_handoff_signatures_stake",
                 "Stake accumulated by the verified handoff signatures this epoch",
-                registry
+                validator_registry
             )
             .unwrap(),
             dwallet_handoff_signatures_buffered: register_int_gauge_with_registry!(
                 "ika_dwallet_handoff_signatures_buffered",
                 "Depth of the pending handoff-signature buffer",
-                registry
+                validator_registry
             )
             .unwrap(),
             dwallet_handoff_signatures_rejected_total: register_int_counter_vec_with_registry!(
                 "ika_dwallet_handoff_signatures_rejected_total",
                 "Handoff signatures rejected by the verification path, by verdict",
                 &["verdict"],
-                registry
+                validator_registry
             )
             .unwrap(),
             own_mpc_data_blob_unhealthy: register_int_gauge_with_registry!(
                 "ika_own_mpc_data_blob_unhealthy",
                 "1 while this validator's own mpc_data blob is missing/invalid in perpetual storage",
-                registry
+                validator_registry
             )
             .unwrap(),
             processed_consensus_messages: register_int_gauge_with_registry!(
                 "ika_epoch_processed_consensus_messages",
                 "Consensus-transaction digests the epoch's fold holds for dedup",
-                registry
+                validator_registry
             )
             .unwrap(),
             pending_dwallet_checkpoint_signatures: register_int_gauge_with_registry!(
                 "ika_epoch_pending_dwallet_checkpoint_signatures",
                 "Peer dWallet checkpoint signatures held for aggregation",
-                registry
+                validator_registry
             )
             .unwrap(),
             pending_system_checkpoint_signatures: register_int_gauge_with_registry!(
                 "ika_epoch_pending_system_checkpoint_signatures",
                 "Peer system checkpoint signatures held for aggregation",
-                registry
+                validator_registry
             )
             .unwrap(),
             pending_dwallet_checkpoints: register_int_gauge_with_registry!(
                 "ika_epoch_pending_dwallet_checkpoints",
                 "Entries in the dWallet checkpoint builder's input queue, sampled on mutation",
-                registry
+                validator_registry
             )
             .unwrap(),
             pending_system_checkpoints: register_int_gauge_with_registry!(
                 "ika_epoch_pending_system_checkpoints",
                 "Entries in the system checkpoint builder's input queue, sampled on mutation",
-                registry
+                validator_registry
             )
             .unwrap(),
         };

--- a/crates/ika-core/src/sui_connector/metrics.rs
+++ b/crates/ika-core/src/sui_connector/metrics.rs
@@ -1,6 +1,7 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
+use ika_config::node::NodeMode;
 use prometheus::{
     IntCounter, IntGauge, IntGaugeVec, Registry, register_int_counter_with_registry,
     register_int_gauge_vec_with_registry, register_int_gauge_with_registry,
@@ -145,7 +146,38 @@ pub struct SuiConnectorMetrics {
 }
 
 impl SuiConnectorMetrics {
+    /// Registers the whole set — the composition a validator process gets.
     pub fn new(registry: &Registry) -> Arc<Self> {
+        Self::new_for_mode(NodeMode::Validator, registry)
+    }
+
+    /// Registers into `registry` only the families whose writers run in
+    /// `mode`.
+    ///
+    /// `SuiConnectorService` starts a different set of tasks per mode, and
+    /// each family here belongs to exactly one of them: the chain-observation
+    /// and off-chain-assembly gauges come from syncer loops that only a
+    /// validator starts, and the checkpoint-writer/gas gauges come from the
+    /// submission path that only a notifier runs. What a mode does not drive
+    /// is registered into a role-local registry that no endpoint gathers, so
+    /// it is absent from that process's `/metrics` instead of exported as a
+    /// constant zero (ika #2051).
+    ///
+    /// A validator keeps the notifier's families: this change only removes
+    /// families from processes that never drove them, leaving the validator
+    /// export set untouched.
+    pub fn new_for_mode(mode: NodeMode, registry: &Registry) -> Arc<Self> {
+        let unexported = Registry::new();
+        let validator_registry = if mode.is_validator() {
+            registry
+        } else {
+            &unexported
+        };
+        let checkpoint_writer_registry = if mode.is_fullnode() {
+            &unexported
+        } else {
+            registry
+        };
         let this = Self {
             last_synced_sui_checkpoints: register_int_gauge_vec_with_registry!(
                 "ika_sui_connector_last_synced_sui_checkpoints",
@@ -158,72 +190,72 @@ impl SuiConnectorMetrics {
             gas_coin_balance: register_int_gauge_with_registry!(
                 "ika_sui_connector_gas_coin_balance",
                 "Current balance of gas coin, in mist",
-                registry,
+                checkpoint_writer_registry,
             )
             .unwrap(),
 
             dwallet_checkpoint_sequence: register_int_gauge_with_registry!(
                 "ika_sui_connector_dwallet_checkpoint_sequence",
                 "Sequence number of the next dwallet checkpoint to write to Sui",
-                registry,
+                checkpoint_writer_registry,
             )
             .unwrap(),
 
             last_written_dwallet_checkpoint_sequence: register_int_gauge_with_registry!(
                 "ika_sui_connector_last_written_dwallet_checkpoint_sequence",
                 "Sequence number of the last dwallet checkpoint successfully written to Sui",
-                registry,
+                checkpoint_writer_registry,
             )
             .unwrap(),
 
             dwallet_checkpoint_write_requests_total: register_int_gauge_with_registry!(
                 "ika_sui_connector_dwallet_checkpoint_write_requests_total",
                 "Total number of dwallet checkpoint write requests sent to Sui",
-                registry,
+                checkpoint_writer_registry,
             )
             .unwrap(),
 
             dwallet_checkpoint_writes_success_total: register_int_gauge_with_registry!(
                 "ika_sui_connector_dwallet_checkpoint_writes_success_total",
                 "Total number of successful dwallet checkpoint writes to Sui",
-                registry,
+                checkpoint_writer_registry,
             )
             .unwrap(),
 
             dwallet_checkpoint_writes_failure_total: register_int_gauge_with_registry!(
                 "ika_sui_connector_dwallet_checkpoint_writes_failure_total",
                 "Total number of failed dwallet checkpoint writes to Sui",
-                registry,
+                checkpoint_writer_registry,
             )
             .unwrap(),
             system_checkpoint_writes_failure_total: register_int_gauge_with_registry!(
                 "ika_sui_connector_system_checkpoint_writes_failure_total",
                 "Total number of failed system checkpoint writes to Sui",
-                registry,
+                checkpoint_writer_registry,
             )
             .unwrap(),
             system_checkpoint_writes_success_total: register_int_gauge_with_registry!(
                 "ika_sui_connector_system_checkpoint_writes_success_total",
                 "Total number of successful system checkpoint writes to Sui",
-                registry,
+                checkpoint_writer_registry,
             )
             .unwrap(),
             system_checkpoint_write_requests_total: register_int_gauge_with_registry!(
                 "ika_sui_connector_system_checkpoint_write_requests_total",
                 "Total number of system checkpoint write requests sent to Sui",
-                registry,
+                checkpoint_writer_registry,
             )
             .unwrap(),
             system_checkpoint_sequence: register_int_gauge_with_registry!(
                 "ika_sui_connector_system_checkpoint_sequence",
                 "Sequence number of the next system checkpoint to write to Sui",
-                registry,
+                checkpoint_writer_registry,
             )
             .unwrap(),
             last_written_system_checkpoint_sequence: register_int_gauge_with_registry!(
                 "ika_sui_connector_last_written_system_checkpoint_sequence",
                 "Sequence number of the last system checkpoint successfully written to Sui",
-                registry,
+                checkpoint_writer_registry,
             )
             .unwrap(),
             network_key_overlay_incomplete: register_int_gauge_with_registry!(
@@ -249,98 +281,98 @@ impl SuiConnectorMetrics {
             off_chain_assembly_incomplete_ticks_total: register_int_counter_with_registry!(
                 "ika_off_chain_assembly_incomplete_ticks_total",
                 "Total sync ticks on which the off-chain validator-mpc_data assembly was incomplete",
-                registry,
+                validator_registry,
             )
             .unwrap(),
             off_chain_assembly_incomplete: register_int_gauge_with_registry!(
                 "ika_off_chain_assembly_incomplete",
                 "1 while the latest off-chain validator-mpc_data assembly attempt is incomplete; 0 after success",
-                registry,
+                validator_registry,
             )
             .unwrap(),
             off_chain_assembly_consecutive_incomplete_ticks:
                 register_int_gauge_with_registry!(
                     "ika_off_chain_assembly_consecutive_incomplete_ticks",
                     "Consecutive incomplete off-chain validator-mpc_data assembly ticks; reset to 0 on success",
-                    registry,
+                    validator_registry,
                 )
                 .unwrap(),
             off_chain_assembly_incomplete_duration_seconds:
                 register_int_gauge_with_registry!(
                     "ika_off_chain_assembly_incomplete_duration_seconds",
                     "Seconds since the current off-chain validator-mpc_data assembly incomplete period began; reset to 0 on success",
-                    registry,
+                    validator_registry,
                 )
                 .unwrap(),
             off_chain_assembly_missing: register_int_gauge_vec_with_registry!(
                 "ika_off_chain_assembly_missing",
                 "Members missing from the latest incomplete off-chain validator-mpc_data assembly attempt by bounded reason",
                 &["reason"],
-                registry,
+                validator_registry,
             )
             .unwrap(),
             off_chain_assembly_last_success_timestamp_seconds:
                 register_int_gauge_with_registry!(
                     "ika_off_chain_assembly_last_success_timestamp_seconds",
                     "Unix timestamp of the latest successful off-chain validator-mpc_data assembly in this process; 0 until the first success",
-                    registry,
+                    validator_registry,
                 )
                 .unwrap(),
             off_chain_assembly_wedged: register_int_gauge_with_registry!(
                 "ika_off_chain_assembly_wedged",
                 "1 while the off-chain validator-mpc_data assembly is permanently incomplete",
-                registry,
+                validator_registry,
             )
             .unwrap(),
             epoch_switch_step_done: register_int_gauge_vec_with_registry!(
                 "ika_sui_connector_epoch_switch_step_done",
                 "Per-step gauge (0/1) for epoch-switch progress within the current epoch, re-derived from chain state each tick (restart-proof for all steps except request_advance_epoch)",
                 &["step"],
-                registry,
+                checkpoint_writer_registry,
             )
             .unwrap(),
             chain_received_end_of_publish: register_int_gauge_vec_with_registry!(
                 "ika_sui_connector_chain_received_end_of_publish",
                 "Mirror of received_end_of_publish on chain, one gauge per object",
                 &["object"],
-                registry,
+                validator_registry,
             )
             .unwrap(),
             chain_user_sessions_lag: register_int_gauge_with_registry!(
                 "ika_sui_connector_chain_user_sessions_lag",
                 "last_user_initiated_session_to_complete_in_current_epoch minus completed user sessions count",
-                registry,
+                validator_registry,
             )
             .unwrap(),
             chain_active_user_sessions_count: register_int_gauge_with_registry!(
                 "ika_sui_connector_chain_active_user_sessions_count",
                 "Number of user sessions currently started but not yet completed on chain",
-                registry,
+                validator_registry,
             )
             .unwrap(),
             chain_active_system_sessions_count: register_int_gauge_with_registry!(
                 "ika_sui_connector_chain_active_system_sessions_count",
                 "Number of system sessions currently started but not yet completed on chain",
-                registry,
+                validator_registry,
             )
             .unwrap(),
             chain_epoch_overdue_seconds: register_int_gauge_with_registry!(
                 "ika_sui_connector_chain_epoch_overdue_seconds",
                 "Seconds elapsed past the planned end of the current epoch (clamped to >=0)",
-                registry,
+                validator_registry,
             )
             .unwrap(),
             end_of_publish_blocked_reason: register_int_gauge_vec_with_registry!(
                 "ika_sui_connector_end_of_publish_blocked_reason",
                 "Per-condition gauge (0/1) indicating which gating condition in sync_dwallet_end_of_publish is currently blocking end-of-publish",
                 &["reason"],
-                registry,
+                validator_registry,
             )
             .unwrap(),
             uncompleted_events_backlog: register_int_gauge_with_registry!(
                 "ika_sui_connector_uncompleted_events_backlog",
                 "Uncompleted session events observed on chain on the most recent pull",
-                registry,
+                validator_registry,
             )
             .unwrap(),
             chain_dwallet_checkpoint_writer_lag: register_int_gauge_with_registry!(
@@ -349,7 +381,7 @@ impl SuiConnectorMetrics {
                  last processed checkpoint sequence number; sustained positive values \
                  mean certified checkpoints are not landing on Sui (checkpoint writer \
                  stalled)",
-                registry,
+                validator_registry,
             )
             .unwrap(),
         };

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -87,7 +87,7 @@ use ika_types::supported_protocol_versions::SupportedProtocolVersions;
 use typed_store::DBMetrics;
 use typed_store::rocks::default_db_options;
 
-use crate::metrics::IkaNodeMetrics;
+use crate::metrics::{IkaNodeMetrics, ValidatorTelemetryMetrics};
 
 pub mod admin;
 mod bind_retry;
@@ -140,6 +140,46 @@ impl ValidatorComponentMetrics {
             system_checkpoint: SystemCheckpointMetrics::new(registry),
             ika_tx_validator: IkaTxValidatorMetrics::new(registry),
         }
+    }
+}
+
+/// The metric families driven exclusively by validator-mode subsystems: the
+/// MPC service, the checkpoint builders and consensus tx validation, and the
+/// handoff-barrier / commit-liveness telemetry.
+///
+/// Built — and therefore REGISTERED — only in validator mode, so a fullnode
+/// or notifier does not export them at all. That is the point: a family
+/// exported at its default value is indistinguishable from a real reading
+/// (`ika_dwallet_mpc_*` at zero reads as an idle validator, not as a process
+/// with no MPC service), so absence is the honest signal for a subsystem this
+/// process does not run. See ika #2051 and
+/// `dev-docs/conventions/metrics.md`.
+///
+/// Registration is per PROCESS, not per epoch: the handles are built once at
+/// startup and cloned into each (re-)construction of the validator
+/// components, for the reason spelled out on `ValidatorComponentMetrics`.
+#[derive(Clone)]
+pub struct ValidatorModeMetrics {
+    dwallet_mpc: Arc<DWalletMPCMetrics>,
+    components: ValidatorComponentMetrics,
+    telemetry: Arc<ValidatorTelemetryMetrics>,
+}
+
+impl ValidatorModeMetrics {
+    /// `Some` in validator mode, `None` in every other mode — a node that
+    /// never starts these subsystems never registers their families.
+    ///
+    /// This keys off the process's `NodeMode` rather than current committee
+    /// membership on purpose: a validator-mode process that is not (yet) in
+    /// the committee still registers them, because it starts those
+    /// subsystems the moment it joins, and re-registering into the
+    /// process-wide registry then would panic.
+    pub fn for_mode(mode: NodeMode, registry: &Registry) -> Option<Self> {
+        mode.is_validator().then(|| Self {
+            dwallet_mpc: DWalletMPCMetrics::new(registry),
+            components: ValidatorComponentMetrics::new(registry),
+            telemetry: Arc::new(ValidatorTelemetryMetrics::new(registry)),
+        })
     }
 }
 
@@ -225,6 +265,11 @@ pub struct IkaNode {
     state: Arc<AuthorityState>,
     registry_service: RegistryService,
     metrics: Arc<IkaNodeMetrics>,
+
+    /// Handoff-barrier and commit-liveness telemetry. `None` outside
+    /// validator mode, where neither subsystem runs and the families are
+    /// deliberately not registered — see `ValidatorModeMetrics`.
+    validator_telemetry: Option<Arc<ValidatorTelemetryMetrics>>,
 
     _discovery: discovery::Handle,
     _connection_monitor_handle: mysten_network::anemo_connection_monitor::ConnectionMonitorHandle,
@@ -756,18 +801,18 @@ impl IkaNode {
                 .ika_dwallet_coordinator_object_id,
         );
 
-        let dwallet_mpc_metrics = DWalletMPCMetrics::new(&registry_service.default_registry());
-        // Registered once for the process; see `ValidatorComponentMetrics`.
-        let validator_component_metrics =
-            ValidatorComponentMetrics::new(&registry_service.default_registry());
-        let validator_component_metrics_for_reconfig = validator_component_metrics.clone();
+        // Registered once for the process, and only in the mode that runs the
+        // subsystems behind them; see `ValidatorModeMetrics`.
+        let validator_metrics =
+            ValidatorModeMetrics::for_mode(mode, &registry_service.default_registry());
+        let validator_metrics_for_reconfig = validator_metrics.clone();
 
         let epoch_store = AuthorityPerEpochStore::new(EpochStoreParams {
             name: config.authority_name(),
             committee: committee_arc.clone(),
             parent_path: config.db_path().join("store"),
             db_options: Some(epoch_options.options),
-            metrics: EpochMetrics::new(&registry_service.default_registry()),
+            metrics: EpochMetrics::new_for_mode(mode, &registry_service.default_registry()),
             epoch_start_configuration,
             chain_identifier,
             packages_config,
@@ -1177,12 +1222,14 @@ impl IkaNode {
             committee_store.clone(),
             dwallet_checkpoint_store.clone(),
             &prometheus_registry,
+            mode,
             config.clone(),
         )
         .await;
         info!("created authority state");
 
-        let sui_connector_metrics = SuiConnectorMetrics::new(&registry_service.default_registry());
+        let sui_connector_metrics =
+            SuiConnectorMetrics::new_for_mode(mode, &registry_service.default_registry());
         let (next_epoch_committee_sender, next_epoch_committee_receiver) =
             watch::channel::<Committee>(committee.clone());
         let (chain_next_committee_sender, chain_next_epoch_committee_receiver) =
@@ -1298,9 +1345,12 @@ impl IkaNode {
         // a reconfiguration. Validator mode only: a fullnode or notifier has
         // no consensus subscriptions to lose. See `commit_liveness_watchdog`
         // for why the #2016 reconfiguration watchdog cannot cover this.
-        let commit_liveness = if mode.is_validator() {
+        let commit_liveness = if let Some(validator_metrics) = &validator_metrics {
             commit_liveness_watchdog::CommitLivenessWatchdog::spawn(
-                ika_node_metrics.consensus_commit_silence_seconds.clone(),
+                validator_metrics
+                    .telemetry
+                    .consensus_commit_silence_seconds
+                    .clone(),
                 ika_node_metrics.reconfig_phase.clone(),
             )
         } else {
@@ -1330,8 +1380,9 @@ impl IkaNode {
                 ika_node_metrics.clone(),
                 previous_epoch_last_dwallet_checkpoint_sequence_number,
                 previous_epoch_last_system_checkpoint_sequence_number,
-                dwallet_mpc_metrics.clone(),
-                validator_component_metrics.clone(),
+                validator_metrics
+                    .clone()
+                    .expect("validator mode registers the validator metric families"),
                 sui_data_receivers.clone(),
                 noa_dwallet_finalized.clone(),
                 noa_system_finalized.clone(),
@@ -1371,6 +1422,7 @@ impl IkaNode {
             state,
             registry_service,
             metrics: ika_node_metrics,
+            validator_telemetry: validator_metrics.map(|metrics| metrics.telemetry),
 
             _discovery: discovery_handle,
             _connection_monitor_handle: connection_monitor_handle,
@@ -1431,8 +1483,7 @@ impl IkaNode {
             let result = Self::monitor_reconfiguration(
                 node_copy,
                 sui_client_clone,
-                dwallet_mpc_metrics,
-                validator_component_metrics_for_reconfig,
+                validator_metrics_for_reconfig,
                 sui_data_receivers.clone(),
             )
             .await;
@@ -1981,8 +2032,7 @@ impl IkaNode {
         ika_node_metrics: Arc<IkaNodeMetrics>,
         previous_epoch_last_dwallet_checkpoint_sequence_number: u64,
         previous_epoch_last_system_checkpoint_sequence_number: u64,
-        dwallet_mpc_metrics: Arc<DWalletMPCMetrics>,
-        validator_component_metrics: ValidatorComponentMetrics,
+        validator_metrics: ValidatorModeMetrics,
         sui_data_receivers: SuiDataReceivers,
         noa_dwallet_finalized: Arc<std::sync::atomic::AtomicBool>,
         noa_system_finalized: Arc<std::sync::atomic::AtomicBool>,
@@ -2025,11 +2075,16 @@ impl IkaNode {
             &registry_service.default_registry(),
         );
 
-        let ValidatorComponentMetrics {
-            dwallet_checkpoint: dwallet_checkpoint_metrics,
-            system_checkpoint: system_checkpoint_metrics,
-            ika_tx_validator: ika_tx_validator_metrics,
-        } = validator_component_metrics;
+        let ValidatorModeMetrics {
+            dwallet_mpc: dwallet_mpc_metrics,
+            components:
+                ValidatorComponentMetrics {
+                    dwallet_checkpoint: dwallet_checkpoint_metrics,
+                    system_checkpoint: system_checkpoint_metrics,
+                    ika_tx_validator: ika_tx_validator_metrics,
+                },
+            telemetry: _,
+        } = validator_metrics;
         Self::start_epoch_specific_validator_components(
             &config,
             state.clone(),
@@ -2522,8 +2577,9 @@ impl IkaNode {
     pub async fn monitor_reconfiguration(
         self: Arc<Self>,
         sui_client: Arc<SuiConnectorClient>,
-        dwallet_mpc_metrics: Arc<DWalletMPCMetrics>,
-        validator_component_metrics: ValidatorComponentMetrics,
+        // `None` outside validator mode; the branch that consumes it runs
+        // only when this process may take up validator duties.
+        validator_metrics: Option<ValidatorModeMetrics>,
         sui_data_receivers: SuiDataReceivers,
     ) -> Result<()> {
         loop {
@@ -3286,8 +3342,9 @@ impl IkaNode {
                             self.metrics.clone(),
                             previous_epoch_last_checkpoint_sequence_number,
                             previous_epoch_last_system_checkpoint_sequence_number,
-                            dwallet_mpc_metrics.clone(),
-                            validator_component_metrics.clone(),
+                            validator_metrics
+                                .clone()
+                                .expect("validator mode registers the validator metric families"),
                             sui_data_receivers.clone(),
                             self.noa_dwallet_finalized.clone(),
                             self.noa_system_finalized.clone(),
@@ -3628,7 +3685,12 @@ impl IkaNode {
             "prepare-then-start: awaiting full verified handoff data for epoch {next_epoch} \
              before starting MPC"
         );
-        self.metrics.handoff_prepare_waiting.set(1);
+        // Present in validator mode, which is the only mode that reaches this
+        // barrier; the families are not registered anywhere else.
+        let telemetry = self.validator_telemetry.clone();
+        if let Some(telemetry) = &telemetry {
+            telemetry.handoff_prepare_waiting.set(1);
+        }
         let started_at = std::time::Instant::now();
         let mut retries: u64 = 0;
 
@@ -3687,10 +3749,12 @@ impl IkaNode {
 
             if ready {
                 let elapsed = started_at.elapsed();
-                self.metrics.handoff_prepare_waiting.set(0);
-                self.metrics
-                    .handoff_prepare_duration_seconds
-                    .observe(elapsed.as_secs_f64());
+                if let Some(telemetry) = &telemetry {
+                    telemetry.handoff_prepare_waiting.set(0);
+                    telemetry
+                        .handoff_prepare_duration_seconds
+                        .observe(elapsed.as_secs_f64());
+                }
                 info!(
                     next_epoch,
                     "prepare-then-start: epoch {next_epoch} handoff data ready+verified after \
@@ -3701,7 +3765,9 @@ impl IkaNode {
             }
 
             retries += 1;
-            self.metrics.handoff_prepare_retries_total.inc();
+            if let Some(telemetry) = &telemetry {
+                telemetry.handoff_prepare_retries_total.inc();
+            }
 
             // Anchor held but some certified output still missing locally:
             // retry fetching JUST the missing ones (the local-presence

--- a/crates/ika-node/src/metrics.rs
+++ b/crates/ika-node/src/metrics.rs
@@ -87,20 +87,6 @@ pub struct IkaNodeMetrics {
     pub binary_max_protocol_version: IntGauge,
     pub configured_max_protocol_version: IntGauge,
 
-    /// 1 while the prepare-then-start barrier is blocking the new epoch's
-    /// MPC components on full verified handoff data; 0 otherwise. A value
-    /// stuck at 1 is the dashboard signal that a validator is wedged
-    /// waiting for handoff data and is not signing.
-    pub handoff_prepare_waiting: IntGauge,
-    /// Number of prepare-then-start barrier poll iterations spent waiting
-    /// for handoff data.
-    pub handoff_prepare_retries_total: IntCounter,
-    /// Wall-clock seconds spent inside the prepare-then-start barrier.
-    /// Observed only on successful barrier exit, so this trends the
-    /// distribution of completed (possibly slow) waits — stuck-barrier
-    /// alerting is `handoff_prepare_waiting` + `handoff_prepare_retries_total`.
-    pub handoff_prepare_duration_seconds: Histogram,
-
     /// Joiner/anchor bootstrap cert-fetch outcomes, by outcome
     /// (`verified` / `rejected` / `unavailable`). `rejected` fail-closes
     /// the node, so its durable value is the `verified` epoch-cadence
@@ -118,8 +104,36 @@ pub struct IkaNodeMetrics {
     /// reconfig watchdog is armed (see `reconfig_watchdog::phase`); 0
     /// outside it. Any nonzero value that persists is a node parked in the
     /// teardown-to-restart window (#1864), and the value names the hanging
-    /// await.
+    /// await. Every mode arms that watchdog — a fullnode or notifier crosses
+    /// the same unbounded awaits in `reconfigure_state` — so this is not
+    /// validator-only telemetry.
     pub reconfig_phase: IntGauge,
+}
+
+/// Telemetry for subsystems only a validator-mode process runs: the
+/// prepare-then-start handoff barrier and the commit-liveness watchdog.
+///
+/// Registered only in validator mode, so a fullnode or notifier does not
+/// export these families at all. Each of them reads as a healthy validator
+/// when it sits at its default — a `handoff_prepare_waiting` of 0 says "not
+/// wedged at the barrier" and a `consensus_commit_silence_seconds` of 0 says
+/// "a commit landed this second" — which is precisely why absence, not a
+/// zero, is the correct signal on a process with no such subsystem
+/// (ika #2051).
+pub struct ValidatorTelemetryMetrics {
+    /// 1 while the prepare-then-start barrier is blocking the new epoch's
+    /// MPC components on full verified handoff data; 0 otherwise. A value
+    /// stuck at 1 is the dashboard signal that a validator is wedged
+    /// waiting for handoff data and is not signing.
+    pub handoff_prepare_waiting: IntGauge,
+    /// Number of prepare-then-start barrier poll iterations spent waiting
+    /// for handoff data.
+    pub handoff_prepare_retries_total: IntCounter,
+    /// Wall-clock seconds spent inside the prepare-then-start barrier.
+    /// Observed only on successful barrier exit, so this trends the
+    /// distribution of completed (possibly slow) waits — stuck-barrier
+    /// alerting is `handoff_prepare_waiting` + `handoff_prepare_retries_total`.
+    pub handoff_prepare_duration_seconds: Histogram,
 
     /// Seconds since this process last finished processing a consensus
     /// commit, while the commit-liveness watchdog is armed and running;
@@ -157,6 +171,34 @@ impl IkaNodeMetrics {
                 registry,
             )
             .unwrap(),
+            joiner_bootstrap_outcomes_total: register_int_counter_vec_with_registry!(
+                "ika_joiner_bootstrap_outcomes_total",
+                "Joiner/anchor bootstrap cert-fetch outcomes",
+                &["outcome"],
+                registry,
+            )
+            .unwrap(),
+            mpc_data_blob_fetch_total: register_int_counter_vec_with_registry!(
+                "ika_dwallet_mpc_data_blob_fetch_total",
+                "P2P mpc_data blob fetch outcomes",
+                &["result"],
+                registry,
+            )
+            .unwrap(),
+            reconfig_phase: register_int_gauge_with_registry!(
+                "ika_reconfig_phase",
+                "Sub-phase of the epoch-reconfiguration critical section while the reconfig \
+                 watchdog is armed; 0 outside it",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
+impl ValidatorTelemetryMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
             handoff_prepare_waiting: register_int_gauge_with_registry!(
                 "ika_handoff_prepare_waiting",
                 "1 while the prepare-then-start barrier is blocking the new epoch's MPC \
@@ -181,27 +223,6 @@ impl IkaNodeMetrics {
                 vec![
                     1.0, 5.0, 15.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1200.0, 1800.0
                 ],
-                registry,
-            )
-            .unwrap(),
-            joiner_bootstrap_outcomes_total: register_int_counter_vec_with_registry!(
-                "ika_joiner_bootstrap_outcomes_total",
-                "Joiner/anchor bootstrap cert-fetch outcomes",
-                &["outcome"],
-                registry,
-            )
-            .unwrap(),
-            mpc_data_blob_fetch_total: register_int_counter_vec_with_registry!(
-                "ika_dwallet_mpc_data_blob_fetch_total",
-                "P2P mpc_data blob fetch outcomes",
-                &["result"],
-                registry,
-            )
-            .unwrap(),
-            reconfig_phase: register_int_gauge_with_registry!(
-                "ika_reconfig_phase",
-                "Sub-phase of the epoch-reconfiguration critical section while the reconfig \
-                 watchdog is armed; 0 outside it",
                 registry,
             )
             .unwrap(),
@@ -382,5 +403,376 @@ ika_counter_2 1"
                 .any(|family| family.name() == "ika_counter"),
             "the registry service must keep collecting even with no server bound"
         );
+    }
+}
+
+/// What each `NodeMode` registers, pinned.
+///
+/// The node used to register every metric family in the shared part of its
+/// start sequence, so a notifier exported `ika_dwallet_mpc_*`, the consensus
+/// handler counters, the handoff-barrier gauges and the chain-observation
+/// gauges it never drives — at values indistinguishable from a healthy
+/// validator's (ika #2051). Registration now follows the subsystems each mode
+/// actually runs, and these lists are what pins it.
+#[cfg(test)]
+mod per_mode_registration {
+    use super::IkaNodeMetrics;
+    use crate::ValidatorModeMetrics;
+    use ika_config::NodeMode;
+    use prometheus::Registry;
+
+    /// The ika-side metric structs the start sequence registers in `mode`,
+    /// composed into one registry, returning the family names the endpoint
+    /// would serve.
+    ///
+    /// `gather()` — what `/metrics` actually serves — is the right domain
+    /// here, and it omits a `*_vec` family with no label children: a family
+    /// nothing has observed never reaches the endpoint. Every registered
+    /// literal, vec or not, is covered instead by
+    /// `scripts/check-metric-names.sh`.
+    ///
+    /// The families left out of this composition are mode-independent (the
+    /// anemo/quinn network, rocksdb, archive and pruner families) or already
+    /// mode-gated elsewhere (the host telemetry in `node_runner`), so none of
+    /// them can move a per-mode difference.
+    fn exported_families(mode: NodeMode) -> Vec<String> {
+        let registry = Registry::new();
+
+        // Registered by every mode, each internally registering only the
+        // families that mode's own subsystems write.
+        let _epoch = ika_core::epoch::epoch_metrics::EpochMetrics::new_for_mode(mode, &registry);
+        let _authority = ika_core::authority::AuthorityMetrics::new_for_mode(mode, &registry);
+        let _sui_connector =
+            ika_core::sui_connector::metrics::SuiConnectorMetrics::new_for_mode(mode, &registry);
+        let _ocs = ika_core::sui_connector::ocs_metrics::OcsMetrics::new(&registry);
+        let _proof_provider = ika_network::proof_provider::ProofProviderMetrics::new(&registry);
+        let _node = IkaNodeMetrics::new(&registry);
+
+        // Registered only where the subsystems behind them run: the MPC
+        // service, the checkpoint builders and the validator telemetry, plus
+        // the consensus handles built inside `construct_validator_components`.
+        let _validator = ValidatorModeMetrics::for_mode(mode, &registry);
+        let _consensus = mode.is_validator().then(|| {
+            (
+                ika_core::consensus_manager::ConsensusManagerMetrics::new(&registry),
+                ika_core::consensus_adapter::ConsensusAdapterMetrics::new(&registry),
+            )
+        });
+
+        let mut names: Vec<String> = registry
+            .gather()
+            .into_iter()
+            .map(|family| family.name().to_string())
+            .collect();
+        names.sort();
+        names.dedup();
+        names
+    }
+
+    fn assert_families(mode: NodeMode, expected: &[&str]) {
+        let actual = exported_families(mode);
+        let expected: Vec<String> = expected.iter().map(|name| name.to_string()).collect();
+        let missing: Vec<&String> = expected.iter().filter(|n| !actual.contains(n)).collect();
+        let unexpected: Vec<&String> = actual.iter().filter(|n| !expected.contains(n)).collect();
+        assert!(
+            missing.is_empty() && unexpected.is_empty(),
+            "{mode} export set changed.\n  no longer exported: {missing:?}\n  newly exported: \
+             {unexpected:?}"
+        );
+    }
+
+    /// The set a validator exports. This change must leave it untouched: it
+    /// is the set EVERY mode registered before registration was gated.
+    const VALIDATOR_FAMILIES: &[&str] = &[
+        "ika_binary_max_protocol_version",
+        "ika_committee_quorum_threshold",
+        "ika_committee_total_stake",
+        "ika_committee_validity_threshold",
+        "ika_configured_max_protocol_version",
+        "ika_consensus_boot_replay_folded_commit_index",
+        "ika_consensus_boot_replay_latency_seconds",
+        "ika_consensus_boot_replay_target_commit_index",
+        "ika_consensus_calculated_throughput",
+        "ika_consensus_calculated_throughput_profile",
+        "ika_consensus_commit_silence_seconds",
+        "ika_consensus_fold_blocked_seconds_total",
+        "ika_consensus_fold_blocked_sends_total",
+        "ika_consensus_handler_cancelled_transactions",
+        "ika_consensus_handler_num_low_scoring_authorities",
+        "ika_consensus_last_committed_timestamp_seconds",
+        "ika_consensus_manager_shutdown_latency",
+        "ika_consensus_manager_start_latency",
+        "ika_consensus_round_channel_depth",
+        "ika_current_epoch",
+        "ika_current_protocol_version",
+        "ika_current_voting_right",
+        "ika_dwallet_checkpoint_aggregator_committed_stake",
+        "ika_dwallet_checkpoint_aggregator_current_seq",
+        "ika_dwallet_checkpoint_aggregator_distinct_digests",
+        "ika_dwallet_checkpoint_aggregator_plurality_stake",
+        "ika_dwallet_checkpoint_aggregator_uncommitted_stake",
+        "ika_dwallet_checkpoint_creation_latency",
+        "ika_dwallet_checkpoint_errors",
+        "ika_dwallet_checkpoint_pending_queue_depth",
+        "ika_dwallet_checkpoint_roots_count",
+        "ika_dwallet_checkpoint_signatures_verified",
+        "ika_dwallet_handoff_cert_epoch",
+        "ika_dwallet_handoff_signatures_buffered",
+        "ika_dwallet_handoff_signatures_collected",
+        "ika_dwallet_handoff_signatures_stake",
+        "ika_dwallet_mpc_catchup_gap_rounds",
+        "ika_dwallet_mpc_catchup_mode",
+        "ika_dwallet_mpc_cryptographic_computation_core_budget",
+        "ika_dwallet_mpc_cryptographic_computations_running",
+        "ika_dwallet_mpc_data_announcements_received",
+        "ika_dwallet_mpc_data_excluded_validators",
+        "ika_dwallet_mpc_data_freeze_epoch",
+        "ika_dwallet_mpc_data_freeze_grace_rounds",
+        "ika_dwallet_mpc_data_freeze_round",
+        "ika_dwallet_mpc_data_locally_validated_peers",
+        "ika_dwallet_mpc_data_ready_quorum_round",
+        "ika_dwallet_mpc_data_ready_signal_deadline_timestamp_seconds",
+        "ika_dwallet_mpc_data_ready_signal_stake",
+        "ika_dwallet_mpc_data_ready_signals",
+        "ika_dwallet_mpc_global_presign_requests_waiting",
+        "ika_dwallet_mpc_internal_presign_requests_pending_for_network_key_data",
+        "ika_dwallet_mpc_malicious_actors_count",
+        "ika_dwallet_mpc_messages_after_terminal_session_total",
+        "ika_dwallet_mpc_network_encryption_key_canonical_dkg_output_version",
+        "ika_dwallet_mpc_network_encryption_key_latest_reconfiguration_output_version",
+        "ika_dwallet_mpc_network_key_instantiations_in_flight",
+        "ika_dwallet_mpc_number_of_expected_sign_sessions",
+        "ika_dwallet_mpc_number_of_unexpected_sign_sessions",
+        "ika_dwallet_mpc_prior_cert_blobs_missing",
+        "ika_dwallet_mpc_requests_pending_for_frozen_mpc_data",
+        "ika_dwallet_mpc_requests_pending_for_next_active_committee",
+        "ika_dwallet_mpc_self_output_to_quorum_consensus_rounds",
+        "ika_dwallet_mpc_service_end_of_publish_local",
+        "ika_dwallet_mpc_sessions_with_self_output_no_quorum",
+        "ika_dwallet_mpc_user_sessions_active_without_local_output",
+        "ika_effective_buffer_stake",
+        "ika_epoch_first_checkpoint_created_time_since_epoch_begin_ms",
+        "ika_epoch_first_system_checkpoint_created_time_since_epoch_begin_ms",
+        "ika_epoch_pending_dwallet_checkpoint_signatures",
+        "ika_epoch_pending_dwallet_checkpoints",
+        "ika_epoch_pending_system_checkpoint_signatures",
+        "ika_epoch_pending_system_checkpoints",
+        "ika_epoch_processed_consensus_messages",
+        "ika_epoch_reconfig_start_time_since_epoch_close_ms",
+        "ika_epoch_total_computation_reward",
+        "ika_epoch_total_duration",
+        "ika_epoch_validator_halt_duration_ms",
+        "ika_handoff_prepare_duration_seconds",
+        "ika_handoff_prepare_retries_total",
+        "ika_handoff_prepare_waiting",
+        "ika_highest_accumulated_system_checkpoint_epoch",
+        "ika_last_certified_dwallet_checkpoint",
+        "ika_last_certified_dwallet_checkpoint_age",
+        "ika_last_certified_system_checkpoint",
+        "ika_last_certified_system_checkpoint_age",
+        "ika_last_committed_leader_consensus_round",
+        "ika_last_constructed_dwallet_checkpoint",
+        "ika_last_constructed_system_checkpoint",
+        "ika_last_created_dwallet_checkpoint_age",
+        "ika_last_created_system_checkpoint_age",
+        "ika_last_dwallet_checkpoint_pending_height",
+        "ika_last_ignored_dwallet_checkpoint_signature_received",
+        "ika_last_ignored_system_checkpoint_signature_received",
+        "ika_last_process_mpc_consensus_round",
+        "ika_last_sent_dwallet_checkpoint_signature",
+        "ika_last_sent_system_checkpoint_signature",
+        "ika_last_skipped_dwallet_checkpoint_signature_submission",
+        "ika_last_skipped_system_checkpoint_signature_submission",
+        "ika_last_system_checkpoint_pending_height",
+        "ika_messages_included_in_dwallet_checkpoint",
+        "ika_messages_included_in_system_checkpoint",
+        "ika_mpc_catch_up_stuck_condition_active",
+        "ika_mpc_consensus_round_lag",
+        "ika_mpc_data_announcement_blob_bytes",
+        "ika_mpc_stopped_contributing_condition_active",
+        "ika_network_key_overlay_incomplete",
+        "ika_network_key_registry_read_empty_condition_active",
+        "ika_ocs_cache_first_stale_total",
+        "ika_ocs_chain_latest_epoch",
+        "ika_ocs_committee_head_epoch",
+        "ika_ocs_dynamic_fields_walk_entries_returned_total",
+        "ika_ocs_dynamic_fields_walk_entries_seen_total",
+        "ika_ocs_dynamic_fields_walk_entries_skipped_transient_total",
+        "ika_ocs_high_water_violations_total",
+        "ika_ocs_last_successful_relay_timestamp_seconds",
+        "ika_ocs_proof_snapshot_cache_hits_total",
+        "ika_ocs_proof_tree_cache_hits_total",
+        "ika_ocs_proof_tree_cache_misses_total",
+        "ika_ocs_pusher_cursor_seq",
+        "ika_ocs_pusher_fetch_failures_total",
+        "ika_ocs_pusher_fold_verify_seconds",
+        "ika_ocs_pusher_gap_archive_repairs_total",
+        "ika_ocs_pusher_gap_dropped_total",
+        "ika_ocs_pusher_pushed_total",
+        "ika_ocs_pusher_skipped_irrelevant_total",
+        "ika_ocs_pusher_stalled",
+        "ika_ocs_ratchet_stalled",
+        "ika_off_chain_assembly_consecutive_incomplete_ticks",
+        "ika_off_chain_assembly_incomplete",
+        "ika_off_chain_assembly_incomplete_duration_seconds",
+        "ika_off_chain_assembly_incomplete_ticks_total",
+        "ika_off_chain_assembly_last_success_timestamp_seconds",
+        "ika_off_chain_assembly_missing",
+        "ika_off_chain_assembly_wedged",
+        "ika_own_mpc_data_blob_unhealthy",
+        "ika_protocol_upgrade_effective_threshold",
+        "ika_protocol_upgrade_supporting_stake",
+        "ika_reconfig_phase",
+        "ika_remote_dwallet_checkpoint_forks",
+        "ika_remote_system_checkpoint_forks",
+        "ika_sequencing_certificate_authority_position",
+        "ika_sequencing_certificate_positions_moved",
+        "ika_sequencing_certificate_preceding_disconnected",
+        "ika_sequencing_in_flight_semaphore_wait",
+        "ika_sequencing_in_flight_submissions",
+        "ika_skipped_consensus_txns",
+        "ika_skipped_consensus_txns_cache_hit",
+        "ika_split_brain_dwallet_checkpoint_forks",
+        "ika_split_brain_system_checkpoint_forks",
+        "ika_stranded_network_key_missing_from_registry_read_condition_active",
+        "ika_sui_connector_chain_active_system_sessions_count",
+        "ika_sui_connector_chain_active_user_sessions_count",
+        "ika_sui_connector_chain_dwallet_checkpoint_writer_lag",
+        "ika_sui_connector_chain_epoch_overdue_seconds",
+        "ika_sui_connector_chain_user_sessions_lag",
+        "ika_sui_connector_dwallet_checkpoint_sequence",
+        "ika_sui_connector_dwallet_checkpoint_write_requests_total",
+        "ika_sui_connector_dwallet_checkpoint_writes_failure_total",
+        "ika_sui_connector_dwallet_checkpoint_writes_success_total",
+        "ika_sui_connector_gas_coin_balance",
+        "ika_sui_connector_last_written_dwallet_checkpoint_sequence",
+        "ika_sui_connector_last_written_system_checkpoint_sequence",
+        "ika_sui_connector_system_checkpoint_sequence",
+        "ika_sui_connector_system_checkpoint_write_requests_total",
+        "ika_sui_connector_system_checkpoint_writes_failure_total",
+        "ika_sui_connector_system_checkpoint_writes_success_total",
+        "ika_sui_connector_uncompleted_events_backlog",
+        "ika_supported_protocol_version_max",
+        "ika_supported_protocol_version_min",
+        "ika_system_checkpoint_creation_latency",
+        "ika_system_checkpoint_errors",
+        "ika_system_checkpoint_roots_count",
+        "ika_system_checkpoint_signatures_verified",
+        "verifier_runtime_per_module_success_latency",
+        "verifier_runtime_per_module_timeout_latency",
+        "verifier_runtime_per_ptb_success_latency",
+        "verifier_runtime_per_ptb_timeout_latency",
+    ];
+
+    const NOTIFIER_FAMILIES: &[&str] = &[
+        "ika_binary_max_protocol_version",
+        "ika_committee_quorum_threshold",
+        "ika_committee_total_stake",
+        "ika_committee_validity_threshold",
+        "ika_configured_max_protocol_version",
+        "ika_current_epoch",
+        "ika_current_protocol_version",
+        "ika_current_voting_right",
+        "ika_effective_buffer_stake",
+        "ika_epoch_reconfig_start_time_since_epoch_close_ms",
+        "ika_epoch_total_duration",
+        "ika_epoch_validator_halt_duration_ms",
+        "ika_network_key_overlay_incomplete",
+        "ika_network_key_registry_read_empty_condition_active",
+        "ika_ocs_cache_first_stale_total",
+        "ika_ocs_chain_latest_epoch",
+        "ika_ocs_committee_head_epoch",
+        "ika_ocs_dynamic_fields_walk_entries_returned_total",
+        "ika_ocs_dynamic_fields_walk_entries_seen_total",
+        "ika_ocs_dynamic_fields_walk_entries_skipped_transient_total",
+        "ika_ocs_high_water_violations_total",
+        "ika_ocs_last_successful_relay_timestamp_seconds",
+        "ika_ocs_proof_snapshot_cache_hits_total",
+        "ika_ocs_proof_tree_cache_hits_total",
+        "ika_ocs_proof_tree_cache_misses_total",
+        "ika_ocs_pusher_cursor_seq",
+        "ika_ocs_pusher_fetch_failures_total",
+        "ika_ocs_pusher_fold_verify_seconds",
+        "ika_ocs_pusher_gap_archive_repairs_total",
+        "ika_ocs_pusher_gap_dropped_total",
+        "ika_ocs_pusher_pushed_total",
+        "ika_ocs_pusher_skipped_irrelevant_total",
+        "ika_ocs_pusher_stalled",
+        "ika_ocs_ratchet_stalled",
+        "ika_protocol_upgrade_effective_threshold",
+        "ika_protocol_upgrade_supporting_stake",
+        "ika_reconfig_phase",
+        "ika_stranded_network_key_missing_from_registry_read_condition_active",
+        "ika_sui_connector_dwallet_checkpoint_sequence",
+        "ika_sui_connector_dwallet_checkpoint_write_requests_total",
+        "ika_sui_connector_dwallet_checkpoint_writes_failure_total",
+        "ika_sui_connector_dwallet_checkpoint_writes_success_total",
+        "ika_sui_connector_gas_coin_balance",
+        "ika_sui_connector_last_written_dwallet_checkpoint_sequence",
+        "ika_sui_connector_last_written_system_checkpoint_sequence",
+        "ika_sui_connector_system_checkpoint_sequence",
+        "ika_sui_connector_system_checkpoint_write_requests_total",
+        "ika_sui_connector_system_checkpoint_writes_failure_total",
+        "ika_sui_connector_system_checkpoint_writes_success_total",
+        "ika_supported_protocol_version_max",
+        "ika_supported_protocol_version_min",
+    ];
+
+    const FULLNODE_FAMILIES: &[&str] = &[
+        "ika_binary_max_protocol_version",
+        "ika_committee_quorum_threshold",
+        "ika_committee_total_stake",
+        "ika_committee_validity_threshold",
+        "ika_configured_max_protocol_version",
+        "ika_current_epoch",
+        "ika_current_protocol_version",
+        "ika_current_voting_right",
+        "ika_effective_buffer_stake",
+        "ika_epoch_reconfig_start_time_since_epoch_close_ms",
+        "ika_epoch_total_duration",
+        "ika_epoch_validator_halt_duration_ms",
+        "ika_network_key_overlay_incomplete",
+        "ika_network_key_registry_read_empty_condition_active",
+        "ika_ocs_cache_first_stale_total",
+        "ika_ocs_chain_latest_epoch",
+        "ika_ocs_committee_head_epoch",
+        "ika_ocs_dynamic_fields_walk_entries_returned_total",
+        "ika_ocs_dynamic_fields_walk_entries_seen_total",
+        "ika_ocs_dynamic_fields_walk_entries_skipped_transient_total",
+        "ika_ocs_high_water_violations_total",
+        "ika_ocs_last_successful_relay_timestamp_seconds",
+        "ika_ocs_proof_snapshot_cache_hits_total",
+        "ika_ocs_proof_tree_cache_hits_total",
+        "ika_ocs_proof_tree_cache_misses_total",
+        "ika_ocs_pusher_cursor_seq",
+        "ika_ocs_pusher_fetch_failures_total",
+        "ika_ocs_pusher_fold_verify_seconds",
+        "ika_ocs_pusher_gap_archive_repairs_total",
+        "ika_ocs_pusher_gap_dropped_total",
+        "ika_ocs_pusher_pushed_total",
+        "ika_ocs_pusher_skipped_irrelevant_total",
+        "ika_ocs_pusher_stalled",
+        "ika_ocs_ratchet_stalled",
+        "ika_protocol_upgrade_effective_threshold",
+        "ika_protocol_upgrade_supporting_stake",
+        "ika_reconfig_phase",
+        "ika_stranded_network_key_missing_from_registry_read_condition_active",
+        "ika_supported_protocol_version_max",
+        "ika_supported_protocol_version_min",
+    ];
+
+    #[test]
+    fn a_validator_exports_every_family() {
+        assert_families(NodeMode::Validator, VALIDATOR_FAMILIES);
+    }
+
+    #[test]
+    fn a_notifier_exports_only_the_families_it_drives() {
+        assert_families(NodeMode::Notifier, NOTIFIER_FAMILIES);
+    }
+
+    #[test]
+    fn a_fullnode_exports_only_the_families_it_drives() {
+        assert_families(NodeMode::Fullnode, FULLNODE_FAMILIES);
     }
 }

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -277,6 +277,62 @@ is exported for every protocol (it is bounded — one series per protocol name)
 and emits zero for a completed protocol while its session remains tracked, so
 tests can distinguish a clean zero from a missing protocol observation.
 
+## A process registers only the families it drives
+
+The three `NodeMode`s share one start sequence, and it used to register nearly
+every family unconditionally. A notifier therefore exported `ika_dwallet_mpc_*`,
+the consensus-handler counters, the handoff-barrier gauges and the
+chain-observation gauges — all pinned forever at the value they were
+constructed with. That value is never a neutral one: `ika_handoff_prepare_waiting`
+at 0 reads "not wedged at the barrier", `ika_consensus_commit_silence_seconds`
+at 0 reads "a commit landed this second", and
+`ika_sui_connector_chain_epoch_overdue_seconds` at 0 reads "the epoch is on
+time". None of the series carry a `host` label, so fleet aggregations keyed on
+`network` or grouped `by (host)` ingested them silently: a nameless validator
+row in the fleet table, a phantom per-network row, and one false "epoch switch
+overdue" critical (ika #2051).
+
+**Absence is the correct signal for a subsystem this process does not run.** So
+the fix lives at registration, never at export — nothing filters a gathered
+family, and a family is not "suppressed to zero", it simply is not there:
+
+- a struct whose families are ALL driven by one role is constructed only in
+  that role (`ValidatorModeMetrics` in `ika-node`: the MPC service, the
+  checkpoint builders, consensus tx validation, handoff/commit telemetry), or
+  registered through a `new_for_mode` that hands a role-local registry to the
+  other modes (`AuthorityMetrics` — every family there is written by the
+  consensus handler);
+- a struct whose families are driven by DIFFERENT roles registers per family:
+  `EpochMetrics::new_for_mode` and `SuiConnectorMetrics::new_for_mode` route
+  each registration to the exported registry or to a role-local one that no
+  endpoint gathers. The handles are always constructed, so write sites stay
+  unconditional and a mis-classified family costs one lost observation on one
+  role rather than a panic.
+
+Two boundaries on the rule:
+
+- **`uptime{process=...}` and the process-level basics stay in every mode.**
+  The protocol-version gauges (`ika_binary_max_protocol_version` and friends)
+  report a real property of any running binary, not a subsystem's state, and
+  operators track notifier rollouts with them.
+- **The validator export set is not trimmed.** A validator keeps the
+  notifier-driven checkpoint-writer and gas families it does not drive. Removing
+  a family from a validator breaks dashboards that already read it, which is a
+  separate change with its own blast radius; this rule removes families only
+  from processes that never drove them.
+
+When a family stays on a mode that looks wrong for it, check what actually
+spawns its writer before "fixing" it. `ika_dwallet_mpc_data_blob_fetch_total`
+and `ika_joiner_bootstrap_outcomes_total` are exported by every mode because
+`monitor_reconfiguration` spawns the peer-blob fetcher and the joiner-bootstrap
+verifier unconditionally — a notifier really does run them (and really can
+fail-closed on a rejected handoff cert). Whether it *should* is a question
+about those subsystems, not about their metrics.
+
+The per-mode sets are pinned by `per_mode_registration` in
+`crates/ika-node/src/metrics.rs`, which composes the same constructors the
+start sequence uses and asserts the gathered family names for each mode.
+
 ## Validator host telemetry
 
 Validator processes register host telemetry in the default registry, so the


### PR DESCRIPTION
## The problem

The three `NodeMode`s share one start sequence, and it registered nearly every
metric family unconditionally. A notifier therefore exported `ika_dwallet_mpc_*`,
the consensus-handler counters, the handoff-barrier gauges and the
chain-observation gauges it never drives — each pinned forever at the value it
was constructed with, and none of those a neutral value:
`ika_handoff_prepare_waiting` at 0 reads "not wedged at the barrier",
`ika_consensus_commit_silence_seconds` at 0 reads "a commit landed this
second", `ika_sui_connector_chain_epoch_overdue_seconds` at 0 reads "the epoch
is on time". None of the series carry a `host` label, so fleet aggregations
keyed on `network` or grouped `by (host)` ingested them silently — a nameless
fleet-table row, a phantom per-network row, and a false "epoch switch overdue"
critical.

Fixes #2051.

## The fix

Registration follows the subsystems a process actually runs. Nothing is
filtered at export and no value is suppressed: a family a mode does not drive is
never registered into the registry the endpoint gathers.

Two shapes, picked by what a struct contains:

- **Whole-struct gating**, where every family belongs to one role.
  `ValidatorModeMetrics` (new, `ika-node`) holds `DWalletMPCMetrics`, the
  dWallet/system checkpoint and consensus-tx-validator metrics, and the new
  `ValidatorTelemetryMetrics` (handoff barrier + commit-liveness), and is
  constructed only in validator mode. `AuthorityMetrics::new_for_mode` does the
  same for the twelve consensus-handler families.
- **Per-family registration**, where the writers differ by role.
  `EpochMetrics::new_for_mode` and `SuiConnectorMetrics::new_for_mode` route
  each registration either to the exported registry or to a role-local registry
  that no endpoint gathers (30 of 43 epoch families and 15 of 31 connector
  families are validator-driven; 12 connector families are the notifier's
  checkpoint-writer/gas set). The handles are always constructed, so write
  sites stay unconditional and a mis-classified family costs one lost
  observation on one role rather than a panic.

`uptime{process=...}` is untouched, and so are the process-level basics
(`ika_binary_max_protocol_version` and the other protocol-version gauges):
they report a real property of any running binary, not a subsystem's state, and
operators track notifier rollouts with them. `ika_reconfig_phase` also stays in
every mode — a fullnode and a notifier arm that watchdog too, in the `else`
branch of `monitor_reconfiguration`.

## Per-mode map

Family counts as served on `/metrics` (`gather()`), over the ika-side structs
the start sequence registers:

| mode | families | delta |
|---|---|---|
| validator | 178 | unchanged |
| notifier | 51 | −127 |
| fullnode | 40 | −138 |

- `notifier ⊂ validator` and `fullnode ⊂ validator` — no mode gained a family.
- `notifier − fullnode` is exactly the eleven checkpoint-writer/gas families
  (`ika_sui_connector_{dwallet,system}_checkpoint_*`,
  `ika_sui_connector_gas_coin_balance`), driven by the submission path only a
  notifier runs.
- What a notifier keeps: the protocol-version and committee gauges, the epoch
  gauges its own epoch store drives (`ika_current_epoch`,
  `ika_epoch_total_duration`, …), the OCS reader/pusher families, the three
  network-key condition gauges from `sync_dwallet_network_keys`,
  `ika_reconfig_phase`, and its checkpoint-writer/gas set.

## Acceptance evidence

**A notifier lists no MPC or validator-telemetry family.** Over the notifier's
51 families, the count matching
`ika_(dwallet_mpc|mpc_|dwallet_handoff|handoff_|consensus_|epoch_pending|off_chain_assembly|sui_connector_chain|skipped_consensus|sequencing_)`
is **0**; the same pattern matches **78** of the validator's 178.

**The validator export set is byte-identical.** Dumped the composed family
names at `905965fc0f` (all constructors unconditional, as the start sequence
had them) and on this branch (`ValidatorModeMetrics::for_mode(Validator, …)` +
the `new_for_mode` constructors), sorted both:

```
$ diff baseline-905965fc0f.txt branch-validator.txt && echo IDENTICAL
IDENTICAL
$ wc -l baseline-905965fc0f.txt branch-validator.txt
     178 baseline-905965fc0f.txt
     178 branch-validator.txt
```

**The metric-name inventory is unchanged** — no name added, removed or
renamed, so `dev-docs/conventions/metrics.md` needed no regeneration:

```
$ ./scripts/check-metric-names.sh
metric names OK (339 literal, 3 dynamic sites skipped; 1 prefixed registry
(consensus_ika), none under `ika`; 3 test-scoped skipped); 296 source files,
no default-registry registration
```

## Deliberate exception

`ika_dwallet_mpc_data_blob_fetch_total` and `ika_joiner_bootstrap_outcomes_total`
stay registered in every mode, because `monitor_reconfiguration` spawns the
peer-blob fetcher and the joiner-bootstrap verifier unconditionally: a notifier
really does run them, really does fetch cert-pinned blobs from committee peers
once a handoff cert lands locally, and really can fail-closed on a rejected
cert. Their values there are observations, not phantoms. (Both are `*_vec`
families with no label children until an outcome is recorded, so neither
appears on a notifier's `/metrics` until its subsystem actually does something
— which is why the counts above are unaffected.) Whether a non-validator should
run those subsystems at all is a question about the subsystems, not their
metrics; gating those two spawns would gate these two families for free.

## Tests

`per_mode_registration` in `crates/ika-node/src/metrics.rs` composes the same
constructors the start sequence uses and asserts the sorted gathered family
names for each of the three modes against a pinned list — so the validator set
cannot drift, and a family newly registered on a non-validator fails the build
with the name in the assertion message.

- `cargo check --release -p ika-node --all-targets` — clean
- `cargo test --release -p ika-node` — see checks
- `cargo fmt --all` — applied
- `./scripts/check-metric-names.sh` — green, inventory unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
