### PR TITLE
fix(validator): verify the class-groups proof before candidate registration (#488)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5028,6 +5028,7 @@ dependencies = [
  "ika-types",
  "mpc",
  "serde",
+ "thiserror 2.0.20",
  "twopc_mpc",
 ]
 

--- a/crates/dwallet-classgroups-types/Cargo.toml
+++ b/crates/dwallet-classgroups-types/Cargo.toml
@@ -10,6 +10,7 @@ group.workspace = true
 mpc.workspace = true
 crypto-bigint.workspace = true
 serde.workspace = true
+thiserror.workspace = true
 ika-types.workspace = true
 twopc_mpc.workspace = true
 

--- a/crates/dwallet-classgroups-types/src/lib.rs
+++ b/crates/dwallet-classgroups-types/src/lib.rs
@@ -1,18 +1,25 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
+use std::collections::HashMap;
+
 use class_groups::publicly_verifiable_secret_sharing::chinese_remainder_theorem::{
     CRT_FUNDAMENTAL_DISCRIMINANT_LIMBS, CRT_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS, MAX_PRIMES,
-    generate_class_groups_keypair,
+    SecretKeyShareCRTPrimeSetupParameters,
+    construct_knowledge_of_decryption_key_public_parameters_per_crt_prime,
+    construct_setup_parameters_per_crt_prime, generate_class_groups_keypair,
+    verify_knowledge_of_decryption_key_proofs,
 };
 use class_groups::publicly_verifiable_secret_sharing::small_prime::encryption::generate_pvss_keypairs;
 use class_groups::{
-    CompactIbqf, RISTRETTO_FUNDAMENTAL_DISCRIMINANT_LIMBS,
-    SECP256K1_FUNDAMENTAL_DISCRIMINANT_LIMBS, SECP256R1_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+    CompactIbqf, DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER, EquivalenceClass,
+    RISTRETTO_FUNDAMENTAL_DISCRIMINANT_LIMBS, SECP256K1_FUNDAMENTAL_DISCRIMINANT_LIMBS,
+    SECP256R1_FUNDAMENTAL_DISCRIMINANT_LIMBS,
 };
 use crypto_bigint::Uint;
 use dwallet_rng::RootSeed;
 use group::GroupElement as _;
+use group::PartyID;
 use ika_types::committee::{
     ClassGroupsEncryptionKeyAndProof, ClassGroupsProof, ValidatorEncryptionKeysAndProofs,
 };
@@ -187,6 +194,139 @@ impl ValidatorMPCSecrets {
     }
 }
 
