### PR TITLE
docs: correct stale and inaccurate comments outside ika-core

### DIFF
--- a/contracts/ika/sources/ika.move
+++ b/contracts/ika/sources/ika.move
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 /// The IKA for the Ika Protocol.
-/// Coin<IKA> is the token used to pay for gas in Ika.
+/// Coin<IKA> is the token used to pay for computation fees in Ika.
 /// It has 9 decimals, and the smallest unit (10^-9) is called "INKU".
 module ika::ika;
 

--- a/contracts/ika_common/sources/validator_cap.move
+++ b/contracts/ika_common/sources/validator_cap.move
@@ -25,17 +25,17 @@ public struct ValidatorCommissionCap has key, store {
     validator_id: ID,
 }
 
-/// A one time witness for the validator capability.
+/// A witness proving the validator capability was verified.
 public struct VerifiedValidatorCap has drop {
     validator_id: ID,
 }
 
-/// A one time witness for the validator operation capability.
+/// A witness proving the validator operation capability was verified.
 public struct VerifiedValidatorOperationCap has drop {
     validator_id: ID,
 }
 
-/// A one time witness for the validator commission capability.
+/// A witness proving the validator commission capability was verified.
 public struct VerifiedValidatorCommissionCap has drop {
     validator_id: ID,
 }

--- a/contracts/ika_dwallet_2pc_mpc/sources/coordinator.move
+++ b/contracts/ika_dwallet_2pc_mpc/sources/coordinator.move
@@ -41,7 +41,7 @@ const EInvalidMigration: u64 = 1;
 const EDeprecatedFunction: u64 = 2;
 
 // === Constants ===
-/// Flag to indicate the version of the ika system.
+/// Current version of the coordinator inner object structure.
 const VERSION: u64 = 2;
 
 // === Structs ===
