### PR TITLE
docs(dev-docs): correct stale and inaccurate claims in the non-spec guides

### DIFF
--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -116,9 +116,12 @@ them has a bug — determine which before changing either.
 - [`playbooks/localnet.md`](playbooks/localnet.md) — running a
   Sui+ika localnet for SDK/integration testing without the traps.
 - [`playbooks/production-alerts.md`](playbooks/production-alerts.md) —
-  the alert rules for the designed halt/block modes (barrier wait,
-  wedged assembly, bootstrap fail-closed) that look healthy from
-  outside, plus secondary dashboard signals.
+  the alert rules for failures that don't page by themselves: broken
+  invariants and self-recognised maliciousness, the designed halt/block
+  modes (barrier wait, wedged assembly, bootstrap fail-closed) that look
+  healthy from outside, and the three MPC-progress conditions
+  (stopped contributing, fold parked on a wedged drain, catch-up stuck),
+  plus secondary dashboard signals.
 
 ### conventions/ — repo-specific procedures
 - [`conventions/sui-version-bump.md`](conventions/sui-version-bump.md)
@@ -157,7 +160,7 @@ them has a bug — determine which before changing either.
   — every `AuthorityEpochTables` field declares whether it is written
   through the commit boundary or directly (and, if directly, the
   reason its consumers survive that); the reader-side rule that #1917 was
-  actually born on, and the one table whose argument does not close.
+  actually born on, and the presign tables whose argument does not close.
   CI-enforced via `scripts/check-epoch-table-write-discipline.sh`.
 - [`conventions/chain-mirror-layout.md`](conventions/chain-mirror-layout.md)
   — the three Rust structs that are UNTAGGED mirrors of deployed Move

--- a/dev-docs/conventions/chain-mirror-layout.md
+++ b/dev-docs/conventions/chain-mirror-layout.md
@@ -96,8 +96,10 @@ drift being guarded against.
   `pricing_and_fee_manager` → `pricing_and_fee_management`,
   `witnesses_approving_advance_epoch` → `witness_approving_advance_epoch`);
   a name-equality check would be a lie.
-- **Rust half** — the golden layout tests beside each mirror
-  (`cargo test --release -p ika-types layout_is_pinned`). Each builds a
+- **Rust half** — the golden layout tests beside each mirror, run by CI as
+  `cargo test -p ika-types --lib -- layout_is_pinned variant_indices_are_pinned`
+  (the second name pins the `DWalletNetworkEncryptionKeyState` variant
+  indices, which are part of the same untagged byte stream). Each builds a
   fully-populated value and pins its encoded length and Blake2b digest.
   The struct literal is itself half of this: every field is written out
   with no `..Default::default()`, so an added or removed Rust field fails
@@ -119,7 +121,8 @@ All of these move in the same PR:
    share a layout, so the `1 | 2 =>` arm must stop claiming they do.
 3. The `const VERSION` bump plus `migrate()` that carries old state
    across.
-4. The golden tests: `cargo test --release -p ika-types layout_is_pinned`.
+4. The golden tests, both names CI runs:
+   `cargo test -p ika-types --lib -- layout_is_pinned variant_indices_are_pinned`.
 5. The Residuals section of `dev-docs/specs/ocs-verified-sui-reads.md`.
 6. The manifest: `./scripts/check-chain-mirror-layout.sh --write`.
 

--- a/dev-docs/conventions/enforce-minimum-cpu.md
+++ b/dev-docs/conventions/enforce-minimum-cpu.md
@@ -35,11 +35,15 @@ When enforcing, startup asserts ≥ 16 cores and panics below that.
 - CI and localnet builds of the CURRENT checkout need no feature
   juggling: default features are inert there (localnet ika system
   objects map to `Chain::Unknown`).
