### PR TITLE
docs(ika-core): correct stale and wrong comments across the crate

### DIFF
--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -4573,14 +4573,10 @@ impl AuthorityPerEpochStore {
                 return Err(e);
             }
         };
-        // The cert names its items in the PRIOR epoch's identity basis. At
-        // the protocol-v6 activation boundary that differs from this epoch's,
-        // and every carry-forward lookup would miss silently — dropping each
-        // seated member that did not freshly announce this epoch into the
-        // excluded set, which is precisely the safety net carry-forward
-        // exists to provide. Translate into this epoch's basis at the source
-        // so every consumer of these digests is keyed consistently; away from
-        // the boundary the map is empty of surprises and this is a no-op.
+        // Extract the cert's `ValidatorMpcData` items as a `validator -> digest`
+        // map, so every carry-forward consumer is keyed consistently. Both the
+        // cert and this epoch name validators by their consensus key, so the
+        // keys carry over as-is.
         Ok(cert
             .attestation
             .items

--- a/crates/ika-core/src/authority/round_transport.rs
+++ b/crates/ika-core/src/authority/round_transport.rs
@@ -73,8 +73,8 @@ use tracing::warn;
 /// Smaller means the fold is pinned to the drain sooner; larger means more
 /// rounds resident in memory, and — once the cap exceeds the burst depth —
 /// no blocking at all, which is the table design's behaviour bought with RAM
-/// instead of disk. 1024 is roughly a few seconds of consensus at mainnet
-/// commit rates: enough that ordinary jitter does not couple the two, small
+/// instead of disk. 1024 is roughly a minute of consensus at mainnet commit
+/// rates (~19.5 rounds/s): enough that ordinary jitter does not couple the two, small
 /// enough that a sustained backlog is felt rather than hoarded.
 pub const DEFAULT_ROUND_CHANNEL_CAPACITY: usize = 1024;
 

--- a/crates/ika-core/src/consensus_handler.rs
+++ b/crates/ika-core/src/consensus_handler.rs
@@ -69,9 +69,11 @@ use tracing::{debug, error, instrument, trace_span, warn};
 /// watchdog, because commits keep arriving. That case is covered by
 /// observability rather than by self-exit: `ika_consensus_round_channel_depth`
 /// pinned at capacity together with `ika_consensus_fold_blocked_seconds_total`
-/// climbing while `ika_last_process_mpc_consensus_round` is flat is a wedged drain,
-/// and the MPC lag alarm fires on it. Do not "fix" this by moving the call
-/// back after the boundary.
+/// climbing while `ika_last_process_mpc_consensus_round` is flat is a wedged
+/// drain. Alert on that triple, not on `ika_mpc_consensus_round_lag`: the
+/// bounded channel holds that gauge within a channel's worth of the drain, so
+/// it never reaches the lag alarm's threshold here. Do not "fix" this by moving
+/// the call back after the boundary.
 ///
 /// Consumers must be cheap and non-blocking: this runs on the commit path,
 /// once per commit, at sub-second cadence.

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs
@@ -1134,8 +1134,9 @@ fn instantiate_dwallet_mpc_network_encryption_key_public_data_from_dkg_public_ou
         bcs::from_bytes(public_output_bytes).map_err(DwalletMPCError::BcsError)?;
 
     // Macro extracts the 8 protocol+decryption-key-share Arcs from a decoded
-    // DKG `PublicOutput` (either `bwd_compat_dkg::Party::PublicOutput` or
-    // `dkg::Party::PublicOutput`; both expose the same per-curve accessor API).
+    // DKG `PublicOutput`. Only the V4 (aggregated) shape reaches it — the match
+    // below rejects every other variant — so the sole instantiation is with
+    // `twopc_mpc::decentralized_party::dkg::PublicOutput`.
     // Each sub-call is individually timed: the instantiation dominates the
     // epoch-boundary cost, and the per-sub-call breakdown localizes any
     // slowdown to a concrete operation instead of one opaque call.
@@ -1423,8 +1424,8 @@ mod network_key_id_derivation_tool {
                         .expect("anchor bytes must decode as VersionedNetworkDkgOutput");
                 match &anchor {
                     VersionedNetworkDkgOutput::V1(v1_inner) => {
-                        // The exact decode the v3 bwd-compat V1 arm performs on
-                        // every reconfiguration of a deployed key.
+                        // The exact decode the reconfiguration party's V1-anchor
+                        // arm performs on every reconfiguration of a deployed key.
                         let decoded: class_groups::dkg::PublicOutput<
                             { twopc_mpc::secp256k1::SCALAR_LIMBS },
                             { twopc_mpc::secp256k1::class_groups::FUNDAMENTAL_DISCRIMINANT_LIMBS },

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/sign.rs
@@ -536,9 +536,9 @@ impl SignPublicInputByProtocol {
                     network_encryption_key_public_data,
                 )?,
             )),
-            // Fast Schnorr (VSS) sign PublicInput: the 8-field struct. Commitments
-            // come from the latest reconfiguration output (see
-            // `vss_reconfiguration_public_output`); dkg_output/presign/sign_data
+            // Fast Schnorr (VSS) sign PublicInput: the 9-field struct. Commitments
+            // come from the pre-derived VSS Shamir cache (`vss_shamir_cache`,
+            // computed once at network-key ingestion); dkg_output/presign/sign_data
             // decode exactly like the AHE Schnorr path (generic over the protocol).
             DWalletSignatureAlgorithm::TaprootVSS => Ok(SignPublicInputByProtocol::TaprootVSS(
                 build_secp256k1_taproot_vss_sign_public_input(
@@ -1357,10 +1357,8 @@ impl DKGAndSignPublicInputByProtocol {
         hash_context: HashContext,
         access_structure: &WeightedThresholdAccessStructure,
         network_encryption_key_public_data: &NetworkEncryptionKeyPublicData,
-        // `None` for non-VSS; `Some` for VSS protocols (unwrapped via
-        // `require_vss_cache`). The combined DKG-and-sign path is never VSS,
-        // so in practice this is always `None` here — but kept symmetric with
-        // the sign-only `try_new`.
+        // `None` for non-VSS; `Some` for the three VSS protocols, which unwrap it
+        // via `require_vss_cache`.
         vss_shamir_cache: Option<&crate::dwallet_mpc::network_dkg::VssShamirCachePerKey>,
         protocol: DWalletSignatureAlgorithm,
     ) -> DwalletMPCResult<Self> {
@@ -1934,7 +1932,7 @@ where
 
 /// `decryption_key_shares` is the sign-protocol private input.
 ///
-/// For AHE-mode protocols (all five sign protocols ika uses at this bump) this resolves to
+/// For the five AHE-mode sign protocols this resolves to
 /// `Option<HashMap<PartyID, SecretKeyShareSizedInteger>>` and is sourced from the network
 /// DKG's decryption-key-shares map (i.e. the output of `decrypt_decryption_key_shares` on
 /// the network DKG output).

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/native_computations/encrypt_user_share.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/native_computations/encrypt_user_share.rs
@@ -16,8 +16,8 @@ use twopc_mpc::dkg;
 use twopc_mpc::dkg::Protocol;
 
 /// Verifies that the given encrypted secret key share matches the encryption of the dWallet's
-/// secret share, validates the signature on the dWallet's public share,
-/// and ensures the signing public key matches the address that initiated this transaction.
+/// secret share, by checking the encryption-of-centralized-party-share proof
+/// against the dWallet's DKG public output.
 pub(crate) fn verify_encrypted_share(
     encrypted_centralized_secret_share_and_proof: &[u8],
     decentralized_public_output: &SerializedWrappedMPCPublicOutput,

--- a/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
+++ b/crates/ika-core/src/dwallet_mpc/crytographic_computation/orchestrator.rs
@@ -9,11 +9,11 @@
 //! tasks when all cores are occupied.
 //!
 //! Key responsibilities:
-//! — Manages a queue of pending cryptographic computations
+//! — Admits computations against the available-core budget; a full budget
+//!   rejects the offer and the manager re-offers on the next tick
 //! — Tracks currently running sessions and available CPU cores
 //! — Handles session spawning and completion notifications.
-//! — Implements special handling for aggregated sign operations
-//! — Ensures computations don't become redundant based on received messages
+//! — Deduplicates by [`ComputationId`] against the running and completed sets
 //!
 //! The orchestrator uses a channel-based notification system to track completed computation.
 
@@ -57,11 +57,11 @@ struct ComputationCompletionUpdate {
 /// It tracks available CPU cores and prevents launching tasks when all cores are occupied.
 ///
 /// Key responsibilities:
-/// — Manages a queue of pending cryptographic computations
+/// — Admits computations against the available-core budget; a full budget
+///   rejects the offer and the manager re-offers on the next tick
 /// — Tracks currently running sessions and available CPU cores
 /// — Handles session spawning and completion notifications
-/// — Implements special handling for aggregated sign operations
-/// — Ensures computations don't become redundant based on received messages
+/// — Deduplicates by [`ComputationId`] against the running and completed sets
 pub(crate) struct CryptographicComputationsOrchestrator {
     /// The number of logical CPUs available for cryptographic computations on the validator's
     /// machine. Used to limit parallel task execution.

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -315,14 +315,6 @@ pub struct DWalletMPCMetrics {
     /// service termination has no source session), and `severity`.
     pub(crate) anomaly_snapshots_total: IntCounterVec,
 
-    /// Expected completion races: the session completed via the peers' output
-    /// quorum before this validator's own output returned through consensus,
-    /// while its local computation was still running, or before that
-    /// computation's late result arrived. This is how threshold cryptography
-    /// behaves for any validator outside the fastest two-thirds of a session,
-    /// so these are counted here — NOT in the anomaly taxonomy — to keep
-    /// `anomaly_snapshots_total` meaningful. Labels: `race` (fixed condition
-    /// strings), `session_type`.
     /// This validator concluded that IT ITSELF is malicious for a session —
     /// its own output diverged from the peers' quorum, or the majority output
     /// reported it. Fleet-visible by design: until this counter existed the
@@ -341,6 +333,14 @@ pub struct DWalletMPCMetrics {
     /// unbounded and identify operators.
     pub(crate) self_malicious_total: IntCounterVec,
 
+    /// Expected completion races: the session completed via the peers' output
+    /// quorum before this validator's own output returned through consensus,
+    /// while its local computation was still running, or before that
+    /// computation's late result arrived. This is how threshold cryptography
+    /// behaves for any validator outside the fastest two-thirds of a session,
+    /// so these are counted here — NOT in the anomaly taxonomy — to keep
+    /// `anomaly_snapshots_total` meaningful. Labels: `race` (fixed condition
+    /// strings), `session_type`.
     pub(crate) completion_races_total: IntCounterVec,
 
     /// Consensus-delivered MPC messages ignored because the local session was

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/create_dwallet.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/create_dwallet.rs
@@ -34,7 +34,7 @@ pub(crate) struct DWalletTestResult {
 
 #[tokio::test]
 #[cfg(test)]
-/// Runs a network DKG and then uses the resulting network key to run the DWallet DKG first round.
+/// Runs a network DKG, then a full dWallet DKG against the resulting network key.
 async fn create_dwallet_test() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let (committee, _) = Committee::new_simple_test_committee();
@@ -79,7 +79,8 @@ async fn create_dwallet_test() {
 
 #[tokio::test]
 #[cfg(test)]
-/// Runs a network DKG and then uses the resulting network key to run the DWallet DKG first round.
+/// Creates a dWallet, then makes its user secret key shares public and asserts
+/// the request is accepted.
 async fn make_dwallet_public() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let (committee, _) = Committee::new_simple_test_committee();
@@ -154,7 +155,8 @@ async fn make_dwallet_public() {
 
 #[tokio::test]
 #[cfg(test)]
-/// Runs a network DKG and then uses the resulting network key to run the DWallet DKG first round.
+/// Creates an imported-key dWallet via the v1 centralized step and asserts the
+/// imported-key verification is accepted.
 async fn create_imported_dwallet() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let (committee, _) = Committee::new_simple_test_committee();
@@ -236,7 +238,8 @@ async fn create_imported_dwallet() {
 
 #[tokio::test]
 #[cfg(test)]
-/// Runs a network DKG and then uses the resulting network key to run the DWallet DKG first round.
+/// Creates an imported-key dWallet via the v2 centralized step and asserts the
+/// imported-key verification is accepted.
 async fn create_imported_dwallet_v2() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let (committee, _) = Committee::new_simple_test_committee();

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/idle_status_voting.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/idle_status_voting.rs
@@ -142,8 +142,9 @@ fn create_idle_status_test_config_guard() -> ika_protocol_config::OverrideGuard 
 ///
 /// Asserts:
 /// 1. `network_is_idle` starts as `false` (default).
-/// 2. `network_is_idle()` undergoes at least 2 transitions through the consensus
-///    path, proving a full cycle (e.g. not_idle → idle → not_idle).
+/// 2. The transition counter reaches 3 through the consensus path — the initial
+///    state observation plus two genuine flips, proving a full cycle
+///    (not_idle → idle → not_idle).
 /// 3. Status updates submitted to consensus carry the correct `is_idle` flag.
 #[tokio::test]
 #[cfg(test)]

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/internal_presign.rs
@@ -356,7 +356,7 @@ async fn test_internal_presign_instantiation_at_correct_rounds() {
     //   1. number_of_consensus_rounds += 1
     //   2. process status updates → update network_is_idle
     //   3. instantiate_internal_presign_sessions (reads pool from epoch_store)
-    //   4. handle messages/outputs (step 5 — deposits presigns into epoch_store)
+    //   4. handle messages/outputs (deposits presigns into epoch_store)
     //
     // Step 3 sees pool BEFORE step 4 deposits. So we must read pool BEFORE
     // run_service_loop_iteration, not after.
@@ -416,7 +416,7 @@ async fn test_internal_presign_instantiation_at_correct_rounds() {
             // Predict using exactly the state step 3 saw:
             // - guard: pre_instantiated == pre_completed (unchanged before step 3)
             // - delay: post_number_of_rounds (incremented before step 3)
-            // - pool: pre_pool (read from epoch_store before step 5 deposits)
+            // - pool: pre_pool (read from epoch_store before step 4 deposits)
             // - idle: post_is_idle (updated from status updates before step 3)
             let guard_open = pre_instantiated == pre_completed;
             let delay_aligned = post_number_of_rounds.is_multiple_of(delay);

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg.rs
@@ -1,10 +1,9 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-//! This module contains the DWalletMPCService struct.
-//! It is responsible to read DWallet MPC messages from the
-//! local DB every [`READ_INTERVAL_MS`] seconds
-//! and forward them to the [`DWalletMPCManager`].
+//! Integration tests for the network DKG and network-key reconfiguration
+//! flows, plus the shared `create_network_key_test` / `reconfigure_network_key`
+//! helpers other test modules build on.
 
 use crate::SuiDataSenders;
 use crate::dwallet_mpc::crytographic_computation::mpc_computations::network_dkg::spawn_network_encryption_key_public_data_instantiation;

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -51,8 +51,6 @@ type AssignedPresigns =
 /// sequence number. Value: (presign session id, blending index, presign bytes).
 type ServedGlobalPresigns = Arc<Mutex<HashMap<u64, (SessionIdentifier, u16, Vec<u8>)>>>;
 
-/// A testing implementation of the `AuthorityPerEpochStoreTrait`.
-/// Records all received data for testing purposes.
 /// How many rounds a test validator's drain may fall behind before the
 /// harness's own "fold" blocks. Generous on purpose: the tests here drive one
 /// round at a time and drain it, so blocking would only ever mean a harness
@@ -101,6 +99,8 @@ pub(crate) fn empty_round_payload(round: Round) -> ConsensusRoundPayload {
     }
 }
 
+/// A testing implementation of the `AuthorityPerEpochStoreTrait`.
+/// Records all received data for testing purposes.
 pub(crate) struct TestingAuthorityPerEpochStore {
     pub(crate) pending_checkpoints: Arc<Mutex<Vec<PendingDWalletCheckpoint>>>,
     /// This validator's half of the real round transport. The harness hands
@@ -1572,7 +1572,8 @@ use crate::dwallet_session_request::DWalletSessionRequest;
 use crate::request_protocol_data::{DWalletDKGData, NetworkEncryptionKeyDkgData, ProtocolData};
 use ika_protocol_config::OverrideGuard;
 
-/// Number of MPC rounds the network DKG runs under `cryptography-private @ 9d35fa76`.
+/// Number of MPC rounds the network DKG runs under the pinned inkrypto
+/// revision (see the root `Cargo.toml`).
 /// Driven by upstream's threshold-encryption-to-sharing sub-protocol; bump if upstream changes.
 pub(crate) const EXPECTED_NETWORK_DKG_ROUND_COUNT: u64 = 7;
 

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -96,7 +96,8 @@ pub(crate) fn authority_name_to_party_id_from_committee(
 /// Per-validator public MPC keys, indexed by `PartyID`. Holds the class-groups
 /// CRT encryption-key map alongside the three per-curve PVSS HPKE encryption-key
 /// maps that `decentralized_party::dkg::PublicInput::new` and the
-/// reconfiguration-party constructors require post-`9d35fa76` bump.
+/// reconfiguration-party constructors require since inkrypto introduced
+/// per-curve PVSS keys.
 ///
 /// Exists so that `network_dkg_v2_public_input` and the three reconfiguration
 /// `generate_public_input` constructors take one parameter instead of four

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -323,11 +323,8 @@ pub(crate) struct DWalletMPCManager {
     pub(crate) committee: Arc<Committee>,
     pub(crate) access_structure: WeightedThresholdAccessStructure,
     /// The CURRENT epoch's per-validator MPC keys (class groups + 3 PVSS HPKE +
-    /// verified VSS), keyed by party id. At network-key-version 2 (no off-chain
-    /// pipeline) this is initialized at construction by re-keying
-    /// `class_groups` straight off the on-chain committee (the bare key Sui
-    /// already carries), with empty PVSS/VSS — all the backward-compatible DKG
-    /// needs. At version 3 it starts empty and the whole set (class_groups
+    /// verified VSS), keyed by party id. It starts empty at construction and
+    /// the whole set (class_groups
     /// included) is filled by `ingest_offchain_mpc_keys`: primarily assembled
     /// from the prior epoch's handoff certificate (restart-safe — issue
     /// #1879), falling back to the `current_epoch_mpc_keys` channel (fed once

--- a/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_session/input.rs
@@ -45,8 +45,8 @@ pub(crate) enum PublicInput {
 }
 
 // TODO (#542): move this logic to run before writing the event to the DB, maybe include within the session info
-/// Parses a [`DWalletSessionRequest`] to extract the corresponding [`MPCParty`],
-/// public input, private input and session information.
+/// Parses a [`DWalletSessionRequest`] into the [`PublicInput`] and private
+/// input of the MPC round it requests.
 ///
 /// Returns an error if the event type does not correspond to any known MPC rounds
 /// or if deserialization fails.

--- a/crates/ika-core/src/dwallet_session_request.rs
+++ b/crates/ika-core/src/dwallet_session_request.rs
@@ -195,7 +195,8 @@ impl Ord for DWalletSessionRequest {
     fn cmp(&self, other: &Self) -> Ordering {
         // System sessions have a higher priority than user session and therefore come first (are smaller).
         // Both system and user sessions are sorted by their sequence number between themselves.
-        // Internal sessions (presign and sign) have lowest priority.
+        // Internal presign sessions have the lowest priority; network-owned-address
+        // sign sessions have the highest.
         match (self.session_type, other.session_type) {
             (SessionType::User, SessionType::User) => self
                 .session_sequence_number

--- a/crates/ika-core/src/epoch/committee_store.rs
+++ b/crates/ika-core/src/epoch/committee_store.rs
@@ -49,7 +49,7 @@ pub struct CommitteeStoreTables {
 /// rather than truncating to a wrong identity. Nothing live reads them: the
 /// only consumers of `get_committee` are the insert-time dedup (current epoch),
 /// joiner bootstrap (`prior_epoch = current - 1`, always v6+ since
-/// `MIN_PROTOCOL_VERSION = 6`), and a `ReadStore` impl whose callers are
+/// `MIN_PROTOCOL_VERSION = 7`), and a `ReadStore` impl whose callers are
 /// blanket forwarding impls. `ReadStore::get_committee` already propagates
 /// decode errors instead of panicking, precisely for old-layout records.
 const COMMITTEE_SCHEMA_VERSION_CURRENT: u64 = 3;

--- a/crates/ika-core/src/epoch/epoch_metrics.rs
+++ b/crates/ika-core/src/epoch/epoch_metrics.rs
@@ -194,9 +194,8 @@ pub struct EpochMetrics {
     pub consensus_last_committed_timestamp_seconds: IntGauge,
 
     /// The configured `mpc_data_freeze_grace_rounds` for the current
-    /// protocol version, or `-1` when the off-chain-metadata feature
-    /// (and thus the freeze) is disabled for it or the value is
-    /// undefined. Constant within an epoch.
+    /// protocol version, or `-1` when that version leaves the value
+    /// undefined (and thus runs no freeze). Constant within an epoch.
     pub dwallet_mpc_data_freeze_grace_rounds: IntGauge,
 
     /// The consensus leader round at which this epoch's mpc_data input

--- a/crates/ika-core/src/epoch_tasks/handoff_signature_sender.rs
+++ b/crates/ika-core/src/epoch_tasks/handoff_signature_sender.rs
@@ -8,9 +8,10 @@
 //! `submit_to_consensus` only hands the tx to a background submitter
 //! that can still fail to sequence at the epoch boundary or on crash.
 //!
-//! Decoupled from `EndOfPublishSender` so the handoff cert is its
-//! own protocol step — the two used to share a task by accident of
-//! triggering on the same condition. Wiring contributors is the
+//! Runs as its own task rather than riding the `EndOfPublish` send
+//! path, so the handoff cert is its own protocol step: the two trigger
+//! on the same condition but retry and fail independently. Wiring
+//! contributors is the
 //! caller's job: pass any number of
 //! `Arc<dyn HandoffItemsBuilder>` and the task will fold their
 //! contributions into the attestation.

--- a/crates/ika-core/src/epoch_tasks/joiner_bootstrap_verifier.rs
+++ b/crates/ika-core/src/epoch_tasks/joiner_bootstrap_verifier.rs
@@ -12,7 +12,7 @@
 //! pubkey set).
 //!
 //! This task fetches that cert from current-committee peers over P2P
-//! and verifies it with [`verify_joiner_bootstrap_cert`] — epoch-bound
+//! and verifies it with [`crate::handoff_cert::verify_joiner_bootstrap_cert`] — epoch-bound
 //! to `E-1`, signatures checked against the `E-1` committee, and the
 //! pinned next-committee hash matched against `E`'s own committee. A
 //! verified cert is the joiner's cryptographic confirmation that the

--- a/crates/ika-core/src/request_protocol_data.rs
+++ b/crates/ika-core/src/request_protocol_data.rs
@@ -222,8 +222,9 @@ pub enum ProtocolData {
 }
 
 impl ProtocolData {
-    /// Returns the signature algorithm this request operates on, if any. Used by
-    /// the protocol-version feature gate (e.g. Fast Schnorr / VSS).
+    /// Returns the signature algorithm this request operates on, if any. Used for
+    /// metric labels and to detect VSS (Fast Schnorr) presigns, whose private
+    /// output must be persisted.
     pub fn signature_algorithm(&self) -> Option<DWalletSignatureAlgorithm> {
         match self {
             ProtocolData::Presign { data, .. } => Some(data.signature_algorithm),

--- a/crates/ika-core/src/sui_connector/bag_event_pump.rs
+++ b/crates/ika-core/src/sui_connector/bag_event_pump.rs
@@ -55,9 +55,8 @@ pub struct BagEventPump {
     new_requests_sender: broadcast::Sender<Vec<DWalletSessionRequest>>,
     uncompleted_requests_sender: watch::Sender<(Vec<DWalletSessionRequest>, EpochId)>,
     metrics: Arc<OcsMetrics>,
-    /// Connector-level metrics: the pump feeds the same
-    /// `uncompleted_events_backlog` gauge the legacy (v≤3) syncer poller
-    /// feeds, so the series name is path-independent.
+    /// Connector-level metrics: the pump is the sole writer of the
+    /// `uncompleted_events_backlog` gauge.
     connector_metrics: Arc<SuiConnectorMetrics>,
     poll_interval: Duration,
     seen: HashSet<ObjectID>,
@@ -192,7 +191,7 @@ impl BagEventPump {
                     consecutive_failures += 1;
                     backoff = next_pump_backoff(backoff, self.poll_interval);
                     // Escalate to a single error once sustained; from then on the
-                    // grown backoff throttles the rate to ~1 line / 30s, so a long
+                    // grown backoff throttles the rate to ~1 line / 5s, so a long
                     // outage no longer floods the log at the poll rate.
                     if consecutive_failures >= PUMP_FAILURE_ESCALATION_TICKS {
                         error!(
@@ -277,8 +276,8 @@ impl BagEventPump {
             );
             let _ = self.new_requests_sender.send(delta_requests);
         }
-        // Same backlog gauge the legacy (v≤3) poller feeds: "chain has N
-        // uncompleted sessions from this validator's perspective".
+        // The backlog gauge: "chain has N uncompleted sessions from this
+        // validator's perspective".
         self.connector_metrics
             .uncompleted_events_backlog
             .set(snapshot_requests.len() as i64);

--- a/crates/ika-core/src/sui_connector/committee_store.rs
+++ b/crates/ika-core/src/sui_connector/committee_store.rs
@@ -31,7 +31,7 @@
 //!   directly, extracted from a Sui genesis blob (verified against the
 //!   compiled-in chain identifier on public chains). The ratchet then walks
 //!   the end-of-epoch checkpoint chain forward from there.
-//! - If neither perpetual state nor bootstrap is available, [`Self::open`]
+//! - If neither perpetual state nor bootstrap is available, [`CommitteeStore::open`]
 //!   errors.
 
 use std::collections::BTreeMap;

--- a/crates/ika-core/src/sui_connector/fallback_transport.rs
+++ b/crates/ika-core/src/sui_connector/fallback_transport.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 //! A [`SuiTransport`] decorator that splits operations between a primary
-//! transport (typically the relayed [`SuiMirrorTransport`]) and a direct gRPC
+//! transport (typically the relayed
+//! [`ika_network::sui_state_mirror::SuiMirrorTransport`]) and a direct gRPC
 //! fallback for the two read methods it routes directly:
 //!
 //! - `get_committee` — not served as a verified read; only the OCS ratchet's
@@ -238,7 +239,7 @@ mod tests {
     }
 
     /// The decorator routes each *relayed* read to the primary (never the
-    /// fallback) and each *directly-routed* write/submission method to the
+    /// fallback) and each *directly-routed* read method to the
     /// fallback (never the primary); a `NotFound` the primary returns on a
     /// relayed read is surfaced unchanged through the decorator.
     #[tokio::test]

--- a/crates/ika-core/src/sui_connector/metrics.rs
+++ b/crates/ika-core/src/sui_connector/metrics.rs
@@ -10,8 +10,9 @@ use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct SuiConnectorMetrics {
-    /// Latest Sui checkpoint synced per module by the legacy (v≤3)
-    /// event-listening task. Unused under v4 (OCS BagEventPump).
+    /// Latest Sui checkpoint synced per module. Registered but no longer
+    /// written: the event-listening task that fed it was removed when the OCS
+    /// `BagEventPump` replaced it, and nothing writes it today.
     pub last_synced_sui_checkpoints: IntGaugeVec,
 
     pub gas_coin_balance: IntGauge,
@@ -138,8 +139,8 @@ pub struct SuiConnectorMetrics {
     /// store trails the chain (local sync lag), which is a different problem.
     pub(crate) chain_dwallet_checkpoint_writer_lag: IntGauge,
 
-    /// Number of uncompleted session events observed on chain on the most
-    /// recent pull (legacy v≤3 poller) or bag-walk snapshot (v4 BagEventPump).
+    /// Number of uncompleted session events observed on chain in the most
+    /// recent `BagEventPump` bag-walk snapshot.
     /// Persistent non-zero means a session backlog (validators are missing
     /// things); drops to 0 once chain processes the responses.
     pub(crate) uncompleted_events_backlog: IntGauge,

--- a/crates/ika-core/src/sui_connector/ocs_currency.rs
+++ b/crates/ika-core/src/sui_connector/ocs_currency.rs
@@ -16,9 +16,9 @@
 //! the committee-signed changeset stream (contiguity-enforced) and `check_currency`
 //! gates every verified read (single / batch / bag) on mirrored / peer-only nodes
 //! — a `Stale`/`NotLive` verdict is rejected `NotCurrent`. Its load-bearing
-//! primitive is the **id-binding** check on non-inclusion proofs (the design's
-//! "Blocker 1"). Design notes:
-//! [`dev-docs/plans/ocs-changeset-stream-mirror-currency.md`].
+//! primitive is the **id-binding** check on non-inclusion proofs: without it a
+//! relay can serve a proof for the wrong id. Design notes:
+//! `dev-docs/specs/ocs-verified-sui-reads.md`.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 

--- a/crates/ika-core/src/sui_connector/ocs_metrics.rs
+++ b/crates/ika-core/src/sui_connector/ocs_metrics.rs
@@ -23,8 +23,10 @@ pub struct OcsMetrics {
     // Committee ratchet
     /// Highest Sui epoch the committee ratchet has reached, or
     /// [`Self::COMMITTEE_HEAD_NOT_APPLICABLE`] (`-1`) on a node that builds no
-    /// ratchet — sui-state-direct and peer-only nodes never construct one, so
-    /// the mirroring task that owns this gauge is never spawned for them.
+    /// OCS stack at all (a notifier/fullnode role with no trust anchor), so the
+    /// mirroring task that owns this gauge is never spawned for it. Every node
+    /// that does build a stack runs a ratchet — direct, mirrored and peer-only
+    /// alike.
     ///
     /// The sentinel exists because `0` is otherwise ambiguous between "no
     /// ratchet, nothing to report" and "ratchet present and holding an empty
@@ -286,8 +288,8 @@ impl OcsMetrics {
             )
             .unwrap(),
         });
-        // Default to "no ratchet". Every node registers these metrics, but only
-        // sui-state-mirrored nodes spawn the task that maintains this gauge, so
+        // Default to "no ratchet". Every node registers these metrics, but a node
+        // with no OCS stack never spawns the task that maintains this gauge, so
         // without seeding it here the untouched value would be 0 — the exact
         // reading that means "ratchet present, committee empty".
         metrics
@@ -307,11 +309,11 @@ mod tests {
 
     /// A freshly-registered `OcsMetrics` must report "no ratchet", not epoch 0.
     ///
-    /// Every node registers these metrics, but only sui-state-mirrored nodes
-    /// spawn the task that maintains the gauge. Without the seed, a
-    /// sui-state-direct node and a mirrored node whose ratchet holds an empty
-    /// committee are indistinguishable at 0 — the ambiguity that made #1980
-    /// require a chain walk and a code read to diagnose.
+    /// Every node registers these metrics, but a node with no OCS stack never
+    /// spawns the task that maintains the gauge. Without the seed, such a node
+    /// and one whose ratchet holds an empty committee are indistinguishable at
+    /// 0 — the ambiguity that made #1980 require a chain walk and a code read
+    /// to diagnose.
     #[test]
     fn committee_head_defaults_to_not_applicable_not_zero() {
         let metrics = OcsMetrics::new(&Registry::new());

--- a/crates/ika-core/src/sui_connector/setup.rs
+++ b/crates/ika-core/src/sui_connector/setup.rs
@@ -135,7 +135,7 @@ pub enum SetupError {
 ///
 /// - `Hydrated`: perpetual tables already have committees; ignore any
 ///   configured genesis blob (we've already verified past it).
-/// - `Genesis`: bootstrap committee[0] from the verified `sui_genesis` blob.
+/// - `Genesis`: bootstrap `committee[0]` from the verified `sui_genesis` blob.
 pub enum BootstrapPlan {
     Hydrated,
     /// Genesis-rooted: load the configured `sui_genesis` blob, verify its

--- a/crates/ika-core/src/sui_connector/sui_syncer.rs
+++ b/crates/ika-core/src/sui_connector/sui_syncer.rs
@@ -351,7 +351,7 @@ where
         // `validator_id -> consensus pubkey`, populated on first sight and
         // dropped at every epoch change. Keeps the consensus-basis re-keying
         // below off the per-tick chain path (see
-        // `committee_names_for_basis`) WITHOUT outliving the value's own
+        // `rekey_committee_to_consensus_names`) WITHOUT outliving the value's own
         // validity: a consensus key is not fixed at registration —
         // `set_next_epoch_consensus_pubkey_bytes` is an operator-callable
         // entry point and `rotate_next_epoch_info` effectuates it at epoch
@@ -678,7 +678,7 @@ where
     /// wedged reconfiguration once before — `get_validators_info_by_ids`
     /// fails transiently while validators restart during a rollout, which
     /// is precisely when the committee must still be assembled (see
-    /// `dev-docs/plans/authority-name-consensus-key.md`). With the cache,
+    /// `dev-docs/specs/committee-consensus-keys.md`). With the cache,
     /// steady-state ticks perform no chain read at all, so a committee
     /// whose members are already known can never be starved by RPC flake.
     async fn rekey_committee_to_consensus_names(

--- a/crates/ika-core/src/sui_connector/verified_transport.rs
+++ b/crates/ika-core/src/sui_connector/verified_transport.rs
@@ -23,9 +23,8 @@
 //!   `setup.rs`). Tracking is memory-safe here because every id on this path
 //!   is long-lived (the System/Coordinator wrappers, their versioned inners,
 //!   validator objects, table entries); the short-lived session-event bag
-//!   children never flow through `get_object` — the legacy uncompleted-events
-//!   walk that would fetch them is gated off whenever the OCS stack (and thus
-//!   this transport) exists. The gRPC backend's high-level reads
+//!   children never flow through `get_object` — their only consumer is the
+//!   `BagEventPump`'s `verified_dynamic_fields_page` walk. The gRPC backend's high-level reads
 //!   (`get_system_inner`, `get_dwallet_coordinator_inner`, the table walks)
 //!   decompose into exactly `get_object` + `list_dynamic_fields` +
 //!   `batch_get_objects`, so layering the stock backend over this transport

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -338,9 +338,10 @@ pub enum CanonicalizeReadySignalOutcome {
 
 /// Byzantine-resistance diagnostics surfaced from
 /// `canonicalize_ready_signal_peers` so callers can decide whether
-/// to `warn!`. A non-empty `non_committee_dropped` or a non-zero
+/// to `warn!`. A large `non_committee_kept` or a non-zero
 /// `duplicates_collapsed` is usually a byzantine padding attempt —
-/// honest emitters send a deduped, committee-only peer set.
+/// honest emitters send a deduped set of committee members and
+/// announced joiners.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct CanonicalizeReadySignalDiagnostics {
     /// Names that appeared in the inbound `validated_peers` with zero
@@ -366,12 +367,14 @@ pub struct CanonicalizeReadySignalDiagnostics {
 ///    consumers treat it as a set. Without dedup-on-receive a
 ///    byzantine signer can list a target N times to inflate that
 ///    target's attested stake by N*signer_stake.
-/// 2. **Committee filter.** Validators not in the current
-///    committee don't have stake and can't legitimately appear
-///    as attestation targets. Drop them so they can't be used as
-///    padding. The committee-filter drops are returned in
-///    `diagnostics.non_committee_dropped` so callers can log
-///    byzantine attempts.
+/// 2. **Committee weighting.** Validators with zero current-committee
+///    weight are KEPT — a next-epoch joiner legitimately has zero
+///    current weight but is a valid freeze target — so the canonical
+///    set stays a pure function of the sequenced bytes. They cannot
+///    serve as padding regardless: they contribute nothing to the
+///    coverage tally in step 3. They are reported in
+///    `diagnostics.non_committee_kept` so callers can log byzantine
+///    attempts.
 /// 3. **Quorum-coverage floor.** Reject signals whose canonical
 ///    peer set attests to less than the committee's quorum
 ///    threshold. An honest validator should not signal until its
@@ -1262,7 +1265,7 @@ pub struct ValidatedPeersDecision {
     /// (see `self_blob_unhealthy`).
     pub validated: std::collections::BTreeSet<AuthorityName>,
     /// `true` iff self's announcement appears in the input AND
-    /// self's blob fails the `blob_valid_for_digest` check. The
+    /// self's blob fails the `blob_decodes_to_valid_mpc_data` check. The
     /// caller is expected to emit a `warn!` when this is true so
     /// operators notice the persist failure.
     pub self_blob_unhealthy: bool,


### PR DESCRIPTION
Comments-only audit of `crates/ika-core/`. **No code changed** — every line in the diff is a `//`, `///` or `//!` line (verified mechanically: `git diff -U0` filtered to non-comment changed lines is empty). `cargo fmt --all --check` clean, `cargo clippy --all-targets --all-features -p ika-core` clean.

Found by three sweeps: a grep sweep for known rot patterns (plan/phase labels, protocol-version claims, removed-machinery names, `unbounded`/`lag` claims), a mechanical dangling-reference sweep (identifiers and types that appear *only* inside comments), and `cargo doc` broken-intra-doc-link warnings. Each hit was then read in full and verified against the code beneath it.

## Behaviour described backwards

**`validator_metadata.rs`** — `canonicalize_ready_signal_peers`'s numbered doc said step 2 **drops** non-committee validators and returns them in `diagnostics.non_committee_dropped`. The code **keeps** them: the field is `non_committee_kept`, and the body comment calls keeping them "the crux of the fix" (a next-epoch joiner has zero current weight but is a legitimate freeze target). The named field does not exist. Retitled the step to "Committee weighting" and corrected both the struct doc and the step.

**`consensus_handler.rs`** — the wedged-drain KNOWN GAP note ended "and the MPC lag alarm fires on it". It cannot: the bounded round channel holds `ika_mpc_consensus_round_lag` within a channel's worth of the drain, so it never reaches `MPC_LAG_ALARM_ROUNDS`. That is stated verbatim in the gauge's own registered help text and in `CatchUpDrainProgress`'s doc. Now points at the metric triple that *does* show it.

**`ocs_metrics.rs`** — `committee_head_epoch`'s `-1` sentinel was documented as "sui-state-direct and peer-only nodes never construct a ratchet". They do: `build_sui_connector_stack` builds the ratchet unconditionally (`setup.rs:398`) and ika-node spawns the head-mirroring task for any node with a stack. `-1` actually means *no OCS stack at all*. Fixed in the field doc, the seeding comment and the test doc. (The exported Prometheus HELP string carries the same error — left alone, since it is a string literal, not a comment. Worth a follow-up.)

**`dwallet_session_request.rs`** — the `Ord` header said "Internal sessions (presign and sign) have lowest priority". `NetworkOwnedAddressSign` is the *highest* priority arm; only `InternalPresign` is lowest.

**`sign.rs`** — "The combined DKG-and-sign path is never VSS, so in practice this is always `None`". `DKGAndSignPublicInputByProtocol::try_new` has three live VSS arms that call `require_vss_cache(vss_shamir_cache)?`, which errors on `None` — every VSS DKG-and-sign would fail if the comment were true.

**`orchestrator.rs`** (module doc + duplicated struct doc) — claimed a queue of pending computations, special handling for aggregated sign operations, and message-based redundancy checks. None exist: the struct holds a core budget plus running/completed `ComputationId` sets, dedups by id, and has no aggregated-sign path.

**`encrypt_user_share.rs`** — claimed it "validates the signature on the dWallet's public share" and "ensures the signing public key matches the address that initiated this transaction". The function only dispatches to the encryption-of-centralized-party-share proof check; neither the signature nor the address check exists.

## Stale protocol/version claims

- **`epoch/committee_store.rs`** — `MIN_PROTOCOL_VERSION = 6` → `7`.
- **`epoch/epoch_metrics.rs`** — the freeze-grace `-1` sentinel was attributed to "the off-chain-metadata feature ... disabled"; that gate was swept and the code's only `-1` path is an undefined config value.
- **`authority_per_epoch_store.rs`** — a paragraph explained translating handoff-cert items out of the prior epoch's identity basis at the v6 boundary. No translation exists; the code is a plain `filter_map`. Remnant of the deleted dual-width machinery.
- **`request_protocol_data.rs`** — `signature_algorithm()` documented as feeding "the protocol-version feature gate (e.g. Fast Schnorr / VSS)". `fast_schnorr` appears zero times in ika-core; real consumers are metric labels and the VSS private-output persist filter.
- **`mpc_manager.rs`** — `validator_mpc_keys_by_party_id` documented a network-key-version-2 branch initialising class-groups off the on-chain committee "all the backward-compatible DKG needs". The constructor unconditionally sets `empty()`; the backward-compatible DKG is gone.

## References to things that no longer exist

- **`handoff_signature_sender.rs`** — "Decoupled from `EndOfPublishSender`". No such symbol anywhere in the repo.
- **`network_dkg.rs`** — named `bwd_compat_dkg::Party::PublicOutput` as one of two possible decoded shapes; that type was removed from inkrypto and only the V4 arm reaches the macro. Also "the v3 bwd-compat V1 arm" → the reconfiguration party's V1-anchor arm.
- **`sign.rs`** — "see `vss_reconfiguration_public_output`" (exists nowhere); commitments come from the pre-derived `vss_shamir_cache`. Also "the 8-field struct" → 9 fields.
- **`verified_transport.rs`** — "the legacy uncompleted-events walk ... is gated off". It was removed, not gated; the bag children's only consumer is the pump's `verified_dynamic_fields_page` walk.
- **`sui_syncer.rs`** — `committee_names_for_basis` → the real `rekey_committee_to_consensus_names`.
- **`validator_metadata.rs`** — `blob_valid_for_digest` → the real `blob_decodes_to_valid_mpc_data`.
- **`metrics.rs` / `bag_event_pump.rs`** — three comments describe a "legacy (v≤3) poller" as a live co-writer of `uncompleted_events_backlog`; the pump is its sole writer. `last_synced_sui_checkpoints` has no writer at all and is now documented as registered-but-unwritten. *(It looks like dead code — see below.)*
- **`dwallet_mpc/mod.rs`, `integration_tests/utils.rs`** — `cryptography-private @ 9d35fa76` is a dead provenance pin; the dependency is `dwallet-labs/inkrypto @ 3ed95fe7`.

## Broken intra-doc links (`cargo doc` warnings — now zero unresolved)

`joiner_bootstrap_verifier.rs` (`verify_joiner_bootstrap_cert`, lives in `handoff_cert`), `sui_connector/committee_store.rs` (`Self::open` in a module-level doc), `fallback_transport.rs` (`SuiMirrorTransport`, lives in `ika_network`), `setup.rs` (`committee[0]` parsed as a link), `mpc_session/input.rs` (`MPCParty` — also claimed the fn returns session info; it returns `(PublicInput, MPCPrivateInput)`).

## Numbers that had drifted

- **`round_transport.rs`** — the 1024-round channel called "a few seconds of consensus at mainnet commit rates". At the ~19.5 rounds/s the repo documents everywhere else, that is ~52 seconds.
- **`bag_event_pump.rs`** — escalated-error throttle "~1 line / 30s"; `MAX_PUMP_BACKOFF` is 5s (its own doc says 5s).
- **`idle_status_voting.rs`** — doc promised "at least 2 transitions"; the assertion requires `>= 3` (initial observation plus two flips).
- **`internal_presign.rs`** — a 4-step list whose item 4 was annotated "(step 5)", with two later comments disagreeing about which number names the deposit.

## Misleading test/field docs

- **`create_dwallet.rs`** — one doc line ("Runs a network DKG and then ... the DWallet DKG first round") was copy-pasted onto four tests. Two run no dWallet DKG at all (imported-key verification v1/v2), one makes user secret shares public, and the fourth drives the *full* DKG, not the first round.
- **`integration_tests/network_dkg.rs`** — module doc described `DWalletMPCService` reading messages "from the local DB every READ_INTERVAL_MS seconds". Wrong module, wrong mechanism, wrong unit.
- **`integration_tests/utils.rs`** — `TestingAuthorityPerEpochStore`'s doc was attached to the `TEST_ROUND_CHANNEL_CAPACITY` constant above it; moved onto the struct.
- **`dwallet_mpc_metrics.rs`** — `completion_races_total`'s doc paragraph was glued to the front of `self_malicious_total`'s, leaving `completion_races_total` undocumented; moved.

## Out-of-context labels

`ocs_currency.rs` referenced the design's "Blocker 1" and an archived `dev-docs/plans/` file; `sui_syncer.rs` referenced another archived plan. Both retargeted to the live specs (`ocs-verified-sui-reads.md`, `committee-consensus-keys.md`).

## Reported, not changed

- **`sui_connector/metrics.rs`** — `last_synced_sui_checkpoints` is registered into the exported registry on every node with **no writer anywhere**: a permanently-zero labeled metric family. Looks like dead code to delete rather than document.
- **`sui_connector/committee_store.rs:170-183`** — `install_genesis`'s doc says "Localnet/test only." and its log line says "installed UNSAFE genesis committee (no digest anchor; localnet/test path)". This is also the mainnet/testnet first-boot path, and on public chains the blob *is* digest-anchored against the compiled-in chain identifier. Left alone because fixing the log string is a code change; the "UNSAFE" line would fire on a normal mainnet first boot.
- **`consensus_throughput_calculator.rs:132-138`** — the warn text and comment say "fall back to the lowest profile"; the code returns `highest_profile()`. Inherited verbatim from upstream sui-core and unreachable in practice. The code looks intended (the constructor deliberately defaults to highest); the strings are wrong, but they are string literals, not comments.
- **`ocs_verifier.rs:14-16`** — "mainnet is still on v121 as of 2026-05" is dated and probably stale, but I could not verify Sui mainnet's live protocol version from here.
- **`ika-protocol-config/src/lib.rs:34-35`** (outside this crate) — "V3-tagged pre-aggregation outputs remain readable forever" contradicts ika-core, where a V3-tagged output is now a hard decode error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