@@ -56,7 +56,7 @@ public struct DWalletCoordinator has key {
 
 // === Functions that can only be called by init ===
 
-/// Create a new System object and make it shared.
+/// Create a new DWalletCoordinator object and make it shared.
 /// This function will be called only once in init.
 public(package) fun create(
     package_id: ID,

--- a/contracts/ika_dwallet_2pc_mpc/sources/coordinator_inner.move
+++ b/contracts/ika_dwallet_2pc_mpc/sources/coordinator_inner.move
@@ -93,7 +93,7 @@ const DWALLET_DKG_PROTOCOL_FLAG: u32 = 9;
 /// DKG with sign protocol identifier
 const DWALLET_DKG_WITH_SIGN_PROTOCOL_FLAG: u32 = 10;
 
-// Message data type constants corresponding to MessageKind enum variants (in ika-types/src/message.rs)
+// Message data type constants corresponding to DWalletCheckpointMessageKind enum variants (in ika-types/src/message.rs)
 #[deprecated, allow(unused)]
 const RESPOND_DWALLET_DKG_FIRST_ROUND_OUTPUT_MESSAGE_TYPE: u32 = 0;
 #[deprecated, allow(unused)]
@@ -205,8 +205,8 @@ public struct DWalletCoordinatorWitness has drop {}
 /// Next, `presign_sessions` holds the outputs of the Presign protocol which are later used for the signing protocol,
 /// and `partial_centralized_signed_messages` holds the partial signatures of users awaiting for a future sign once a `MessageApproval` is presented.
 ///
-/// Additionally, this structure holds management information, like the `previous_committee` and `active_committee` committees,
-/// information regarding `pricing_and_fee_manager`, all the `sessions_manager` and the `next_session_sequence_number` that will be used for the next session,
+/// Additionally, this structure holds management information, like the `active_committee` and `next_epoch_active_committee` committees,
+/// information regarding `pricing_and_fee_manager`, all the `sessions_manager` state,
 /// and various other fields, like the supported and paused curves, signing algorithms and hashes.
 ///
 /// ## Key Components:
@@ -217,7 +217,7 @@ public struct DWalletCoordinatorWitness has drop {}
 /// - `partial_centralized_signed_messages`: Future sign capabilities
 /// - `sessions_manager`: MPC session coordination
 /// - `pricing_and_fee_manager`: Economic incentives and fee collection
-/// - `active_committee`/`previous_committee`: Validator consensus groups
+/// - `active_committee`/`next_epoch_active_committee`: Validator consensus groups
 /// - `support_config`: Cryptographic algorithm support and emergency controls
 public struct DWalletCoordinatorInner has store {
     /// Current epoch number
@@ -383,7 +383,7 @@ public struct EncryptionKey has key, store {
 /// 3. User signs the public output to accept the share
 ///
 /// ## Creation Methods
-/// - **Direct**: Created during DKG second round
+/// - **Direct**: Created during dWallet DKG
 /// - **Re-encryption**: Created when transferring access to another user
 ///
 /// ## Security Properties
@@ -1073,17 +1073,17 @@ public enum UserSecretKeyShareEventType has copy, drop, store {
     },
 }
 
-/// Event requesting the second round of DKG from the validator network.
+/// Event requesting dWallet DKG from the validator network.
 ///
-/// This event initiates the final phase of distributed key generation where
-/// the user's contribution is combined with the network's first round output
-/// to complete the dWallet creation process.
+/// This event initiates the single-round dWallet DKG flow: the user generates
+/// their contribution up front (from the protocol public parameters), and the
+/// network runs its round of DKG and validates the user's contribution to
+/// complete the dWallet creation process.
 ///
 /// ## Process Flow
-/// 1. User processes the first round output from validators
-/// 2. User generates their cryptographic contribution
-/// 3. User encrypts their secret key share
-/// 4. Network validates and completes the DKG process
+/// 1. User generates their cryptographic contribution
+/// 2. User encrypts their secret key share (or makes it public)
+/// 3. Network runs its DKG round, validates the contribution, and completes the process
 ///
 /// ## Security Properties
 /// - User contribution ensures the user controls part of the key
@@ -1108,7 +1108,7 @@ public struct DWalletDKGRequestEvent has copy, drop, store {
     sign_during_dkg_request: Option<SignDuringDKGRequestEvent>,
 }
 
-/// Event emitted when DKG second round completes successfully.
+/// Event emitted when dWallet DKG completes successfully.
 ///
 /// Signals the successful completion of the distributed key generation process.
 /// The dWallet is now ready for user acceptance and can begin signing operations
@@ -1134,7 +1134,7 @@ public struct CompletedDWalletDKGEvent has copy, drop, store {
     sign_id: Option<ID>,
 }
 
-/// Event emitted when DKG second round is rejected by the network.
+/// Event emitted when dWallet DKG is rejected by the network.
 ///
 /// Indicates that the validator network rejected the user's contribution
 /// to the DKG process, typically due to invalid proofs or malformed data.
@@ -1145,7 +1145,7 @@ public struct CompletedDWalletDKGEvent has copy, drop, store {
 /// - Encryption verification failures
 /// - Network consensus issues
 public struct RejectedDWalletDKGEvent has copy, drop, store {
-    /// ID of the dWallet whose DKG second round was rejected
+    /// ID of the dWallet whose DKG was rejected
     dwallet_id: ID,
     /// Public output that was being processed when rejection occurred
     public_output: vector<u8>,
@@ -2646,30 +2646,32 @@ public(package) fun sign_during_dkg_request(
     }
 }
 
-/// Initiates the second round of Distributed Key Generation (DKG) with encrypted user shares.
+/// Initiates the single-round dWallet DKG flow with an encrypted user share.
 ///
-/// This function represents the user's contribution to the DKG second round, where they
-/// provide their encrypted secret share and request validator network verification.
-/// It creates the encrypted share object and transitions the dWallet to network verification.
+/// The user provides their DKG contribution up front (generated from the
+/// protocol public parameters) together with their encrypted secret share,
+/// and requests validator network verification. Creates the dWallet and the
+/// encrypted share object, both pending network verification.
 ///
 /// ### Parameters
 /// - `self`: Mutable reference to the coordinator
-/// - `dwallet_cap`: User's capability proving dWallet ownership
+/// - `dwallet_network_encryption_key_id`: Network encryption key securing the network share
+/// - `curve`: Elliptic curve for the dWallet
 /// - `centralized_public_key_share_and_proof`: User's public key contribution with ZK proof
 /// - `encrypted_centralized_secret_share_and_proof`: User's encrypted secret share with proof
 /// - `encryption_key_address`: Address of the encryption key for securing the share
 /// - `user_public_output`: User's contribution to the final public key
 /// - `signer_public_key`: Ed25519 key for signature verification
+/// - `sign_during_dkg_request`: Optional request to also sign a message in the DKG session
 /// - `payment_ika`: User's IKA payment for computation
 /// - `payment_sui`: User's SUI payment for gas reimbursement
 /// - `ctx`: Transaction context
 ///
-/// ### DKG Second Round Process
-/// 1. **Validation**: Verifies encryption key compatibility and dWallet state
+/// ### DKG Process
+/// 1. **Validation**: Verifies encryption key compatibility and curve support
 /// 2. **Share Creation**: Creates `EncryptedUserSecretKeyShare` with verification pending
 /// 3. **Payment Processing**: Charges user for validator computation and consensus
-/// 4. **Event Emission**: Requests validator network to verify encrypted share
-/// 5. **State Transition**: Updates dWallet to `AwaitingNetworkDKGVerification`
+/// 4. **Event Emission**: Requests validator network to run DKG and verify the encrypted share
 ///
 /// ### Cryptographic Security
 /// - **Zero-Knowledge Proofs**: User provides proofs of correct share encryption
@@ -2678,13 +2680,14 @@ public(package) fun sign_during_dkg_request(
 /// - **Threshold Security**: Maintains distributed key generation properties
 ///
 /// ### Network Integration
-/// Emits `DWalletDKGSecondRoundRequestEvent` for validator processing,
-/// triggering network verification of the encrypted share.
+/// Emits `DWalletDKGRequestEvent` for validator processing,
+/// triggering the network's DKG round and verification of the encrypted share.
+///
+/// ### Returns
+/// The new `DWalletCap` and, if signing during DKG was requested, the sign session ID.
 ///
 /// ### Aborts
-/// - `EImportedKeyDWallet`: If called on imported key dWallet
 /// - `EMismatchCurve`: If encryption key curve doesn't match dWallet curve
-/// - `EWrongState`: If dWallet not in correct state for second round
 /// - Various validation and payment errors
 public(package) fun request_dwallet_dkg(
     self: &mut DWalletCoordinatorInner,
@@ -2931,10 +2934,11 @@ public fun request_dwallet_dkg_impl(
     (dwallet_cap, sign_id)
 }
 
-/// This function is called by the Ika network to respond to the dWallet DKG second round request made by the user.
+/// This function is called by the Ika network to respond to the dWallet DKG request made by the user.
 ///
-/// Completes the second round of the Distributed Key Generation (DKG) process and
-/// advances the [`DWallet`] state to `AwaitingKeyHolderSignature` with the DKG public output registered in it.
+/// Completes the Distributed Key Generation (DKG) process and
+/// advances the [`DWallet`] state to `AwaitingKeyHolderSignature` (or straight to
+/// `Active` when the user secret key share is public) with the DKG public output registered in it.
 ///
 /// Advances the `EncryptedUserSecretKeyShareState` to `NetworkVerificationCompleted`.
 ///

--- a/contracts/ika_dwallet_2pc_mpc/sources/pricing.move
+++ b/contracts/ika_dwallet_2pc_mpc/sources/pricing.move
@@ -49,34 +49,19 @@ public struct PricingInfoCalculationVotes has copy, drop, store {
 
 // === Public Functions ===
 
-/// Creates a new [`PricingInfo`] object.
-///
-/// Initializes the table with the given pricing values for each operation.
-///
-/// # Parameters
-///
-/// - `ctx`: The transaction context.
+/// Creates a new empty [`PricingInfo`] object.
 ///
 /// # Returns
 ///
-/// A newly created instance of `PricingInfo`.
+/// A newly created instance of `PricingInfo` with an empty pricing map.
 public fun empty(): PricingInfo {
     PricingInfo {
         pricing_map: vec_map::empty(),
     }
 }
 
-/// Inserts pricing information for a specific operation into the [`PricingInfo`] table.
-///
-/// # Parameters
-///
-/// - `self`: The [`PricingInfo`] object.
-/// - `key`: The key for the operation.
-/// - `value`: The pricing information for the operation.
-///
-/// # Returns
-///
-/// The [`PricingInfo`] object.
+/// Inserts or updates the pricing information for a specific
+/// (curve, signature algorithm, protocol) operation in the [`PricingInfo`] map.
 public fun insert_or_update_pricing(
     self: &mut PricingInfo,
     curve: u32,

--- a/contracts/ika_dwallet_2pc_mpc/sources/sessions_manager.move
+++ b/contracts/ika_dwallet_2pc_mpc/sources/sessions_manager.move
@@ -234,7 +234,7 @@ public(package) fun lock_last_user_initiated_session_to_complete_in_current_epoc
 /// Registers a new session identifier.
 ///
 /// This function is used to register a new session identifier, the bytes length must be 32 bytes.
-/// SessionIdentifier's `identifier_preimage` is an keccak256 hash of the bytes and the sender address,
+/// SessionIdentifier's `identifier_preimage` is a keccak256 hash of the sender address followed by the bytes,
 /// this can be calculated on the client side before even calling this function onchain.
 ///
 /// ### Parameters

--- a/contracts/ika_system/sources/staking/pending_active_set.move
+++ b/contracts/ika_system/sources/staking/pending_active_set.move
@@ -39,7 +39,7 @@ public struct PendingActiveSet has copy, drop, store {
     /// The maximum number of validators in the active set
     max_validator_count: u64,
     /// The minimum amount of staked IKA needed to enter the active set. This is used to
-    /// determine if a storage validator can be added to the active set
+    /// determine if a validator can be added to the active set
     min_validator_joining_stake: u64,
     /// The maximum number of validators that can be added or removed to the active set in an epoch
     max_validator_change_count: u64,

--- a/contracts/ika_system/sources/staking/staked_ika.move
+++ b/contracts/ika_system/sources/staking/staked_ika.move
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 /// Implements the `StakedIka` functionality - a staked IKA is an object that
-/// represents a staked amount of IKAs in a staking pool. It is created in the
-/// `staking_pool` on staking and can be split, joined, and burned. The burning
-/// is performed via the `withdraw_stake` method in the `staking_pool`.
+/// represents a staked amount of IKAs in a validator's staking pool. It is
+/// created in the `validator` on staking and can be split, joined, and burned.
+/// The burning is performed via the `withdraw_stake` method in the `validator`.
 module ika_system::staked_ika;
 
 use ika::ika::IKA;
@@ -48,11 +48,11 @@ public struct StakedIka has key, store {
     id: UID,
     /// Whether the staked IKA is active or withdrawing.
     state: StakedIkaState,
-    /// ID of the staking pool.
+    /// ID of the validator.
     validator_id: ID,
     /// The staked amount.
     principal: Balance<IKA>,
-    /// The Ikarus epoch when the staked IKA was activated.
+    /// The Ika epoch when the staked IKA was activated.
     activation_epoch: u64,
 }
 

--- a/contracts/ika_system/sources/staking/validator.move
+++ b/contracts/ika_system/sources/staking/validator.move
@@ -41,7 +41,7 @@ const EValidatorAlreadyWithdrawing: u64 = 5;
 const EValidatorIsNotActive: u64 = 6;
 /// Trying to stake zero amount.
 const EZeroStake: u64 = 7;
-/// StakedIka is already in `Withdrawing` state.
+/// StakedIka is not in `Staked` state.
 const ENotStaked: u64 = 8;
 /// Trying to withdraw stake from the incorrect validator.
 const EIncorrectValidatorId: u64 = 9;

--- a/contracts/ika_system/sources/staking/validator_metadata.move
+++ b/contracts/ika_system/sources/staking/validator_metadata.move
@@ -1,7 +1,7 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-/// Metadata that describes a validator. Attached to the `StakingPool`
+/// Metadata that describes a validator. Attached to the `Validator`
 module ika_system::validator_metadata;
 
 use std::string::String;

--- a/contracts/ika_system/sources/system.move
+++ b/contracts/ika_system/sources/system.move
@@ -30,7 +30,6 @@
 /// - Epoch progression and timing
 /// - Staking and delegation logic
 /// - Protocol treasury and rewards distribution
-/// - dWallet network coordination
 /// - System parameter management
 ///
 /// ## Key Responsibilities
@@ -53,11 +52,11 @@
 /// - Managing epoch timing and duration
 /// - Distributing stake subsidies and rewards
 ///
-/// ### dWallet Integration
-/// - Coordinating with dWallet 2PC MPC system
-/// - Managing encryption keys and DKG processes
-/// - Handling pricing and curve configurations
-/// - Processing dWallet network operations
+/// ### dWallet Coordination
+/// dWallet 2PC-MPC coordination itself lives in the separate `ika_dwallet_2pc_mpc`
+/// package; this module interacts with it only through the shared status and
+/// epoch-advancement objects (`SystemCurrentStatusInfo`, `AdvanceEpochApprover`,
+/// witness approvals).
 ///
 /// ### System Governance
 /// - Managing protocol upgrades via UpgradeCap
@@ -85,7 +84,7 @@
 /// To perform a proper type upgrade of `SystemInner`, follow these steps:
 /// 1. Define a new `SystemInnerV2` type in system_inner.move.
 /// 2. Create a data migration function that transforms `SystemInner` to `SystemInnerV2`.
-/// 3. Update the `VERSION` constant to 2 and replace all references to `SystemInner` with `SystemInnerV2`
+/// 3. Update the `VERSION` constant to the next version and replace all references to `SystemInner` with `SystemInnerV2`
 ///    in both system.move and system_inner.move.
 /// 4. Modify the `migrate` function to handle the version upgrade by:
 ///    - Removing the old inner object from the dynamic field
@@ -254,11 +253,11 @@ public fun initialize(
 }
 
 /// Can be called by anyone who wishes to become a validator candidate and starts accruing delegated
-/// stakes in their staking pool. Once they have at least `MIN_VALIDATOR_JOINING_STAKE` amount of stake they
+/// stakes in their staking pool. Once they have at least the minimum joining stake they
 /// can call `request_add_validator` to officially become an active validator at the next epoch.
 /// Aborts if the caller is already a pending or active validator, or a validator candidate.
-/// Note: `proof_of_possession_bytes` MUST be a valid signature using sui_address and protocol_pubkey_bytes.
-/// To produce a valid PoP, run [fn test_proof_of_possession_bytes].
+/// Note: `proof_of_possession_bytes` MUST be a valid BLS signature by `protocol_pubkey_bytes`
+/// over the protocol key and the sender's address (see `validator_info::verify_proof_of_possession`).
 public fun request_add_validator_candidate(
     self: &mut System,
     name: String,
@@ -307,10 +306,7 @@ public fun request_add_validator(self: &mut System, cap: &ValidatorCap) {
 }
 
 /// A validator can call this function to request a removal in the next epoch.
-/// We use the sender of `ctx` to look up the validator
-/// (i.e. sender must match the sui_address in the validator).
-/// At the end of the epoch, the `validator` object will be returned to the sui_address
-/// of the validator.
+/// The validator is looked up by the `ValidatorCap`.
 public fun request_remove_validator(self: &mut System, cap: &ValidatorCap) {
     self.inner_mut().request_remove_validator(cap)
 }
@@ -336,8 +332,7 @@ public fun request_add_stake(
 }
 
 /// Marks the amount as a withdrawal to be processed and removes it from the stake weight of the
-/// node. Allows the user to call withdraw_stake after the epoch change to the next epoch and
-/// shard transfer is done.
+/// node. Allows the user to call withdraw_stake after the epoch change to the next epoch.
 public fun request_withdraw_stake(self: &mut System, staked_ika: &mut StakedIka) {
     self.inner_mut().request_withdraw_stake(staked_ika);
 }
@@ -472,7 +467,7 @@ public fun set_next_epoch_network_pubkey_bytes(
     self.inner_mut().set_next_epoch_network_pubkey_bytes(network_pubkey, cap)
 }
 
-/// Sets a validator's public key of worker key.
+/// Sets a validator's public key of consensus key.
 /// The change will only take effects starting from the next epoch.
 public fun set_next_epoch_consensus_pubkey_bytes(
     self: &mut System,

--- a/contracts/ika_system/sources/system/protocol_treasury.move
+++ b/contracts/ika_system/sources/system/protocol_treasury.move
@@ -23,9 +23,9 @@ public struct ProtocolTreasury has store {
     /// Count of the number of times stake subsidies have been distributed.
     stake_subsidy_distribution_counter: u64,
     /// The rate at which the amount per distribution is calculated based on
-    /// period nad total supply. Expressed in basis points.
+    /// period and total supply. Expressed in basis points.
     stake_subsidy_rate: u16,
-    /// The amount of stake subsidy to be destructured per distribution.
+    /// The amount of stake subsidy to be distributed per distribution.
     /// This amount changes based on `stake_subsidy_rate`.
     stake_subsidy_amount_per_distribution: u64,
     /// Number of distributions to occur before the amount per distribution will be recalculated.

--- a/contracts/ika_system/sources/system/system_inner.move
+++ b/contracts/ika_system/sources/system/system_inner.move
@@ -85,7 +85,7 @@ const EHaveNotReachedMidEpochTime: u64 = 7;
 
 // === Structs ===
 
-/// Uses SystemParametersV1 as the parameters.
+/// The inner system state object, wrapped by `System`.
 public struct SystemInner has store {
     /// The current epoch ID, starting from 0.
     epoch: u64,
@@ -215,7 +215,7 @@ public struct SetApprovedUpgradeEvent has copy, drop {
     digest: Option<vector<u8>>,
 }
 
-/// Event emitted when the epoch ends.
+/// Event emitted when the end-of-publish checkpoint message is processed.
 public struct EndOfPublishEvent has copy, drop {
     epoch: u64,
 }
@@ -307,12 +307,12 @@ public(package) fun initialize(
     )
 }
 
-/// Can be called by anyone who wishes to become a validator candidate and starts accusing delegated
-/// stakes in their staking pool. Once they have at least `MIN_VALIDATOR_JOINING_STAKE` amount of stake they
+/// Can be called by anyone who wishes to become a validator candidate and starts accruing delegated
+/// stakes in their staking pool. Once they have at least the minimum joining stake they
 /// can call `request_add_validator` to officially become an active validator at the next epoch.
 /// Aborts if the caller is already a pending or active validator, or a validator candidate.
-/// Note: `proof_of_possession_bytes` MUST be a valid signature using proof_of_possession_sender and protocol_pubkey_bytes.
-/// To produce a valid PoP, run [fn test_proof_of_possession_bytes].
+/// Note: `proof_of_possession_bytes` MUST be a valid BLS signature by `protocol_pubkey_bytes`
+/// over the protocol key and the sender's address (see `verify_proof_of_possession`).
 public(package) fun request_add_validator_candidate(
     self: &mut SystemInner,
     name: String,
@@ -363,10 +363,7 @@ public(package) fun request_add_validator(self: &mut SystemInner, cap: &Validato
 }
 
 /// A validator can call this function to request a removal in the next epoch.
-/// We use the sender of `ctx` to look up the validator
-/// (i.e. sender must match the sui_address in the validator).
-/// At the end of the epoch, the `validator` object will be returned to the sui_address
-/// of the validator.
+/// The validator is looked up by the `ValidatorCap`.
 public(package) fun request_remove_validator(self: &mut SystemInner, cap: &ValidatorCap) {
     self.validator_set.request_remove_validator(self.epoch, cap);
 }
@@ -542,7 +539,7 @@ public(package) fun set_next_epoch_network_pubkey_bytes(
     self.validator_set.set_next_epoch_network_pubkey_bytes(network_pubkey_bytes, cap);
 }
 
-/// Sets a validator's public key of worker key.
+/// Sets a validator's public key of consensus key.
 /// The change will only take effects starting from the next epoch.
 public(package) fun set_next_epoch_consensus_pubkey_bytes(
     self: &mut SystemInner,
@@ -617,11 +614,10 @@ public(package) fun initiate_advance_epoch(
 
 /// This function should be called at the end of an epoch, and advances the system to the next epoch.
 /// It does the following things:
-/// 1. Add storage charge to the storage fund.
-/// 2. Burn the storage rebates from the storage fund. These are already refunded to transaction sender's
-///    gas coins.
-/// 3. Distribute computation charge to validator stake.
-/// 4. Update all validators.
+/// 1. Collects the epoch's fee rewards and, once past `stake_subsidy_start_epoch`,
+///    the stake subsidy for distribution.
+/// 2. Distributes the rewards to validator stake.
+/// 3. Updates all validators and switches to the next epoch's committee.
 public(package) fun advance_epoch(
     self: &mut SystemInner,
     advance_epoch_approver: AdvanceEpochApprover,

--- a/contracts/ika_system/sources/system/validator_set.move
+++ b/contracts/ika_system/sources/system/validator_set.move
@@ -856,8 +856,7 @@ fun calculate_total_stakes(self: &mut ValidatorSet): u64 {
     stake
 }
 
-/// Compute both the individual reward adjustments and total reward adjustment for staking rewards
-/// as well as storage fund rewards.
+/// Compute both the individual reward adjustments and total reward adjustment for staking rewards.
 fun compute_reward_adjustments(
     mut slashed_validator_indices: vector<u64>,
     reward_slashing_rate: u16,

--- a/contracts/ika_system/tests/e2e_runner.move
+++ b/contracts/ika_system/tests/e2e_runner.move
@@ -46,7 +46,7 @@ public struct TestRunner {
     admin: address,
 }
 
-/// Add any parameters to the initialization, such as epoch zero duration and number of shards.
+/// Add any parameters to the initialization, such as the protocol version and epoch duration.
 /// They will be used by the e2e runner admin during the initialization.
 public struct InitBuilder {
     protocol_version: Option<u64>,

--- a/contracts/ika_system/tests/test_utils.move
+++ b/contracts/ika_system/tests/test_utils.move
@@ -422,7 +422,7 @@ public fun bls_aggregate_sigs(signatures: &vector<vector<u8>>): vector<u8> {
     *aggregate.bytes()
 }
 
-/// Test committee with one committee member and 100 shards, using
+/// Test committee with one committee member, using
 /// `test_utils::bls_sk_for_testing()` as secret key.
 public fun new_bls_committee_for_testing(): bls_committee::BlsCommittee {
     let validator_id = tx_context::dummy().fresh_object_address().to_id();
@@ -435,8 +435,8 @@ public fun new_bls_committee_for_testing(): bls_committee::BlsCommittee {
     bls_committee::new_bls_committee(vector[member])
 }
 
-/// Test committee with 10 committee member and 100 shards, using
-/// `test_utils::bls_sk_for_testing()` as secret key.
+/// Test committee with `num_members` committee members, using
+/// `test_utils::bls_secret_keys_for_testing()` as secret keys.
 public fun new_bls_committee_with_multiple_members_for_testing(
     num_members: u64,
     tx_context: &mut TxContext,

--- a/crates/dwallet-mpc-centralized-party/src/lib.rs
+++ b/crates/dwallet-mpc-centralized-party/src/lib.rs
@@ -94,7 +94,9 @@ pub fn reconfiguration_public_output_to_protocol_pp_inner(
 
 pub type DWalletDKGFirstParty = twopc_mpc::secp256k1::class_groups::EncryptionOfSecretKeyShareParty;
 
-/// Executes the second phase of the DKG protocol, part of a three-phase DKG flow.
+/// Executes the centralized party's DKG round from the protocol public
+/// parameters alone (unlike [`create_dkg_output_v1`], it does not consume a
+/// decentralized first-round output).
 ///
 /// This function is invoked by the centralized party to produce:
 /// - A public key share and its proof.
@@ -104,14 +106,15 @@ pub type DWalletDKGFirstParty = twopc_mpc::secp256k1::class_groups::EncryptionOf
 /// and should always be kept private.
 ///
 /// # Parameters
-/// — `decentralized_first_round_output`:
-///    Serialized output of the decentralized party from the first DKG round.
-/// — `session_id`: Unique hexadecimal string identifying the session.
+/// — `dwallet_curve`: The curve identifier (see [`try_into_curve`]).
+/// — `protocol_pp`: Serialized protocol public parameters.
+/// — `session_id`: Session identifier bytes.
 ///
 /// # Returns
-/// A tuple containing:
+/// A [`CentralizedDKGWasmResult`] containing:
 /// - Serialized public key share and proof.
-/// - Serialized centralized DKG output.
+/// - Serialized centralized DKG public output.
+/// - Serialized centralized secret key share.
 ///
 /// # Errors
 /// Return an error if decoding or advancing the protocol fails.
@@ -215,14 +218,16 @@ pub fn centralized_dkg_output_v2_with_rng<P: twopc_mpc::dkg::Protocol, R: group:
 /// and should always be kept private.
 ///
 /// # Parameters
-/// — `decentralized_first_round_output`:
-///    Serialized output of the decentralized party from the first DKG round.
-/// — `session_id`: Unique hexadecimal string identifying the session.
+/// — `protocol_pp`: Serialized protocol public parameters.
+/// — `decentralized_first_round_public_output`:
+///    Serialized output of the decentralized party from the first DKG round
+///    (carries the session identifier).
 ///
 /// # Returns
-/// A tuple containing:
+/// A [`CentralizedDKGWasmResult`] containing:
 /// - Serialized public key share and proof.
-/// - Serialized centralized DKG output.
+/// - Serialized centralized DKG public output.
+/// - Serialized centralized secret key share.
 ///
 /// # Errors
 /// Return an error if decoding or advancing the protocol fails.
@@ -392,8 +397,9 @@ fn centralized_and_decentralized_parties_dkg_output_match_by_protocol<
 /// Executes the centralized phase of the Sign protocol,
 ///  the first part of the protocol.
 ///
-/// The [`advance_centralized_sign_party`] function is
-/// called by the client (the centralized party).
+/// Called by the client (the centralized party); takes the centralized
+/// party's own DKG output (unlike [`advance_centralized_sign_party`], which
+/// takes the decentralized party's).
 pub fn advance_centralized_sign_party_with_centralized_party_dkg_output(
     protocol_pp: Vec<u8>,
     centralized_party_dkg_public_output: SerializedWrappedMPCPublicOutput,
@@ -1514,13 +1520,11 @@ fn decrypt_user_share_inner<P: twopc_mpc::dkg::Protocol>(
         bcs::from_bytes(encrypted_user_share_and_proof)?;
     let dwallet_dkg_output = match bcs::from_bytes(dwallet_dkg_output)? {
         VersionedDwalletDKGPublicOutput::V1(output) => {
-            // return Err(anyhow::anyhow!("2.1"));
             let versioned_output: P::DecentralizedPartyDKGOutput =
                 bcs::from_bytes::<P::DecentralizedPartyTargetedDKGOutput>(&output)?.into();
             versioned_output
         }
         VersionedDwalletDKGPublicOutput::V2 { dkg_output, .. } => {
-            // return Err(anyhow::anyhow!("2.2"));
             bcs::from_bytes::<P::DecentralizedPartyDKGOutput>(&dkg_output)?
         }
     };

--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -107,7 +107,9 @@ pub struct NetworkEncryptionKeyPublicData {
     pub latest_network_reconfiguration_public_output:
         Option<VersionedDecryptionKeyReconfigurationOutput>,
     /// The public output of the `NetworkDKG` process (the first and only one).
-    /// On first instance it will be equal to `latest_public_output`.
+    /// Until the first reconfiguration
+    /// (`latest_network_reconfiguration_public_output` is `None`), this is the
+    /// latest output.
     pub network_dkg_output: VersionedNetworkDkgOutput,
     pub secp256k1_protocol_public_parameters:
         Arc<twopc_mpc::secp256k1::class_groups::ProtocolPublicParameters>,

--- a/crates/ika-network/build.rs
+++ b/crates/ika-network/build.rs
@@ -166,8 +166,8 @@ fn build_anemo_services(out_dir: &Path) {
         // NOTE: no `get_reference_gas_price` RPC. Gas price is only needed to
         // build transactions, which is notifier-gated to a direct uplink — no
         // read-only mirrored/peer-only node ever needs it, so the relay doesn't
-        // serve it. (It remains a `SuiTransport` method for the direct writer
-        // path; on the mirror client it errors like the other non-relayed reads.)
+        // serve it. (It lives on the `SuiWriter` trait for the direct writer
+        // path; the mirror transport implements no writer surface at all.)
         .method(
             anemo_build::manual::Method::builder()
                 .name("get_latest_checkpoint")
@@ -225,8 +225,8 @@ fn build_anemo_services(out_dir: &Path) {
         // NOTE: no `get_transaction_checkpoint` RPC. It was only ever reached
         // by `get_events_by_tx_digest` (the notifier's removed tx-commit gate);
         // the committee ratchet uses `last_checkpoint_of_epoch` /
-        // `get_current_epoch` / `get_full_checkpoint`, not this. The
-        // `SuiTransport` trait method survives for *direct* proof building
+        // `get_current_epoch` / `get_full_checkpoint`, not this. It survives
+        // as an inherent `SuiGrpcClient` method for *direct* proof building
         // (`LocalProofProvider` over the node's own gRPC), which never relays.
         // Verified-read surface (the hot path for consumers). Each response
         // carries the object, the BLS-signed summary at the checkpoint

--- a/crates/ika-network/src/mpc_artifacts.rs
+++ b/crates/ika-network/src/mpc_artifacts.rs
@@ -65,11 +65,6 @@ pub use handoff_cert::{
     GetCertifiedHandoffAttestationRequest, HandoffCertStorage, fetch_certified_handoff_attestation,
 };
 
-/// Build a `ValidatorMetadataServer` backed by `storage`, an
-/// announcement-relay handle, and a certified-handoff store. The
-/// relay handle starts empty; the node installs a relay impl into
-/// it once per-epoch state is up. The cert store is wired directly
-/// to perpetual storage at construction time.
 /// Concurrent `GetMpcDataBlob` reads. A blob is multi-megabyte MPC data
 /// served out of storage, so this is the heaviest of the three — calibrated
 /// alongside `sui_state_mirror`'s heaviest read (`changeset_page`, 16).
@@ -84,6 +79,11 @@ const INFLIGHT_SUBMIT_ANNOUNCEMENT: usize = 16;
 /// cheap, matching `sui_state_mirror`'s checkpoint-read tier.
 const INFLIGHT_GET_HANDOFF_CERT: usize = 64;
 
+/// Build a `ValidatorMetadataServer` backed by `storage`, an
+/// announcement-relay handle, and a certified-handoff store. The
+/// relay handle starts empty; the node installs a relay impl into
+/// it once per-epoch state is up. The cert store is wired directly
+/// to perpetual storage at construction time.
 pub fn build_server<S: MpcDataBlobStorage, C: HandoffCertStorage>(
     storage: Arc<S>,
     relay: Arc<AnnouncementRelayHandle>,

--- a/crates/ika-network/src/state_sync/mod.rs
+++ b/crates/ika-network/src/state_sync/mod.rs
@@ -74,20 +74,6 @@ use tokio::{
 };
 use tracing::{debug, error, info, instrument, trace, warn};
 
-/// Live feed of the highest checkpoint sequence numbers the chain has already
-/// PROCESSED (the coordinator's / system's `last_processed_checkpoint_sequence_number`),
-/// fed by the node's Sui connector. `None` until the first successful chain
-/// read of a cursor.
-///
-/// Pull-mode state sync (notifiers/fullnodes — nodes that don't build
-/// checkpoints from consensus) uses this as a sync FLOOR: checkpoints at or
-/// below the cursor have already landed on Sui and are useless to a writer,
-/// and on a long-lived network no peer can serve deep history anyway —
-/// validators only ever hold what consensus gave them since their own last
-/// (re)deploy, and there is no backfill. Without the floor, a notifier
-/// deployed on a fresh database chases checkpoint 1 forever ("no peers were
-/// able to help sync checkpoint 1"), synced pinned at 0 while known grows —
-/// the 2026-07 epoch-close outage shape (issue #1892).
 /// Ceiling on peer-pushed checkpoint bodies held per stream.
 ///
 /// Generous relative to any legitimate backlog — sync advances sequentially,
@@ -95,6 +81,20 @@ use tracing::{debug, error, info, instrument, trace, warn};
 /// bounding what an unauthenticated push can pin in memory.
 const MAX_UNPROCESSED_CHECKPOINTS: usize = 10_000;
 
+/// Live feed of the highest checkpoint sequence numbers the chain has
+/// already PROCESSED (the coordinator's / system's
+/// `last_processed_checkpoint_sequence_number`), fed by the node's Sui
+/// connector. `None` until the first successful chain read of a cursor.
+///
+/// Pull-mode state sync (notifiers/fullnodes — nodes that don't build
+/// checkpoints from consensus) uses this as a sync FLOOR: checkpoints at
+/// or below the cursor have already landed on Sui and are useless to a
+/// writer, and on a long-lived network no peer can serve deep history
+/// anyway — validators only ever hold what consensus gave them since their
+/// own last (re)deploy, and there is no backfill. Without the floor, a
+/// notifier deployed on a fresh database chases checkpoint 1 forever ("no
+/// peers were able to help sync checkpoint 1"), synced pinned at 0 while
+/// known grows — the 2026-07 epoch-close outage shape (issue #1892).
 #[derive(Clone)]
 pub struct OnChainCheckpointCursors {
     pub dwallet: watch::Receiver<Option<DWalletCheckpointSequenceNumber>>,

--- a/crates/ika-network/src/state_sync/server.rs
+++ b/crates/ika-network/src/state_sync/server.rs
@@ -212,7 +212,7 @@ where
     }
 }
 
-/// [`Layer`] for adding a per-checkpoint limit to the number of inflight GetCheckpointContent
+/// [`Layer`] for adding a per-checkpoint limit to the number of inflight GetCheckpointMessage
 /// requests.
 #[derive(Clone)]
 pub(super) struct CheckpointMessageDownloadLimitLayer {
@@ -250,7 +250,7 @@ impl<S> tower::layer::Layer<S> for CheckpointMessageDownloadLimitLayer {
     }
 }
 
-/// Middleware for adding a per-checkpoint limit to the number of inflight GetCheckpointContent
+/// Middleware for adding a per-checkpoint limit to the number of inflight GetCheckpointMessage
 /// requests.
 #[derive(Clone)]
 pub(super) struct CheckpointMessageDownloadLimit<S> {
@@ -350,7 +350,7 @@ impl<S> tower::layer::Layer<S> for SystemCheckpointDownloadLimitLayer {
     }
 }
 
-/// Middleware for adding a per-system_checkpoint limit to the number of inflight GetSystemCheckpointContent
+/// Middleware for adding a per-system_checkpoint limit to the number of inflight GetSystemCheckpoint
 /// requests.
 #[derive(Clone)]
 pub(super) struct SystemCheckpointDownloadLimit<S> {

--- a/crates/ika-node/src/admin.rs
+++ b/crates/ika-node/src/admin.rs
@@ -246,7 +246,6 @@ async fn set_filter(
 async fn capabilities(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
     let epoch_store = state.node.state().load_epoch_store_one_call_per_task();
 
-    // Only one of v1 or v2 will be populated at a time
     let capabilities = epoch_store.get_capabilities_v1();
     let mut output = String::new();
     for capability in capabilities.unwrap_or_default() {

--- a/crates/ika-node/src/handle.rs
+++ b/crates/ika-node/src/handle.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-//! IkaNodeHandle wraps IkaNode in a way ikatable for access by test code.
+//! IkaNodeHandle wraps IkaNode in a way suitable for access by test code.
 //!
 //! When starting a IkaNode directly, in a test (as opposed to using Swarm), the node may be
 //! running inside of a simulator node. It is therefore a mistake to do something like:

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -31,8 +31,10 @@ const MAX_PROTOCOL_VERSION: u64 = 7;
 //            PVSS HPKE) and DKG/Reconfiguration use `twopc_mpc::decentralized_party::*`.
 // Version 5: aggregated_network_key_public_outputs on — network DKG /
 //            reconfiguration public outputs switch to the aggregated wire
-//            format (V4-tagged); V3-tagged pre-aggregation outputs remain
-//            readable forever (testnet persisted them at v4).
+//            format (V4-tagged). The V3 variant index is retained for BCS
+//            stability, but V3 BYTES no longer decode: the crypto crate
+//            removed the pre-aggregation type, so any key still tagged V3
+//            must have reconfigured to V4 before this binary runs.
 // Version 6: two coordinated flips activated together at the v6 boundary.
 //   (a) consensus_key_authority_names — `AuthorityName` (validator identity)
 //            became the Ed25519 consensus key, zero-padded to the 48-byte
@@ -161,7 +163,7 @@ struct FeatureFlags {
     // Add feature flags here, e.g.:
     // #[serde(skip_serializing_if = "is_false")]
     // new_protocol_feature: bool,
-    // === Used at Sui consensus for current ProtocolConfig version (MAX 84) ===
+    // === Mirrors of Sui's consensus settings, fed to consensus-core ===
 
     // Probe rounds received by peers from every authority.
     #[serde(skip_serializing_if = "is_false")]
@@ -259,7 +261,9 @@ struct FeatureFlags {
     // versioned output enums; false kept producing the pre-aggregation V3
     // format. Set at version 5 and therefore true at every supported
     // version, so nothing reads it anymore — V4 is the only format produced.
-    // V3-tagged outputs stay DECODABLE forever (testnet persisted them).
+    // V3 bytes are no longer decodable either: the crypto crate removed the
+    // pre-aggregation type, so those decode arms are hard errors and a key
+    // still tagged V3 must have reconfigured to V4 before this binary runs.
     //
     // Kept for the same reason as `off_chain_validator_metadata` above: the
     // flag set is part of the BCS-serialized `ProtocolConfig` whose digest
@@ -281,9 +285,10 @@ struct FeatureFlags {
     // and carried on `Committee` for BLS aggregate-certificate (checkpoint)
     // verification. Set at version 6 and therefore true at every supported
     // version, so nothing reads it anymore — the consensus key is the only
-    // identity basis a supported epoch uses. Committees persisted under
-    // BLS-basis names stay READABLE through `Committee`'s alias translation
-    // (`expanded_keys`), which is structural, not gated on this flag.
+    // identity basis a supported epoch uses. A BLS key can no longer be
+    // recovered from a name, so committees that verify BLS
+    // aggregate certificates carry the `AuthorityName -> BLS pubkey` map
+    // explicitly from chain via `Committee::new_with_protocol_keys`.
     //
     // Kept for the same reason as `off_chain_validator_metadata` above: the
     // flag set is part of the BCS-serialized `ProtocolConfig` whose digest
@@ -434,7 +439,7 @@ pub struct ProtocolConfig {
     /// If the total session count is below this threshold, the validator is considered idle.
     idle_session_count_threshold: Option<u64>,
 
-    // === Used at Sui consensus for current ProtocolConfig version (MAX 84) ===
+    // === Mirrors of Sui's consensus settings, fed to consensus-core ===
     /// The maximum serialised transaction size (in bytes) accepted by consensus. That should be bigger than the
     /// `max_tx_size_bytes` with some additional headroom.
     consensus_max_transaction_size_bytes: Option<u64>,

--- a/crates/ika-proxy/src/sui_chain.rs
+++ b/crates/ika-proxy/src/sui_chain.rs
@@ -53,7 +53,7 @@ mod tests {
     use super::*;
 
     /// The public Sui chain identifiers, as reported by a fullnode's
-    /// `getChainIdentifier` and logged by `ika_sui_client` on connect.
+    /// chain-identifier RPC and logged by `ika_sui_client` on connect.
     const SUI_MAINNET: &str = "35834a8a";
     const SUI_TESTNET: &str = "4c78adac";
 

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -556,7 +556,6 @@ where
         }
     }
 
-    /// Get the validators' info by their IDs.
     /// The `validator_id`s currently in the on-chain `pending_active_set` — the
     /// staging set for the next epoch, updated continuously as validators
     /// join/leave (so a freshly-registered joiner appears here before it reaches

--- a/crates/ika-swarm-config/src/network_config_builder.rs
+++ b/crates/ika-swarm-config/src/network_config_builder.rs
@@ -276,9 +276,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
         let mut validator_initialization_configs = match committee {
             CommitteeConfig::Size(size) => {
                 // We always get fixed protocol keys from this function (which is isolated from
-                // external test randomness because it uses a fixed seed). Necessary because some
-                // tests call `make_tx_certs_and_signed_effects`, which locally forges a cert using
-                // this same committee.
+                // external test randomness because it uses a fixed seed).
                 let (_, keys) = Committee::new_simple_test_committee_of_size(size.into());
 
                 keys.into_iter()

--- a/crates/ika-swarm-config/src/node_config_builder.rs
+++ b/crates/ika-swarm-config/src/node_config_builder.rs
@@ -390,8 +390,8 @@ impl FullnodeConfigBuilder {
         ika_dwallet_coordinator_object_id: ObjectID,
         notifier_client_key_pair: Option<SuiKeyPair>,
     ) -> NodeConfig {
-        // Take advantage of ValidatorGenesisConfigBuilder to build the keypairs and addresses,
-        // even though this is a fullnode.
+        // Take advantage of ValidatorInitializationConfigBuilder to build the keypairs and
+        // addresses, even though this is a fullnode.
         let validator_config_builder = ValidatorInitializationConfigBuilder::new();
 
         let validator_config = validator_config_builder.build(rng);

--- a/crates/ika-swarm-config/src/sui_client.rs
+++ b/crates/ika-swarm-config/src/sui_client.rs
@@ -685,21 +685,16 @@ fn new_curve_to_signature_algorithm_vecmap(
 pub enum GenesisGlobalPresignConfig {
     /// Route the production curve/algorithm set to global presign — the
     /// actual mainnet on-chain state (verified: mainnet's
-    /// `GlobalPresignConfig` holds exactly these maps). Servable at every
-    /// protocol version: at v4+ from the validators' internal presign pool
-    /// (`internal_presign_sessions`), below that as a user-requested MPC
-    /// session — the 1.1.8 behavior, which this branch retains as the
-    /// pre-activation fallback in `handle_mpc_request` (the `v118_upgrade`
-    /// rehearsal exercises both serving modes across its swap).
+    /// `GlobalPresignConfig` holds exactly these maps). Global presigns are
+    /// served from the validators' internal presign pool.
     Full,
     /// Empty config: every curve/algorithm allows per-dWallet presign —
     /// what `migrate()` creates, *not* the mainnet state (mainnet's config
     /// is the populated [`Self::Full`] shape). A harness arrangement that
     /// routes workload presigns through the per-dWallet (targeted) path —
     /// the only coverage of that path, since a populated config makes it
-    /// unreachable. The cross-binary churn test genesises with this and
-    /// applies the full config after its upgrade via
-    /// [`set_global_presign_config`].
+    /// unreachable. The cross-binary malicious-party rehearsal
+    /// (`malicious_v140`) genesises with this.
     Empty,
 }
 

--- a/crates/ika-swarm-config/src/validator_initialization_config.rs
+++ b/crates/ika-swarm-config/src/validator_initialization_config.rs
@@ -61,10 +61,10 @@ impl ValidatorInitializationConfig {
 
         // It is okay to unwrap here because we are using ValidatorInitializationConfig only on swarm.
         //
-        // Publish the BARE mainnet-v1.1.8 `ClassGroupsEncryptionKeyAndProof`
-        // shape on-chain — the `.class_groups` component of the full validator
-        // bundle — so a mainnet-v1.1.8 binary can decode this record and the
-        // v118 upgrade rehearsal boots. The richer `ValidatorEncryptionKeysAndProofs`
+        // Publish the BARE `ClassGroupsEncryptionKeyAndProof` shape on-chain —
+        // the `.class_groups` component of the full validator bundle — the
+        // same shape deployed release binaries decode from chain state (the
+        // cross-binary upgrade rehearsals rely on this). The richer `ValidatorEncryptionKeysAndProofs`
         // bundle (class groups + per-curve PVSS + the Fast Schnorr VSS HPKE key)
         // travels off-chain via validator P2P; chain reads decode the bare shape.
         let mpc_data = VersionedMPCData::V1(MPCDataV1 {

--- a/crates/ika-swarm/src/memory/container.rs
+++ b/crates/ika-swarm/src/memory/container.rs
@@ -128,7 +128,7 @@ impl Container {
     /// Check to see that the Node is still alive by checking if the receiving side of the
     /// `cancel_sender` has been dropped.
     ///
-    //TODO When we move to rust 1.61 we should also use
+    //TODO We should also use
     // https://doc.rust-lang.org/stable/std/thread/struct.JoinHandle.html#method.is_finished
     // in order to check if the thread has finished.
     pub fn is_alive(&self) -> bool {

--- a/crates/ika-swarm/src/memory/node.rs
+++ b/crates/ika-swarm/src/memory/node.rs
@@ -89,9 +89,8 @@ impl Node {
             .and_then(|c| c.get_node_handle())
     }
 
-    /// Perform a health check on this Node by:
-    /// * Checking that the node is running
-    /// * Calling the Node's gRPC Health service if it's a validator.
+    /// Perform a health check on this Node by checking that the node is
+    /// running.
     pub async fn health_check(&self, _is_validator: bool) -> Result<(), HealthCheckError> {
         {
             let lock = self.container.lock().unwrap();

--- a/crates/ika-types/src/committee.rs
+++ b/crates/ika-types/src/committee.rs
@@ -286,17 +286,14 @@ impl Committee {
         )
     }
 
-    // We call this if these have not yet been computed
-    /// Builds the `expanded_keys` (`AuthorityName -> BLS protocol pubkey`,
-    /// for aggregate-cert verification) and `index_map`
-    /// (`AuthorityName -> position`) caches. A BLS-basis name IS the BLS
-    /// key, so `expanded_keys` is decoded directly from `voting_rights`; a
-    /// name that does not decode as a BLS key (a consensus-basis name — a
-    /// zero-padded Ed25519 key is not a valid BLS12-381 point) is skipped,
-    /// NOT an error: committees with consensus-basis names that verify BLS
-    /// certs are built via [`Committee::new_with_protocol_keys`], and one
-    /// built through this path fails closed at `public_key()` (signer not
-    /// found) rather than panicking at construction.
+    /// Builds the `index_map` (`AuthorityName -> position`) cache, and an
+    /// `expanded_keys` (`AuthorityName -> BLS protocol pubkey`) map that is
+    /// always EMPTY: a name is the Ed25519 consensus key, and no BLS key can
+    /// be derived from it. Committees that verify BLS aggregate certificates
+    /// must be built via [`Committee::new_with_protocol_keys`], which carries
+    /// the map from chain; one built through this path fails closed at
+    /// `public_key()` (signer not found) rather than panicking at
+    /// construction.
     pub fn load_inner(
         voting_rights: &[(AuthorityName, StakeUnit)],
     ) -> (

--- a/crates/ika-types/src/crypto.rs
+++ b/crates/ika-types/src/crypto.rs
@@ -484,13 +484,14 @@ where {
         AuthorityPublicKeyBytes(bytes)
     }
 
-    /// The canonical `AuthorityName` of a validator identified by its
-    /// consensus Ed25519 key: the 32 key bytes zero-padded up to the 48-byte
-    /// container, so the wire encoding (and every name-keyed map) is
-    /// untouched by the identity basis. Zero padding is enforced here — the
-    /// only constructor for consensus-basis names — so equality and hashing
-    /// are consistent. The consensus key is recoverable as the first 32
-    /// bytes, symmetric to how a BLS-basis name decodes to the BLS key.
+    /// A consensus Ed25519 key placed in the 48-byte BLS container: the 32 key
+    /// bytes zero-padded up to the container width.
+    ///
+    /// This is NOT how a validator is named. Through protocol v6 the padded
+    /// container WAS the `AuthorityName`; since v7 [`AuthorityName`] is a
+    /// separate type holding the raw 32 bytes, built by
+    /// [`AuthorityName::from_consensus_key`]. This constructor only reproduces
+    /// the historical padded encoding.
     pub fn from_consensus_key(key: &NetworkPublicKey) -> Self {
         let mut bytes = [0u8; AuthorityPublicKey::LENGTH];
         bytes[..Ed25519PublicKey::LENGTH].copy_from_slice(key.as_bytes());

--- a/crates/ika-types/src/handoff.rs
+++ b/crates/ika-types/src/handoff.rs
@@ -74,8 +74,8 @@ pub struct HandoffAttestation {
 /// like this one use the consensus key, which verifiers look up in the
 /// previous committee's on-chain validator info as `consensus_pubkey`.
 ///
-/// `signer` identifies the validator (by their `AuthorityName`, i.e.
-/// protocol pubkey), but the `signature` is over
+/// `signer` identifies the validator by their `AuthorityName`, which IS
+/// that consensus pubkey, and the `signature` is over
 /// `bcs(IntentMessage::new(Intent::ika_app(HandoffAttestation), attestation))`
 /// using `signer`'s consensus key.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -105,9 +105,9 @@ mod tests {
     use super::*;
 
     fn make_authority(byte: u8) -> AuthorityName {
-        // BLS12381 min_pk public keys are 48 bytes. The fake bytes
-        // never need to verify a real signature in the type-level
-        // roundtrip tests below.
+        // An `AuthorityName` is a 32-byte Ed25519 consensus key. The
+        // fake bytes never need to verify a real signature in the
+        // type-level roundtrip tests below.
         AuthorityName([byte; 32])
     }
 

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -368,7 +368,7 @@ pub enum ConsensusTransactionKind {
     DWalletCheckpointSignature(Box<DWalletCheckpointSignatureMessage>),
     SystemCheckpointSignature(Box<SystemCheckpointSignatureMessage>),
     CapabilityNotificationV1(AuthorityCapabilitiesV1),
-    /// DECODE-ONLY since `MIN_PROTOCOL_VERSION = 5`. No supported binary
+    /// DECODE-ONLY ever since `MIN_PROTOCOL_VERSION` reached 5. No supported binary
     /// emits this — `EndOfPublishV2` is the only form produced, and the
     /// consumer drops any V1 it receives (a peer sending one is
     /// misconfigured). The variant itself must stay: its BCS index is wire

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -912,7 +912,7 @@ pub enum UserSecretKeyShareEventType {
     },
 }
 
-/// Represents the Rust version of the Move struct `ika_system::dwallet_2pc_mpc_coordinator_inner::DWalletDKGFirstRoundRequestEvent`.
+/// Represents the Rust version of the Move struct `ika_system::dwallet_2pc_mpc_coordinator_inner::DWalletDKGRequestEvent`.
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Eq, PartialEq, Hash)]
 pub struct DWalletDKGRequestEvent {
     pub dwallet_id: ObjectID,
@@ -979,7 +979,7 @@ pub struct DWalletImportedKeyVerificationRequestEvent {
     pub curve: u32,
 }
 
-/// Represents the Rust version of the Move struct `ika_system::dwallet_2pc_mpc_coordinator_inner::DWalletDKGFirstRoundRequestEvent`.
+/// Represents the Rust version of the Move struct `ika_system::dwallet_2pc_mpc_coordinator_inner::MakeDWalletUserSecretKeySharePublicRequestEvent`.
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Eq, PartialEq, Hash)]
 pub struct MakeDWalletUserSecretKeySharesPublicRequestEvent {
     pub public_user_secret_key_shares: Vec<u8>,
@@ -991,7 +991,7 @@ pub struct MakeDWalletUserSecretKeySharesPublicRequestEvent {
 
 impl DWalletSessionEventTrait for MakeDWalletUserSecretKeySharesPublicRequestEvent {
     /// This function allows comparing this event with the Move event.
-    /// It is used to detect [`DWalletDKGFirstRoundRequestEvent`] events from the chain and initiate the MPC session.
+    /// It is used to detect [`MakeDWalletUserSecretKeySharesPublicRequestEvent`] events from the chain and initiate the MPC session.
     fn type_(packages_config: &IkaNetworkConfig) -> StructTag {
         StructTag {
             address: *packages_config.packages.ika_dwallet_2pc_mpc_package_id,
@@ -1004,7 +1004,7 @@ impl DWalletSessionEventTrait for MakeDWalletUserSecretKeySharesPublicRequestEve
 
 impl DWalletSessionEventTrait for DWalletImportedKeyVerificationRequestEvent {
     /// This function allows comparing this event with the Move event.
-    /// It is used to detect [`DWalletDKGFirstRoundRequestEvent`] events from the chain and initiate the MPC session.
+    /// It is used to detect [`DWalletImportedKeyVerificationRequestEvent`] events from the chain and initiate the MPC session.
     fn type_(packages_config: &IkaNetworkConfig) -> StructTag {
         StructTag {
             address: *packages_config.packages.ika_dwallet_2pc_mpc_package_id,

--- a/crates/ika-types/src/messages_system_checkpoints.rs
+++ b/crates/ika-types/src/messages_system_checkpoints.rs
@@ -71,9 +71,9 @@ pub enum SystemCheckpointMessageKind {
 pub struct SystemCheckpointMessage {
     pub epoch: EpochId,
     pub sequence_number: SystemCheckpointSequenceNumber,
-    /// Timestamp of the system checkpoint - number of milliseconds from the Unix epoch
-    /// System checkpoint timestamps are monotonic, but not strongly monotonic - subsequent
-    /// system checkpoints can have same timestamp if they originate from the same underlining consensus commit
+    /// The system-configuration changes this checkpoint applies, in order.
+    /// Move reads them as one flat BCS stream, so both the order and each
+    /// variant's encoded width are part of the wire contract.
     pub messages: Vec<SystemCheckpointMessageKind>,
 }
 

--- a/crates/ika-types/src/sui/epoch_start_system.rs
+++ b/crates/ika-types/src/sui/epoch_start_system.rs
@@ -169,11 +169,11 @@ impl EpochStartSystemV1 {
     }
 }
 
-/// A validator's `AuthorityName`: its consensus Ed25519 key, zero-padded into
-/// the 48-byte container. The BLS protocol key was the identity basis through
-/// protocol version 5 and is below this binary's minimum, so the consensus key
-/// is the only basis a supported epoch uses. The BLS key stays on `Committee`
-/// for aggregate-certificate (checkpoint) verification.
+/// A validator's `AuthorityName`: its consensus Ed25519 key, the raw 32 bytes.
+/// The BLS protocol key was the identity basis through protocol version 5 and
+/// is below this binary's minimum, so the consensus key is the only basis a
+/// supported epoch uses. The BLS key stays on `Committee` for
+/// aggregate-certificate (checkpoint) verification.
 pub fn validator_authority_name(validator: &EpochStartValidatorInfoV1) -> AuthorityName {
     AuthorityName::from_consensus_key(&validator.consensus_pubkey)
 }

--- a/crates/ika-types/src/sui/mod.rs
+++ b/crates/ika-types/src/sui/mod.rs
@@ -226,7 +226,7 @@ pub trait SystemInnerTrait {
         committee: &BlsCommittee,
     ) -> Vec<(ObjectID, (AuthorityPublicKeyBytes, StakeUnit))>;
     /// Like [`read_bls_committee`], but skips (rather than panics on) a member
-    /// whose `protocol_pubkey` bytes don't parse into an `AuthorityName`.
+    /// whose `protocol_pubkey` bytes don't parse into a BLS `AuthorityPublicKey`.
     /// For the PRIOR-committee bootstrap anchor only, where a departed member
     /// may carry a stale/unreadable on-chain record and one bad member must
     /// not crash-loop the reading node. NOTE the consequence of a skip: the


### PR DESCRIPTION
Comment-only audit of the crates outside `ika-core`, plus the Move contracts.

**Zero behavior changes.** Verified mechanically: `git diff 31e19b58dec708c49db43cfade9a9f5de7b895e2` contains no non-comment lines in any of the 41 files.

The v7-only sweep (`MIN = MAX = 7`) left behind comments describing machinery that no longer exists, and a number of docs had simply drifted from the code they sit on. Grouped by file, one line of evidence each.

## Docs that contradict the code they document

- **`crates/ika-types/src/committee.rs`** — `load_inner`'s doc described decoding BLS keys out of `voting_rights` and "skipping" names that don't decode. The body returns `HashMap::new()` unconditionally, and the comment *inside* the function already said so.
- **`crates/ika-types/src/messages_system_checkpoints.rs`** — a "Timestamp of the system checkpoint … monotonic, but not strongly monotonic" block sat on `messages: Vec<SystemCheckpointMessageKind>`. The struct has no timestamp field at all.
- **`crates/ika-network/src/state_sync/mod.rs`** — the `OnChainCheckpointCursors` doc was separated from its struct by the `MAX_UNPROCESSED_CHECKPOINTS` const, so both doc blocks bound to the const and the type had no doc. Fixed by moving only the comment lines; the `const` line itself is untouched.
- **`crates/ika-types/src/sui/mod.rs`** — `read_bls_committee_lossy` said it skips members whose bytes "don't parse into an `AuthorityName`"; it parses a BLS `AuthorityPublicKey`, as the sibling comment in `system_inner_v1.rs` states explicitly.
- **`crates/dwallet-mpc-centralized-party/src/lib.rs`** — two DKG entry points carried identical copy-pasted docs listing a `decentralized_first_round_output` parameter that one of them does not take. Also removed two commented-out `return Err(anyhow!("2.1"))` debug lines.

## `AuthorityName` width claims (v7: raw 32 bytes)

- **`crates/ika-types/src/sui/epoch_start_system.rs`** — called the name "zero-padded into the 48-byte container"; `from_consensus_key` returns the raw 32 bytes.
- **`crates/ika-types/src/crypto.rs`** — `AuthorityPublicKeyBytes::from_consensus_key` was documented as producing "the canonical `AuthorityName`". Since v7 that is a different type; this constructor only reproduces the historical padded encoding (and has no callers).
- **`crates/ika-types/src/handoff.rs`** — called `AuthorityName` the "protocol pubkey" 15 lines after the same file correctly says a name *is* the consensus key. A test helper also explained 48-byte BLS keys while building `AuthorityName([byte; 32])`.

## Protocol-version and format claims

- **`crates/ika-protocol-config/src/lib.rs`** — claimed V3-tagged outputs "remain readable forever" / "stay DECODABLE forever" in two places. The crypto crate removed the pre-aggregation type, so V3 decode arms are hard errors; `dwallet_mpc.rs` already documents this.
- **`crates/ika-protocol-config/src/lib.rs`** — claimed BLS-basis committees stay readable via `Committee`'s "alias translation (`expanded_keys`)". No such translation exists; the map is carried from chain via `new_with_protocol_keys`.
- **`crates/ika-types/src/messages_consensus.rs`** — "DECODE-ONLY since `MIN_PROTOCOL_VERSION = 5`" read as a claim about the current MIN, which is 7.

## Wrong cross-references

- **`crates/ika-types/src/messages_dwallet_mpc.rs`** — four docs on `MakeDWalletUserSecretKeySharesPublicRequestEvent` / `DWalletImportedKeyVerificationRequestEvent` / `DWalletDKGRequestEvent` all named `DWalletDKGFirstRoundRequestEvent`. Move defines distinct `DWalletDKGRequestEvent` and `MakeDWalletUserSecretKeySharePublicRequestEvent` structs.
- **`contracts/ika_system/sources/staking/staked_ika.move`** — pointed at a `staking_pool` module three times; no such module exists, the code lives in `validator.move`.
- **`contracts/ika_system/sources/system/system_inner.move`** — pointed at `[fn test_proof_of_possession_bytes]`, which does not exist.

## Inherited-from-Sui text that was never true for ika

- **`contracts/ika_system/sources/system/system_inner.move`** — `advance_epoch` documented a four-step storage-fund flow (storage charge, storage rebates, gas coin refunds). ika has no storage fund; the function collects fee rewards plus a gated stake subsidy and distributes them.
- **`contracts/ika_system/sources/system/validator_set.move`** — `compute_reward_adjustments` mentioned "storage fund rewards".
- **`crates/ika-protocol-config/src/lib.rs`** — a `(MAX 84)` section header against the pinned Sui's `MAX_PROTOCOL_VERSION = 133`. Replaced with a description that does not carry a rotting number.
- **`contracts/ika/sources/ika.move`** — `Coin<IKA>` described as paying "for gas"; it pays computation fees.
- **`contracts/ika_common/sources/validator_cap.move`** — three `Verified*Cap` structs called "one time witness". None is a Move OTW.

## Rename artifacts and typos

- **`crates/ika-node/src/handle.rs`** — "in a way ikatable", a `sui` → `ika` replace that ate the word "suitable".
- **`contracts/ika_system/sources/staking/staked_ika.move`** — "the Ikarus epoch".
- **`contracts/ika_system/sources/system/protocol_treasury.move`** — "period nad total supply"; "destructured per distribution" (should be distributed).
- **`contracts/ika_system/sources/system/system_inner.move`** — "starts accusing delegated stakes" (accruing).

## Deliberately left alone

`bls_checkpoints` gating comments. That flag is still read in seven places and its gates are kept on purpose until NOA checkpoints supersede BLS, so comments saying it is gated are correct.

## Validation

- `cargo fmt --all --check` — clean.
- `cargo clippy --all-targets --all-features` on `ika-types`, `ika-node`, `dwallet-mpc-types`, `ika-protocol-config`, `ika-sui-client`, `ika-network`, `ika-proxy`, `dwallet-mpc-centralized-party` — exit 0, no warnings.
- Comment-only invariant re-checked against the base commit after every change.
- **`sui move build` could not be run**: no `sui` binary is installed on this machine. As a substitute the Move edits were confirmed comment-only and structurally checked for doc comments stranded before a closing brace (none). The Move packages should be built in CI before merge.

## Comment-vs-code disagreements left unfixed (code looks wrong)

These were not touched, per the comments-only scope:

- `crates/ika-sui-client/src/lib.rs:697` — a `sui_rpc_errors` metric is incremented on a path that is not an RPC error, so the counter appears mislabelled relative to what it counts.
- `crates/ika-types/src/crypto.rs:494` — `AuthorityPublicKeyBytes::from_consensus_key` has no callers anywhere in the workspace; it is `pub`, so no dead-code lint fires. Likely removable now that `AuthorityName` is its own type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