-- The upgrade-test harness still builds OLD refs
-  `--no-default-features` (`.github/workflows/upgrade-test.yaml` OLD
-  build step, `ika-upgrade-test/src/binary.rs`): at historical tags
-  enforcement was compile-time-only and panics on cgroup-throttled /
-  <16-core pods. Do not "clean" those flags.
+- The upgrade-test harness's own builder still builds OLD refs
+  `--no-default-features` (`ika-upgrade-test/src/binary.rs`): at historical
+  tags enforcement was compile-time-only and panics on cgroup-throttled /
+  <16-core pods. Do not "clean" that flag — it is there for refs older than
+  the runtime gate, not for the ref the suite happens to target today.
+  `.github/workflows/upgrade-test.yaml` is the opposite case and is also
+  deliberate: its OLD build step passes NO feature flags, because the ref it
+  builds (v1.4.0) already carries the runtime gate and the CI localnet's ika
+  system object maps to `Chain::Unknown`.
 - `IKA_PROTOCOL_CONFIG_CHAIN_OVERRIDE` (honored only when the real
   chain is `Unknown` — `ika-types/src/digests.rs`) makes a localnet
   claim testnet/mainnet for protocol-config selection, and that ALSO

--- a/dev-docs/conventions/epoch-table-write-discipline.md
+++ b/dev-docs/conventions/epoch-table-write-discipline.md
@@ -54,9 +54,10 @@ validators, so "usually equal" is a divergence with a longer fuse.
 (The per-round streams this rule used to be mostly about are gone: the MPC
 drain is fed from the fold over a channel. So is everything the commits
 determine — votes, anchors, the freeze partition, checkpoint construction —
-which now lives in memory. What is left on disk is the presign material, the
-private VSS outputs, the output caches and the operator override, and every
-one of them is `direct`.)
+which now lives in memory. What is left on disk is the presign material and
+its markers, this validator's own presign private outputs, the network-key
+output digest caches and the operator override — 25 fields, and every one of
+them is `direct`.)
 
 **`commit-batched`** still exists, but it describes the in-memory
 commit-boundary group rather than a table. `ConsensusCommitOutput::apply_to_epoch_state`
@@ -81,9 +82,13 @@ Fixed vocabulary, so the reasons stay comparable:
 | `content-addressed` | the key is a hash of the value | can a rewrite ever store different bytes under the same key? |
 
 **`direct — UNPROVEN (#issue)`** — a direct write whose argument does not
-close. Tracked, not blessed. One exists today: the presign pools (#1928,
-pops commit in their own batch, so a replay can bind a different presign
-than peers). Adding a consumer that depends on the unproven property is a
+close. Tracked, not blessed. One issue accounts for all of them today —
+#1928 — but it covers 17 of the 25 fields, in two groups: the eight
+`internal_presign_pool_*` tables plus `internal_presign_pool_sizes` (pops
+commit in their own batch, so a replay can bind a different presign than
+peers), and the eight `assigned_presigns_*` tables, whose insert rides the
+pool's pop batch and therefore INHERITS that exposure rather than having
+its own. Adding a consumer that depends on the unproven property is a
 blocker, not a judgement call.
 
 `handoff_signatures` was the other one until #1927 moved all three of its

--- a/dev-docs/conventions/logging.md
+++ b/dev-docs/conventions/logging.md
@@ -9,12 +9,14 @@ Pick the level by **how often the line fires** and **who has to read it**:
   ingest off-chain keys, a `send` on a live channel returned `Err`.)
 - `warn!` — a recoverable or expected-but-notable anomaly the node
   handles itself: a rejected peer message, a dropped stale announcement,
-  a transient that will retry. Not a failure of *this* node. Example:
-  a per-validator on-chain key that fails to decode is logged at `warn!`
-  and the validator is dropped from the committee — construction
-  proceeds (`sui_connector/sui_syncer.rs`, `new_committee`). Logging that
-  at `error!` — on a path that re-runs every poll tick — is exactly the
-  noise this rule exists to prevent.
+  a transient that will retry. Not a failure of *this* node. Example: a
+  validator whose on-chain metadata will not parse fails the whole
+  re-keying of the committee to consensus-basis names
+  (`rekey_committee_to_consensus_names` returns `InvalidCommittee`); the
+  caller logs `warn!` and `continue`s to the next sync tick
+  (`sui_connector/sui_syncer.rs`). Logging that at `error!` — on a path
+  that re-runs every poll tick — is exactly the noise this rule exists to
+  prevent.
 - `info!` — a low-frequency lifecycle milestone: roughly **once per
   epoch / session / reconfiguration**. Rule of thumb: if a healthy node
   can emit it more than a handful of times per epoch, it is not `info!`.
