### PR TITLE
fix: correct audit-reported defects in logs, metrics, and dead code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ covers the change; escalate to the full suite before merge):
 
 - `dwallet_mpc/**` → `cargo test --release -p ika-core <nearest integration filter>`
 - Epoch boundaries / reconfiguration / `sui_connector` → cluster suite on CI
-- `sdk/typescript/**` → `./scripts/run-integration-tests-sequential.sh --filter <file-stem>`
+- `sdk/typescript/**` → `./sdk/typescript/scripts/run-integration-tests-sequential.sh --filter <file-stem>`
 - `contracts/**` → `sui move build` per touched package
 - `ika-protocol-config` → `cargo test -p ika-protocol-config` (snapshot tests)
 
@@ -265,7 +265,7 @@ already validated, branch names, and in-flight CI run IDs/URLs.
   `dev-docs/reference/sui-upstream.md`.
 - **Sui version is pinned in MULTIPLE places** (currently `mainnet-v1.77.2`;
   sometimes a `testnet-v*` tag): when bumping it, bump EVERYWHERE in one
-  PR — root `Cargo.toml` (~90 tag pins), excluded wasm workspace locks,
+  PR — root `Cargo.toml` (~45 tag pins), excluded wasm workspace locks,
   the sui-binary downloads in the TS CI workflows, this file, and every
   developer's local `sui` binary (a mismatched localnet binary completes
   DKG but silently stalls reconfiguration). Checklist:

--- a/crates/ika-core/src/consensus_throughput_calculator.rs
+++ b/crates/ika-core/src/consensus_throughput_calculator.rs
@@ -130,11 +130,11 @@ impl ThroughputProfileRanges {
         }
 
         warn!(
-            "Could not resolve throughput profile for throughput {} - we shouldn't end up here. Fallback to lowest profile as default.",
+            "Could not resolve throughput profile for throughput {} - we shouldn't end up here. Fallback to highest profile as default.",
             current_throughput
         );
 
-        // If not found, then we should return the lowest possible profile as default to stay on safe side.
+        // If not found, then we should return the highest possible profile as default to stay on safe side.
         self.highest_profile()
     }
 }

