### PR TITLE
chore: post-merge review follow-ups for #2103-#2107

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,7 +119,14 @@ jobs:
         # ika-types' tests (Cargo Test Check is compile-only), so the pins
         # must run here or a retype merges green. ika-types has no MPC
         # crypto, so the debug profile is fine.
-        run: cargo test -p ika-types --lib -- layout_is_pinned variant_indices_are_pinned
+        run: |
+          set -o pipefail
+          cargo test -p ika-types --lib -- layout_is_pinned variant_indices_are_pinned \
+            | tee "$RUNNER_TEMP/layout-pins.log"
+          # cargo exits 0 when a name filter matches nothing, so renaming a
+          # pinned test would silently disable this gate. Require that tests
+          # actually ran.
+          grep -qE '^test result: ok\. [1-9][0-9]* passed' "$RUNNER_TEMP/layout-pins.log"
       - name: System checkpoint message widths
         # Move peels a checkpoint's whole message vector as one flat BCS stream,
         # with no per-message length prefix to resynchronize on, so a Rust
@@ -127,7 +134,13 @@ jobs:
         # every message after it in the same checkpoint. The pins live in
         # ika-types' tests, which PR CI otherwise never executes (Cargo Test
         # Check is compile-only), so they must be named here to run at all.
-        run: cargo test -p ika-types --lib -- variant_encodings_are_pinned_to_the_move_peel_widths
+        run: |
+          set -o pipefail
+          cargo test -p ika-types --lib -- variant_encodings_are_pinned_to_the_move_peel_widths \
+            | tee "$RUNNER_TEMP/width-pins.log"
+          # Same vacuity guard as the layout pins above: a name filter that
+          # matches nothing still exits 0.
+          grep -qE '^test result: ok\. [1-9][0-9]* passed' "$RUNNER_TEMP/width-pins.log"
       - name: Sui version consistency
         # The Sui pin lives in several places that don't update together;
         # see dev-docs/conventions/sui-version-bump.md.