@@ -48,8 +50,9 @@ line on the compute path, it is `debug!`.
 
 - Off-chain validator-MPC-key **ingestion** (`mpc_manager.rs`) and
   **delivery** (`sui_connector/sui_syncer.rs`) of the agreed frozen set
-  — each guarded so it fires once per epoch (e.g. `sui_syncer` gates on
-  `current_keys_sent_for_epoch == Some(epoch)`). An `info!` here is only
+  — each guarded so it fires once per epoch (e.g. `sui_syncer` only enters
+  the delivery block while `current_keys_sent_for_epoch != Some(current_epoch)`,
+  and stamps it on success). An `info!` here is only
   correct *because* of that guard; the same log without a guard would be
   spam and belongs at `debug!`.
 - Epoch open/close, reconfiguration start/finish, committee changes.

--- a/dev-docs/conventions/simtest.md
+++ b/dev-docs/conventions/simtest.md
@@ -49,7 +49,7 @@ feature removed that cost, and `ika-test-cluster`'s dev-dependency
 self-reference builds the crate's tests with the mock unconditionally: a
 full 4-validator cluster boots and crosses epoch boundaries in ~3 minutes
 under msim, and the fault-simulation suite (`tests/sim_fault_*.rs`, plan:
-`../plans/simtest-fault-matrix.md`) is built on exactly that. Plain
+`../plans/archive/simtest-fault-matrix.md`) is built on exactly that. Plain
 `#[tokio::test]` functions are listed but IGNORED under the sim runner —
 `#[sim_test]` is the only runnable form there. For real-crypto coverage,
 `#[tokio::test]` remains the right tool.
@@ -86,8 +86,10 @@ can't rot between (manual/nightly) simtest runs.
 `ika-test-cluster` runs TWO epoch clocks, and they are independent:
 
 - **ika epoch** — set by `IkaTestClusterBuilder::with_sui_epoch_duration_ms`'s sibling
-  `with_epoch_duration_ms` (default `DEFAULT_EPOCH_DURATION_MS`), written into the
-  on-chain `InitiationParameters`. This is what `wait_for_epoch(n)` tracks.
+  `with_epoch_duration_ms`, written into the on-chain `InitiationParameters`. Unset,
+  the builder leaves it `None` and `InitiationParameters::default_epoch_duration_ms()`
+  supplies **24 hours** — so a test that never calls it never crosses an ika boundary
+  either. This is what `wait_for_epoch(n)` tracks.
 - **Sui epoch** — the underlying in-process Sui localnet's own committee clock.
 
 By default the test never sets the Sui clock, so the Sui `TestClusterBuilder` inherits

--- a/dev-docs/conventions/sui-version-bump.md
+++ b/dev-docs/conventions/sui-version-bump.md
@@ -12,7 +12,8 @@ the locations below and runs in CI; it fails the build on drift.
 ## Checklist (current tag: the single `mainnet-v*` or `testnet-v*` pin in root Cargo.toml)
 
 1. **Root `Cargo.toml`** — every Sui git dependency carries the
