### PR TITLE
docs(specs): correct stale, wrong and ambiguous statements in dev-docs/specs

### DIFF
--- a/dev-docs/specs/README.md
+++ b/dev-docs/specs/README.md
@@ -42,9 +42,10 @@ here.
   every user-session completion path must follow, and the
   batch-processing rule for computation results.
 - [`committee-consensus-keys.md`](committee-consensus-keys.md) — the two
-  per-validator keys (BLS identity vs Ed25519 consensus key), why the
-  mapping is carried as `Committee` data rather than derived, the
-  same-snapshot rule for key and stake, and the 1.1.8 on-disk migration.
+  per-validator keys (the aggregatable BLS key vs the Ed25519 consensus
+  key, which IS the validator's identity), why the BLS mapping is carried
+  as `Committee` data rather than derived, the same-snapshot rule for key
+  and stake, and the 1.1.8 on-disk migration.
 - [`cross-binary-upgrade.md`](cross-binary-upgrade.md) — the in-place
   protocol-version upgrade contract: the stake-weighted version vote, the
   wire/on-disk compatibility invariants a mixed committee must preserve,
@@ -53,11 +54,13 @@ here.
 - [`fast-schnorr-vss.md`](fast-schnorr-vss.md) — Fast Schnorr (VSS)
   signing: the three VSS algorithms and their curve/algorithm numbering,
   the version-3 PVSS key bundle and its off-chain transport, the V3
-  presign/sign flow, and what is internal-NOA-only vs. still gated.
+  presign/sign flow, and what is reachable only on the internal
+  network-owned-address path vs. still disabled in code.
 - [`checkpoint-sync-floor.md`](checkpoint-sync-floor.md) — why pull-mode
   checkpoint sync starts from the on-chain processed cursor (a fresh-DB
   notifier can never fetch deep history from peers), the cold-start
-  deferral, and the gap-tolerant store invariants.
+  deferral, the matching floor under a validator's checkpoint aggregator
+  at epoch entry, and the gap-tolerant store invariants.
 - [`checkpoint-writer-observability.md`](checkpoint-writer-observability.md)
   — the deliberate single-notifier write path, why a stalled writer blocks
   the epoch close, and the two stall signals.

--- a/dev-docs/specs/checkpoint-writer-observability.md
+++ b/dev-docs/specs/checkpoint-writer-observability.md
@@ -11,10 +11,12 @@ misattribution). Actors: the notifier's `sui_executor`, every validator's
 
 MPC session completions only reach the chain inside certified dwallet
 checkpoints, submitted by the single notifier via
-`process_checkpoint_message_by_quorum`. The close gate
-(`all_epoch_sessions_finished` in `sui_syncer`, mirroring Move's
-`advance_epoch` assertion) compares the coordinator's on-chain
-`completed_sessions_count` with the frozen lock target — chain state only.
+`process_checkpoint_message_by_quorum`. The close gate's user-session term
+(`all_epoch_sessions_finished` in `sui_syncer`, one conjunct of both Move's
+`advance_epoch` assertion and the wider Rust EndOfPublish gate — see
+[`epoch-close-session-lock.md`](epoch-close-session-lock.md)) compares the
+coordinator's on-chain `completed_sessions_count` with the frozen lock
+target — chain state only.
 The epoch-switch calls (`process_mid_epoch`, pricing, the session lock,
 `request_advance_epoch`) are likewise notifier-submitted.
 

--- a/dev-docs/specs/committee-consensus-keys.md
+++ b/dev-docs/specs/committee-consensus-keys.md
@@ -7,7 +7,7 @@ different identity basis or a different encoding width, and the code that
 used to switch between them has been deleted rather than disabled.
 The design record — including the first, reverted identity-flip attempt
 and why it failed — is
-[`../plans/authority-name-consensus-key.md`](../plans/archive/authority-name-consensus-key.md).
+[`../plans/archive/authority-name-consensus-key.md`](../plans/archive/authority-name-consensus-key.md).
 
 A validator has **two** long-lived public keys with different jobs:
 