--- a/crates/ika-core/src/sui_connector/committee_store.rs
+++ b/crates/ika-core/src/sui_connector/committee_store.rs
@@ -170,7 +170,18 @@ impl CommitteeStore {
     /// Genesis bootstrap: install the supplied `committee[0]`
     /// directly (it has no preceding summary to derive from). The ratchet
     /// picks up `committee[1]` once the chain's first end-of-epoch summary
-    /// appears upstream. Localnet/test only.
+    /// appears upstream.
+    ///
+    /// This is the normal first-boot path on *every* chain, mainnet and
+    /// testnet included — not a test-only one. How much the installed
+    /// committee is worth is decided by the caller, which loads and verifies
+    /// the blob: on Mainnet/Testnet the blob's genesis-checkpoint digest is
+    /// checked against the binary's compiled-in chain identifier and
+    /// `committee[0]` is re-bound to that digest, so the committee is
+    /// digest-anchored. On Devnet/Custom (localnet, private nets) there is no
+    /// compiled-in root to check against, so the blob is only verified for
+    /// internal consistency and the trust sits entirely with whoever supplied
+    /// it. The caller logs which of the two applied.
     fn install_genesis(&self, committee: SuiCommittee) -> IkaResult<()> {
         let epoch = committee.epoch;
         self.tables.install_sui_committee(&committee)?;
@@ -178,7 +189,7 @@ impl CommitteeStore {
         self.cache_committee(epoch, committee);
         info!(
             head_epoch = epoch,
-            "installed UNSAFE genesis committee (no digest anchor; localnet/test path)"
+            "installed genesis-blob committee[0] as the OCS trust root"
         );
         Ok(())
     }

--- a/crates/ika-core/src/sui_connector/metrics.rs
+++ b/crates/ika-core/src/sui_connector/metrics.rs
@@ -10,11 +10,6 @@ use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct SuiConnectorMetrics {
-    /// Latest Sui checkpoint synced per module. Registered but no longer
-    /// written: the event-listening task that fed it was removed when the OCS
-    /// `BagEventPump` replaced it, and nothing writes it today.
-    pub last_synced_sui_checkpoints: IntGaugeVec,
-
     pub gas_coin_balance: IntGauge,
 
     /// Sequence number of the next dwallet checkpoint to write to Sui.
@@ -180,14 +175,6 @@ impl SuiConnectorMetrics {
             registry
         };
         let this = Self {
-            last_synced_sui_checkpoints: register_int_gauge_vec_with_registry!(
-                "ika_sui_connector_last_synced_sui_checkpoints",
-                "The latest sui checkpoints synced for each module",
-                &["module_name"],
-                registry,
-            )
-            .unwrap(),
-
             gas_coin_balance: register_int_gauge_with_registry!(
                 "ika_sui_connector_gas_coin_balance",
                 "Current balance of gas coin, in mist",

--- a/crates/ika-core/src/sui_connector/setup.rs
+++ b/crates/ika-core/src/sui_connector/setup.rs
@@ -46,7 +46,7 @@ use ika_network::sui_state_mirror::{
     self, Server as SuiStateMirrorImpl, SuiMirrorPeers, SuiMirrorProofProvider, SuiMirrorTransport,
     SuiStateMirrorServer,
 };
-use ika_sui_client::genesis::load_and_verify_sui_genesis;
+use ika_sui_client::genesis::{compiled_in_chain_identifier, load_and_verify_sui_genesis};
 use ika_sui_client::grpc::SuiGrpcClient;
 use ika_sui_client::rate_limit::RateLimitGate;
 use ika_sui_client::transport::{SuiTransport, TransportError};
@@ -357,12 +357,29 @@ pub async fn build_sui_connector_stack(
                 .as_ref()
                 .ok_or(SetupError::GenesisPathMissing)?;
             let boot = load_and_verify_sui_genesis(path, cfg.sui_chain_identifier)?;
-            info!(
-                epoch = boot.committee.epoch,
-                chain_identifier = %boot.chain_identifier.base58_encode(),
-                "OCS bootstrap: genesis-rooted committee[0] loaded; Sui chain identifier \
-                 verified against the compiled-in constant"
-            );
+            // Mainnet/Testnet carry a compiled-in genesis digest, so the blob
+            // — and `committee[0]`, which the loader re-binds to that digest —
+            // is anchored to a root the binary itself ships. Devnet/Custom
+            // have no such root: the blob is only checked for internal
+            // consistency, so the OCS trust chain is rooted in whatever the
+            // operator supplied. Only that second case warrants a warning.
+            if compiled_in_chain_identifier(cfg.sui_chain_identifier).is_some() {
+                info!(
+                    epoch = boot.committee.epoch,
+                    chain_identifier = %boot.chain_identifier.base58_encode(),
+                    "OCS bootstrap: genesis-rooted committee[0] loaded; Sui chain identifier \
+                     verified against the compiled-in constant"
+                );
+            } else {
+                warn!(
+                    epoch = boot.committee.epoch,
+                    chain = %cfg.sui_chain_identifier,
+                    chain_identifier = %boot.chain_identifier.base58_encode(),
+                    "OCS bootstrap: UNSAFE genesis committee[0] — this chain has no compiled-in \
+                     genesis digest to anchor the blob against, so the whole OCS trust chain is \
+                     only as trustworthy as the supplied genesis blob"
+                );
+            }
             Some(CommitteeBootstrap::Genesis(boot.committee))
         }
     };

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -693,7 +693,7 @@ where
         self.inner.get_chain_identifier().await.map_err(|e| {
             self.sui_client_metrics
                 .sui_rpc_errors
-                .with_label_values(&["get_validators_info_by_ids"])
+                .with_label_values(&["get_chain_identifier"])
                 .inc();
             IkaError::SuiClientInternalError(format!("Can't get_chain_identifier: {e}"))
         })

--- a/crates/ika-types/src/crypto.rs
+++ b/crates/ika-types/src/crypto.rs
@@ -483,20 +483,6 @@ impl AuthorityPublicKeyBytes {
 where {
         AuthorityPublicKeyBytes(bytes)
     }
-
-    /// A consensus Ed25519 key placed in the 48-byte BLS container: the 32 key
-    /// bytes zero-padded up to the container width.
-    ///
-    /// This is NOT how a validator is named. Through protocol v6 the padded
-    /// container WAS the `AuthorityName`; since v7 [`AuthorityName`] is a
-    /// separate type holding the raw 32 bytes, built by
-    /// [`AuthorityName::from_consensus_key`]. This constructor only reproduces
-    /// the historical padded encoding.
-    pub fn from_consensus_key(key: &NetworkPublicKey) -> Self {
-        let mut bytes = [0u8; AuthorityPublicKey::LENGTH];
-        bytes[..Ed25519PublicKey::LENGTH].copy_from_slice(key.as_bytes());
-        AuthorityPublicKeyBytes(bytes)
-    }
 }
 
 impl FromStr for AuthorityPublicKeyBytes {

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -701,7 +701,6 @@ ika_sui_connector_dwallet_checkpoint_writes_success_total
 ika_sui_connector_end_of_publish_blocked_reason
 ika_sui_connector_epoch_switch_step_done
 ika_sui_connector_gas_coin_balance
-ika_sui_connector_last_synced_sui_checkpoints
 ika_sui_connector_last_written_dwallet_checkpoint_sequence
 ika_sui_connector_last_written_system_checkpoint_sequence
 ika_sui_connector_system_checkpoint_sequence
@@ -790,7 +789,11 @@ registry, and CI now rejects any attempt to.
 ## 1.2.0 rename table (legacy → current)
 
 Renamed in the 1.2.0 release; update dashboards/alerts accordingly.
-(`dwallet_nativee_calls` also had its typo fixed.)
+(`dwallet_nativee_calls` also had its typo fixed.
+`sui_connector_last_synced_sui_checkpoints` was renamed here too but has
+since been deleted rather than renamed onward: nothing ever wrote the
+gauge after the event-listening task that fed it was replaced, so it is
+absent from both the inventory above and the table below.)
 
 | legacy (≤1.1.x) | current |
 |---|---|
@@ -879,7 +882,6 @@ Renamed in the 1.2.0 release; update dashboards/alerts accordingly.
 | `sui_connector_dwallet_checkpoint_writes_failure_total` | `ika_sui_connector_dwallet_checkpoint_writes_failure_total` |
 | `sui_connector_dwallet_checkpoint_writes_success_total` | `ika_sui_connector_dwallet_checkpoint_writes_success_total` |
 | `sui_connector_gas_coin_balance` | `ika_sui_connector_gas_coin_balance` |
-| `sui_connector_last_synced_sui_checkpoints` | `ika_sui_connector_last_synced_sui_checkpoints` |
 | `sui_connector_last_written_dwallet_checkpoint_sequence` | `ika_sui_connector_last_written_dwallet_checkpoint_sequence` |
 | `sui_connector_last_written_system_checkpoint_sequence` | `ika_sui_connector_last_written_system_checkpoint_sequence` |
 | `sui_connector_system_checkpoint_sequence` | `ika_sui_connector_system_checkpoint_sequence` |


### PR DESCRIPTION
Follow-ups from the recent comment/doc audits. Each item was reported but
left unfixed at the time because the fix is a code change, not a comment
change. Every claim was re-verified against the code before changing
anything; one item turned out to be misstated and was fixed differently
than reported (item 4).

## 1. `install_genesis` claimed to be localnet-only and warned "UNSAFE" on every mainnet boot

**Wrong:** `CommitteeStore::install_genesis` was documented "Localnet/test
only" and logged `installed UNSAFE genesis committee (no digest anchor;
localnet/test path)`.

**Evidence:** its only production callers are
`sui_connector/setup.rs` (bootstrap plan) and `ika-node/src/lib.rs`, i.e.
the first-boot path on *every* chain — the module-level doc in the same
file already says so correctly. And the "no digest anchor" claim is false
on public chains: `verify_genesis` checks the blob's genesis-checkpoint
digest against `compiled_in_chain_identifier(chain)` and re-binds
`committee[0]` to that digest through the
summary → contents → effects → objects chain. So the UNSAFE line fired on
every normal mainnet/testnet boot, training operators to ignore it.

**Changed:** the doc now states what the function actually does and where
the trust comes from, and the log line is a neutral factual statement.
The genuinely-unanchored case still warns — moved to the caller, which is
the only place that knows the chain: `setup.rs` now branches on
`compiled_in_chain_identifier(...).is_some()`, keeping the existing info
line for Mainnet/Testnet and emitting the UNSAFE warning only for
Devnet/Custom, where there is no compiled-in root and the blob is checked
for internal consistency alone. This also fixes that call site's own
overclaim — it previously asserted "verified against the compiled-in
constant" unconditionally, including on chains that have no such constant.

## 2. Throughput profile fallback text contradicted the code

**Wrong:** the warn said `Fallback to lowest profile as default.` and the
comment said "return the lowest possible profile", while the code returns
`self.highest_profile()`.

**Evidence:** the whole block matches the pinned upstream sui-core
(`crates/sui-core/src/consensus_throughput_calculator.rs` at
`mainnet-v1.77.2`) verbatim, including the mismatch — ika inherited stale
upstream text. Upstream also seeds `last_throughput_profile` from
`highest_profile()`, so returning the highest profile is deliberate. (The
branch is unreachable anyway: `new()` asserts a `Low` profile at
throughput 0, so any `current_throughput >= 0` resolves.)

**Changed:** both strings now say "highest", matching the code. No
behavior change, and no divergence from upstream logic.

## 3. Removed `last_synced_sui_checkpoints`, a registered metric with zero writers

**Wrong:** `ika_sui_connector_last_synced_sui_checkpoints` was registered
but never written.

**Evidence:** repo-wide grep finds the name only at its declaration, its
registration, and two references in `dev-docs/conventions/metrics.md` — no
writers anywhere, tests and `ika-proxy` included. Its own doc comment
already admitted it: "Registered but no longer written: the
event-listening task that fed it was removed when the OCS `BagEventPump`
replaced it."

**Changed:** field and registration deleted. Because this removes a metric
name, the generated inventory in `dev-docs/conventions/metrics.md` was
regenerated from `./scripts/check-metric-names.sh --list` (the diff
against the old block is exactly the one removed line, 338 names now), and
`./scripts/check-metric-names.sh` passes. The metric's row in the 1.2.0
rename table was removed too, with a note in that table's preamble saying
the metric was renamed there but has since been deleted — so anyone
grepping the old name still lands on an accurate answer.

## 4. `sui_rpc_errors` mislabeled — reported as "not an RPC error", actually a wrong label

**Reported as:** the counter is incremented on a path that is not an RPC
error (`crates/ika-sui-client/src/lib.rs` ~697).

**What the code actually shows:** that increment *is* on a genuine RPC
error — `self.inner.get_chain_identifier()` failing. The real defect at
that exact line is a copy-pasted **label**: the failure was recorded as
`method="get_validators_info_by_ids"`. The metric is declared
`&["method"]` with help "Total number of errors from sui RPC, by RPC
method", so every chain-identifier RPC failure was attributed to a
different method on any dashboard that groups by the label.

**Changed:** label corrected to `get_chain_identifier`. The metric name is
untouched, so dashboards keep working.

**Not changed (out of scope, flagged for a follow-up):** elsewhere in the
same file `sui_rpc_errors` *is* incremented on genuinely non-RPC failures
— BCS decode errors (`bcs::from_bytes::<StakingPool>`), a
validator-not-found lookup, key-parse failures, and a missing `mpc_data`
record. Those are a metric-semantics decision, not a mechanical fix, and
changing them would silently drop signal from existing alerts.

## 5. Removed `AuthorityPublicKeyBytes::from_consensus_key` (no callers)

**Evidence:** every `from_consensus_key` call site in the repo —
`ika-config`, `ika-core`, `ika-node`, `ika-types`, `ika-swarm-config`,
`ika-test-cluster`, `ika-upgrade-test`, and the sdk trees — resolves to
`AuthorityName::from_consensus_key`. Since v7 `AuthorityName` is its own
type holding the raw 32 bytes, and the 48-byte zero-padded BLS-container
form this constructor reproduced is no longer built by anything. Its own
doc said as much ("This constructor only reproduces the historical padded
encoding").

**Changed:** constructor deleted. Decoding of historical padded records is
untouched — that lives in the lenient `AuthorityName` decoder, not here.

## 6. CLAUDE.md: two stale facts

- The Sui-version gotcha said root `Cargo.toml` holds "~90 tag pins".
  `grep -o "mainnet-v1.77.2" Cargo.toml | wc -l` reports **44** (and 45
  lines contain `tag = ` in total). Corrected to `~45 tag pins`.
- The Testing section pointed at
  `./scripts/run-integration-tests-sequential.sh`. The script is at
  `sdk/typescript/scripts/run-integration-tests-sequential.sh` (its own
  usage block is written relative to `sdk/typescript`). Corrected to the
  repo-root-relative path; the script resolves its own `SCRIPT_DIR`, so it
  runs from anywhere.

Nothing else in CLAUDE.md was touched.

## Validation

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --all-features -p ika-core -p ika-sui-client -p ika-types` — exit 0, zero warnings
- `cargo test --release -p ika-types` — 44 + 3 passed, 0 failed
- `cargo test --release -p ika-sui-client` — 49 passed, 0 failed
- `cargo test --release -p ika-core consensus_throughput` — 6 passed, 0 failed
- `cargo test --release -p ika-core sui_connector::committee_store` — 6 passed, 0 failed
- `./scripts/check-metric-names.sh` — green (338 literal names, no default-registry registrations)

No Move contracts and no `bls_checkpoints` gates were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eV22TCyg8SFh6iANdYwdW