-   `tag = "mainnet-vX.Y.Z"` (or `testnet-vX.Y.Z`) pin (~90+ occurrences; sed them together):
+   `tag = "mainnet-vX.Y.Z"` (or `testnet-vX.Y.Z`) pin (43 occurrences at
+   `mainnet-v1.77.2`; sed them together):
    ```bash
    sed -i "" "s/mainnet-v<OLD>/mainnet-v<NEW>/g" Cargo.toml   # adjust flavor if moving to/from testnet-v
    cargo update   # refresh Cargo.lock for the new revs

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -20,10 +20,12 @@ with that suite's default inputs. It only *dispatches* — each run reports
 under its own workflow (Test Cluster / Integration Tests CI / TS
 Integration Tests / Simtest) on the targeted branch, with its own logs.
 
-Caveat: GitHub fires `schedule:` triggers only from the repository
-DEFAULT branch (`main`). Until this orchestrator also lands on `main`,
-the nightly cron does not run; `workflow_dispatch` works from any branch
-it exists on.
+GitHub fires `schedule:` triggers only from the repository DEFAULT branch
+(`main`), where this orchestrator now lives, so the nightly cron is live;
+`workflow_dispatch` works from any branch it exists on. A branch in the
+matrix that does not currently exist — `dev` comes and goes with release
+trains — is skipped with a `::notice::` rather than failing the job, so
+a nightly that dispatched only the `main` half is expected, not broken.
 
 ## Dispatch commands
 
@@ -63,10 +65,15 @@ gh run download <run-id> -n <artifact>   # localnet-logs / cluster-tests-log-<at
 `.github/workflows/upgrade-test.yaml` runs the out-of-process harness
 (`crates/ika-upgrade-test/`) — real, separately-compiled `ika-validator`
 child processes against an external `sui` localnet. Manual dispatch remains
-available. Pull requests that touch `ika-core/src`, `ika-types`,
-`ika-network`, the MPC or crypto crates, protocol configuration, the upgrade
-harness, or `Cargo.lock` automatically run the `v140_rollout` deployed-release
-gate rather than the entire matrix. Those are whole-crate globs on purpose:
+available. Pull requests matching the workflow's `paths:` filter — today
+`crates/ika-core/src/**`, `crates/ika-types/**`, `crates/ika-network/**`,
+`crates/dwallet-mpc-*/**`, `crates/ika-protocol-config/**`,
+`crates/ika-upgrade-test/**`, the root and per-crate `Cargo.toml`s,
+`Cargo.lock`, and the upgrade-test and release workflow files — automatically
+run the `v140_rollout` deployed-release gate rather than the entire matrix.
+Read that list rather than paraphrasing it: `crates/dwallet-mpc-*/**` is
+narrower than "the crypto crates" and does not match `dwallet-classgroups-types`
+or `dwallet-rng`. Those are whole-crate globs on purpose:
 the filter previously listed individual modules and silently stopped covering
 code three separate times as modules were added or split out — if you are
 adding a trigger for a module, widen to its crate instead. A change outside
@@ -167,8 +174,11 @@ accepting mocks.
 ```bash
 # `test` selects scenarios: 'all' (the default) fans EVERY scenario out as its
 # own matrix job on its own runner, in parallel (fail-fast off). Pass a
-# comma-separated subset to run several, or a single name to run one. All
-# scenarios need only the current build and run --test-threads=1.
+# comma-separated subset to run several, or a single name to run one. Every
+# scenario runs --test-threads=1 (each binds the fixed Sui localnet ports and
+# chdirs during publish, so only one can run per job). smoke, workload and
+# restart_spectator need only the current build; the three v140 gates also
+# build `old_ref` in an isolated git worktree at that ref's own toolchain.
 
 # Everything in parallel (default), or a subset:
 gh workflow run upgrade-test.yaml --ref <branch>                       # = test=all
@@ -213,6 +223,10 @@ gh workflow run upgrade-test.yaml --ref <branch> -f test=malicious_v140
 # removes an original validator (5→4).
 gh workflow run upgrade-test.yaml --ref <branch> -f test=v140_churn
 
+# The mid-epoch-restart gate (#1952). Current build only, but it runs at
+# production presign-pool sizing, so it is not a cheap scenario.
+gh workflow run upgrade-test.yaml --ref <branch> -f test=restart_spectator
+
 # NOTE: there is no rollback gate any more, and no backward direction in the
 # matrix. `mid_epoch_rollback` proved a v1.4.0 -> v1.3.1 mid-epoch rollback
 # safe for the v1.4.0 release commit (#2077, #2064) and was deleted once