+/// Why a [`ClassGroupsEncryptionKeyAndProof`] failed
+/// [`verify_class_groups_encryption_key_and_proof`].
+#[derive(Debug, thiserror::Error)]
+pub enum ClassGroupsKeyVerificationError {
+    /// The class-groups CRT setup / language public parameters could not be
+    /// derived. Not a property of the payload — this means the local build's
+    /// class-groups parameters are unusable, which would break MPC entirely.
+    #[error(
+        "failed to derive the class-groups CRT public parameters needed to verify the key: {0}"
+    )]
+    PublicParameters(String),
+
+    /// The bytes at CRT prime `crt_prime_index` are not a well-formed class-groups
+    /// encryption key (they do not instantiate as a group element under that
+    /// prime's public parameters).
+    #[error("the class-groups encryption key for CRT prime #{crt_prime_index} is malformed")]
+    MalformedEncryptionKey { crt_prime_index: usize },
+
+    /// The payload is well-formed but at least one UC knowledge-of-decryption-key
+    /// proof does not verify against its encryption key: the key and the proof do
+    /// not belong to the same decryption key.
+    #[error(
+        "the class-groups knowledge-of-decryption-key proof does not verify against the encryption key"
+    )]
+    InvalidProof,
+}
+
+/// Party id used to address the single key-and-proof being checked. The
+/// verification is per-key and stateless, so any id works; `1` matches the
+/// crypto library's 1-based party numbering.
+const PREFLIGHT_PARTY_ID: PartyID = 1;
+
+/// Cryptographically verifies a validator's class-groups CRT encryption key
+/// together with its UC knowledge-of-decryption-key proof, per CRT prime.
+///
+/// # What this protects, and what it does not
+///
+/// This is a **client-side pre-flight** for an *honest* operator. It catches a
+/// corrupt, truncated, hand-edited or seed-mismatched `mpc_data` payload — e.g. a
+/// `validator.info` regenerated against one `root-seed.key` and then registered
+/// while a different seed is on the node — *before* the candidate-registration
+/// transaction is built, instead of letting the operator discover it an epoch
+/// later as an unexplained malicious-party conviction.
+///
+/// It is **NOT an on-chain guarantee**. Nothing stops a byzantine actor from
+/// skipping this check and submitting arbitrary bytes: Move cannot run
+/// class-groups arithmetic, so `request_add_validator_candidate` stores
+/// `mpc_data_bytes` opaquely (`contracts/ika_system/sources/staking/validator_info.move:135`)
+/// and verifies only the BLS proof-of-possession (`:117-125`).
+///
+/// The on-chain-equivalent guarantee is enforced at MPC time, by every honest
+/// validator independently, against exactly the same proof: the class-groups DKG
+/// and reconfiguration first rounds deal PVSS shares through
+/// `class_groups::publicly_verifiable_secret_sharing::chinese_remainder_theorem::
+/// Party::deal_and_encrypt_shares_to_valid_encryption_key_holders`, which calls
+/// [`verify_knowledge_of_decryption_key_proofs`] (inkrypto `3ed95fe`,
+/// `class-groups/src/publicly_verifiable_secret_sharing/chinese_remainder_theorem/deal_shares.rs:106-111`)
+/// before dealing. A validator whose proof fails there is added to that round's
+/// malicious set, receives no share, and is excluded — while the remaining honest
+/// parties, as long as they still form an authorized subset, complete the session.
+/// Party construction itself (`class_groups::dkg::PublicInput::new`) does not
+/// verify: it only stores the keys and proofs.
+///
+/// This function deliberately calls that *same* upstream entry point, so the
+/// pre-flight verdict and the MPC-time verdict cannot drift apart.
+pub fn verify_class_groups_encryption_key_and_proof(
+    encryption_key_and_proof: &ClassGroupsEncryptionKeyAndProof,
+) -> Result<(), ClassGroupsKeyVerificationError> {
+    let setup_parameters_per_crt_prime =
+        construct_setup_parameters_per_crt_prime(DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER)
+            .map_err(|e| ClassGroupsKeyVerificationError::PublicParameters(e.to_string()))?;
+
+    let language_public_parameters_per_crt_prime =
+        construct_knowledge_of_decryption_key_public_parameters_per_crt_prime(
+            setup_parameters_per_crt_prime.each_ref(),
+        )
+        .map_err(|e| ClassGroupsKeyVerificationError::PublicParameters(e.to_string()))?;
+
+    let instantiated =
+        instantiate_encryption_keys(&setup_parameters_per_crt_prime, encryption_key_and_proof)?;
+
+    let (malicious_parties, _verified_encryption_keys) = verify_knowledge_of_decryption_key_proofs(
+        language_public_parameters_per_crt_prime,
+        Vec::new(),
+        HashMap::from([(PREFLIGHT_PARTY_ID, instantiated)]),
+    )
+    .map_err(|e| ClassGroupsKeyVerificationError::PublicParameters(e.to_string()))?;
+
+    if malicious_parties.contains(&PREFLIGHT_PARTY_ID) {
+        return Err(ClassGroupsKeyVerificationError::InvalidProof);
+    }
+
+    Ok(())
+}
+
+/// The per-CRT-prime encryption keys as live group elements, paired with the
+/// proofs that are about to be checked against them — the input shape
+/// [`verify_knowledge_of_decryption_key_proofs`] expects.
+type InstantiatedEncryptionKeysAndProofs = [(
+    EquivalenceClass<{ CRT_NON_FUNDAMENTAL_DISCRIMINANT_LIMBS }>,
+    ClassGroupsProof,
+); MAX_PRIMES];
+
+/// Instantiates each per-prime encryption key as a group element, exactly as
+/// `instantiate_encryption_keys_per_crt_prime` does inside the PVSS party
+/// constructor the DKG uses. There, a key that fails to instantiate silently
+/// lands its owner in `parties_without_valid_encryption_keys`; here there is a
+/// single owner and a human to tell, so name the offending prime instead.
+fn instantiate_encryption_keys(
+    setup_parameters_per_crt_prime: &[SecretKeyShareCRTPrimeSetupParameters; MAX_PRIMES],
+    encryption_key_and_proof: &ClassGroupsEncryptionKeyAndProof,
+) -> Result<InstantiatedEncryptionKeysAndProofs, ClassGroupsKeyVerificationError> {
+    let mut instantiated = Vec::with_capacity(MAX_PRIMES);
+    for (crt_prime_index, (encryption_key_value, proof)) in
+        encryption_key_and_proof.iter().enumerate()
+    {
+        let encryption_key = EquivalenceClass::new(
+            *encryption_key_value,
+            setup_parameters_per_crt_prime[crt_prime_index].equivalence_class_public_parameters(),
+        )
+        .map_err(|_| ClassGroupsKeyVerificationError::MalformedEncryptionKey { crt_prime_index })?;
+
+        instantiated.push((encryption_key, proof.clone()));
+    }
+
+    instantiated.try_into().map_err(|_| {
+        // Unreachable: `ClassGroupsEncryptionKeyAndProof` is itself `[_; MAX_PRIMES]`.
+        ClassGroupsKeyVerificationError::MalformedEncryptionKey {
+            crt_prime_index: MAX_PRIMES,
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -208,5 +348,157 @@ mod tests {
         let decoded: ValidatorEncryptionKeysAndProofs =
             bcs::from_bytes(&bytes).expect("BCS deserialize");
         assert_eq!(original, decoded);
+    }
+
+    /// Only the class-groups half of the validator's key material — skips the
+    /// three PVSS keypairs and the VSS HPKE keypair `ValidatorMPCSecrets::from_seed`
+    /// would also generate, none of which reach `mpc_data_bytes` on chain.
+    fn class_groups_key_and_proof(seed_byte: u8) -> ClassGroupsEncryptionKeyAndProof {
+        let (_secret, key_and_proof) =
+            ClassGroupsSecret::from_seed(&RootSeed::new([seed_byte; 32]));
+        key_and_proof
+    }
+
+    /// Asserts the payload is exactly what `blob_decodes_to_valid_mpc_data`-style
+    /// structural checks accept: it BCS round-trips at the on-chain shape. Every
+    /// "invalid" payload below is invalid *cryptographically only* — the whole
+    /// point of the issue.
+    fn assert_structurally_valid(key_and_proof: &ClassGroupsEncryptionKeyAndProof) {
+        let bytes = bcs::to_bytes(key_and_proof).expect("BCS serialize");
+        let decoded: ClassGroupsEncryptionKeyAndProof =
+            bcs::from_bytes(&bytes).expect("a structurally valid payload must BCS round-trip");
+        assert_eq!(*key_and_proof, decoded);
+    }
+
+    #[test]
+    fn preflight_accepts_a_key_and_proof_generated_from_the_same_seed() {
+        let key_and_proof = class_groups_key_and_proof(0xA5);
+        assert_structurally_valid(&key_and_proof);
+        verify_class_groups_encryption_key_and_proof(&key_and_proof)
+            .expect("a seed-generated key and proof must verify");
+    }
+
+    /// The seed-mismatch failure the pre-flight exists for: a `validator.info`
+    /// carrying the encryption key of one root seed and the proof of another
+    /// (an operator who regenerated one file but not the other, or restored a
+    /// stale backup). Structurally perfect, cryptographically dead.
+    #[test]
+    fn preflight_rejects_a_proof_generated_for_a_different_key() {
+        let ours = class_groups_key_and_proof(0xA5);
+        let theirs = class_groups_key_and_proof(0x5A);
+
+        let mismatched: ClassGroupsEncryptionKeyAndProof =
+            std::array::from_fn(|i| (ours[i].0, theirs[i].1.clone()));
+
+        assert_structurally_valid(&mismatched);
+        assert!(
+            matches!(
+                verify_class_groups_encryption_key_and_proof(&mismatched),
+                Err(ClassGroupsKeyVerificationError::InvalidProof)
+            ),
+            "a proof generated for a different key must be rejected"
+        );
+    }
+
+    /// Tampering *within* one otherwise-good payload: the per-CRT-prime proofs
+    /// are transposed, so every proof is checked against a key it was not made
+    /// for, under that prime's own language parameters.
+    #[test]
+    fn preflight_rejects_proofs_transposed_across_crt_primes() {
+        const {
+            assert!(
+                MAX_PRIMES >= 2,
+                "the transposition needs at least two primes"
+            );
+        }
+
+        let good = class_groups_key_and_proof(0xA5);
+
+        let tampered: ClassGroupsEncryptionKeyAndProof = std::array::from_fn(|i| {
+            let proof_from_the_next_prime = good[(i + 1) % MAX_PRIMES].1.clone();
+            (good[i].0, proof_from_the_next_prime)
+        });
+
+        assert_structurally_valid(&tampered);
+        assert!(
+            matches!(
+                verify_class_groups_encryption_key_and_proof(&tampered),
+                Err(ClassGroupsKeyVerificationError::InvalidProof)
+            ),
+            "proofs transposed across CRT primes must be rejected"
+        );
+    }
+
+    /// The compensating control from issue #488, exercised directly.
+    ///
+    /// This calls `verify_knowledge_of_decryption_key_proofs` the way the
+    /// class-groups DKG and reconfiguration first rounds call it — inkrypto
+    /// `3ed95fe`, `class-groups/src/publicly_verifiable_secret_sharing/`
+    /// `chinese_remainder_theorem/deal_shares.rs:106-111`, inside
+    /// `deal_and_encrypt_shares_to_valid_encryption_key_holders`, before any
+    /// PVSS share is dealt — over a four-party committee in which one party
+    /// registered a structurally-valid but cryptographically-invalid payload.
+    ///
+    /// What it establishes: the offending party alone is convicted and dropped
+    /// from the set that receives shares; the three honest parties keep their
+    /// keys and the session goes on. It is *not* a full DKG session (that needs
+    /// a cluster) — it pins the verification and exclusion step that a
+    /// byzantine registration actually runs into.
+    #[test]
+    fn dkg_time_verification_convicts_only_the_offending_party() {
+        let setup_parameters_per_crt_prime =
+            construct_setup_parameters_per_crt_prime(DEFAULT_COMPUTATIONAL_SECURITY_PARAMETER)
+                .expect("CRT setup parameters");
+        let language_public_parameters_per_crt_prime =
+            construct_knowledge_of_decryption_key_public_parameters_per_crt_prime(
+                setup_parameters_per_crt_prime.each_ref(),
+            )
+            .expect("knowledge-of-decryption-key language parameters");
+
+        let honest_a = class_groups_key_and_proof(0x01);
+        let honest_b = class_groups_key_and_proof(0x02);
+        let honest_c = class_groups_key_and_proof(0x03);
+        // Party 4 publishes A's encryption key with B's proof.
+        let byzantine: ClassGroupsEncryptionKeyAndProof =
+            std::array::from_fn(|i| (honest_a[i].0, honest_b[i].1.clone()));
+
+        const BYZANTINE_PARTY_ID: PartyID = 4;
+        let committee: HashMap<PartyID, _> = [
+            (1, &honest_a),
+            (2, &honest_b),
+            (3, &honest_c),
+            (BYZANTINE_PARTY_ID, &byzantine),
+        ]
+        .into_iter()
+        .map(|(party_id, key_and_proof)| {
+            (
+                party_id,
+                instantiate_encryption_keys(&setup_parameters_per_crt_prime, key_and_proof)
+                    .expect("every payload here is structurally valid"),
+            )
+        })
+        .collect();
+
+        let (malicious_parties, surviving_encryption_keys) =
+            verify_knowledge_of_decryption_key_proofs(
+                language_public_parameters_per_crt_prime,
+                // No party was already excluded for a malformed key.
+                Vec::new(),
+                committee,
+            )
+            .expect("verification itself must not error out");
+
+        assert_eq!(
+            malicious_parties,
+            vec![BYZANTINE_PARTY_ID],
+            "exactly the party with the invalid proof must be convicted"
+        );
+        let mut survivors: Vec<PartyID> = surviving_encryption_keys.into_keys().collect();
+        survivors.sort_unstable();
+        assert_eq!(
+            survivors,
+            vec![1, 2, 3],
+            "the honest parties must keep their keys and go on dealing"
+        );
     }
 }

--- a/crates/ika-core/src/validator_metadata.rs
+++ b/crates/ika-core/src/validator_metadata.rs
@@ -648,11 +648,34 @@ pub fn verify_peer_blob_for_relay(bytes: &[u8], expected_digest: &[u8; 32]) -> P
 ///   of signers are excluded from the frozen working set.
 ///
 /// This is the structural check, not a cryptographic-validity
-/// check: it doesn't verify class-groups proofs (those happen
-/// inside MPC). A byzantine actor can produce bytes that pass
-/// this check but contain mathematically invalid keys; that
-/// failure surfaces in MPC, where the standard malicious-party
-/// detection catches it.
+/// check: it doesn't verify class-groups proofs. A byzantine actor
+/// can produce bytes that pass this check but contain
+/// mathematically invalid keys. Deliberately so — the
+/// cryptographic check lives in two other places, and neither
+/// belongs on this hot, per-blob path:
+///
+/// - **Client-side pre-flight (honest operators, issue #488):**
+///   `dwallet_classgroups_types::verify_class_groups_encryption_key_and_proof`,
+///   called by the `ika validator` CLI when it writes
+///   `validator.info` and again in `preflight_verify_class_groups_mpc_data`
+///   before `become-candidate` builds the registration
+///   transaction. Catches a corrupt or seed-mismatched payload
+///   before it ever reaches the chain; binds nobody who skips the
+///   CLI.
+/// - **The enforcing check (everyone, byzantine included):** MPC
+///   time. The class-groups DKG and reconfiguration first rounds
+///   run `verify_knowledge_of_decryption_key_proofs` (inkrypto
+///   `3ed95fe`, `class-groups/src/publicly_verifiable_secret_sharing/`
+///   `chinese_remainder_theorem/deal_shares.rs:106-111`) before
+///   dealing PVSS shares. A validator whose proof fails is put in
+///   that round's malicious set and dealt no share; the remaining
+///   honest parties finish the session as long as they still form
+///   an authorized subset. That verdict reaches the standard
+///   malicious-party detection here in ika via the round result.
+///
+/// On-chain enforcement is not available: Move cannot run
+/// class-groups arithmetic, so `mpc_data_bytes` is stored
+/// opaquely.
 pub fn blob_decodes_to_valid_mpc_data(blob: &[u8]) -> bool {
     use dwallet_mpc_types::dwallet_mpc::{MPCDataTrait, VersionedMPCData};
     let Ok(versioned) = bcs::from_bytes::<VersionedMPCData>(blob) else {

--- a/crates/ika/src/validator_commands.rs
+++ b/crates/ika/src/validator_commands.rs
@@ -14,8 +14,10 @@ use sui_types::{base_types::SuiAddress, multiaddr::Multiaddr};
 use crate::{IkaPackagesConfigFile, read_ika_sui_config_yaml};
 use clap::*;
 use colored::Colorize;
-use dwallet_classgroups_types::ValidatorMPCSecrets;
-use dwallet_mpc_types::dwallet_mpc::{MPCDataV1, VersionedMPCData};
+use dwallet_classgroups_types::{
+    ValidatorMPCSecrets, verify_class_groups_encryption_key_and_proof,
+};
+use dwallet_mpc_types::dwallet_mpc::{MPCDataTrait, MPCDataV1, VersionedMPCData};
 use dwallet_rng::RootSeed;
 use fastcrypto::traits::{KeyPair, ToFromBytes};
 use ika_config::node::read_authority_keypair_from_file;
@@ -439,6 +441,27 @@ impl IkaValidatorCommand {
                 // `validator_encryption_keys_and_proofs` is the public payload —
                 // only its class-groups slice is published on chain.
                 let _ = validator_mpc_secrets;
+
+                // Pre-flight: prove the class-groups key and proof about to be
+                // written into `validator.info` actually belong together, before
+                // the operator carries the file to `become-candidate`. See
+                // `preflight_verify_class_groups_mpc_data` for why this is an
+                // honest-operator guard and not an on-chain guarantee.
+                verify_class_groups_encryption_key_and_proof(
+                    &validator_encryption_keys_and_proofs.class_groups,
+                )
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "the class-groups key material derived from the root seed at {:?} failed \
+                         cryptographic verification: {e}. The validator info was NOT written. A \
+                         validator registered with this payload would be convicted as a malicious \
+                         party at the next network DKG or reconfiguration and would hold a \
+                         committee seat without being able to participate in MPC. Check that the \
+                         root seed file is intact (restore it from your backup if not) and re-run.",
+                        dir.join("root-seed.key"),
+                    )
+                })?;
+
                 let mpc_data_bytes =
                     bcs::to_bytes(&validator_encryption_keys_and_proofs.class_groups)?;
                 let mpc_data = VersionedMPCData::V1(MPCDataV1 { mpc_data_bytes });
@@ -516,8 +539,20 @@ impl IkaValidatorCommand {
                     ika_sui_config.unwrap_or(ika_config_dir()?.join(IKA_SUI_CONFIG));
                 let config = read_ika_sui_config_yaml(context, &ika_on_sui_config_path)?;
 
-                let validator_info_bytes = fs::read_to_string(validator_info_file)?;
+                let validator_info_bytes = fs::read_to_string(&validator_info_file)?;
                 let validator_info: ValidatorInfo = serde_yaml::from_str(&validator_info_bytes)?;
+
+                // Pre-flight: the registration transaction stores `mpc_data` opaquely
+                // on chain, so this is the last point at which a bad payload can be
+                // caught cheaply. Verify before spending gas.
+                preflight_verify_class_groups_mpc_data(&validator_info.mpc_data).with_context(
+                    || {
+                        format!(
+                            "refusing to register the candidate from {validator_info_file:?}: its \
+                             class-groups MPC data did not pass cryptographic verification"
+                        )
+                    },
+                )?;
 
                 let (res, validator_caps) = request_add_validator_candidate(
                     context,
@@ -1176,6 +1211,56 @@ fn make_key_files(
     Ok(())
 }
 
+/// Client-side pre-flight for the class-groups material inside a candidate's
+/// [`VersionedMPCData`]: decode the on-chain payload shape and cryptographically
+/// verify the encryption key against its UC knowledge-of-decryption-key proof.
+///
+/// # This protects an honest operator; it is not an on-chain guarantee
+///
+/// It catches a corrupt, truncated, or seed-mismatched `mpc_data` — the common
+/// real failure, e.g. a `validator.info` generated against one `root-seed.key`
+/// and registered while the node runs a different one — before any gas is spent
+/// and before the operator is left debugging a malicious-party conviction an
+/// epoch later.
+///
+/// It cannot bind a byzantine actor, who simply skips this code path and submits
+/// bytes directly. Move cannot run class-groups arithmetic, so
+/// `request_add_validator_candidate` verifies only the BLS proof-of-possession
+/// (`contracts/ika_system/sources/staking/validator_info.move:117-125`) and
+/// stores `mpc_data_bytes` opaquely (`:135`).
+///
+/// The guarantee that does bind everyone is enforced at MPC time by every honest
+/// validator, against this same proof: see
+/// [`verify_class_groups_encryption_key_and_proof`], which calls the identical
+/// upstream verification the class-groups DKG and reconfiguration first rounds
+/// call before dealing PVSS shares. A validator whose proof fails there is put in
+/// that round's malicious set and excluded; the session continues for everyone
+/// else.
+fn preflight_verify_class_groups_mpc_data(mpc_data: &VersionedMPCData) -> Result<()> {
+    let VersionedMPCData::V1(v1) = mpc_data;
+
+    // The on-chain field carries the bare `ClassGroupsEncryptionKeyAndProof`
+    // (see `ika_types::committee::ValidatorEncryptionKeysAndProofs`); the fuller
+    // off-chain bundle never reaches this path.
+    let class_groups: ika_types::committee::ClassGroupsEncryptionKeyAndProof =
+        bcs::from_bytes(&v1.mpc_data_bytes()).context(
+            "the MPC data does not decode as a class-groups encryption key and proof; the \
+             validator info file is corrupt or was produced by an incompatible ika version",
+        )?;
+
+    verify_class_groups_encryption_key_and_proof(&class_groups).map_err(|e| {
+        anyhow::anyhow!(
+            "the class-groups encryption key and proof do not verify: {e}. This payload does not \
+             match the root seed it claims to come from — regenerate the validator info with \
+             `ika validator make-validator-info` against the root seed the node actually runs, or \
+             restore the correct root seed from backup. Registering it anyway would buy a \
+             committee seat that cannot participate in MPC: the same proof is re-verified by \
+             every honest validator at network DKG and at each reconfiguration, and this \
+             validator would be excluded there as a malicious party."
+        )
+    })
+}
+
 /// Generates the validator's complete MPC key material (class groups + per-curve PVSS HPKE +
 /// VSS HPKE) from a seed file if it exists, otherwise generates and saves the seed.
 /// Returns both the secrets (held locally) and the public encryption-keys-and-proofs payload
@@ -1297,6 +1382,76 @@ mod tests {
             fs::read(&seed_path).unwrap(),
             first_bytes,
             "the existing seed must be left byte-identical"
+        );
+    }
+
+    /// Builds the exact on-chain payload `make-validator-info` writes and
+    /// `become-candidate` submits: `VersionedMPCData::V1` wrapping the BCS of
+    /// the bare `ClassGroupsEncryptionKeyAndProof`.
+    fn mpc_data_from(
+        class_groups: &ika_types::committee::ClassGroupsEncryptionKeyAndProof,
+    ) -> VersionedMPCData {
+        VersionedMPCData::V1(MPCDataV1 {
+            mpc_data_bytes: bcs::to_bytes(class_groups).unwrap(),
+        })
+    }
+
+    fn class_groups_key_and_proof(
+        seed_byte: u8,
+    ) -> ika_types::committee::ClassGroupsEncryptionKeyAndProof {
+        let (_secret, key_and_proof) = dwallet_classgroups_types::ClassGroupsSecret::from_seed(
+            &RootSeed::new([seed_byte; 32]),
+        );
+        key_and_proof
+    }
+
+    #[test]
+    fn preflight_accepts_the_payload_make_validator_info_produces() {
+        let mpc_data = mpc_data_from(&class_groups_key_and_proof(0xA5));
+        preflight_verify_class_groups_mpc_data(&mpc_data)
+            .expect("the payload this CLI itself generates must pass its own pre-flight");
+    }
+
+    /// A structurally-valid-but-cryptographically-invalid payload: the on-chain
+    /// bytes decode perfectly into `ClassGroupsEncryptionKeyAndProof` (so every
+    /// structural gate, on chain and off, accepts them), but the encryption key
+    /// came from one root seed and the proof from another. `become-candidate`
+    /// must refuse before spending gas.
+    #[test]
+    fn preflight_rejects_a_seed_mismatched_payload_before_registration() {
+        let ours = class_groups_key_and_proof(0xA5);
+        let theirs = class_groups_key_and_proof(0x5A);
+        let mismatched: ika_types::committee::ClassGroupsEncryptionKeyAndProof =
+            std::array::from_fn(|i| (ours[i].0, theirs[i].1.clone()));
+
+        let mpc_data = mpc_data_from(&mismatched);
+        // Structurally indistinguishable from a good payload.
+        let VersionedMPCData::V1(v1) = &mpc_data;
+        bcs::from_bytes::<ika_types::committee::ClassGroupsEncryptionKeyAndProof>(
+            &v1.mpc_data_bytes(),
+        )
+        .expect("the tampered payload must still decode — that is the whole point");
+
+        let error = preflight_verify_class_groups_mpc_data(&mpc_data)
+            .expect_err("a mismatched key and proof must not reach the chain");
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("do not verify"),
+            "the operator needs to be told the proof failed, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn preflight_rejects_mpc_data_that_is_not_a_class_groups_payload() {
+        let mpc_data = VersionedMPCData::V1(MPCDataV1 {
+            mpc_data_bytes: vec![0u8; 32],
+        });
+
+        let error = preflight_verify_class_groups_mpc_data(&mpc_data)
+            .expect_err("undecodable MPC data must not reach the chain");
+        assert!(
+            format!("{error:#}").contains("does not decode"),
+            "the operator needs to be told the file is corrupt"
         );
     }
 }


### PR DESCRIPTION
Resolves #488.

**Resolution:** on-chain verification is infeasible; the honest-operator path is now
verified client-side; the byzantine path was already rejected at DKG time. The issue
can be closed on merge.

## 1. On-chain verification is infeasible, not merely deferred

Move cannot run class-groups arithmetic. `request_add_validator_candidate` verifies only
the BLS proof-of-possession
(`contracts/ika_system/sources/staking/validator_info.move:117-125`) and stores
`mpc_data_bytes` opaquely (`:135`); there are zero `class_groups` references anywhere
under `contracts/`. This PR does not attempt to change that.

## 2. Discovery: the compensating control, with evidence

Traced the class-groups proof from registration into the pinned inkrypto
(`rev 3ed95fe74e08419b33c181910a4e163169fffc8f`, `class-groups` / `2pc-mpc` crates).

**Party construction does NOT verify.**
`network_dkg_v2_public_input` (`crates/ika-core/src/dwallet_mpc/crytographic_computation/mpc_computations/network_dkg.rs:790-813`)
-> `twopc_mpc::decentralized_party::dkg::PublicInput::new`
(`2pc-mpc/src/decentralized_party/dkg.rs:258`, forwarding at `:322-328`)
-> `class_groups::dkg::PublicInput::new` (`class-groups/src/dkg.rs:291`), which checks
only parameter bounds and then *stores* the keys and proofs verbatim at `:339`. A garbage
proof does not prevent the session from starting.

**Verification happens at DKG round 1, before any share is dealt.**
`advance` -> `class_groups::dkg::Party::prepare_advance` builds the CRT PVSS party
(`class-groups/src/dkg/party.rs:360-384`); its constructor first instantiates each
per-prime key as a group element
(`class-groups/src/publicly_verifiable_secret_sharing/chinese_remainder_theorem/party.rs:224-228`
— a malformed key puts its owner straight into `parties_without_valid_encryption_keys`).
Round 1 then calls `deal_and_encrypt_shares_to_valid_encryption_key_holders`
(`class-groups/src/dkg/first_round.rs:181-186`), which calls
**`verify_knowledge_of_decryption_key_proofs`** at
**`class-groups/src/publicly_verifiable_secret_sharing/chinese_remainder_theorem/deal_shares.rs:106-111`**.
The cryptographic check itself is `proof.verify(...)` at
`class-groups/src/publicly_verifiable_secret_sharing/chinese_remainder_theorem.rs:496`
(function at `:469`).

Construction is therefore not the gate, but the gate still closes *before use*: round 1
verifies before a single share is dealt or encrypted to any of those keys, so an invalid
class-groups key is never actually used by the protocol.

**Fate of the offending validator: convicted and excluded, alone.**
It is added to that round's malicious set
(`chinese_remainder_theorem.rs:504-507`), filtered out of `encryption_keys_per_crt_prime`,
and dealt no PVSS share. Every other party proceeds, provided the surviving valid parties
still form an authorized subset (`deal_shares.rs:116-120`) — only if they do not does the
session fail for everyone. On the ika side that verdict lands in `record_malicious_actors`
(`crates/ika-core/src/dwallet_mpc/mpc_manager.rs:4661-4668`). So one bad registration costs
its owner a useless committee seat; it does not wedge an epoch.

**The same control covers a validator joining an existing network**, which goes through
reconfiguration rather than a fresh network DKG:
`class-groups/src/reconfiguration/party.rs:406-430` builds the upcoming-committee PVSS
party from `upcoming_encryption_key_values_and_proofs_per_crt_prime`, and
`class-groups/src/reconfiguration/first_round.rs:208-217` deals through the same verified
path.

The byzantine path is therefore already covered. What was missing is any way for an
*honest* operator to learn about a bad payload before paying gas and losing an epoch.

## 3. What this PR adds

`dwallet_classgroups_types::verify_class_groups_encryption_key_and_proof` — deliberately
calling the *same* upstream `verify_knowledge_of_decryption_key_proofs` that the DKG and
reconfiguration first rounds call, so the pre-flight verdict and the MPC-time verdict
cannot drift apart.

Wired into both points of the registration path, in `crates/ika/src/validator_commands.rs`:

1. **`make-validator-info`** — verifies the key material derived from `root-seed.key`
   before `validator.info` is written.
2. **`become-candidate`** — `preflight_verify_class_groups_mpc_data` decodes
   `validator_info.mpc_data` (the exact on-chain shape) and verifies it before
   `request_add_validator_candidate` assembles the transaction. This is the last cheap
   point of refusal.

Both failures print an operator-facing message naming the likely cause (a corrupt or
mismatched `root-seed.key`) and the consequence of ignoring it.

The check is not placed inside `ika_sui_client::request_add_validator_candidate`: that
would pull the class-groups crypto into `ika-sui-client` and onto the genesis /
test-cluster registration paths, which use mocked key material and register many
validators at once. The CLI is the path a real operator uses, and it is covered end to end.

Doc comments state plainly what this is: it protects an honest operator from a corrupt or
mismatched root seed; it is **not** an on-chain guarantee — the on-chain-equivalent
guarantee is the DKG-time rejection above.

## 4. Doc update at the structural check

`crates/ika-core/src/validator_metadata.rs` — `blob_decodes_to_valid_mpc_data`'s doc
comment used to say only "that failure surfaces in MPC". It now names both places the
cryptographic check actually happens (the new client-side pre-flight, and
`verify_knowledge_of_decryption_key_proofs` at DKG/reconfiguration round 1 with the
offender's fate). The function itself is unchanged.

## 5. Tests

`crates/dwallet-classgroups-types/src/lib.rs`:

- `preflight_accepts_a_key_and_proof_generated_from_the_same_seed`
- `preflight_rejects_a_proof_generated_for_a_different_key` — encryption key from seed A,
  proof from seed B. The payload BCS round-trips at the on-chain shape (asserted), so it
  passes every structural gate; only the cryptography rejects it.
- `preflight_rejects_proofs_transposed_across_crt_primes` — tampering inside one otherwise
  good payload.
- `dkg_time_verification_convicts_only_the_offending_party` — the compensating control,
  exercised directly: four parties, one with a mismatched payload, run through
  `verify_knowledge_of_decryption_key_proofs` exactly as `deal_shares.rs:106-111` does.
  Asserts the offender alone is convicted and the three honest parties keep their keys.
  Not a full DKG session (that needs a cluster) — it pins the verification-and-exclusion
  step a byzantine registration actually runs into.

`crates/ika/src/validator_commands.rs`:

- `preflight_accepts_the_payload_make_validator_info_produces`
- `preflight_rejects_a_seed_mismatched_payload_before_registration` — at the
  `VersionedMPCData::V1` level, first asserting the bytes still decode.
- `preflight_rejects_mpc_data_that_is_not_a_class_groups_payload`

Run with `--release`; the debug profile runs class-groups math at `opt-level=0`.

```
cargo test --release -p dwallet-classgroups-types -p ika
```

## Files changed

- `crates/dwallet-classgroups-types/src/lib.rs` (+ `Cargo.toml`: `thiserror`)
- `crates/ika/src/validator_commands.rs`
- `crates/ika-core/src/validator_metadata.rs` (doc comment only)
- `Cargo.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
