### PR TITLE
fix(ci): trigger the upgrade suite on ika-node/src and the rest of the validator's crate closure

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -70,8 +70,28 @@ name: Upgrade Test
 on:
   pull_request:
     paths:
+      # WHAT THIS LIST IS, so the next person does not have to re-derive it:
+      # the `ika-validator` binary's own in-repo dependency closure — the crate
+      # that builds the binary (`ika-node`) plus every workspace crate it pulls
+      # in — together with the harness crate and the workflows that run it.
+      # If a source change can end up INSIDE the binary this suite spawns, or
+      # can change how the harness drives it, it belongs here. Re-derive with
+      # `cargo tree -p ika-node -e normal --workspace` when a crate is added;
+      # today that closure is ika-node, ika-core, ika-network, ika-types,
+      # ika-protocol-config, ika-config, ika-archival, ika-sui-client,
+      # ika-telemetry, dwallet-mpc-types, dwallet-mpc-centralized-party,
+      # dwallet-classgroups-types and dwallet-rng. (`ika-protocol-config-macros`
+      # is a workspace member but nothing depends on it, and the `consensus-*`,
+      # inkrypto and `sui-*` deps live OUT of this repo, pinned by tag/rev in
+      # the root manifest — so `Cargo.toml`/`Cargo.lock` below already catch
+      # every bump to them.)
       - "Cargo.toml"
       - "Cargo.lock"
+      # ika-core and ika-node are the only closure crates whose manifest carries
+      # feature flags this workflow itself toggles (enforce-minimum-cpu,
+      # dwallet-mpc-unsafe-mock, test-testing, jemalloc), so those two are
+      # listed whole; any other manifest edit that changes what gets built also
+      # moves `Cargo.lock`.
       - "crates/ika-core/Cargo.toml"
       # Whole crates, not module lists. This suite spawns REAL validator
       # processes that reach each other over anemo and swap binaries across
@@ -101,8 +121,37 @@ on:
       - "crates/ika-types/**"
       - "crates/ika-network/**"
       - "crates/ika-node/Cargo.toml"
+      # The binary itself. `ika-validator` is a bin target of THIS crate
+      # (`src/bin/ika-validator.rs`), and only its manifest was listed — so a
+      # change to node startup, the validator bin, service wiring or the
+      # archival/telemetry plumbing shipped without this suite ever running.
+      # Same failure mode as the per-module rot above, one level up.
+      - "crates/ika-node/src/**"
       - "crates/dwallet-mpc-*/**"
       - "crates/ika-protocol-config/**"
+      # The remainder of the closure. Source globs only (`src/**`): these crates
+      # carry READMEs, fixtures and config templates whose churn cannot change
+      # the binary, and a doc-only edit should not spend an `ika-k8s-large`
+      # runner. Broad within the crate, though — everything below is
+      # wire-format- or chain-contract-bearing across a binary swap:
+      #   ika-sui-client  — the chain reads/writes both binaries share; its
+      #                     untagged BCS mirrors ARE the wire format.
+      #   ika-config      — node + genesis config both binaries must parse
+      #                     identically for a mixed committee to boot.
+      #   ika-archival    — checkpoint archive/sync formats read across epochs.
+      #   ika-telemetry   — linked into the binary; its init runs before the
+      #                     node does, so a break there is a boot failure.
+      #   dwallet-classgroups-types, dwallet-rng — the class-groups key and
+      #                     RNG types that go out in mpc_data announcements and
+      #                     into MPC messages. NOT matched by
+      #                     `crates/dwallet-mpc-*/**`; that glob is narrower
+      #                     than "the crypto crates".
+      - "crates/ika-sui-client/src/**"
+      - "crates/ika-config/src/**"
+      - "crates/ika-archival/src/**"
+      - "crates/ika-telemetry/src/**"
+      - "crates/dwallet-classgroups-types/src/**"
+      - "crates/dwallet-rng/src/**"
       - "crates/ika-upgrade-test/**"
       - ".github/workflows/upgrade-test.yaml"
       - ".github/workflows/release.yaml"

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -65,19 +65,26 @@ gh run download <run-id> -n <artifact>   # localnet-logs / cluster-tests-log-<at
 `.github/workflows/upgrade-test.yaml` runs the out-of-process harness
 (`crates/ika-upgrade-test/`) — real, separately-compiled `ika-validator`
 child processes against an external `sui` localnet. Manual dispatch remains