@@ -240,6 +254,7 @@ notifier + a validator committee:
 | `v140_rollout` | **one current + three literal v1.4.0**, then all swapped | mixed aggregated reshares converge byte-identically with zero malicious reports; the fully-swapped committee converges and keeps serving |
 | `v140_churn` | all swapped, then a mirrored joiner (4→5) and a removal (5→4) | the v1.4.0-origin key reshares to a party that never held it (OCS joiner trust-anchor path) and back down |
 | `malicious_v140` | three literal v1.4.0 + one FAULTY current (test-testing build) | honest committee convicts the faulty validator and reshares without it — detection is not vacuous |
+| `restart_spectator` | current only, production presign-pool sizing | the #1952 mid-epoch-restart gate: a validator restarted far from a boundary, in an epoch with an established network key and ongoing internal-presign volume, resumes LIVE registry-driven top-up instantiation within the epoch — not merely staying consensus-healthy while peers absorb its sessions |
 
 ### CI runner resources
 
@@ -256,9 +271,15 @@ profile).
 
 ## Facts that save debugging time
 
-- **Concurrency groups cancel in-flight runs**: re-dispatching a workflow
-  on the same branch cancels the previous run of that workflow+ref. Don't
-  re-dispatch while a run you care about is in flight.
+- **Concurrency groups QUEUE, they don't cancel — with one exception.**
+  Every heavy suite uses a per-ref group (`<workflow>-<ref>`) with
+  `cancel-in-progress: false` (`upgrade-test.yaml` omits the key, which
+  means the same), so re-dispatching on the same branch leaves the
+  in-flight run alone and the new one waits its turn. The exception is
+  `ts-integration-tests.yaml`, which sets `cancel-in-progress: true` and
+  really does kill the previous run — and `ci.yaml`, which cancels on
+  every ref except `main`. So a re-dispatch is cheap on four of the five
+  suites and destructive on the TS one.
 - **Workflow definitions are pinned at dispatch**: a run uses the
   workflow file from the commit it was dispatched on; pushing fixes does
   not affect in-flight runs.

--- a/dev-docs/playbooks/mpc-anomaly-diagnostics.md
+++ b/dev-docs/playbooks/mpc-anomaly-diagnostics.md
@@ -568,7 +568,7 @@ Two metric readings name it directly, and both are cheap:
   `ika_dwallet_mpc_sessions_reconstructed_total` for the reconstruction-only
   shape; a session marked `session_origin="reconstructed_from_consensus"`
   with `active=false` is the signature.
-- **`ready_to_advance_result_total` with NO series at all** is a different
+- **`ika_dwallet_mpc_ready_to_advance_result_total` with NO series at all** is a different
   failure class from the same metric showing `not_ready` samples. No series
   means zero sessions ever reached the readiness check — nothing was ever
   attempted. Samples labelled `not_ready` mean sessions were attempted and

--- a/dev-docs/playbooks/mpc-stall-postmortem.md
+++ b/dev-docs/playbooks/mpc-stall-postmortem.md
@@ -19,7 +19,7 @@ log-grepping, opposite goal.
 ```bash
 L=<log file>
 grep -o "run_epoch epoch=[0-9]*" $L | sort -u | tail -3          # highest epoch entered
-grep -E "Successfully locked last session|EndOfPublishV2 active" $L | awk '{print $1, $NF}' | tail -6
+grep -E "Successfully locked last session|handoff-cert quorum reached" $L | awk '{print $1, $NF}' | tail -6
 grep "MPC output reached quorum" $L | tail -1 | awk '{print $1}' # last quorum = stall onset
 ```
 