--- a/dev-docs/specs/cross-binary-upgrade.md
+++ b/dev-docs/specs/cross-binary-upgrade.md
@@ -8,7 +8,7 @@ serve dWallet sessions throughout. This file is the protocol-level
 contract that any change touching versioning, serialization, or the
 epoch boundary must preserve. The out-of-process harness that verifies
 it lives in `crates/ika-upgrade-test/`; the design record and findings
-are in [`../plans/cross-binary-upgrade-testing.md`](../plans/archive/cross-binary-upgrade-testing.md).
+are in [`../plans/archive/cross-binary-upgrade-testing.md`](../plans/archive/cross-binary-upgrade-testing.md).
 
 ## How a version advances
 
@@ -25,9 +25,10 @@ The version is not config-driven — it is a stake-weighted on-chain vote:
   `SET_NEXT_PROTOCOL_VERSION` system checkpoint message.
 
 Move packages upgrade through Sui package upgrades; the coordinator
-schema may gain behavior at a version boundary (e.g.
-`internal_presign_sessions` activates at v4). Crypto/MPC payloads are
-versioned implicitly inside bcs-encoded enums — `VersionedMPCData`,
+schema may gain behavior at a version boundary (the worked example,
+`internal_presign_sessions` activating at v4, is now history — the flag is
+true at every supported version and its gates have been swept). Crypto/MPC
+payloads are versioned implicitly inside bcs-encoded enums — `VersionedMPCData`,
 `VersionedNetworkDkgOutput`, `VersionedPresignOutput`,
 `VersionedSignOutput`.
 
@@ -66,11 +67,14 @@ serialization/schema change, MUST preserve all of the following.
    failure mode: **an in-flight session that can never complete on the
    running version wedges the epoch permanently** — the epoch cannot
    close, so the version can never advance to the one that would serve
-   it. The pre-activation global-presign fallback in `handle_mpc_request`
-   exists precisely for this: a global presign requested at v3 on a
-   binary that *serves* global presigns from the v4-only internal pool
-   must fall through to a user-requested MPC session, or one in-flight
-   presign at restart deadlocks the whole network. See
+   it. The worked instance was the v3→v4 global-presign boundary:
+   `handle_mpc_request` carried a pre-activation fallback so that a global
+   presign requested while the internal pool that serves it did not yet
+   exist ran as an ordinary user-requested MPC session, rather than
+   stranding and deadlocking the network on one in-flight presign. That
+   fallback is **gone** — the flag it tested is true at every supported
+   version and its gates were swept — but the hazard it answered is one
+   any future activation boundary must answer again. See
    [`epoch-close-session-lock.md`](epoch-close-session-lock.md) for the
    completion-target / close-predicate rules this builds on.
 

--- a/dev-docs/specs/epoch-close-session-lock.md
+++ b/dev-docs/specs/epoch-close-session-lock.md
@@ -34,8 +34,10 @@ Skew delays *when* a validator acts on a session, never *whether*.
 is set, user `completed_sessions_count == frozen target`, and system
 sessions `completed == started`. Nothing about network keys enters here.
 
-The Rust EndOfPublish gate (`sui_syncer`) is a strict SUPERSET, not a
-mirror: it requires those three AND `all_immediate_sessions_completed`,
+The Rust EndOfPublish gate (`ready_to_end_publish` in `sui_syncer`) is a
+strict SUPERSET, not a mirror: it requires those same three — spelled
+`session_locked`, `all_epoch_sessions_finished` and
+`all_immediate_sessions_completed` on the Rust side — AND
 `next_epoch_committee_exists`,
 `all_network_encryption_keys_reconfiguration_completed`,
 `all_noa_checkpoints_finalized` and no outstanding pricing-calculation