-available. Pull requests matching the workflow's `paths:` filter — today
-`crates/ika-core/src/**`, `crates/ika-types/**`, `crates/ika-network/**`,
-`crates/dwallet-mpc-*/**`, `crates/ika-protocol-config/**`,
-`crates/ika-upgrade-test/**`, the root and per-crate `Cargo.toml`s,
-`Cargo.lock`, and the upgrade-test and release workflow files — automatically
+available. Pull requests matching the workflow's `paths:` filter automatically
 run the `v140_rollout` deployed-release gate rather than the entire matrix.
-Read that list rather than paraphrasing it: `crates/dwallet-mpc-*/**` is
-narrower than "the crypto crates" and does not match `dwallet-classgroups-types`
-or `dwallet-rng`. Those are whole-crate globs on purpose:
-the filter previously listed individual modules and silently stopped covering
-code three separate times as modules were added or split out — if you are
-adding a trigger for a module, widen to its crate instead. A change outside
-those crates that could still affect cross-binary behaviour needs a manual
+**Read that filter in the workflow; do not paraphrase it here** — every
+paraphrase written so far has been wrong, and a wrong one hides gaps. The
+comment above the list states the rule the list follows: the `ika-validator`
+binary's in-repo dependency closure (the crate that builds the binary plus
+every workspace crate it pulls in), plus the harness crate and the workflows
+that run it. Two shapes in it are easy to misread: `crates/dwallet-mpc-*/**`
+is narrower than "the crypto crates" — it does not match
+`dwallet-classgroups-types` or `dwallet-rng`, which are listed separately —
+and several closure crates are listed as `src/**` source globs rather than
+whole-crate ones, so a README-only edit in those deliberately does not spend
+a runner.
+Entries are per-crate, never per-module: the filter once listed individual
+modules and silently stopped covering code three separate times as modules
+were added or split out, and the same rot then recurred one level up, with
+`crates/ika-node/src/**` — the crate that builds the very binary this suite
+spawns — missing while only its `Cargo.toml` was listed. If you are adding a
+trigger for a module, widen to its crate instead. A change outside those
+crates that could still affect cross-binary behaviour needs a manual
 dispatch; the suite not appearing on a PR is not evidence that it passed.
 There is currently **no protocol-version transition gate**: `MIN` and `MAX`
 are both 7, so no boundary exists to cross. `v127_v7_upgrade` and the
@@ -272,10 +279,19 @@ profile).
 ## Facts that save debugging time
 
 - **Concurrency groups QUEUE, they don't cancel — with one exception.**
-  Every heavy suite uses a per-ref group (`<workflow>-<ref>`) with
-  `cancel-in-progress: false` (`upgrade-test.yaml` omits the key, which
-  means the same), so re-dispatching on the same branch leaves the
-  in-flight run alone and the new one waits its turn. The exception is
+  Every heavy suite uses a per-ref group with `cancel-in-progress: false`,
+  so re-dispatching on the same branch leaves the in-flight run alone and
+  the new one waits its turn. Most spell that group
+  `${{ github.workflow }}-${{ github.ref }}`; `upgrade-test.yaml`
+  deliberately does not — it sets a LITERAL prefix,
+  `upgrade-test-${{ github.ref }}`, and spells `cancel-in-progress: false`
+  out. Inside a `workflow_call`, `${{ github.workflow }}` resolves to the
+  CALLER's workflow name, so the interpolated form made the release gate
+  compute the very group its caller was already holding; GitHub killed it
+  at startup as a self-deadlock and silently skipped the release Draft job
+  (first hit: `release/testnet-1.2.1`). Any workflow that is both
+  dispatchable and `workflow_call`-able needs the literal-prefix form. The
+  exception is
   `ts-integration-tests.yaml`, which sets `cancel-in-progress: true` and
   really does kill the previous run — and `ci.yaml`, which cancels on
   every ref except `main`. So a re-dispatch is cheap on four of the five