@@ -102,10 +102,11 @@ four fixed; kept for the diagnostic shapes):
 - **mid-epoch-restart strand (issue #1852): sessions parked, zero
   instantiation attempts.** Signature (per wedged validator):
   `ika_dwallet_mpc_requests_pending_for_network_key` climbing while
-  `network_key_instantiations_in_flight` stays 0,
-  `network_key_instantiation_failures_total` shows no increase (never
-  attempted, not failing), and `network_key_loaded_epoch` cut off
-  exactly at process restart. Mechanism: the validator restarted after
+  `ika_dwallet_mpc_network_key_instantiations_in_flight` stays 0,
+  `ika_dwallet_mpc_network_key_instantiation_failures_total` shows no
+  increase (never attempted, not failing), and
+  `ika_dwallet_mpc_network_key_loaded_epoch` cut off exactly at process
+  restart. Mechanism: the validator restarted after
   this epoch's reconfiguration completed; the overlay served only the
   just-produced next-committee output, which adoption skips
   (`adoption skipping network key` log with
@@ -209,12 +210,16 @@ Narrow the dead layer by checking each pipeline stage independently:
 grep -c "Presign request reached majority vote" $L   # consensus + votes alive?
 grep -c "Adding a new MPC session" $L                # admission alive?
 grep -c "popped presign from internal pool" $L       # serving alive?
-grep "retrieved missed events" $L | tail -2          # event sync alive? (count growing = backlog)
+grep -c "broadcasting new requests" $L               # event sync alive? (debug-level)
 ```
 
 The combination "votes flow + sessions added + zero quorums + zero
 serving" pinpoints computation/messaging; "nothing flows" pinpoints
-consensus or the service loop.
+consensus or the service loop. The event-sync backlog itself is a gauge
+rather than a log line: `ika_sui_connector_uncompleted_events_backlog`
+is how many sessions the chain still shows uncompleted from this
+validator's view, so a climbing value with the pump still ticking is a
+consumption problem, not a delivery one.
 
 ## 6. Trace ONE session end-to-end
 
@@ -244,7 +249,9 @@ construction; divergence = determinism bug).
   drain even mid-replay — an unremarkable reading there is not evidence the
   backlog is small. The MPC service announces the drain itself (`MPC
   service entered catch-up mode`), and the catch-up gap falls fast while
-  it runs (~40x the tip rate, with computation suppressed). What to act on is
+  it runs — with computation suppressed the drain manages ~1-2k rounds/s
+  against a ~19.5 rounds/s tip, so a backlog closes at fifty to a hundred
+  times the rate it grows. What to act on is
   `ika_mpc_stopped_contributing_condition_active == 1` (nothing is
   draining and MPC has stopped: `MPC subsystem has stopped keeping up
   with consensus`) or `ika_mpc_catch_up_stuck_condition_active == 1`

--- a/dev-docs/playbooks/production-alerts.md
+++ b/dev-docs/playbooks/production-alerts.md
@@ -110,10 +110,15 @@ current-committee peer served a handoff certificate and none verified
 bootstrap"). Alert on process exit plus the log line:
 
 ```
-joiner bootstrap rejected: no peer-served certificate verified
+cross-epoch bootstrap trust anchor REJECTED — halting the node (fail-closed)
+prepare-then-start: cross-epoch anchor REJECTED — halting the node (fail-closed)
 ```
 
-(or the `Rejected` outcome marker in `JoinerBootstrapVerifier` logs).
+The first fires on the joiner-bootstrap path, the second on the
+prepare-then-start barrier; either one is the halt. `JoinerBootstrapVerifier`
+also logs the `Rejected` classification just before it
+(`joiner fetched handoff cert(s) for the prior epoch but NONE verified`),
+and `ika_joiner_bootstrap_outcomes_total{outcome="rejected"}` counts it.
 **Operator action**: this is fail-closed on a real contradiction — do
 NOT auto-restart into it; verify the node's configured trust anchors
 and the peer set before bringing it back.


### PR DESCRIPTION
Audited every file in `dev-docs/playbooks/`, `dev-docs/conventions/`, `dev-docs/learnings/`, `dev-docs/reference/` and `dev-docs/README.md` end to end against the code, scripts and workflows at this commit. Every line changed is a claim that no longer matched something checkable.

`conventions/metrics.md` is **deliberately untouched** — its generated inventory block is pinned byte-for-byte by `./scripts/check-metric-names.sh`, and its prose verified clean (including the counterintuitive "six `ika_sui_connector_*checkpoint_write*_total` series are registered as gauges", which is correct).

## playbooks/production-alerts.md

- **Alert 5 grepped a log line that does not exist.** `joiner bootstrap rejected: no peer-served certificate verified` appears nowhere. The fail-closed halt logs `cross-epoch bootstrap trust anchor REJECTED — halting the node (fail-closed)` (`ika-node/src/lib.rs:2965`) or `prepare-then-start: cross-epoch anchor REJECTED — …` (`:3623`). Added both, plus the `Rejected` classification line and `ika_joiner_bootstrap_outcomes_total{outcome="rejected"}`. The halt claim itself was correct.

## playbooks/mpc-stall-postmortem.md

- **Timeline anchor `EndOfPublishV2 active` is never emitted.** The epoch-close anchor is `EndOfPublish + handoff-cert quorum reached — closing the epoch` (`authority_per_epoch_store.rs:5456`, `info!`).
- **`retrieved missed events` no longer exists** — it went with the old event poller. Event-sync liveness is now `broadcasting new requests` (`bag_event_pump.rs:276`, debug). Added the backlog gauge `ika_sui_connector_uncompleted_events_backlog`, which is what the removed grep's "count growing = backlog" hint was for.
- **Three metric names missing their `ika_` prefix** in the #1852 signature — a paste into a query silently returns nothing. Now `ika_dwallet_mpc_network_key_{instantiations_in_flight,instantiation_failures_total,loaded_epoch}`.
- **"~40x the tip rate"** understated the code's own figures: ~1–2k rounds/s drain against a ~19.5 rounds/s tip (`authority_per_epoch_store.rs:144-146`) is fifty to a hundred times.

## playbooks/mpc-anomaly-diagnostics.md

- `ready_to_advance_result_total` → `ika_dwallet_mpc_ready_to_advance_result_total`. Same silent-empty-query class as above.

## playbooks/ci-suites.md

- **"Concurrency groups cancel in-flight runs" is wrong for four of the five heavy suites.** `test-cluster`, `integration-tests-ci` and `simtest` set `cancel-in-progress: false`; `upgrade-test` omits the key (same effect). Only `ts-integration-tests.yaml` sets `true`. The advice "don't re-dispatch while a run you care about is in flight" was backwards for most of them.
- **The `restart_spectator` scenario was missing entirely.** `ALL` in `upgrade-test.yaml:246` is six scenarios; the table and dispatch block listed five. Added a table row and a dispatch example.
- **"All scenarios need only the current build" is false** — the three v140 gates also build `old_ref` in an isolated git worktree.
- **The `paths:` filter was paraphrased as "the MPC or crypto crates".** The glob is `crates/dwallet-mpc-*/**`, which does not match `dwallet-classgroups-types` or `dwallet-rng`. Replaced the paraphrase with the actual list and flagged the gap — see *Doc-vs-code* below.
- **Stale nightly caveat.** "Until this orchestrator also lands on `main`, the nightly cron does not run" — `scheduled-all-suites.yaml` is on `main` at this SHA. Replaced with the live state plus the missing-branch skip, which explains a nightly that dispatches only the `main` half.

## conventions/enforce-minimum-cpu.md

- **`upgrade-test.yaml`'s OLD build step does not pass `--no-default-features`** (and its in-step comment says so deliberately: v1.4.0 carries the runtime gate). Only `ika-upgrade-test/src/binary.rs:179` still does, for historical refs. Kept the "do not clean this" instruction on the half where it applies.

## conventions/logging.md

- **The `warn!` example described behavior that no longer exists.** A per-validator on-chain key that fails to decode is no longer warned-and-dropped — `new_committee` now routes it through `report_invariant_violation!` and fails the whole committee build, because "exclusion decisions belong to the consensus-agreed freeze, never to a local read" (`sui_syncer.rs:904-945`). Replaced with a genuine current `warn!`-and-retry path, `rekey_committee_to_consensus_names`.
- The `info!` guard was quoted as `current_keys_sent_for_epoch == Some(epoch)`; the real guard is `!= Some(current_epoch)` (`sui_syncer.rs:412`).

## conventions/epoch-table-write-discipline.md

- **"One exists today" for `direct — UNPROVEN`.** 17 of 25 fields carry it, in two groups: nine `internal_presign_pool_*` and eight `assigned_presigns_*`, the latter inheriting the pools' exposure rather than having its own argument. Verified with `./scripts/check-epoch-table-write-discipline.sh --list`.
- The on-disk summary named "the private VSS outputs"; the table is `presign_private_outputs`, this validator's own presign secret share.

## conventions/sui-version-bump.md

- **"~90+ occurrences"** of the Sui tag in root `Cargo.toml`. There are 43.

## conventions/simtest.md

- **Broken path:** `../plans/simtest-fault-matrix.md` — the plan is archived at `../plans/archive/simtest-fault-matrix.md`. (Only broken path in scope; all others verified resolving.)
- **`DEFAULT_EPOCH_DURATION_MS` is not the test-cluster default.** No such constant on that path — the builder leaves `epoch_duration_ms: None` and `InitiationParameters::default_epoch_duration_ms()` supplies 24 hours, which matters because it is the same vacuous-pass trap the section is about.

## conventions/chain-mirror-layout.md

- CI runs **two** ika-types pin tests, not one: `cargo test -p ika-types --lib -- layout_is_pinned variant_indices_are_pinned`. The second pins the `DWalletNetworkEncryptionKeyState` variant discriminants, which are part of the same untagged byte stream.

## README.md

- The `production-alerts.md` one-liner named only the halt/block modes; the file now leads with invariant/self-malicious alerts and the three MPC-progress conditions.
- The epoch-table one-liner said "the one table whose argument does not close".

## Verified correct — no change

MIN=MAX=v7 and `bls_checkpoints` gates still present (kept for NOA supersession, not "corrected" away); the gap-based catch-up-stuck detector, its 15-minute bound, and that it samples the catch-up gate rather than the gate's gauge; the NodeMode-gated registration section, and that nothing elsewhere tells an operator to read a metric on a mode that no longer registers it; the `SystemCheckpointMessageKind` width pins in their dedicated `System checkpoint message widths` CI step; every anomaly-diagnostics constant (64-event trace, 1024 untracked, 16 KiB backtrace, 100/60s aggregation); every symbol and test name in `pitfalls.md`; all `sui-client-dependencies.md` claims; the pinned Sui rev `51d177ad…` cited in `consensus-output-consumption.md` still matches `Cargo.lock`.

## Doc-vs-code disagreements — reported, not fixed

- `.github/workflows/upgrade-test.yaml:104` — the PR trigger glob `crates/dwallet-mpc-*/**` misses `crates/dwallet-classgroups-types/**` and `crates/dwallet-rng/**`. This is the exact "a per-module list has now rotted three times" failure the filter's own comment guards against, one level up at the crate name. A crypto change in either crate merges without the cross-binary gate running. Left as-is (docs-only PR); the doc now states the real coverage.
- `crates/ika-core/src/dwallet_mpc/mpc_manager.rs:3491` — `Adding a new MPC session to the active sessions map` is `info!`, on a path that fires once per session including internal-presign churn. `conventions/logging.md`'s own rule ("if a healthy node can emit it more than a handful of times per epoch, it is not `info!`") suggests `debug!`. Judgement call for the owner, not a doc fix.

## CLAUDE.md issues — reported, not edited

- Gotchas: "root `Cargo.toml` (~90 tag pins)" — same stale count as the dev-doc; there are 43.
- Testing: `./scripts/run-integration-tests-sequential.sh --filter <file-stem>` — the script lives at `sdk/typescript/scripts/run-integration-tests-sequential.sh` (correct in `playbooks/localnet.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