--- a/dev-docs/specs/event-sourced-epoch.md
+++ b/dev-docs/specs/event-sourced-epoch.md
@@ -122,8 +122,9 @@ memory-bounded — it scans in the same 250-commit batches and yields between
 commits — but it is not the path this spec describes and not the path the
 observability watches. Measured on a 4-validator net with real class-groups
 traffic: 72,592 and 74,388 commits, both restarts, deterministic (ika #2085,
-found during the #2064 gate-1 measurement). Every unit test built its fixture
-with finalized commits, which is why CI stayed green through all of it; the
+found during the ika #2064 release-validation measurements). Every unit test
+built its fixture with finalized commits, which is why CI stayed green
+through all of it; the
 regression test is now built the way production writes the store —
 `replay_folds_every_commit_when_transaction_voting_is_off`, with
 `replay_folds_nothing_when_voting_is_on_and_no_commit_has_finalized` pinning
@@ -274,7 +275,7 @@ that window: the capability notification, both epoch-task senders on their
 timers, and — because the replay regenerates their whole input queue — the
 checkpoint builders.
 
-Two changes make that window safe:
+Three changes make that window safe:
 
 - **`UpdatableConsensusClient` waits instead of aborting.** It used to panic
   if the client was still unset 300 seconds after a submission was issued,

--- a/dev-docs/specs/fast-schnorr-vss.md
+++ b/dev-docs/specs/fast-schnorr-vss.md
@@ -49,6 +49,17 @@ path is internal NOA-VSS.
 
 ## Key material — the version-3 bundle + per-curve PVSS
 
+**Two different "version 3"s meet in this section; they are separate axes
+that happen to coincide.** "Version-3" on its own always means the network
+key's CRYPTO version (`ProtocolConfig::network_encryption_key_version`,
+raised to 3 at protocol v4) — the bump that introduced
+`ValidatorEncryptionKeysAndProofs` and the `decentralized_party` protocols.
+A bare `V1`…`V4` always means the BCS wire tag on
+`VersionedNetworkDkgOutput` / `VersionedDecryptionKeyReconfigurationOutput`.
+Crypto-version-3 outputs were first written with the V3 tag (pre-aggregation,
+now undecodable) and are always V4 today, so "a crypto-version-3 key" and "a
+V4-tagged output" select the same keys by different routes.
+
 - Every committee member publishes the version-3 bundle OFF-CHAIN,
   `ValidatorEncryptionKeysAndProofs` = the class-groups CRT key + three
   per-curve PVSS HPKE keys. This is not an either/or with the bare
@@ -67,7 +78,7 @@ path is internal NOA-VSS.
   `dwallet-classgroups-types`).
 - The per-curve VSS Shamir cache (`VssShamirCachePerKey` — `first_` /
   `second_secret_key_polynomial_commitments` per curve) derives **only from a
-  version-3 network-key DKG output**. A pre-version-3 key has no VSS cache.
+  crypto-version-3 network key**. A pre-version-3 key has no VSS cache.
   The full-shape output is the aggregated (V4) wire tag — the only one the
   current crypto crates can decode (the pre-aggregation V3 type was removed
   from inkrypto; a V3-tagged output is a hard derivation failure, and such
@@ -96,9 +107,9 @@ against the active committee directly.
   DKG-and-sign builders) and reads the presign private output keyed by
   `vss_public_presign_identity(signature_algorithm, presign)` — the same
   `(session_id, blending_index)` the public- and private-input builders use.
-- Decoders are version-strict: the VSS decoders **require** V3; the AHE/ECDSA
-  decoders **reject** V3. A non-V3 presign on a VSS path is rejected (fail
-  closed).
+- Decoders are version-strict: the VSS decoders **require** V3; the non-VSS
+  (AHE/ECDSA) decoders **reject** V3. A non-V3 presign on a VSS path is
+  rejected (fail closed).
 - Per-curve dispatch is consistent across the protocol public parameters, the
   VSS Shamir cache field, signature parsing (`TaprootVSS → TaprootSignature`,
   `EdDSAVSS → EdDSASignature`, `SchnorrkelVSS → SchnorrkelSignature`), and the
