### PR TITLE
fix(metrics): split response-interpretation failures out of ika_sui_client_sui_rpc_errors (#2116 follow-up)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -239,3 +239,26 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: cargo check (ika-core tests)
         run: cargo check -p ika-core --features test-utils --tests --target x86_64-unknown-linux-gnu
+      - name: Sui RPC vs. response error split pins
+        # `ika_sui_client_sui_rpc_errors` is what the fleet's Sui-uplink alert
+        # fires on, and the split that keeps a decoding defect off it is
+        # enforced by nothing but these tests: which counter a failure reaches
+        # is invisible to the type checker, so a regression compiles clean and
+        # only shows up as an on-call page against a healthy fullnode. This
+        # job is otherwise compile-only and nothing else on PR CI executes
+        # ika-sui-client's tests, so they must be named here or they never
+        # run. The crate is already compiled by the ika-core check above, and
+        # no MPC crypto is involved, so the debug profile is fine.
+        run: |
+          set -o pipefail
+          cargo test -p ika-sui-client --lib -- \
+            a_decode_failure_on_a_successful_rpc_is_not_an_rpc_error \
+            a_transport_failure_is_an_rpc_error_only \
+            the_retry_wrappers_route_by_error_variant \
+            an_unlisted_error_variant_stays_on_the_rpc_counter \
+            | tee "$RUNNER_TEMP/rpc-response-split-pins.log"
+          # cargo exits 0 when a name filter matches nothing, so a renamed
+          # test would silently disable this gate. Require the exact count:
+          # unlike a `[1-9][0-9]*` floor, this also catches renaming SOME of
+          # the pins. Bump the number when adding one.
+          grep -qE '^test result: ok\. 4 passed' "$RUNNER_TEMP/rpc-response-split-pins.log"

--- a/crates/ika-proxy/README.md
+++ b/crates/ika-proxy/README.md
@@ -202,7 +202,11 @@ The proxy exposes comprehensive metrics about its operation:
 
 - **`ika_proxy_http_handler_hits`**: Request count by handler and peer
 - **`ika_proxy_http_handler_duration_seconds`**: Request latency by handler and peer
-- **`ika_sui_client_sui_rpc_errors`**: Sui gRPC call errors by method
+- **`ika_sui_client_sui_rpc_errors`**: Sui gRPC calls that did not come back
+  with an answer, by method
+- **`ika_sui_client_sui_response_errors_total`**: Sui gRPC calls that answered
+  but whose response could not be used (decode failures, missing records,
+  unparsable key material), by method and kind
 - **`ika_proxy_uptime`**: Proxy uptime information
 
 ### Log Output

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-use crate::metrics::SuiClientMetrics;
+use crate::metrics::{SuiClientMetrics, SuiResponseErrorKind};
 use crate::rate_limit::RateLimitGate;
 use async_trait::async_trait;
 use core::panic;
@@ -413,10 +413,12 @@ where
                     .iter()
                     .map(|v| {
                         bcs::from_bytes::<StakingPool>(v).map_err(|e| {
-                            self.sui_client_metrics
-                                .sui_rpc_errors
-                                .with_label_values(&["get_epoch_start_system"])
-                                .inc();
+                            // The RPC answered; the bytes it answered with are
+                            // what is wrong. Not an uplink failure.
+                            self.sui_client_metrics.record_response_error(
+                                "get_epoch_start_system",
+                                SuiResponseErrorKind::Decode,
+                            );
                             IkaError::SuiClientSerializationError(format!(
                                 "Can't serialize StakingPool: {e}"
                             ))
@@ -448,10 +450,10 @@ where
                             .iter()
                             .find(|v| v.id == m.validator_id)
                             .ok_or_else(|| {
-                                self.sui_client_metrics
-                                    .sui_rpc_errors
-                                    .with_label_values(&["get_epoch_start_system"])
-                                    .inc();
+                                self.sui_client_metrics.record_response_error(
+                                    "get_epoch_start_system",
+                                    SuiResponseErrorKind::NotFound,
+                                );
                                 IkaError::InvalidCommittee(format!(
                                     "Validator with ID {} not found in the active committee",
                                     m.validator_id
@@ -461,10 +463,10 @@ where
                         // chain, so parsing them can fail. Fail the read and
                         // let it be retried.
                         let info = validator.verified_validator_info().map_err(|code| {
-                            self.sui_client_metrics
-                                .sui_rpc_errors
-                                .with_label_values(&["epoch_start_invalid_validator_info"])
-                                .inc();
+                            self.sui_client_metrics.record_response_error(
+                                "get_epoch_start_system",
+                                SuiResponseErrorKind::ValidatorInfoParse,
+                            );
                             IkaError::InvalidCommittee(format!(
                                 "validator {} has unparsable on-chain metadata (Move error code {code})",
                                 validator.id
@@ -481,10 +483,10 @@ where
                         // rebuilt on every restart. Fail the whole read instead;
                         // `must_get_epoch_start_system` retries until it completes.
                         let Some(mpc_data) = validators_mpc_data.get(&validator.id) else {
-                            self.sui_client_metrics
-                                .sui_rpc_errors
-                                .with_label_values(&["epoch_start_missing_mpc_data"])
-                                .inc();
+                            self.sui_client_metrics.record_response_error(
+                                "get_epoch_start_system",
+                                SuiResponseErrorKind::MissingField,
+                            );
                             ika_types::report_invariant_violation!(
                                 "epoch_start_mpc_data_missing",
                                 validator_id = ?validator.id,
@@ -509,10 +511,10 @@ where
                         // per-signature check would disagree with the on-chain
                         // aggregate check for a full epoch.
                         let protocol_pubkey = m.parsed_protocol_pubkey().map_err(|e| {
-                            self.sui_client_metrics
-                                .sui_rpc_errors
-                                .with_label_values(&["epoch_start_invalid_committee_pubkey"])
-                                .inc();
+                            self.sui_client_metrics.record_response_error(
+                                "get_epoch_start_system",
+                                SuiResponseErrorKind::InvalidCommitteePubkeyParse,
+                            );
                             IkaError::InvalidCommittee(format!(
                                 "active committee member {} has an unparsable BLS protocol \
                                  public key: {e}",
@@ -606,10 +608,12 @@ where
             .iter()
             .map(|v| {
                 bcs::from_bytes::<StakingPool>(v).map_err(|e| {
-                    self.sui_client_metrics
-                        .sui_rpc_errors
-                        .with_label_values(&["get_validators_info_by_ids"])
-                        .inc();
+                    // `get_validators` above succeeded — the fetch is fine and
+                    // the bytes are not.
+                    self.sui_client_metrics.record_response_error(
+                        "get_validators_info_by_ids",
+                        SuiResponseErrorKind::Decode,
+                    );
                     IkaError::SuiClientSerializationError(format!(
                         "failed to de-serialize Validator info: {e}"
                     ))
@@ -787,9 +791,7 @@ where
                 Ok(Ok(ika_system_state)) => return ika_system_state,
                 Ok(Err(err)) => {
                     self.sui_client_metrics
-                        .sui_rpc_errors
-                        .with_label_values(&["must_get_system_inner_object"])
-                        .inc();
+                        .record_read_error("must_get_system_inner_object", &err);
                     warn!(
                         error=?err,
                         "Received error from `get_system_inner()`. Retrying...",
@@ -797,9 +799,7 @@ where
                 }
                 Err(err) => {
                     self.sui_client_metrics
-                        .sui_rpc_errors
-                        .with_label_values(&["must_get_system_inner_object"])
-                        .inc();
+                        .record_read_error("must_get_system_inner_object", &err);
                     warn!(
                         error=?err,
                         system_object_id=%self.ika_network_config.objects.ika_system_object_id,
@@ -866,9 +866,7 @@ where
                 Ok(Ok(ika_system_state)) => return ika_system_state,
                 Ok(Err(err)) => {
                     self.sui_client_metrics
-                        .sui_rpc_errors
-                        .with_label_values(&["must_get_dwallet_coordinator_inner"])
-                        .inc();
+                        .record_read_error("must_get_dwallet_coordinator_inner", &err);
                     warn!(
                         error=?err,
                         "Received error from `get_dwallet_coordinator_inner()`. Retrying...",
@@ -876,9 +874,7 @@ where
                 }
                 Err(err) => {
                     self.sui_client_metrics
-                        .sui_rpc_errors
-                        .with_label_values(&["must_get_dwallet_coordinator_inner"])
-                        .inc();
+                        .record_read_error("must_get_dwallet_coordinator_inner", &err);
                     warn!(
                         error=?err,
                         system_object_id=%self.ika_network_config.objects.ika_system_object_id,
@@ -901,9 +897,7 @@ where
                 Ok(Ok(ika_system_state)) => return ika_system_state,
                 Ok(Err(err)) => {
                     self.sui_client_metrics
-                        .sui_rpc_errors
-                        .with_label_values(&["must_get_epoch_start_system"])
-                        .inc();
+                        .record_read_error("must_get_epoch_start_system", &err);
                     warn!(
                         error=?err,
                         "Received error from `get_epoch_start_system()`. Retrying...",
@@ -911,9 +905,7 @@ where
                 }
                 Err(err) => {
                     self.sui_client_metrics
-                        .sui_rpc_errors
-                        .with_label_values(&["must_get_epoch_start_system"])
-                        .inc();
+                        .record_read_error("must_get_epoch_start_system", &err);
                     warn!(
                         error=?err,
                         "Received error from `get_epoch_start_system` retry wrapper. Retrying...",
@@ -1096,6 +1088,273 @@ mod pending_active_set_tests {
                 "0x35e3903f1cb93fde2005ee4983091879bfa21c193ba5ac7cf112bb0c7b77021f",
                 "0xa183df56e91f88e839d8da3ca3c83a42a70c3897dfe8af7545c37875c09d5b99",
             ]
+        );
+    }
+}
+
+/// The split between `ika_sui_client_sui_rpc_errors` (Sui did not answer) and
+/// `ika_sui_client_sui_response_errors_total` (Sui answered, the answer was
+/// unusable). The fleet alerts on the former, so a decoding or data defect
+/// landing there reads as an operator's fullnode outage.
+#[cfg(test)]
+mod rpc_vs_response_error_tests {
+    use super::*;
+    use prometheus::core::Collector;
+
+    /// A backend whose only live method is `get_validators`, set to either
+    /// fail at the transport or answer with bytes that are not a
+    /// `StakingPool`. Every other method is unreachable from the two reads
+    /// under test.
+    struct ValidatorsStub {
+        /// `Ok` — the RPC answered with these per-validator BCS blobs;
+        /// `Err` — it never answered.
+        validators: Result<Vec<Vec<u8>>, ()>,
+    }
+
+    impl ValidatorsStub {
+        fn client(validators: Result<Vec<Vec<u8>>, ()>) -> SuiClient<Self> {
+            SuiClient::new_for_testing(Self { validators })
+        }
+    }
+
+    #[async_trait]
+    impl SuiClientInner for ValidatorsStub {
+        type Error = std::io::Error;
+
+        async fn get_validators(
+            &self,
+            _validator_ids: Vec<ObjectID>,
+        ) -> Result<Vec<Vec<u8>>, Self::Error> {
+            self.validators.clone().map_err(|()| {
+                std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "sui rpc unreachable")
+            })
+        }
+
+        async fn get_chain_identifier(&self) -> Result<String, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_sui_epoch(&self) -> Result<u64, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_sui_chain_identifier(&self) -> Result<SuiNetworkChainIdentifier, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_sui_funds(
+            &self,
+            _address: SuiAddress,
+        ) -> Result<SuiFundsBreakdown, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_reference_gas_price(&self) -> Result<u64, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_latest_checkpoint_sequence_number(&self) -> Result<u64, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_system(&self, _id: ObjectID) -> Result<Vec<u8>, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_extended_field_value_bcs(
+            &self,
+            _ef_id: ObjectID,
+        ) -> Result<Vec<u8>, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_clock(&self, _clock_obj_id: ObjectID) -> Result<Vec<u8>, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_dwallet_coordinator(&self, _id: ObjectID) -> Result<Vec<u8>, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_mpc_data_from_validators_pool(
+            &self,
+            _validators: &Vec<StakingPool>,
+            _read_next_epoch_mpc_data: bool,
+        ) -> Result<HashMap<ObjectID, VersionedMPCData>, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_network_encryption_keys(
+            &self,
+            _dwallet_coordinator_inner: &DWalletCoordinatorInnerV1,
+        ) -> Result<HashMap<ObjectID, DWalletNetworkEncryptionKey>, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_network_encryption_key_with_full_data_by_epoch(
+            &self,
+            _network_decryption_key: &DWalletNetworkEncryptionKey,
+            _epoch: EpochId,
+        ) -> Result<DWalletNetworkEncryptionKeyData, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_current_reconfiguration_public_output(
+            &self,
+            _epoch_id: EpochId,
+            _table_id: ObjectID,
+        ) -> Result<ObjectID, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn read_table_vec_as_raw_bytes(
+            &self,
+            _table_id: ObjectID,
+        ) -> Result<Vec<u8>, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_system_inner(
+            &self,
+            _id: ObjectID,
+            _version: u64,
+        ) -> Result<Vec<u8>, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_dwallet_coordinator_inner(
+            &self,
+            _id: ObjectID,
+            _version: u64,
+        ) -> Result<Vec<u8>, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_validator_inners(
+            &self,
+            _validators: Vec<Validator>,
+        ) -> Result<Vec<Vec<u8>>, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_mutable_shared_arg(&self, _id: ObjectID) -> Result<ObjectArg, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_shared_arg(&self, _obj_id: ObjectID) -> Result<ObjectArg, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn get_available_move_packages(
+            &self,
+            _ika_package_id: ObjectID,
+            _ika_system_package_id: ObjectID,
+        ) -> Result<Vec<(ObjectID, MovePackageDigest)>, Self::Error> {
+            unimplemented!("not exercised")
+        }
+        async fn execute_transaction_block_with_effects(
+            &self,
+            _tx: Transaction,
+        ) -> Result<SubmittedTransaction, IkaError> {
+            unimplemented!("not exercised")
+        }
+        async fn get_gas_objects(&self, _address: SuiAddress) -> Vec<ObjectRef> {
+            unimplemented!("not exercised")
+        }
+    }
+
+    /// Every child of `vec` summed — "this family recorded nothing at all",
+    /// which is the assertion that matters here and which a per-label read
+    /// cannot make.
+    fn family_total(vec: &prometheus::IntCounterVec) -> u64 {
+        vec.collect()
+            .iter()
+            .flat_map(|family| family.get_metric())
+            .map(|metric| metric.get_counter().value() as u64)
+            .sum()
+    }
+
+    /// `get_validators` answers; the bytes it answers with are 4 long, and a
+    /// `StakingPool` opens with a 32-byte `UID`. The uplink is healthy.
+    #[tokio::test]
+    async fn a_decode_failure_on_a_successful_rpc_is_not_an_rpc_error() {
+        let client = ValidatorsStub::client(Ok(vec![vec![0xff; 4]]));
+
+        let err = client
+            .get_validators_info_by_ids(vec![ObjectID::random()])
+            .await
+            .expect_err("4 bytes cannot decode as a StakingPool");
+        assert!(
+            matches!(err, IkaError::SuiClientSerializationError(_)),
+            "expected a serialization error, got {err:?}"
+        );
+
+        let metrics = &client.sui_client_metrics;
+        assert_eq!(
+            metrics
+                .sui_response_errors
+                .with_label_values(&["get_validators_info_by_ids", "decode"])
+                .get(),
+            1,
+            "the decode failure belongs to the response counter"
+        );
+        assert_eq!(
+            family_total(&metrics.sui_rpc_errors),
+            0,
+            "a decoding bug must not show up as a Sui uplink failure"
+        );
+    }
+
+    /// The mirror case: the call never came back, which is exactly what
+    /// `ika_sui_client_sui_rpc_errors` is for.
+    #[tokio::test]
+    async fn a_transport_failure_is_an_rpc_error_only() {
+        let client = ValidatorsStub::client(Err(()));
+
+        let err = client
+            .get_validators_info_by_ids(vec![ObjectID::random()])
+            .await
+            .expect_err("the stubbed transport refuses the connection");
+        assert!(
+            matches!(err, IkaError::SuiClientInternalError(_)),
+            "expected an internal/transport error, got {err:?}"
+        );
+
+        let metrics = &client.sui_client_metrics;
+        assert_eq!(
+            metrics
+                .sui_rpc_errors
+                .with_label_values(&["get_validators_info_by_ids"])
+                .get(),
+            1,
+        );
+        assert_eq!(
+            family_total(&metrics.sui_response_errors),
+            0,
+            "nothing was decoded, so nothing can be a response failure"
+        );
+    }
+
+    /// The `must_get_*` wrappers see only the terminal error, and they fire
+    /// once per 30-second retry round — ~120/hour, above the fleet's
+    /// RPC-error alert threshold on their own. Routing them by error variant
+    /// is what keeps a persistent decoding bug off that alert.
+    #[test]
+    fn the_retry_wrappers_route_by_error_variant() {
+        let metrics = SuiClientMetrics::new_for_testing();
+        let method = "must_get_epoch_start_system";
+
+        metrics.record_read_error(
+            method,
+            &IkaError::SuiClientInternalError("uplink refused".to_string()),
+        );
+        metrics.record_read_error(
+            method,
+            &IkaError::SuiClientSerializationError("short read".to_string()),
+        );
+        metrics.record_read_error(
+            method,
+            &IkaError::InvalidCommittee("member missing from the fetched set".to_string()),
+        );
+
+        assert_eq!(
+            metrics.sui_rpc_errors.with_label_values(&[method]).get(),
+            1,
+            "only the transport failure belongs to the RPC counter"
+        );
+        assert_eq!(
+            metrics
+                .sui_response_errors
+                .with_label_values(&[method, "decode"])
+                .get(),
+            1,
+        );
+        assert_eq!(
+            metrics
+                .sui_response_errors
+                .with_label_values(&[method, "invalid_committee"])
+                .get(),
+            1,
         );
     }
 }

--- a/crates/ika-sui-client/src/lib.rs
+++ b/crates/ika-sui-client/src/lib.rs
@@ -1316,9 +1316,12 @@ mod rpc_vs_response_error_tests {
     }
 
     /// The `must_get_*` wrappers see only the terminal error, and they fire
-    /// once per 30-second retry round — ~120/hour, above the fleet's
-    /// RPC-error alert threshold on their own. Routing them by error variant
-    /// is what keeps a persistent decoding bug off that alert.
+    /// once per exhausted retry round — the backoff runs
+    /// 0.4+0.8+1.6+3.2+6.4+12.8s and the 7th check exceeds the 30s budget, so
+    /// a round is ~25.2s and a persistent failure yields ~143 wrapper
+    /// increments/hour, above the fleet's RPC-error alert threshold on their
+    /// own. Routing them by error variant is what keeps a persistent decoding
+    /// bug off that alert.
     #[test]
     fn the_retry_wrappers_route_by_error_variant() {
         let metrics = SuiClientMetrics::new_for_testing();
@@ -1355,6 +1358,30 @@ mod rpc_vs_response_error_tests {
                 .with_label_values(&[method, "invalid_committee"])
                 .get(),
             1,
+        );
+    }
+
+    /// The stability guarantee `SuiResponseErrorKind::classify` documents: a
+    /// variant it does not list falls through to `sui_rpc_errors`, i.e. the
+    /// behaviour every site had before the split. Without this, adding an
+    /// `IkaError` variant could quietly move traffic off the counter the
+    /// fleet alert reads, and nothing would say so.
+    #[test]
+    fn an_unlisted_error_variant_stays_on_the_rpc_counter() {
+        let metrics = SuiClientMetrics::new_for_testing();
+        let method = "must_get_system_inner_object";
+
+        metrics.record_read_error(method, &IkaError::Unknown("something new".to_string()));
+
+        assert_eq!(
+            metrics.sui_rpc_errors.with_label_values(&[method]).get(),
+            1,
+            "an unclassified variant keeps its historical counter"
+        );
+        assert_eq!(
+            family_total(&metrics.sui_response_errors),
+            0,
+            "classify() must not guess a response kind it was never taught"
         );
     }
 }

--- a/crates/ika-sui-client/src/metrics.rs
+++ b/crates/ika-sui-client/src/metrics.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
+use ika_types::error::IkaError;
 use prometheus::{
     IntCounterVec, IntGauge, IntGaugeVec, Registry, register_int_counter_vec_with_registry,
     register_int_gauge_vec_with_registry, register_int_gauge_with_registry,
@@ -49,9 +50,113 @@ pub fn chain_blob_read_counts() -> (u64, u64) {
     )
 }
 
+/// The `kind` label of [`SuiClientMetrics::sui_response_errors`] — *why* a read
+/// failed once the Sui RPC had already answered it.
+///
+/// Closed set, and deliberately small: the label's whole job is to let one
+/// panel say "this is a decoding/data bug" instead of "Sui is down", so it
+/// needs enough resolution to point at a code path and no more. Every variant
+/// corresponds to at least one increment site in [`crate::SuiClient`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SuiResponseErrorKind {
+    /// The response bytes did not deserialize (BCS).
+    Decode,
+    /// The RPC answered, but the record we asked about is not in the answer —
+    /// e.g. a committee member with no row in the fetched validator set.
+    NotFound,
+    /// The record is present but a field/table entry the caller requires is
+    /// absent — e.g. an active committee member with no `mpc_data` row.
+    MissingField,
+    /// A `StakingPool`'s on-chain validator metadata (keys, addresses) is
+    /// present but does not parse.
+    ValidatorInfoParse,
+    /// A frozen committee member's BLS protocol public key does not parse.
+    /// Kept apart from [`Self::ValidatorInfoParse`] because the two read from
+    /// different on-chain sources (the committee snapshot vs. the validator
+    /// record), which is the first thing you need to know when one fires.
+    InvalidCommitteePubkeyParse,
+    /// A retry wrapper gave up on a read that failed with
+    /// [`IkaError::InvalidCommittee`]. The precise kind was already recorded
+    /// by the site inside the read that produced the error; this is the
+    /// coarser once-per-retry-round re-count, which is all the wrapper can
+    /// see.
+    InvalidCommittee,
+}
+
+impl SuiResponseErrorKind {
+    /// The `kind` label value. Stable — dashboards and alerts match on these.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Decode => "decode",
+            Self::NotFound => "not_found",
+            Self::MissingField => "missing_field",
+            Self::ValidatorInfoParse => "validator_info_parse",
+            Self::InvalidCommitteePubkeyParse => "committee_pubkey_parse",
+            Self::InvalidCommittee => "invalid_committee",
+        }
+    }
+
+    /// Classify a read that already came back as an [`IkaError`]: `Some(kind)`
+    /// if Sui answered and the answer was unusable, `None` if the RPC itself
+    /// is what failed.
+    ///
+    /// Used where the only thing in hand is the terminal error — the
+    /// `must_get_*` retry wrappers, which sit above a read that may have
+    /// failed for either reason and would otherwise re-count every decoding
+    /// bug as an RPC outage once per retry round (at a 30-second budget that
+    /// is ~120/hour, above the fleet's RPC-error alert threshold on its own).
+    ///
+    /// The catch-all arm resolves to "RPC failure", i.e. the historical
+    /// behaviour, so a variant added later keeps landing on the counter it
+    /// lands on today rather than silently changing an alert's meaning.
+    pub fn classify(error: &IkaError) -> Option<Self> {
+        match error {
+            IkaError::SuiClientSerializationError(_) => Some(Self::Decode),
+            IkaError::InvalidCommittee(_) => Some(Self::InvalidCommittee),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct SuiClientMetrics {
+    /// Failures of the Sui RPC *transport*: the call did not come back with an
+    /// answer. Name, labels and help are unchanged since 1.2.0 and must stay
+    /// that way — this is the counter the fleet's Sui-uplink alerting is built
+    /// on, and its healthy baseline (0–6/hour) is what makes it a usable lead
+    /// indicator for a boot wedge.
+    ///
+    /// Failures where Sui *did* answer and the answer was unusable belong on
+    /// [`Self::sui_response_errors`]; mixing the two is what made an outage and
+    /// a decoding bug indistinguishable here (ika #2116 follow-up).
     pub sui_rpc_errors: IntCounterVec,
+    /// Failures of reads whose RPC **succeeded** and whose response could not
+    /// be used: BCS decode failures, a committee member missing from a fetched
+    /// validator set, unparsable on-chain key material, an absent `mpc_data`
+    /// record.
+    ///
+    /// Every one of these is a defect in ika's own data or decoding path (or in
+    /// what is on chain), not in the operator's fullnode — the opposite
+    /// on-call response from [`Self::sui_rpc_errors`], which is why they cannot
+    /// share a counter.
+    ///
+    /// # Cardinality
+    ///
+    /// `method` is the client method name, from the same closed set as
+    /// `sui_rpc_errors`; `kind` is [`SuiResponseErrorKind`], six values. Ten
+    /// `(method, kind)` pairs are reachable today — six from sites that name
+    /// their own kind, four more from the three `must_get_*` wrappers, which
+    /// can only reach `decode` and `invalid_committee`.
+    ///
+    /// # No zero baseline
+    ///
+    /// Deliberately not pre-registered at `0`, unlike
+    /// [`Self::sui_rate_limited_errors`]. The pairs are a cross product that
+    /// only the increment sites know, so seeding them means a second hand-kept
+    /// list of exactly the kind this repo's metric conventions exist to avoid —
+    /// and the counter it splits off from has no zero baseline either, so a
+    /// companion alert is written the same way its sibling already is.
+    pub sui_response_errors: IntCounterVec,
     /// Counts on-chain reads of the heavy blob fields backed by
     /// `mpc_data` / network-key / reconfig outputs. Each label is the
     /// name of a method that performs a chain-side blob fetch. Used by
@@ -136,6 +241,13 @@ impl SuiClientMetrics {
                 registry,
             )
             .unwrap(),
+            sui_response_errors: register_int_counter_vec_with_registry!(
+                "ika_sui_client_sui_response_errors_total",
+                "Total number of sui RPC calls that answered but whose response could not be used, by RPC method and failure kind",
+                &["method", "kind"],
+                registry,
+            )
+            .unwrap(),
             chain_blob_reads: register_int_counter_vec_with_registry!(
                 "ika_sui_client_chain_blob_reads",
                 "Total chain-side blob reads (mpc_data, network DKG output, reconfig output)",
@@ -192,6 +304,30 @@ impl SuiClientMetrics {
     pub fn new_for_testing() -> Arc<Self> {
         let registry = Registry::new();
         Self::new(&registry)
+    }
+
+    /// Record one failure of `method` whose RPC succeeded and whose response
+    /// was unusable. Never touches [`Self::sui_rpc_errors`].
+    pub fn record_response_error(&self, method: &str, kind: SuiResponseErrorKind) {
+        self.sui_response_errors
+            .with_label_values(&[method, kind.label()])
+            .inc();
+    }
+
+    /// Record one failed read of `method`, routing it to the counter its cause
+    /// belongs to: [`Self::sui_response_errors`] when Sui answered and the
+    /// answer was unusable, [`Self::sui_rpc_errors`] otherwise.
+    ///
+    /// For call sites that hold only the terminal [`IkaError`] and cannot see
+    /// which of the two happened — the `must_get_*` retry wrappers. A site
+    /// that *knows* it is looking at a bad response (a `bcs::from_bytes` arm,
+    /// say) should call [`Self::record_response_error`] with the precise kind
+    /// instead.
+    pub fn record_read_error(&self, method: &str, error: &IkaError) {
+        match SuiResponseErrorKind::classify(error) {
+            Some(kind) => self.record_response_error(method, kind),
+            None => self.sui_rpc_errors.with_label_values(&[method]).inc(),
+        }
     }
 
     /// Publish a fresh `GetServiceInfo` answer: flip the previously-active

--- a/crates/ika-sui-client/src/metrics.rs
+++ b/crates/ika-sui-client/src/metrics.rs
@@ -69,6 +69,19 @@ pub enum SuiResponseErrorKind {
     MissingField,
     /// A `StakingPool`'s on-chain validator metadata (keys, addresses) is
     /// present but does not parse.
+    ///
+    /// **Effectively unreachable against the gRPC backend, and pre-existing.**
+    /// `get_epoch_start_system` calls `get_mpc_data_from_validators_pool`
+    /// before its committee-member loop, and that backend method runs
+    /// `verified_validator_info()` over the same validator set
+    /// (`grpc_backend.rs`), short-circuiting on the first failure. So the
+    /// identical defect surfaces one call earlier, collapsed into
+    /// `SuiClientInternalError`, and is counted on `sui_rpc_errors` — the
+    /// residual described on [`SuiClientMetrics::sui_rpc_errors`]. The
+    /// synthetic `epoch_start_invalid_validator_info` label this replaced was
+    /// dead for exactly the same reason. Kept because the site is real, the
+    /// shadowing is a property of one backend, and a kind that exists costs
+    /// nothing until it fires.
     ValidatorInfoParse,
     /// A frozen committee member's BLS protocol public key does not parse.
     /// Kept apart from [`Self::ValidatorInfoParse`] because the two read from
@@ -103,8 +116,10 @@ impl SuiResponseErrorKind {
     /// Used where the only thing in hand is the terminal error — the
     /// `must_get_*` retry wrappers, which sit above a read that may have
     /// failed for either reason and would otherwise re-count every decoding
-    /// bug as an RPC outage once per retry round (at a 30-second budget that
-    /// is ~120/hour, above the fleet's RPC-error alert threshold on its own).
+    /// bug as an RPC outage once per retry round. The backoff runs
+    /// 0.4+0.8+1.6+3.2+6.4+12.8s and the 7th check exceeds the 30s budget, so
+    /// a round is ~25.2s: ~143 wrapper increments/hour while the failure
+    /// persists, above the fleet's RPC-error alert threshold on its own.
     ///
     /// The catch-all arm resolves to "RPC failure", i.e. the historical
     /// behaviour, so a variant added later keeps landing on the counter it
@@ -129,6 +144,24 @@ pub struct SuiClientMetrics {
     /// Failures where Sui *did* answer and the answer was unusable belong on
     /// [`Self::sui_response_errors`]; mixing the two is what made an outage and
     /// a decoding bug indistinguishable here (ika #2116 follow-up).
+    ///
+    /// # Known residual
+    ///
+    /// The split is clean in one direction only: nothing that reaches
+    /// [`Self::sui_response_errors`] is a transport failure. The reverse does
+    /// not hold. Every `self.inner.*` call in [`crate::SuiClient`] collapses
+    /// its backend error into `IkaError::SuiClientInternalError` before the
+    /// counter sees it, and the backend errors it collapses include genuine
+    /// bad-payload cases — `GrpcSuiClientError::Decode` (a fetched object that
+    /// is not a `MoveObject`, a `decode_chain_mirror` failure, an unparsable
+    /// validator record) and `TransportError::Encoding` (a response with no
+    /// `object.bcs`, an `Object` that will not decode). Those still land here.
+    ///
+    /// Left alone deliberately: fixing it means changing error *variants*
+    /// across the backend rather than moving an increment site, and it would
+    /// shift the calibration of the fleet's rate alert on this counter. Read a
+    /// spike here as "the uplink is unhealthy" — usually true, occasionally
+    /// "the uplink answered with something we could not read".
     pub sui_rpc_errors: IntCounterVec,
     /// Failures of reads whose RPC **succeeded** and whose response could not
     /// be used: BCS decode failures, a committee member missing from a fetched

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -289,6 +289,47 @@ is exported for every protocol (it is bounded — one series per protocol name)
 and emits zero for a completed protocol while its session remains tracked, so
 tests can distinguish a clean zero from a missing protocol observation.
 
+## Sui client: "they didn't answer" and "the answer was wrong" are two counters
+
+`ika_sui_client_sui_rpc_errors{method}` counts **transport** failures — the Sui
+RPC did not come back with an answer.
+`ika_sui_client_sui_response_errors_total{method, kind}` counts reads whose
+**RPC succeeded** and whose answer could not be used: BCS decode failures, a
+committee member absent from a fetched validator set, unparsable on-chain key
+material, a missing `mpc_data` record. `kind` is a closed set — `decode`,
+`not_found`, `missing_field`, `validator_info_parse`, `committee_pubkey_parse`,
+`invalid_committee` (see `SuiResponseErrorKind` in
+`crates/ika-sui-client/src/metrics.rs`).
+
+They were one counter until the #2116 follow-up, and the conflation was not
+cosmetic. The two point at opposite owners: an RPC error is the operator's
+fullnode (upgrade it, repoint it, check the endpoint), a response error is a bug
+in ika's own decoding or in what is on chain — and no ika change will fix the
+first while no operator action will fix the second. `sui_rpc_errors` is also the
+fleet's lead indicator for the epoch-boundary boot wedge, whose whole value comes
+from a healthy baseline of 0–6 errors/hour; a decoding defect firing into it both
+raises a Sui-outage page at the wrong team and blunts the band that made the
+wedge visible hours ahead.
+
+Two consequences for anyone touching these:
+
+- **`sui_rpc_errors` keeps its name, labels and help forever.** Dashboards and
+  the fleet's `rate()`-over-30m alert are built on it. Split *out of* it; never
+  rename it.
+- **The `must_get_*` retry wrappers classify by error variant**
+  (`SuiResponseErrorKind::classify`), because they see only a terminal
+  `IkaError` and cannot tell which half they are looking at. They fire once per
+  30-second retry round — ~120/hour — which on its own clears the alert
+  threshold, so a wrapper that counted every failure as an RPC failure would
+  have left a persistent decoding bug paging as an outage no matter how the
+  sites below it were labelled. Unknown variants fall through to
+  `sui_rpc_errors`, i.e. the historical behaviour, so adding an `IkaError`
+  variant cannot silently change an alert's meaning.
+
+An alert on one of these wants a companion rule on the other, not a replacement:
+"the uplink is failing" and "we cannot read what the uplink returns" are both
+worth knowing, and neither implies the other.
+
 ## A process registers only the families it drives
 
 The three `NodeMode`s share one start sequence, and it used to register nearly
@@ -687,6 +728,7 @@ ika_sui_client_chain_blob_reads
 ika_sui_client_rate_limited_errors_total
 ika_sui_client_sui_node_info
 ika_sui_client_sui_node_info_last_success_unixtime
+ika_sui_client_sui_response_errors_total
 ika_sui_client_sui_rpc_errors
 ika_sui_connector_chain_active_system_sessions_count
 ika_sui_connector_chain_active_user_sessions_count

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -319,7 +319,9 @@ Two consequences for anyone touching these:
 - **The `must_get_*` retry wrappers classify by error variant**
   (`SuiResponseErrorKind::classify`), because they see only a terminal
   `IkaError` and cannot tell which half they are looking at. They fire once per
-  30-second retry round — ~120/hour — which on its own clears the alert
+  exhausted retry round (~25.2s: the backoff runs 0.4+0.8+1.6+3.2+6.4+12.8s and
+  the 7th check exceeds the 30s budget) — ~143/hour, plus ~1000/hour from the
+  seven inner attempts each round — which on its own clears the alert
   threshold, so a wrapper that counted every failure as an RPC failure would
   have left a persistent decoding bug paging as an outage no matter how the
   sites below it were labelled. Unknown variants fall through to
@@ -329,6 +331,22 @@ Two consequences for anyone touching these:
 An alert on one of these wants a companion rule on the other, not a replacement:
 "the uplink is failing" and "we cannot read what the uplink returns" are both
 worth knowing, and neither implies the other.
+
+**The split is clean in one direction only.** Nothing that reaches
+`sui_response_errors_total` is a transport failure — every site behind it is a
+decode or lookup over bytes already in hand. The reverse does not hold: every
+`self.inner.*` call in `SuiClient` collapses its backend error into
+`IkaError::SuiClientInternalError` before the counter sees it, and the backend
+errors it collapses include real bad-payload cases —
+`GrpcSuiClientError::Decode` (an object that is not a `MoveObject`, a
+`decode_chain_mirror` failure, an unparsable validator record) and
+`TransportError::Encoding` (a response with no `object.bcs`, an undecodable
+`Object`). Those still land on `sui_rpc_errors`, as does the
+`"Unsupported SystemInner version"` arm. Closing that gap means changing error
+*variants* across the backend rather than moving an increment site, and it would
+shift the calibration of the fleet's rate alert, so it is a separate change. A
+spike on `sui_rpc_errors` is "the uplink is unhealthy" in the common case and
+"the uplink answered with something we could not read" in the rest.
 
 ## A process registers only the families it drives
 

--- a/dev-docs/playbooks/production-alerts.md
+++ b/dev-docs/playbooks/production-alerts.md
@@ -320,7 +320,11 @@ a page.
   is on chain, and neither implies the other. Split the second by `kind` before
   reading it; `invalid_committee` is the coarse re-count the `must_get_*` retry
   wrappers emit once per 30-second round, so expect it alongside whichever
-  precise kind the read below it recorded.
+  precise kind the read below it recorded. Note the split is one-directional:
+  nothing on the response counter is a transport failure, but `sui_rpc_errors`
+  still absorbs backend-level decode failures that the client collapses into
+  `SuiClientInternalError` — so it is "the uplink is unhealthy" in the common
+  case, not always.
 - The five `ika_epoch_*` memory series report what an epoch's fold is holding
   in RAM, which is where the epoch's derived state lives
   ([`../specs/event-sourced-epoch.md`](../specs/event-sourced-epoch.md)). Read

--- a/dev-docs/playbooks/production-alerts.md
+++ b/dev-docs/playbooks/production-alerts.md
@@ -306,6 +306,21 @@ a page.
   [`mpc-stall-postmortem.md`](mpc-stall-postmortem.md)'s interpretation rules
   plus
   [`../specs/ocs-verified-sui-reads.md`](../specs/ocs-verified-sui-reads.md).
+- `rate(ika_sui_client_sui_rpc_errors[30m])` is the Sui-uplink health signal, and
+  the lead indicator for the epoch-boundary boot wedge — a validator's fullnode
+  erroring at hundreds/hour against a fleet baseline of 0–6 gives hours of
+  warning ([`../conventions/metrics.md`](../conventions/metrics.md)). It counts
+  **only transport failures**. Reads whose RPC succeeded and whose response was
+  unusable — BCS decode failures, a committee member missing from a fetched
+  validator set, unparsable on-chain key material, an absent `mpc_data` record —
+  land on `ika_sui_client_sui_response_errors_total{method,kind}` instead.
+  **Any rate alert on `sui_rpc_errors` wants a companion rule on
+  `sui_response_errors_total`**, because the two have opposite owners: the first
+  is the operator's fullnode, the second is a bug in ika's decoding or in what
+  is on chain, and neither implies the other. Split the second by `kind` before
+  reading it; `invalid_committee` is the coarse re-count the `must_get_*` retry
+  wrappers emit once per 30-second round, so expect it alongside whichever
+  precise kind the read below it recorded.
 - The five `ika_epoch_*` memory series report what an epoch's fold is holding
   in RAM, which is where the epoch's derived state lives
   ([`../specs/event-sourced-epoch.md`](../specs/event-sourced-epoch.md)). Read


### PR DESCRIPTION
Follow-up to #2116, which fixed one mislabelled increment at
`ika_sui_client_sui_rpc_errors` and deliberately left the counter's semantics
for a separate change. This is that change.

## The problem

`ika_sui_client_sui_rpc_errors{method}` had 24 increment sites in
`crates/ika-sui-client/src/lib.rs`. Most were genuine transport failures — Sui
did not answer. Six were not: the RPC succeeded and the *response* was
unusable (BCS decode failures, a committee member missing from a fetched
validator set, unparsable on-chain key material, an absent `mpc_data` record).

The two have opposite owners. An RPC error is the operator's fullnode — repoint
it, upgrade it, check the endpoint. A response error is a bug in ika's own
decoding or in what is on chain, and no operator action will fix it. Sharing a
counter means a dashboard cannot tell them apart, and the fleet's
`ika-sui-rpc-errors-elevated` rule pages the wrong team for the second kind
while the first kind's healthy 0–6/hour baseline — the thing that makes this
counter a usable lead indicator for the epoch-boundary boot wedge — gets
blunted by the noise.

## Per-site classification

Line numbers are `crates/ika-sui-client/src/lib.rs` **before** this change.
"unchanged" means the site still increments
`ika_sui_client_sui_rpc_errors{method="<same>"}`.

Read "transport" below as *the class this PR treats as transport*, not as a
guarantee that only transport failures reach it — every `inner.*` row is
**predominantly** transport but also absorbs backend-level bad-payload
failures. See [Known residuals](#known-residuals-deliberately-not-in-scope); it
is the one place this split is not clean, and it is not new.

| Line | Site (`method` label before) | What failed | Class | After |
| --- | --- | --- | --- | --- |
| 376 | `get_mpc_data_from_validators_pool` | pool fetch returned an error | transport† | unchanged |
| 405 | `get_epoch_start_system` (`inner.get_validators`) | validator fetch returned an error | transport† | unchanged |
| 417 | `get_epoch_start_system` (`bcs::from_bytes::<StakingPool>`) | fetched bytes do not decode | **response** | `sui_response_errors_total{method="get_epoch_start_system",kind="decode"}` |
| 433 | `get_epoch_start_system` (`inner.get_mpc_data_from_validators_pool`) | mpc_data fetch returned an error | transport† | unchanged |
| 452 | `get_epoch_start_system` (committee member lookup) | member absent from the fetched validator set | **response** | `…{method="get_epoch_start_system",kind="not_found"}` |
| 465 | `epoch_start_invalid_validator_info` | `verified_validator_info()` — stored metadata does not parse | **response** | `…{method="get_epoch_start_system",kind="validator_info_parse"}` |
| 485 | `epoch_start_missing_mpc_data` | active member has no `mpc_data` record | **response** | `…{method="get_epoch_start_system",kind="missing_field"}` |
| 513 | `epoch_start_invalid_committee_pubkey` | `parsed_protocol_pubkey()` — committee BLS key does not parse | **response** | `…{method="get_epoch_start_system",kind="committee_pubkey_parse"}` |
| 598 | `get_validators_info_by_ids` (`inner.get_validators`) | validator fetch returned an error | transport† | unchanged |
| 610 | `get_validators_info_by_ids` (`bcs::from_bytes::<StakingPool>`) | fetched bytes do not decode | **response** | `…{method="get_validators_info_by_ids",kind="decode"}` |
| 695 | `get_chain_identifier` | call returned an error | transport | unchanged |
| 709 | `get_reference_gas_price_until_success` | retry budget exhausted | transport | unchanged |
| 729 | `get_sui_epoch_until_success` | retry budget exhausted | transport | unchanged |
| 744 | `get_sui_chain_identifier` | call returned an error | transport | unchanged |
| 755 | `get_sui_funds` | call returned an error | transport | unchanged |
| 768 | `get_latest_checkpoint_sequence_number` | call returned an error | transport | unchanged |
| 790 | `must_get_system_inner_object` (`Ok(Err)`) | retry wrapper, terminal error | **either** | routed by error variant |
| 800 | `must_get_system_inner_object` (`Err`) | retry wrapper, terminal error | **either** | routed by error variant |
| 823 | `get_dwallet_mpc_network_keys` | call returned an error | transport† | unchanged |
| 849 | `get_network_encryption_key_with_full_data_by_epoch` | call returned an error | transport† | unchanged |
| 869 | `must_get_dwallet_coordinator_inner` (`Ok(Err)`) | retry wrapper, terminal error | **either** | routed by error variant |
| 879 | `must_get_dwallet_coordinator_inner` (`Err`) | retry wrapper, terminal error | **either** | routed by error variant |
| 904 | `must_get_epoch_start_system` (`Ok(Err)`) | retry wrapper, terminal error | **either** | routed by error variant |
| 914 | `must_get_epoch_start_system` (`Err`) | retry wrapper, terminal error | **either** | routed by error variant |

† **Not pure transport.** These six go through `self.inner.*`, which collapses
the backend error into `IkaError::SuiClientInternalError` before the counter
sees it — and the backend errors it collapses include real bad-payload cases.
See Known residuals below. Not changed here on purpose: it would mean editing
error *variants* across the backend and would move the fleet alert's
calibration.

18 sites stay on `sui_rpc_errors`, 6 move outright, and 6 (the three retry
wrappers × two match arms) are routed at runtime.

### `kind="validator_info_parse"` is shadowed (pre-existing)

Row 465's kind is effectively unreachable against the gRPC backend, and the
synthetic `epoch_start_invalid_validator_info` label it replaces was equally
dead. `get_epoch_start_system` calls `inner.get_mpc_data_from_validators_pool`
(lib.rs:430-441) **before** its committee-member loop, and
`GrpcSuiClient::get_mpc_data_from_validators_pool` runs
`verified_validator_info()` over the same validator set
(`grpc_backend.rs:306-311`), short-circuiting with `?` on the first failure. So
the identical defect surfaces one call earlier, as
`GrpcSuiClientError::Decode` → `SuiClientInternalError`, and is counted at
lib.rs:435 on `sui_rpc_errors`.

**Reachable `(method, kind)` pairs are therefore 9, not 10.** The kind is kept
because the site is real, the shadowing is a property of one backend rather
than of the client, and a kind that never fires costs nothing. Noted in the
variant's doc comment so the next reader does not re-derive it.

### Why the wrappers had to be routed, not left alone

Leaving the `must_get_*` wrappers on `sui_rpc_errors` would have defeated the
split. Each fires once per exhausted retry round (~25.2s — see the rate
calculation below), so a *persistent* decoding bug drives ~143/hour through the
wrapper alone — above the fleet alert's `> 60`/hour threshold — no matter how
the sites below it are labelled.
The wrapper only has the terminal `IkaError` in hand, so
`SuiResponseErrorKind::classify` maps `SuiClientSerializationError` → `decode`
and `InvalidCommittee` → `invalid_committee`, and **everything else falls
through to `sui_rpc_errors`**, i.e. the historical behaviour. An `IkaError`
variant added later therefore cannot silently move an existing alert's meaning.

(The `Ok(Err(_))` arms are unreachable given `retry_with_max_elapsed_time!`'s
shape — it only returns `Ok(_)` when the inner result is `Ok` — but they are
part of the match and are routed identically.)

## The new metric

```
ika_sui_client_sui_response_errors_total{method, kind}
```

`IntCounterVec`, registered in `crates/ika-sui-client/src/metrics.rs` beside
`sui_rpc_errors`. Help: *"Total number of sui RPC calls that answered but whose
response could not be used, by RPC method and failure kind"*.

`kind` is a closed Rust enum (`SuiResponseErrorKind`), six values:
`decode`, `not_found`, `missing_field`, `validator_info_parse`,
`committee_pubkey_parse`, `invalid_committee`. `method` comes from the same
closed set as `sui_rpc_errors`. Nine `(method, kind)` pairs are reachable today
(ten sites, minus the shadowed `validator_info_parse` above).

Three notes on the shape:

- **`_total` suffix.** `dev-docs/conventions/metrics.md` binds new counters to
  `_total` and lists `ika_sui_client_sui_rpc_errors` itself under
  "Grandfathered, do not copy", so the new counter follows the convention even
  though its sibling cannot.
- **`sui_rpc_errors` is untouched** — same name, same `["method"]` labels, same
  help string. Dashboards depend on it. The only change to it is which
  increments reach it.
- **No zero baseline.** Unlike `sui_rate_limited_errors`, the children are not
  pre-registered at 0: the `(method, kind)` pairs are a cross product only the
  increment sites know, and seeding them would mean a second hand-kept list of
  exactly the kind this repo's metric conventions exist to prevent. The counter
  it splits from has no zero baseline either, so a companion alert is written
  the same way its sibling already is.

## ⚠️ Impact on the infra alert (`ika-sui-rpc-errors-elevated`)

The production rule

```
sum by (network,host)(rate(ika_sui_client_sui_rpc_errors[30m])) * 3600 > 60
```

**will stop seeing these failure kinds.** After this lands they are counted on
`ika_sui_client_sui_response_errors_total` instead:

| Failure | Old contribution to `sui_rpc_errors` | New home |
| --- | --- | --- |
| `StakingPool` BCS decode, in `get_epoch_start_system` | one per validator per attempt (~7 attempts / 30s round) | `kind="decode"` |
| `StakingPool` BCS decode, in `get_validators_info_by_ids` | one per validator per call | `kind="decode"` |
| committee member missing from the fetched validator set | one per member per attempt | `kind="not_found"` |
| unparsable on-chain validator metadata | one per member per attempt | `kind="validator_info_parse"` |
| missing on-chain `mpc_data` record | one per member per attempt | `kind="missing_field"` |
| unparsable committee BLS protocol key | one per member per attempt | `kind="committee_pubkey_parse"` |
| any of the above surfacing at a `must_get_*` wrapper | ~143/hour while persistent | `kind="decode"` / `kind="invalid_committee"` |

**`epoch_start_missing_mpc_data` is on that list, and the production alert's own
description names it verbatim as the wedge symptom.** It moves to
`sui_response_errors_total{method="get_epoch_start_system", kind="missing_field"}`
— the alert's description needs updating alongside its companion rule, or it
will keep pointing at a label that no longer exists.

### The number the companion threshold gets reasoned from

During a *persistent* `get_epoch_start_system` defect the two contributions
compound. `retry_with_max_elapsed_time!` backs off 0.4 + 0.8 + 1.6 + 3.2 + 6.4 +
12.8s, and the 7th check exceeds the 30s `max_elapsed_time` — so one round is
~25.2s and lands **7 inner increments + 1 wrapper increment**. That is 8 per
25.2s ≈ **~1150/hour**, all of which used to be on `sui_rpc_errors` and all of
which now moves to `sui_response_errors_total`.

Two things follow. First, the wrapper contribution *alone* (~143/hour) already
cleared the `> 60` threshold, so a sustained decoding or data defect could page
`ika-sui-rpc-errors-elevated` against a perfectly healthy Sui uplink — it no
longer can. Second, a companion rule sized like its sibling would be far too
loose: this counter's healthy value is a hard zero, and a real defect arrives at
~1150/hour, so anything above 0 is worth acting on.

**The alert should gain a companion rule on the new counter** — the moved
failures are not less serious, they are differently owned, and `sui_rpc_errors`
going quiet must not read as "nothing is wrong". A reasonable starting shape,
to be tuned against real data:

```
sum by (network,host)(rate(ika_sui_client_sui_response_errors_total[30m])) * 3600 > 0
```

A non-zero rate here is a code/data defect, not an endpoint problem, so it wants
a much lower threshold than its sibling and should route to the protocol side
rather than to infra. Splitting by `kind` before reading it is worthwhile;
`invalid_committee` is the coarse wrapper re-count and will appear alongside
whichever precise kind the read below it recorded.

**The infra-repo change is out of scope for this PR and is not included here.**

## Docs

- `dev-docs/conventions/metrics.md`
  - regenerated the `## Inventory (generated)` block from
    `./scripts/check-metric-names.sh --list` (339 names, +1);
  - new section **"Sui client: 'they didn't answer' and 'the answer was wrong'
    are two counters"** covering what each counter means, why the split exists,
    that `sui_rpc_errors` must never be renamed, and why the retry wrappers
    classify by error variant.
- `dev-docs/playbooks/production-alerts.md` — new bullet under *Secondary
  signals worth dashboarding* stating plainly that a rate alert on
  `sui_rpc_errors` wants a companion rule on
  `sui_response_errors_total`, and how to read `kind`.
- `crates/ika-proxy/README.md` — the proxy builds `SuiClientMetrics::new`, so it
  exports both families; its metric list said `sui_rpc_errors` was "Sui gRPC
  call errors by method", which is now only half true.

## Known residuals (deliberately not in scope)

- **The split is clean in one direction only.** Nothing that reaches
  `sui_response_errors_total` is a transport failure — every site behind it
  decodes or looks up bytes already in hand. The reverse does not hold: every
  `self.inner.*` call collapses its backend error into
  `IkaError::SuiClientInternalError` before the counter sees it, and that
  collapses genuine bad-payload cases onto `sui_rpc_errors` —
  `GrpcSuiClientError::Decode` (`grpc_backend.rs:210-214` an object that is not
  a `MoveObject`; `:306-311` `verified_validator_info` inside
  `get_mpc_data_from_validators_pool`; `:355-368` `decode_chain_mirror` in
  `get_network_encryption_keys`; `:424-445` the `Field` decodes) and
  `TransportError::Encoding` (`grpc.rs:511-550` — missing `object.bcs`, an
  `Object` that will not decode). Same class as the note below and far more
  reachable. **Not reclassified here on purpose**: it means changing error
  *variants* across the backend rather than moving an increment site, and it
  would shift the calibration of the fleet's rate alert — which is exactly the
  thing this PR is trying to keep stable. Documented on the `sui_rpc_errors`
  field, in the metrics convention, and in the alerts playbook.
- The `"Unsupported SystemInner version"` / `"Unsupported DWalletCoordinatorInner
  version"` arms build a `SuiClientInternalError`, so at a `must_get_*` wrapper
  they classify as transport and stay on `sui_rpc_errors`. They are really
  response-interpretation failures. Changing them means changing an error
  *variant* rather than an increment site, which is a wider blast radius than
  this PR wants.
- Several decode sites have never been instrumented at all and still are not:
  `get_clock`, `get_pending_active_set_ids`, and the `System` /
  `DWalletCoordinator` wrapper decodes inside `get_system_inner` /
  `get_dwallet_coordinator_inner`. They reach a counter only via a `must_get_*`
  wrapper, where they now correctly land on `kind="decode"`.

## Registration

`SuiClientMetrics::new` is the single construction point (`ika-node/src/lib.rs`,
`ika-proxy/src/main.rs`, and `new_for_testing` everywhere else), so the new
family is registered everywhere the old one is.

The per-`NodeMode` pin lists from #2106
(`crates/ika-node/src/metrics.rs::per_mode_registration`) needed **no change**:
`exported_families()` does not compose `SuiClientMetrics` at all — no
`ika_sui_client_*` name appears in any of the three pinned lists — and the new
family has no pre-registered children, so it could not reach `gather()` even if
it did. Verified by running the tests, not by reading the list.

## Test evidence

New in `crates/ika-sui-client/src/lib.rs`, module `rpc_vs_response_error_tests`,
over a stub `SuiClientInner` whose `get_validators` either refuses the
connection or answers with 4 bytes (a `StakingPool` opens with a 32-byte `UID`):

- `a_decode_failure_on_a_successful_rpc_is_not_an_rpc_error` — a successful RPC
  whose bytes do not decode increments
  `sui_response_errors_total{method="get_validators_info_by_ids",kind="decode"}`
  and leaves the **entire** `sui_rpc_errors` family at 0 (summed across all
  children, not just the matching label).
- `a_transport_failure_is_an_rpc_error_only` — the mirror case.
- `the_retry_wrappers_route_by_error_variant` — pins the classifier: a
  `SuiClientInternalError` lands on `sui_rpc_errors`, a
  `SuiClientSerializationError` on `kind="decode"`, an `InvalidCommittee` on
  `kind="invalid_committee"`.

```
cargo test --release -p ika-sui-client   → 52 passed; 0 failed
cargo test --release -p ika-node         → 39 passed; 0 failed, including
                                           metrics::per_mode_registration::
                                             a_validator_exports_every_family
                                             a_fullnode_exports_only_the_families_it_drives
                                             a_notifier_exports_only_the_families_it_drives
cargo clippy --all-targets --all-features -p ika-sui-client -p ika-node -p ika-core
                                         → clean (no new warnings)
cargo fmt --all                          → applied
./scripts/check-metric-names.sh          → metric names OK (339 literal, 3 dynamic
                                           sites skipped; …), inventory in sync
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