--- a/dev-docs/playbooks/mpc-stall-postmortem.md
+++ b/dev-docs/playbooks/mpc-stall-postmortem.md
@@ -207,7 +207,7 @@ stale `~/.ika/ika_config/network.yaml`):
 Narrow the dead layer by checking each pipeline stage independently:
 
 ```bash
-grep -c "Presign request reached majority vote" $L   # consensus + votes alive?
+grep -c "Presign request reached majority vote" $L   # consensus + votes alive? (debug-level)
 grep -c "Adding a new MPC session" $L                # admission alive?
 grep -c "popped presign from internal pool" $L       # serving alive?
 grep -c "broadcasting new requests" $L               # event sync alive? (debug-level)

--- a/scripts/check-chain-mirror-layout.sh
+++ b/scripts/check-chain-mirror-layout.sh
@@ -19,7 +19,8 @@
 # where a red build is the cheapest possible signal.
 #
 # The Rust half of the guard is the golden layout tests beside each mirror
-# (`cargo test --release -p ika-types layout_is_pinned`); this script is the
+# (`cargo test -p ika-types --lib -- layout_is_pinned variant_indices_are_pinned`,
+# exactly as CI runs them); this script is the
 # Move half plus the mapping between them.
 #
 # Convention: dev-docs/conventions/chain-mirror-layout.md
@@ -242,7 +243,8 @@ if problems:
         "  3. the `const VERSION` bump plus `migrate()` that carries old state across (an\n"
         "     in-place field-add is rejected by Sui's compatible-policy upgrade checker, so\n"
         "     there is no same-version path to chain),\n"
-        "  4. the golden layout tests: cargo test --release -p ika-types layout_is_pinned,\n"
+        "  4. the golden layout tests, both names CI runs:\n"
+        "     cargo test -p ika-types --lib -- layout_is_pinned variant_indices_are_pinned,\n"
         f"  5. the Residuals section of {SPEC},\n"
         "  6. this manifest: ./scripts/check-chain-mirror-layout.sh --write\n\n"
         f"See {CONVENTION}."


### PR DESCRIPTION
Adversarial review of the merged docs PR #2110 turned up one real CI gap plus three wrong/stale lines. All four fixes are here; no Rust changes.

## 1. The fix: `upgrade-test.yaml` never ran on changes to the crate that builds the binary

The `paths:` filter that gates the release-validating upgrade suite listed
`crates/ika-node/Cargo.toml` but **not** `crates/ika-node/src/**` — and
`ika-validator` is a bin target of that crate (`src/bin/ika-validator.rs`).
A source change to node startup, the validator bin or its service wiring
merged without this suite ever running. That is exactly the failure mode the
comment already in the file rails about ("A per-module list has now rotted
three times"), one level up: the crate, not a module, was missing.

The same audit — walking `ika-node`'s real in-repo dependency closure rather
than memory — found the rest of the closure missing too.

Filter after this PR (unchanged entries elided):

| added | why |
| --- | --- |
| `crates/ika-node/src/**` | **the gap.** Builds `ika-validator` itself; only its manifest was listed. |
| `crates/ika-sui-client/src/**` | the chain reads/writes both binaries share; its untagged BCS mirrors *are* the wire format. |
| `crates/ika-config/src/**` | node + genesis config both binaries must parse identically for a mixed committee to boot. |
| `crates/ika-archival/src/**` | checkpoint archive/sync formats read across epochs. |
| `crates/ika-telemetry/src/**` | linked into the binary; its init runs before the node does, so a break there is a boot failure. |
| `crates/dwallet-classgroups-types/src/**` | class-groups key types that go out in `mpc_data` announcements. **Not** matched by `crates/dwallet-mpc-*/**`. |
| `crates/dwallet-rng/src/**` | same — outside the `dwallet-mpc-*` glob, in the closure. |

Deliberate choices, all written into a new comment above the list so the
next person does not re-derive them:

- **Source globs (`src/**`) only** for the additions — broad within each
  crate (they are all wire-format- or chain-contract-bearing across a binary
  swap) but not so broad that a README edit spends an `ika-k8s-large` runner.
- **Not added:** `ika-protocol-config-macros` — a workspace member that
  nothing depends on. `consensus-*`, the inkrypto crates and `sui-*` live out
  of this repo, pinned by tag/rev in the root manifest, so the existing
  `Cargo.toml` / `Cargo.lock` entries already catch every bump to them.
- `crates/ika-core/Cargo.toml` and `crates/ika-node/Cargo.toml` stay listed
  individually because those two are the only closure manifests carrying
  feature flags this workflow itself toggles (`enforce-minimum-cpu`,
  `dwallet-mpc-unsafe-mock`, `test-testing`, `jemalloc`); any other manifest
  edit that changes what gets built also moves `Cargo.lock`.

Validation: `yaml.safe_load` parses the file; every one of the 19 globs was
checked against `git ls-files` under GitHub's filter-pattern semantics and
each matches at least one tracked file.

**Adjacent gap, deliberately left out of this PR:** the harness publishes the
*current tree's* Move packages (`ika-upgrade-test` → `ika-swarm-config` →
`ika-move-contracts`, which `include_directory!`s `contracts/`) and then boots
the **old** v1.4.0 binary against them — so a `contracts/**` or
`ika-swarm-config` change is also a cross-binary hazard that does not trigger
the suite today. That is a scope call about the harness side rather than the
binary closure; happy to add `contracts/**` + `crates/ika-swarm-config/src/**`
here if you want it (churn there is ~1 commit / 60 days, so the cost is low).

## 2. Two wrong claims from #2110 in `dev-docs/playbooks/ci-suites.md`

**a. Concurrency.**

> before: Every heavy suite uses a per-ref group (`<workflow>-<ref>`) with `cancel-in-progress: false` (`upgrade-test.yaml` omits the key, which means the same)

False — the file sets both keys, at lines 217-218: a **literal** group
`upgrade-test-${{ github.ref }}` with `cancel-in-progress: false` spelled out.
The literal prefix is deliberate and load-bearing (the comment above it
explains): inside a `workflow_call`, `${{ github.workflow }}` resolves to the
**caller's** workflow name, so the interpolated form made the release gate
compute the very group its caller was holding, and GitHub killed it at startup
as a self-deadlock — silently skipping the release Draft job (first hit
`release/testnet-1.2.1`).

> after: … Most spell that group `${{ github.workflow }}-${{ github.ref }}`; `upgrade-test.yaml` deliberately does not — it sets a LITERAL prefix, `upgrade-test-${{ github.ref }}`, and spells `cancel-in-progress: false` out. Inside a `workflow_call`, `${{ github.workflow }}` resolves to the CALLER's workflow name … Any workflow that is both dispatchable and `workflow_call`-able needs the literal-prefix form.

**b. The `paths:` paraphrase.**

> before: … — today `crates/ika-core/src/**`, `crates/ika-types/**`, `crates/ika-network/**`, `crates/dwallet-mpc-*/**`, `crates/ika-protocol-config/**`, `crates/ika-upgrade-test/**`, **the root and per-crate `Cargo.toml`s**, `Cargo.lock`, and the upgrade-test and release workflow files —

"per-crate `Cargo.toml`s" read as *all* of them when there were exactly two,
and the paraphrase is precisely what hid the ika-node gap — it mentioned the
manifest and never the sources.

> after: Pull requests matching the workflow's `paths:` filter automatically run the `v140_rollout` deployed-release gate rather than the entire matrix. **Read that filter in the workflow; do not paraphrase it here** — every paraphrase written so far has been wrong, and a wrong one hides gaps. …

taking the playbook's own advice: it now states the *rule* the list follows,
keeps only the two shapes that are genuinely easy to misread
(`dwallet-mpc-*/**` being narrower than "the crypto crates"; `src/**` vs
whole-crate globs), and records the ika-node rot as the second instance of the
per-module lesson.

## 3. Two pre-existing one-liners from the same review

- `dev-docs/playbooks/mpc-stall-postmortem.md:210` — `"Presign request reached
  majority vote"` is emitted by `debug!`
  (`crates/ika-core/src/dwallet_mpc/mpc_manager.rs:1332`). Without the
  `(debug-level)` annotation its neighbour recipe carries, an operator
  grepping an info-level log reads 0 for the first line of the
  narrow-the-dead-layer table and concludes "consensus dead".
- `scripts/check-chain-mirror-layout.sh:22,245` — both advertised
  `cargo test --release -p ika-types layout_is_pinned`. What CI actually runs
  (`ci.yaml`, "Chain-mirror layout (Rust half)"), matching
  `dev-docs/conventions/chain-mirror-layout.md`, is
  `cargo test -p ika-types --lib -- layout_is_pinned variant_indices_are_pinned`
  — no `--release` (ika-types has no MPC crypto, so debug is fine) and with
  the second pinned test name, which the stale form silently skipped.
  Verified: `bash -n` clean, the script still exits 0, and its embedded Python
  (including the edited failure message) compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