@@ -135,8 +146,9 @@ against the active committee directly.
   stale-batch expiry. Any other input-construction error stays terminal.
 - **VSS Shamir-cache outcome tri-state (epoch-tagged).** The per-key cache
   map stores the derivation OUTCOME, not only successes: `Derived` (the
-  three-curve cache), `NotApplicable` (the key data had no full-shape V3/V4
-  output — a pre-V3 key), or `Failed` (a real deserialization/derivation failure,
+  three-curve cache), `NotApplicable` (every stored output for the key is
+  V1/V2-tagged — a pre-crypto-version-3 key; note a V3 tag lands in `Failed`,
+  not here), or `Failed` (a real deserialization/derivation failure,
   logged once at insertion). Every variant carries the epoch of the key data
   it was derived from, and the accessor treats an epoch mismatch — terminal
   variants INCLUDED — exactly like a missing entry (the not-ready class,
@@ -211,8 +223,8 @@ against the active committee directly.
 - A VSS presign is always V3; a non-V3 presign on a VSS path is rejected.
 - The published VSS HPKE public key equals the public counterpart of the
   orchestrator's secret (same seed-derived RNG stream).
-- VSS key material exists only for a version-3 key; the sign path needs the
-  per-curve VSS Shamir cache, which is absent pre-version-3.
+- VSS key material exists only for a crypto-version-3 key; the sign path
+  needs the per-curve VSS Shamir cache, which is absent pre-version-3.
 
 ## Tests
 

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -196,7 +196,7 @@ next epoch inherits.
   Consensus pubkeys are fixed at registration; members that have since
   left the active set are resolved from chain (their staking pool
   object persists) so churn cannot wrongly reject a valid certificate.
-  Two properties of the chain-read prior committee
+  Three properties of the chain-read prior committee
   (`fetch_previous_committee`) are load-bearing here:
   - **Snapshot-name keying.** The consensus-key map is keyed by each
     member's PRIOR-epoch snapshot name (resolved by validator id from
@@ -283,14 +283,15 @@ next epoch inherits.
    their digests match the prior epoch's certificate
    (`adopt_cert_verified_keys`): a reconfigured key must match BOTH its
    DKG digest and its epoch-specific reconfiguration digest. The DKG
-   digest migrates once (V1|V2 -> V4, above): at that single boundary an
-   ALREADY-ADOPTED key whose overlay DKG digest has moved past the prior
-   epoch's (pre-migration) certificate is the expected defer — it keeps its adopted
-   value rather than being dropped, exactly as a moved reconfiguration
-   output is tolerated; only an UNADOPTED key contradicting the
-   certificate is the security-relevant anomaly (the output-quorum
-   byte-equality tally remains the guard against a divergent output). A
-   certificate READ ERROR skips adoption for the tick (retry) — it must
+   digest is now stable across epochs (the one-per-key migration above is
+   finished), so a mismatch against the prior epoch's certificate is never
+   expected. Adoption is skipped either way: an ALREADY-ADOPTED key keeps
+   its installed value rather than being dropped, exactly as a moved
+   reconfiguration output is tolerated; only an UNADOPTED key
+   contradicting the certificate is the security-relevant anomaly worth a
+   warn (the output-quorum byte-equality tally remains the guard against a
+   divergent output). A certificate READ ERROR skips adoption for the tick
+   (retry) — it must
    not be conflated with a genuinely-absent certificate, which is an
    answer: a reconfigured key with no prior certificate is REJECTED
    (its output has no quorum anchor — a certificate is built durably
@@ -306,7 +307,7 @@ next epoch inherits.
    and adopting them cert-less; that scaffolding is removed — a
    network with keys DKG'd under v3 can no longer upgrade into v4+.)
 
-   Three adoption guards keep the installed parameter set identical
+   Five adoption guards keep the installed parameter set identical
    across the committee (a validator that installs anything else
    honestly computes byte-divergent MPC outputs and is convicted
    malicious by the output-quorum byte-equality tally — silently
@@ -360,14 +361,17 @@ next epoch inherits.
      holds exactly (asserted by the
      `off_chain_metadata_v4_does_not_read_blobs_from_chain` cluster
      test), and both paths install the identical canonical output for
-     the epoch (no fork surface). KNOWN RESIDUAL: a mid-epoch
-     restart during the single canonical-migration epoch is NOT
-     recovered — the prior cert pins the V1/V2 DKG digest while the
-     restarted validator's mirror already flipped to V4 (the pre-migration
-     bytes no longer exist locally), so adoption warns and skips until the
-     next epoch's cert pins V4. Fail-closed, bounded to that one
-     epoch, identical to pre-recovery behavior; epoch close is
-     unaffected (the validator still votes EndOfPublish).
+     the epoch (no fork surface). HISTORICAL RESIDUAL, no longer
+     reachable: while the one-per-key canonical migration was in flight, a
+     mid-epoch restart during a key's migration epoch was NOT recovered —
+     the prior cert pinned the V1/V2 DKG digest while the restarted
+     validator's mirror had already flipped to V4 (the pre-migration bytes
+     no longer existing locally), so adoption warned and skipped until the
+     next epoch's cert pinned V4. It was fail-closed, bounded to that one
+     epoch, and left the epoch close unaffected (the validator still voted
+     EndOfPublish). The migration has completed on both live networks and
+     the machinery that performed the flip is gone, so no epoch can enter
+     this state again.
    - Current-epoch validator MPC keys (mid-epoch restart, issue #1879).
      The manager's current-epoch key bundle
      (`validator_mpc_keys_by_party_id` — consumed by the within-epoch

--- a/dev-docs/specs/internal-presign-pool.md
+++ b/dev-docs/specs/internal-presign-pool.md
@@ -3,9 +3,9 @@
 How the internal presign pool is filled and drained, and the rule that keeps
 a validator that restarted mid-epoch serving the same presigns as the peers
 that did not (issue #1928). Actors: the internal-presign top-up loop and
-output handler in `DWalletMPCManager`, the global-presign and NOA-demand
-drains in `DWalletMPCService`, and the pool tables in
-`AuthorityEpochTables`.
+output handler in `DWalletMPCManager`, the global-presign and
+network-owned-address (NOA) demand drains in `DWalletMPCService`, and the
+pool tables in `AuthorityEpochTables`.
 
 ## What the pool is
 

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -1014,7 +1014,7 @@ on the changeset index's version+digest currency signal *plus* the TTL
 bound — two attestations of the same "still current" property. Extending
 the cache-first serve beyond the singleton anchors to *all* slowly-changing
 mirror reads remains future work — see
-[`../plans/ocs-changeset-stream-mirror-currency.md`](../plans/archive/ocs-changeset-stream-mirror-currency.md).
+[`../plans/archive/ocs-changeset-stream-mirror-currency.md`](../plans/archive/ocs-changeset-stream-mirror-currency.md).
 
 ## Retained state: surviving a restart and a pruning fullnode
 
@@ -1156,7 +1156,7 @@ because the bytes came from a peer's disk rather than its fullnode.
     both addresses — it is **load-bearing**, not defensive: without it those DKG
     events are dropped.
 
-    Two consequences:
+    Three consequences:
 
     - **This invariant is unaffected.** It asserts the type of the two
       singleton ANCHOR objects, and those were created by the original

--- a/dev-docs/specs/trusted-peer-discovery.md
+++ b/dev-docs/specs/trusted-peer-discovery.md
@@ -1,9 +1,10 @@
 # Continuous trusted-peer discovery (peer-only joiner bootstrap)
 
 How a freshly-registered **peer-only** validator gets dialed and boots with
-no static seed peers and no direct Sui uplink. Landed on
-`feat/ocs-grpc-migration` (#1744); supersedes the `validator_seed_peers`
-upgrade-test workaround.
+no static seed peers and no direct Sui uplink. This replaced an earlier
+workaround in which a joiner was reachable only because the test harness
+hand-configured its dialers with a static peer list; the mechanism below
+needs no such list, in tests or in production.
 
 ## The problem
 
@@ -70,7 +71,7 @@ parallel reader and no special-casing per topology.
   the whole set. Only the whole-refresh failure warn is throttled.
   Likewise a single unresolvable/withdrawn validator is skipped, not fatal —
   including one whose `p2p_address` does not convert to an anemo address,
-  which is dropped silently during the mapping step.
+  which is dropped with a warn during the mapping step.
 - **Keep the last good set.** A transient read error leaves `last_sent` untouched; the
   watch channel still holds the last value, so `known_peers` is unaffected.
 


### PR DESCRIPTION
Audit of **every** file in `dev-docs/specs/` against the code at this commit. Twenty corrections, grouped by file. No code changed; where I concluded the *code* was the wrong side, I left the spec alone and recorded it at the bottom instead.

Two of these are fallout the recent sweeps left behind — `#2104` (retired always-true flag gates) and `#2105` (anchor-reconstruction removal) each updated one section and missed others.

## `cross-binary-upgrade.md`

- **Stale — invariant 3 presented removed machinery as live.** It said "the pre-activation global-presign fallback in `handle_mpc_request` **exists** precisely for this". `#2104` deleted that fallback: `mpc_session.rs` now reads `// Global presigns are served from the internal presign pool.` with the `internal_presign_sessions_enabled()` guard gone. Rewritten as the historical instance it now is, keeping the hazard statement (which still binds any future activation boundary) intact.
- **Stale — `internal_presign_sessions` cited as a live version-boundary example.** The flag is no longer read anywhere; `crates/ika-protocol-config/src/lib.rs:209-217` says so explicitly ("nothing reads it anymore — instantiation is unconditional"). Marked as history rather than deleted, since the *mechanism* it illustrates is still real.
- **Clarity — link text disagreed with its target** (`../plans/…` vs the actual `../plans/archive/…`).

## `handoff.md`

- **Stale — the DKG-digest adoption rule still described the completed migration.** The spec said the digest "migrates once (V1|V2 -> V4)" and that an already-adopted key moving past the prior cert "is the expected defer". `mpc_manager.rs` now says the opposite after `#2105`: *"The canonical DKG output is now stable across epochs, so a mismatch against the prior epoch's cert is never expected."* Corrected while preserving the still-true behaviour (skip either way; only an **unadopted** key warns).
- **Stale — a KNOWN RESIDUAL that can no longer occur.** The mid-epoch-restart-during-the-migration-epoch residual depended on the mirror flipping V1/V2→V4; `reconstruct_full_network_dkg_output` and the flip are gone (`#2105`). Re-marked HISTORICAL rather than deleted, so the record survives without reading as a live hazard.
- **Incorrect — "Two properties of the chain-read prior committee" introduces three bullets.** The third (`Skipping a signer is safe…`) arrived with `#2011`. Now "Three".
- **Incorrect — "Three adoption guards" introduces five bullets.** Now "Five". The "(third guard below)" back-reference earlier in the file still resolves correctly.

## `epoch-close-session-lock.md`

- **Incorrect — the EndOfPublish gate double-counted a conjunct.** It read "requires those three AND `all_immediate_sessions_completed`, …", but `all_immediate_sessions_completed` *is* the Move predicate's third conjunct, not an extra one. Verified both sides: `sessions_manager.move:613-619` has exactly three; `sui_syncer.rs:1522-1528` has exactly seven — those same three plus four more. Now names the three Rust identifiers explicitly and lists only the genuine additions.

## `checkpoint-writer-observability.md`

- **Incorrect — contradicted its sibling spec.** It called `all_epoch_sessions_finished` "the close gate … mirroring Move's `advance_epoch` assertion", while `epoch-close-session-lock.md` says in bold that the Rust gate is "a strict SUPERSET, **not** a mirror". The code agrees with the latter: `all_epoch_sessions_finished` (`sui_syncer.rs:1482`) is one conjunct of the seven at `:1522`. Reworded as the gate's user-session *term* and cross-linked.

## `fast-schnorr-vss.md`

- **Clarity — two unrelated "version 3"s used interchangeably.** The spec uses "version-3" for the network key's crypto version (`network_encryption_key_version`, raised at protocol v4) *and* `V1`…`V4` for the BCS wire tag on `VersionedNetworkDkgOutput` — while also saying a V3 *tag* is undecodable. A reader cannot tell which axis "a version-3 network-key DKG output" means. Added a short note naming both axes, then disambiguated the three sentences that needed it.
- **Incorrect — the `NotApplicable` arm was described wrongly.** It said "no full-shape V3/V4 output", but a V3-tagged output is a hard error that lands in `Failed`, never `NotApplicable`. Corrected, with the V3→`Failed` distinction called out.
- **Clarity — bare `AHE/ECDSA`.** The acronym is never expanded anywhere in the repo; tied it instead to "non-VSS", the contrast this spec already defines.

## `trusted-peer-discovery.md`

- **Incorrect — a validator whose `p2p_address` will not convert is "dropped silently".** It is dropped with a warn.
- **Clarity — provenance stated as a merged branch name** (`feat/ocs-grpc-migration`) plus a superseded workaround nobody can now reconstruct. Replaced with a plain description of what the workaround was.

## `event-sourced-epoch.md`

- **Incorrect — "Two changes make that window safe:" introduces three bullets.**
- **Clarity — "the #2064 gate-1 measurement"**, exactly the internal label the repo standard bans. Replaced with its plain description.

## `ocs-verified-sui-reads.md`

- **Incorrect — "Two consequences:" introduces three bullets.**
- **Clarity — link text disagreed with its `…/archive/…` target.**

## `committee-consensus-keys.md`

- **Clarity — link text disagreed with its `…/archive/…` target.**

## `specs/README.md`

- **Incorrect — described the keys as "BLS identity vs Ed25519 consensus key".** The spec it indexes says the reverse in bold: the BLS key "is NOT the validator's identity", the Ed25519 consensus key is.
- **Stale — the `checkpoint-sync-floor` entry omitted the validator-aggregator floor** that the spec's own title advertises (added by `#2008`).
- **Stale — "what is internal-NOA-only vs. still gated"** implies a protocol gate; after `#2104` the external VSS limit is a code state, which the spec itself now says.

## `internal-presign-pool.md`

- **Clarity — "NOA" used 15 times, never expanded**, unlike the sibling specs. Expanded on first use.

## Verified correct — no edit made

Checked and confirmed against code, so recorded here rather than changed: `MIN`/`MAX_PROTOCOL_VERSION` = 7; `end_of_publish_grace_rounds` = 50; `mpc_data_freeze_grace_rounds` = 50; buffer stake 5000 bps; `NOA_PRESIGN_DEMAND_PARK_ROUNDS` = 70_000; `REPLAY_BATCH_COMMITS` = 250; `DEFAULT_ROUND_CHANNEL_CAPACITY` = 1024; `ANCHOR_REFRESH_INTERVAL` = 2 s; `BURST_ALLOWANCE` = 15_000 with `SUSTAINED_CHECKPOINTS_PER_SECOND` = 10; `REFRESH_INTERVAL` = 3 s; the surviving `ika-upgrade-test` scenario list and the retirement of `mid_epoch_rollback` / `protocol_version_transition`.

**Every metric name cited across all 14 specs exists verbatim in the code** — all 15 `ika_ocs_*`, the `ika_consensus_boot_replay_*` / fold-blocked / `ika_epoch_pending_*` families, the `ika_dwallet_mpc_data_*` and `ika_off_chain_assembly_*` families, and the presign/stall/writer-lag gauges. No phantom names.

Also confirmed the `bls_checkpoints` gates are still read and deliberately kept (`lib.rs:219-227`), so nothing was "corrected" to claim that flag is unread. The NodeMode metric-registration change (`#2106`) left no spec stale — no spec makes a per-mode export claim that the new `per_mode_registration` sets contradict. Likewise the catch-up-stuck detector change (`#2107`): no spec describes that detector or the round-lag gauge, so there was nothing to correct.

## One discrepancy where I judged the CODE side wrong — not fixed

`crates/ika-core/src/authority/round_transport.rs:76` says `1024` is "roughly a few seconds of consensus at mainnet commit rates". `event-sourced-epoch.md` says the same capacity is "about a minute of mainnet". The spec is the one consistent with the repo's own stated mainnet rate — `internal-presign-pool.md` anchors 70,000 rounds ≈ one hour at ~19.5 rounds/s, which puts 1024 rounds at ~52 s. I left the spec as written and did not touch the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