--- a/crates/dwallet-mpc-types/src/dwallet_mpc.rs
+++ b/crates/dwallet-mpc-types/src/dwallet_mpc.rs
@@ -164,9 +164,9 @@ pub struct NetworkEncryptionKeyPublicData {
 /// It is a deterministic function of the network DKG output (the NOA DKG
 /// is seeded on the class-group encryption key), so every validator
 /// derives the same value; and it is invariant across reconfiguration
-/// and the v2->v3 DKG-output reconstruction because that encryption key
-/// is invariant. Kept Sui-free (no `ObjectID`): `dwallet-mpc-types` does
-/// not depend on `sui-types`.
+/// and across any re-tagging of the DKG output, because that encryption
+/// key is invariant. Kept Sui-free (no `ObjectID`): `dwallet-mpc-types`
+/// does not depend on `sui-types`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct NetworkKeyId(pub [u8; 32]);
 
@@ -463,18 +463,18 @@ pub enum VersionedSignOutput {
 ///   every dealer's full PVSS dealing. Its inkrypto type
 ///   (`NonAggregatedPublicOutput`) was REMOVED — V3 bytes can no longer be
 ///   decoded, and every decode arm errors. The variant remains only for BCS
-///   variant-index stability. Persisted V3 anchors must have migrated to V4
-///   (via the anchor migration, on a binary that still carried the type)
-///   before this binary runs.
+///   variant-index stability. A persisted V3 anchor is therefore unreadable
+///   here: it must already have been rewritten to V4 by an earlier binary
+///   that still carried the type.
 /// - `V4` — bytes from
 ///   `twopc_mpc::decentralized_party::dkg::PublicOutput`: the same
 ///   `PublicOutputCore` prefix, with the trailing sharing output in the
 ///   aggregated shape (one summed randomizer-share ciphertext per receiver
 ///   instead of every dealer's full PVSS dealing — O(n) instead of O(n²)).
 ///   The protocol aggregates at output formation, so the DKG Party's output
-///   IS this shape and `advance_network_dkg_v2` tags it V4 as-is. A V4-tagged
-///   anchor also arises from the anchor migration once the reconfiguration
-///   output is V4.
+///   IS this shape and `advance_network_dkg_v2` tags it V4 as-is. This binary
+///   never rewrites an existing anchor, so a V4-tagged anchor is either one a
+///   V4-era DKG produced or one an earlier binary already rewrote.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema, Hash)]
 pub enum VersionedNetworkDkgOutput {
     V1(MPCPublicOutput),
@@ -504,7 +504,7 @@ impl VersionedNetworkDkgOutput {
 /// Wire-tagged decentralized-reconfiguration public output.
 ///
 /// - `V1` — previously-deployed shape; never produced anymore. Retained for
-///   BCS variant-index stability of `V2`/`V3`.
+///   BCS variant-index stability of `V2`/`V3`/`V4`.
 /// - `V2` — bytes with the shape of
 ///   `twopc_mpc::decentralized_party::reconfiguration::PublicOutputCore` (the
 ///   historical backward-compatible reconfiguration party's output). No

--- a/crates/ika-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/ika-core/src/authority/authority_per_epoch_store.rs
@@ -3712,6 +3712,21 @@ impl AuthorityPerEpochStore {
         let stalled_for = if draining {
             let now = Instant::now();
             let mut drain = self.mpc_catch_up_drain.lock();
+            // The seeded low can be tiny, zero included, and that is not a
+            // latch waiting to happen. It is NOT the case that a reported
+            // catch-up implies a gap near the gate's entry threshold: the gate
+            // enters above `CATCH_UP_ENTER_GAP_ROUNDS` but HOLDS all the way
+            // down to `CATCH_UP_EXIT_GAP_ROUNDS`, and it measures its gap once
+            // per drain iteration against the cursor from BEFORE that
+            // iteration, while the round below is republished after every
+            // round the same iteration consumes. So the round travelling with
+            // a `catching_up` flag is strictly fresher than the one the gate
+            // judged, and the gap computed here can already be zero.
+            // What keeps that from latching the alarm is time, not distance:
+            // the drain re-observes on a seconds scale, and the moment the
+            // gate disengages `draining` goes false and the branch below drops
+            // this tracker outright — so an end-of-catch-up low is discarded
+            // orders of magnitude sooner than `MPC_CATCH_UP_STUCK_DRAIN`.
             let progress = drain.get_or_insert(CatchUpDrainProgress {
                 lowest_gap_rounds: gap_rounds,
                 lowest_gap_at: now,

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_metrics.rs
@@ -241,12 +241,14 @@ pub struct DWalletMPCMetrics {
     /// computations (the admission ceiling `running` is compared against).
     pub(crate) cryptographic_computation_core_budget: IntGauge,
 
-    /// Version (2 or 3) of the canonical network DKG output this validator most
-    /// recently mirrored into the off-chain handoff. Migrates 2 -> 3 once, when
-    /// a deployed key's cert-pinned reconfiguration output becomes V3 (protocol
-    /// v4) and the validator reconstructs the full V3 output. `0` until the
-    /// first off-chain instantiation. (With one network key this reflects that
-    /// key; with several it reflects the most recently instantiated.)
+    /// Wire version tag of the canonical network DKG output this validator most
+    /// recently mirrored into the off-chain handoff: 1 or 2 for the deployed
+    /// keys' original anchors, 4 for an aggregated full-shape output (V3 is
+    /// undecodable and never observed). `0` until the first off-chain
+    /// instantiation. This binary never rewrites an anchor, so the value simply
+    /// reports the tag the overlay serves and does not move within a key's
+    /// lifetime. (With one network key this reflects that key; with several it
+    /// reflects the most recently instantiated.)
     pub(crate) network_encryption_key_canonical_dkg_output_version: IntGauge,
 
     /// Version of the latest network-key reconfiguration output installed on

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/fixed_vectors.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/fixed_vectors.rs
@@ -1,16 +1,22 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-//! Fixed-vector determinism pins for the aggregated-output anchor migration.
+//! Fixed-vector wire-format pin for the aggregated (V4) canonical anchor.
 //!
-//! Every validator independently derives and persists the aggregated (V4)
-//! canonical anchor via `new_from_reconfiguration_output`, so byte-identical
-//! quorum rests entirely on that derivation being canonically ordered
-//! (receivers, curve-parts, summation, bcs map encoding) across binaries and
-//! refactors. This test pins the derivation against committed fixtures
-//! captured from one real protocol run: any change to the derived bytes — an
-//! iteration-order regression, a serializer change, a struct reshape — fails
-//! it.
+//! Nothing in this binary calls
+//! `decentralized_party::dkg::PublicOutput::new_from_reconfiguration_output`
+//! any more — the derivation ran once, on an earlier binary, and the V4
+//! anchors it produced are the live state the deployed networks hold. The pin
+//! stays because that encoding is still load-bearing wire format here: every
+//! epoch this binary decodes those very bytes and derives the protocol public
+//! parameters from them, so an inkrypto-side reshape of
+//! `decentralized_party::dkg::PublicOutput` — a field reorder, a serializer
+//! change, an ordering regression in the derivation — would silently
+//! reinterpret state nobody can regenerate, and every MPC output computed
+//! against it would byte-diverge from the rest of the committee. Re-running
+//! the original derivation is simply the sharpest way to pin that encoding: it
+//! reproduces the exact bytes of a real protocol run, inputs and output both
+//! committed as fixtures.
 //!
 //! The pre-aggregation (V3) fixture pins that lived here were removed with
 //! the crypto types they exercised (`NonAggregatedPublicOutput` and its
@@ -28,9 +34,10 @@ const PINNED_AGGREGATED_RECONFIGURATION_OUTPUT: &[u8] =
 const DKG_OUTPUT_CORE: &[u8] = include_bytes!("fixtures/dkg_output_core.bcs");
 const PINNED_AGGREGATED_ANCHOR: &[u8] = include_bytes!("fixtures/dkg_anchor_aggregated.bcs");
 
-/// Anchor-migration determinism: rebuilding the canonical anchor from a V2
-/// (core-only) anchor's class-group DKG output and the aggregated
-/// reconfiguration output must yield the exact pinned V4 anchor bytes.
+/// Anchor encoding pin: rebuilding the canonical anchor from a V2 (core-only)
+/// anchor's class-group DKG output and the aggregated reconfiguration output
+/// must yield the exact pinned V4 anchor bytes — the bytes the deployed keys
+/// hold today and that this binary re-reads every epoch.
 #[test]
 fn v2_start_anchor_migration_matches_fixed_vector() {
     let core: twopc_mpc::decentralized_party::dkg::PublicOutputCore =
@@ -49,8 +56,9 @@ fn v2_start_anchor_migration_matches_fixed_vector() {
     assert_eq!(
         bcs::to_bytes(&anchor).expect("serialize the rebuilt anchor"),
         PINNED_AGGREGATED_ANCHOR,
-        "the V2-start anchor migration no longer reproduces the pinned V4 anchor bytes — \
-         a determinism regression that would split the byte-identical quorum on the \
-         deployed keys' one-time anchor migration"
+        "the pinned V4 anchor bytes are no longer reproduced — the encoding of \
+         `decentralized_party::dkg::PublicOutput` moved out from under the anchors the \
+         deployed keys already hold, so this binary would derive different protocol \
+         public parameters from that unregenerable state than its peers do"
     );
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -239,6 +239,119 @@ async fn stale_epoch_network_key_data_is_not_spawned() {
     );
 }
 
+/// A cert-digest mismatch on a key that is ALREADY adopted must leave that
+/// adopted value in place — not drop it, and not overwrite it with the
+/// mismatching overlay. The two outcomes differ sharply: the adopted value is
+/// the one the committee certified and the one this validator is instantiating
+/// from, so dropping it on a mismatch would silently stop the validator from
+/// signing with the key for the rest of the epoch, while keeping it is the
+/// intended skip-and-retry (the overlay re-merges every sync tick). Only an
+/// UNADOPTED key contradicting the cert is the security-relevant anomaly, and
+/// that one is rejected (covered by the empty-reconfiguration test above).
+#[tokio::test]
+async fn already_adopted_key_survives_a_cert_digest_mismatch() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (
+        mut dwallet_mpc_services,
+        _sui_data_senders,
+        _sent_consensus_messages_collectors,
+        epoch_stores,
+        _notify_services,
+        _network_owned_address_sign_request_senders,
+        _network_owned_address_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services(1);
+    let service = dwallet_mpc_services.first_mut().unwrap();
+    let epoch_id = service.epoch;
+    let prior_epoch = epoch_id - 1;
+
+    let key_id = ObjectID::random();
+    let network_key_id = NetworkKeyId([0x43; 32]);
+    crate::network_key_id_mapping::register(key_id, network_key_id);
+
+    let dkg_output = b"cert-pinned network dkg public output".to_vec();
+    let reconfiguration_output = b"cert-pinned network reconfiguration public output".to_vec();
+
+    // The prior epoch's cert pins both digests for this key (items sorted by
+    // `HandoffItemKey`: DKG < reconfiguration).
+    let attestation = HandoffAttestation {
+        epoch: prior_epoch,
+        next_committee_pubkey_set_hash: [0u8; 32],
+        items: vec![
+            (
+                HandoffItemKey::NetworkDkgOutput {
+                    key_id: network_key_id,
+                },
+                mpc_data_blob_hash(&dkg_output),
+            ),
+            (
+                HandoffItemKey::NetworkReconfigurationOutput {
+                    key_id: network_key_id,
+                },
+                mpc_data_blob_hash(&reconfiguration_output),
+            ),
+        ],
+    };
+    epoch_stores
+        .first()
+        .unwrap()
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(
+            prior_epoch,
+            CertifiedHandoffAttestation {
+                attestation,
+                signatures: vec![],
+            },
+        );
+
+    let manager = service.dwallet_mpc_manager_mut();
+
+    // First pass: the overlay matches the cert on both digests, so the key is
+    // adopted.
+    let matching_overlay = Arc::new(HashMap::from([(
+        key_id,
+        network_key_data(
+            key_id,
+            epoch_id,
+            dkg_output.clone(),
+            reconfiguration_output.clone(),
+        ),
+    )]));
+    manager.adopt_cert_verified_keys(&matching_overlay);
+    assert!(
+        manager.adopted_network_key_data.contains_key(&key_id),
+        "the cert-matching overlay entry must be adopted"
+    );
+
+    // Second pass: the overlay's DKG output no longer matches the cert. The
+    // pass must skip the key (no adoption of the mismatching bytes) while
+    // leaving the already-adopted value untouched.
+    let mismatching_overlay = Arc::new(HashMap::from([(
+        key_id,
+        network_key_data(
+            key_id,
+            epoch_id,
+            b"some other network dkg public output".to_vec(),
+            reconfiguration_output.clone(),
+        ),
+    )]));
+    manager.adopt_cert_verified_keys(&mismatching_overlay);
+    let adopted = manager
+        .adopted_network_key_data
+        .get(&key_id)
+        .expect("the already-adopted key must survive a cert-digest mismatch");
+    assert_eq!(
+        adopted.network_dkg_public_output, dkg_output,
+        "the adopted value must stay at the cert-matching bytes, not be overwritten \
+         by the mismatching overlay"
+    );
+    assert_eq!(
+        adopted.current_reconfiguration_public_output, reconfiguration_output,
+        "the adopted reconfiguration bytes must be untouched by the skipped pass"
+    );
+}
+
 /// A cert-referenced key whose `ObjectID` has no `NetworkKeyId` mapping
 /// (a joiner that never instantiated the key — the mapping registers at
 /// instantiation, which needs adoption first) must NOT be treated as

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -2019,6 +2019,13 @@ impl DWalletMPCManager {
                                  the handoff cert (key unadopted) — skipping adoption"
                             );
                         }
+                    } else {
+                        debug!(
+                            ?key_id,
+                            "overlay reconfiguration output does not match the prior \
+                             epoch's cert (expected once this epoch's reconfiguration \
+                             completes) — keeping the adopted prior value"
+                        );
                     }
                     continue;
                 }

--- a/crates/ika-types/src/messages_system_checkpoints.rs
+++ b/crates/ika-types/src/messages_system_checkpoints.rs
@@ -248,7 +248,7 @@ mod tests {
     ///
     /// Each row pins one variant's complete BCS encoding against the arm that
     /// consumes it in the `message_data_enum_tag` match of
-    /// `process_checkpoint_message_by_quorum`
+    /// `process_checkpoint_message`
     /// (`contracts/ika_system/sources/system/system_inner.move`): the leading byte
     /// is the tag the arm's `*_MESSAGE_TYPE` constant matches, and the remaining
     /// bytes are what that arm's `peel_*` sequence consumes.
@@ -325,7 +325,7 @@ mod tests {
                 bcs::to_bytes(&kind).unwrap(),
                 expected,
                 "{kind:?} no longer encodes as the Move dispatch reads it (tag {} then {move_peels}, \
-                 in `process_checkpoint_message_by_quorum` in \
+                 in `process_checkpoint_message` in \
                  contracts/ika_system/sources/system/system_inner.move). Move peels the \
                  checkpoint's messages as one flat stream, so a width or tag change here \
                  desynchronizes every message that follows it in the same checkpoint. Change the \

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -1708,9 +1708,9 @@ impl ClusterOfProcesses {
     /// The minimum canonical network DKG output version reported across all
     /// running validators' `/metrics`. Returns 0 if a running validator has not
     /// reported the gauge yet (or is unreachable), so a poller keeps waiting
-    /// until the whole committee has migrated. The off-chain handoff carries the
-    /// migrated version; the on-chain copy stays V2, so this metric — not a Sui
-    /// read — is how the V2->V4 migration is observed.
+    /// until every validator has reported. The version lives in the off-chain
+    /// handoff the validators serve each other, not in a chain field, so this
+    /// metric — not a Sui read — is the only way a scenario can observe it.
     pub async fn min_canonical_network_dkg_output_version(&self) -> u64 {
         let http = reqwest::Client::new();
         let mut min: Option<u64> = None;

--- a/crates/ika-upgrade-test/src/scenario.rs
+++ b/crates/ika-upgrade-test/src/scenario.rs
@@ -64,8 +64,9 @@ pub enum Step {
     WaitForNetworkKeyReconfigurationCompleted(u64),
     /// Poll until every running validator reports a canonical network DKG
     /// output version `>= at_least` (via its `/metrics`), or time out. Confirms
-    /// the off-chain handoff migrated the DKG output (e.g. 2 -> 3 after the v4
-    /// reconfiguration); the on-chain copy stays V2, so this is metric-based.
+    /// the whole committee agrees on the DKG-output wire version it serves in
+    /// the off-chain handoff; that version has no chain field, so this is
+    /// metric-based.
     ExpectNetworkDkgOutputVersionAtLeast(u64),
     ExpectReconfigurationOutputVersionAtLeast(u64),
     /// Register a brand-new validator on chain (candidate → stake → join) and

--- a/dev-docs/playbooks/production-alerts.md
+++ b/dev-docs/playbooks/production-alerts.md
@@ -232,6 +232,19 @@ while a genuinely stuck drain's lag jitter kept resetting the clock. The gap
 falls on every round a replay drains and freezes only when the drain stops
 closing on the tip, which is the distinction this alert is for.
 
+**The monitoring side's uptime guard is temporary — remove it only when every
+validator runs the fix.** The alert rule currently suppresses this condition
+for the first hour of a validator's uptime, because a binary from before the
+ika #2107 fix still times the condition on the clamped round lag and
+false-latches during a boot replay. That false latch lives in the validator
+binary, so merging the fix and tagging a release removes nothing: the guard
+comes off only once every validator on BOTH mainnet and testnet is actually
+running a release that carries it (v1.4.1 or newer), which has to be confirmed
+per network against what the committee is running, not against what has been
+published. Take it off then, and do not leave it standing longer: it blinds the
+alert for the first hour after a restart, which is precisely the window in
+which a post-restart replay can get stuck.
+
 **Do not alert on `ika_mpc_consensus_round_lag` directly.** It can carry
 neither alert. The fold hands each round to the drain over a bounded blocking
 channel (capacity 1,024) and the drain consumes during the boot replay, so the


### PR DESCRIPTION
Post-merge review follow-ups for #2103–#2107. An adversarial review of those
five merged PRs found no blocking bugs; these are the six small items it left,
shipped together. No behavior changes except the one restored log line.

## 1. Restore the every-epoch debug log in `adopt_cert_verified_keys`

#2105 deleted two `else { debug!(...) }` tolerance arms. The first was
genuinely migration-specific and is correctly gone. The second was not: it
covered the ongoing, by-design case where this epoch's reconfiguration output
mismatches the PRIOR epoch's handoff cert while the key is already adopted —
the intended defer-to-next-epoch, which happens every epoch. That case now
logged nothing at all, so the most common skip in the pass was invisible.

Restored just that arm, minus the migration phrasing. Behavior is unchanged:
the `continue` was and stays unconditional.

## 2. Restore orphaned test coverage for a still-live invariant

#2105 also deleted `already_adopted_key_survives_dkg_output_migration`, which
exercised "an already-adopted network key survives a cert-digest mismatch
instead of being dropped" through the removed V2→V4 migration. The migration is
gone; the invariant is not — it is what the `!adopted.contains_key(key_id)`
guards in both mismatch arms exist for, and dropping the adopted value there
would silently stop the validator signing with that key for the rest of the
epoch.

New test `already_adopted_key_survives_a_cert_digest_mismatch` exercises it
through a plain, non-migration mismatch: adopt a key whose overlay matches the
prior cert on both digests, then present an overlay whose DKG output no longer
matches. The adopted value must remain, unchanged and un-overwritten.

## 3. Fix #2103's wrong Move reference

The width-pin test's doc comment and assert message pointed at
`process_checkpoint_message_by_quorum` (`system_inner.move:823`). That function
only verifies the certificate and delegates; the `message_data_enum_tag` match
the test actually pins lives in `process_checkpoint_message` (:842). Corrected
both occurrences, so the next person to change a Move arm is sent to the right
one.

## 4. Refresh docs left stale by #2105's machinery removal

Docs only, no behavior:

- `dwallet_mpc_metrics.rs` — the canonical-DKG-output-version gauge's Rust doc
  comment still described the removed reconstruction and a 2→3 migration. (The
  registered help string had already been updated; the doc comment had not.)
- `dwallet-mpc-types/src/dwallet_mpc.rs` — `NetworkKeyId`'s "v2->v3
  DKG-output reconstruction", and the `VersionedNetworkDkgOutput` V3/V4 arms
  describing an anchor migration this binary no longer performs. Also corrected
  the reconfiguration `V1` arm, which named `V2`/`V3` as the variants it keeps
  index-stable but omitted `V4`.
- `ika-upgrade-test` `cluster.rs` / `scenario.rs` — doc comments describing a
  migration that no longer exists; reworded to what the metric actually
  reports, which is still the only way a scenario can observe the version.
- `fixed_vectors.rs` — `new_from_reconfiguration_output` now has no production
  caller. The pin is KEPT, and the comment now says why: the encoding is still
  load-bearing wire format, because the V4 anchors that derivation produced are
  live state on the deployed networks that this binary decodes every epoch and
  nobody can regenerate. Re-running the derivation is simply the sharpest way
  to pin that encoding.

No metric names changed, so the metrics inventory is untouched.

## 5. Correct a wrong invariant in #2107's reasoning

#2107's reasoning claimed the catch-up gate "can only be engaged while the head
is at least the entry threshold (5,000) ahead of the cursor". That is false, and
someone building on it could conclude the stuck-drain tracker can never seed a
near-zero low. Verified against the code:

- the gate ENTERS above `CATCH_UP_ENTER_GAP_ROUNDS` (5,000) but HOLDS all the
  way down to `CATCH_UP_EXIT_GAP_ROUNDS` (500) — `catchup_gate.rs:88-91`;
- the gate measures its gap once per drain iteration, against the cursor from
  BEFORE that iteration, while `progress.consumed_round` is republished after
  every round the same iteration consumes. The detector's cursor is therefore
  strictly fresher, and its computed gap can already be 0 while `catching_up`
  is still true.

The claim appears only in the merged PR body, not in any comment, so rather
than fixing a comment this adds a short one at the tracker's seed point stating
the real protection: not distance but time — the drain re-observes on a
seconds scale, and the gate-exit path resets the tracker to `None`, so an
end-of-catch-up low is discarded long before `MPC_CATCH_UP_STUCK_DRAIN`.

## 6. Record the alert-guard removal condition in the playbook

`dev-docs/playbooks/production-alerts.md`, in the catch-up-stuck alert's
section: the monitoring-side TEMPORARY uptime>1h guard on
`ika_mpc_catch_up_stuck_condition_active` stays until every validator on both
networks runs a release carrying the #2107 fix (v1.4.1 or newer). The false
latch lives in the validator binary, so merging the fix and tagging a release
removes nothing — the guard comes off only against what the committees are
actually running, confirmed per network. Also noted why it should not outstay
that: it blinds the alert for the first hour after a restart, exactly when a
post-restart replay can get stuck. The infra-repo side is already done; nothing
outside this repo is touched here.

## Also: harden the CI width-guard steps against silent vacuity

`cargo test` exits 0 when a name filter matches nothing, so renaming a pinned
test would silently disable its gate while CI stayed green. Both filtered steps
in `ci.yaml` — the layout/variant-index pins from #2083 and the width pins from
#2103 — now run under `set -o pipefail`, tee to `$RUNNER_TEMP`, and require a
nonzero "N passed" line.

## Testing

- `cargo fmt --all --check` clean.
- `cargo clippy --all-targets --all-features -p ika-core -p ika-types -p dwallet-mpc-types` clean.
- `cargo test --release -p ika-core network_key_adoption` — 7 passed, 0 failed.
- `cargo test --release -p ika-types` — 44 + 3 passed, 1 ignored, 0 failed.
- CI step logic checked locally: the grep matches a real "7 passed" line and
  rejects a "0 passed" one, and both step shell lines pass with the tests
  present.

The new test was proven non-vacuous rather than merely green. Injecting the
regression it guards — dropping the adopted key on a cert-digest mismatch in
`adopt_cert_verified_keys` — produced `FAILED. 6 passed; 1 failed`, the single
failure being the new test panicking on `the already-adopted key must survive a
cert-digest mismatch`; the other six stayed green, so it is specific to the
invariant. With the fault reverted the run is back to 7 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
