### PR TITLE
feat(handoff): run the prepare-then-start barrier on cold start and joiner promotion

### DIFF
--- a/crates/ika-config/src/node.rs
+++ b/crates/ika-config/src/node.rs
@@ -991,6 +991,21 @@ pub struct NodeConfig {
     /// each unbounded validator's class-groups crypto otherwise starves the pod.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_mpc_computation_cores: Option<usize>,
+
+    /// TESTS ONLY — not readable from or writable to a config file
+    /// (`serde(skip)`, like `supported_protocol_versions` above), so no
+    /// deployment can set it by accident.
+    ///
+    /// For this long after the prepare-then-start barrier is entered, the
+    /// barrier reports the epoch's handoff certificate as not obtainable and
+    /// fetches nothing, exactly as if no peer were serving it yet
+    /// (the benign propagation-lag outcome the barrier already retries on).
+    /// It exists so a cluster test can hold a validator's handoff data back
+    /// long enough to prove the validator does NOT start its epoch's
+    /// consensus and MPC components without it. Setting it on a real
+    /// validator would keep a healthy node out of consensus for the window.
+    #[serde(skip)]
+    pub withhold_handoff_anchor_for_testing: Option<Duration>,
 }
 
 /// Keep the current epoch plus this many prior per-epoch authority store
@@ -1547,6 +1562,7 @@ mod tests {
             authority_db_retention_epochs: None,
             authority_db_pruner_period_secs: None,
             max_mpc_computation_cores: None,
+            withhold_handoff_anchor_for_testing: None,
         }
     }
 

--- a/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
+++ b/crates/ika-core/src/sui_connector/pubkey_provider_updater.rs
@@ -70,10 +70,18 @@ fn select_next_epoch_committee(system_inner: &SystemInnerV1) -> Vec<ObjectID> {
 /// so an advanced on-chain view can't hand back a wrong-epoch committee —
 /// which would make a valid handoff cert fail to verify and (via
 /// `BootstrapOutcome::Rejected`) fail-closed-halt the node.
+///
+/// `Ok(None)` is a definitive chain ANSWER, not a failure: the on-chain
+/// epoch matches, and the chain says no committee preceded it. That is the
+/// state of a network whose first off-chain epoch is the one being entered —
+/// nothing ever ran as `expected_prior_epoch`, so no handoff certificate can
+/// exist for it and none ever will. Callers must not wait for one. Every
+/// other outcome (`Err`) is "cannot answer right now", which is worth
+/// retrying.
 pub async fn fetch_previous_committee<C: SuiClientInner>(
     sui_client: &SuiClient<C>,
     expected_prior_epoch: EpochId,
-) -> anyhow::Result<Committee> {
+) -> anyhow::Result<Option<Committee>> {
     let (_, system_inner) = sui_client
         .get_system_inner()
         .await
@@ -89,7 +97,8 @@ pub async fn fetch_previous_committee<C: SuiClientInner>(
     }
     let bls_committee = &system_inner.validator_set.previous_committee;
     if bls_committee.members.is_empty() {
-        anyhow::bail!("validator_set.previous_committee is empty");
+        // An answer, not an error — see this function's doc.
+        return Ok(None);
     }
     // Resolving by object id is what lets this recover signers that have
     // *departed* the active set since they signed the handoff cert: their
@@ -142,13 +151,13 @@ pub async fn fetch_previous_committee<C: SuiClientInner>(
              means a corrupt prior-committee record, not wrong peers"
         );
     }
-    Ok(build_prior_committee(
+    Ok(Some(build_prior_committee(
         expected_prior_epoch,
         &bls_members,
         &staking_pools,
         bls_committee.quorum_threshold,
         bls_committee.validity_threshold,
-    ))
+    )))
 }
 
 /// The prior committee named by consensus key. Both name-keyed maps use that

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -1378,6 +1378,36 @@ impl IkaNode {
         // its caller here (see `HandoffBarrierOutcome::FailedClosed`).
         let (shutdown_channel, _) = broadcast::channel::<Option<RunWithRange>>(1);
 
+        // Continuously feed the p2p trusted-peer set from the on-chain
+        // {active, next, previous} committee + pending_active_set, refreshed
+        // every few seconds so the pending/next sets stay current mid-epoch.
+        // This is what makes a DIRECT validator dial a registered-but-not-yet-
+        // active joiner (inbound), so a peer-only joiner boots without static
+        // seed peers. Runs on every node for its lifetime.
+        //
+        // Started BEFORE the boot barrier below, not after the node is built:
+        // the barrier fetches the handoff certificate and its key blobs from
+        // committee peers and can block for a long time doing it, and without
+        // this loop running the dial set would stay pinned to the single
+        // trusted-peer publish made at network setup for however long that
+        // takes. It needs nothing from the assembled node.
+        let trusted_peer_change_tx_for_refresh = trusted_peer_change_tx.clone();
+        let trusted_peer_sui_client = sui_client.clone();
+        let trusted_peer_authority_name = config.authority_name();
+        spawn_monitored_task!(async move {
+            ika_core::sui_connector::trusted_peer_updater::refresh_trusted_peers_loop(
+                trusted_peer_sui_client,
+                trusted_peer_change_tx_for_refresh,
+                // Self-exclusion compares against committee identities, which
+                // are consensus keys — passing the BLS protocol key here made
+                // the node never recognise itself and add itself as a trusted
+                // peer. It compiled only while `AuthorityName` was an alias
+                // for the BLS container.
+                trusted_peer_authority_name,
+            )
+            .await;
+        });
+
         let validator_components = if mode.is_validator() && is_committee_member {
             // Prepare-then-start barrier on the BOOT path: a process starting
             // (or restarting) straight into an epoch reaches consensus and MPC
@@ -1409,25 +1439,36 @@ impl IkaNode {
                     committee_store: state.committee_store().clone(),
                     sui_client: sui_client.clone(),
                 };
-                if matches!(
-                    wait_for_handoff_data_ready(
-                        &barrier,
-                        epoch_store.epoch() - 1,
-                        &anchor_committee,
-                        &epoch_peer_ids(&epoch_store),
-                        &epoch_store,
-                    )
-                    .await,
-                    HandoffBarrierOutcome::FailedClosed
-                ) {
-                    // The shutdown signal the barrier sent has no subscriber
-                    // this early, so halt by failing the start instead: the
-                    // node runner exits the process on a start error.
-                    return Err(anyhow!(
-                        "cross-epoch handoff anchor for epoch {} is contradicted; refusing to \
-                         start validator components (fail-closed)",
-                        epoch_store.epoch() - 1
-                    ));
+                let anchor_epoch = epoch_store.epoch() - 1;
+                // Anything but `Ready` means the epoch must not be entered.
+                // The shutdown signal the barrier may have sent has no
+                // subscriber this early, so halt by failing the start instead:
+                // the node runner exits the process on a start error, and a
+                // supervised restart re-reads the chain — which is also the
+                // recovery for an unresolvable anchor committee.
+                match wait_for_handoff_data_ready(
+                    &barrier,
+                    anchor_epoch,
+                    &anchor_committee,
+                    &epoch_peer_ids(&epoch_store),
+                    &epoch_store,
+                )
+                .await
+                {
+                    HandoffBarrierOutcome::Ready => {}
+                    HandoffBarrierOutcome::FailedClosed => {
+                        return Err(anyhow!(
+                            "cross-epoch handoff anchor for epoch {anchor_epoch} is contradicted; \
+                             refusing to start validator components (fail-closed)"
+                        ));
+                    }
+                    HandoffBarrierOutcome::AnchorCommitteeUnresolved => {
+                        return Err(anyhow!(
+                            "could not resolve the epoch-{anchor_epoch} committee that signed \
+                             this epoch's handoff certificate; refusing to start validator \
+                             components without a verifiable cross-epoch anchor"
+                        ));
+                    }
                 }
             }
             let components = Self::construct_validator_components(
@@ -1514,7 +1555,6 @@ impl IkaNode {
         let node = Arc::new(node);
         let node_copy = node.clone();
         let sui_client_clone = sui_client.clone();
-        let trusted_peer_sui_client = sui_client.clone();
 
         // Joiner-side announcement fan-out: a node selected into the
         // next-epoch committee but not yet in the current one isn't a
@@ -1550,27 +1590,6 @@ impl IkaNode {
             if let Err(error) = result {
                 warn!("Reconfiguration finished with error {:?}", error);
             }
-        });
-
-        // Continuously feed the p2p trusted-peer set from the on-chain
-        // {active, next, previous} committee + pending_active_set, refreshed
-        // every few seconds so the pending/next sets stay current mid-epoch.
-        // This is what makes a DIRECT validator dial a registered-but-not-yet-
-        // active joiner (inbound), so a peer-only joiner boots without static
-        // seed peers. Runs on every node for its lifetime.
-        let trusted_peer_node = node.clone();
-        spawn_monitored_task!(async move {
-            ika_core::sui_connector::trusted_peer_updater::refresh_trusted_peers_loop(
-                trusted_peer_sui_client,
-                trusted_peer_node.trusted_peer_change_tx.clone(),
-                // Self-exclusion compares against committee identities, which
-                // are consensus keys — passing the BLS protocol key here made
-                // the node never recognise itself and add itself as a trusted
-                // peer. It compiled only while `AuthorityName` was an alias
-                // for the BLS container.
-                trusted_peer_node.config.authority_name(),
-            )
-            .await;
         });
 
         Ok(node)
@@ -3336,7 +3355,7 @@ impl IkaNode {
                 // (validator last epoch, not this one) must not block on
                 // handoff data it will never use.
                 if self.state.is_validator(&new_epoch_store)
-                    && matches!(
+                    && !matches!(
                         wait_for_handoff_data_ready(
                             &HandoffBarrierContext::from_node(&self),
                             cur_epoch_store.epoch(),
@@ -3347,12 +3366,20 @@ impl IkaNode {
                             &new_epoch_store,
                         )
                         .await,
-                        HandoffBarrierOutcome::FailedClosed
+                        HandoffBarrierOutcome::Ready
                     )
                 {
                     // The cross-epoch anchor is contradicted and the node has
-                    // been signalled to halt. Leave the reconfiguration loop
-                    // instead of starting the epoch's components on it.
+                    // been signalled to halt (the barrier logged why). Leave
+                    // the reconfiguration loop instead of starting the epoch's
+                    // components on it — consensus is already torn down at
+                    // this point, so the node is deliberately inert from here.
+                    error!(
+                        next_epoch,
+                        "prepare-then-start: refusing to enter epoch {next_epoch}; leaving the \
+                         reconfiguration loop with consensus down. The node has been signalled to \
+                         shut down."
+                    );
                     return Ok(());
                 }
 
@@ -3428,7 +3455,7 @@ impl IkaNode {
                     // anchor epoch even though this node was not in that
                     // committee: the store still carries the committee the
                     // cert was signed by and the peers that serve it.
-                    if matches!(
+                    if !matches!(
                         wait_for_handoff_data_ready(
                             &HandoffBarrierContext::from_node(&self),
                             cur_epoch_store.epoch(),
@@ -3437,8 +3464,14 @@ impl IkaNode {
                             &new_epoch_store,
                         )
                         .await,
-                        HandoffBarrierOutcome::FailedClosed
+                        HandoffBarrierOutcome::Ready
                     ) {
+                        error!(
+                            next_epoch,
+                            "prepare-then-start: refusing to promote this node into the epoch \
+                             {next_epoch} committee; leaving the reconfiguration loop. The node \
+                             has been signalled to shut down."
+                        );
                         return Ok(());
                     }
 
@@ -3616,16 +3649,55 @@ enum AnchorCommittee {
     /// Resolved on the boot path, where this process holds no store for the
     /// anchor epoch: the local committee store if this node followed that
     /// epoch, else `validator_set.previous_committee` from chain. This is the
-    /// joiner bootstrap's own resolution, reused. A resolution failure leaves
-    /// the barrier not-ready and it retries — it never lets the epoch start
-    /// on an unverifiable anchor.
+    /// joiner bootstrap's own resolution, reused.
+    ///
+    /// Unlike every other not-ready condition in the barrier, failure here is
+    /// not always transient, so it is the one thing the barrier does NOT wait
+    /// out indefinitely — see `ANCHOR_COMMITTEE_RESOLVE_ATTEMPTS`.
     Resolved {
         committee_store: Arc<CommitteeStore>,
         sui_client: Arc<SuiConnectorClient>,
     },
 }
 
+/// How many times the boot path re-tries resolving the anchor epoch's
+/// committee before giving up and failing the node's startup, and how long it
+/// waits between attempts.
+///
+/// The chain-read fallback refuses to serve `validator_set.previous_committee`
+/// unless the on-chain epoch is exactly `anchor_epoch + 1` — otherwise it
+/// would hand back a committee for the wrong epoch. The barrier's
+/// `anchor_epoch` is fixed at `entering_epoch - 1`, decided from the chain read
+/// this process booted with, so once the chain crosses the next boundary that
+/// condition is false FOREVER. A node whose local committee store also lacks
+/// the epoch (it was down across all of it) would then spin at the barrier
+/// with nothing that could ever satisfy it, inside `start_with_mode` — before
+/// the reconfiguration loop that would re-read the chain, before the admin
+/// server, and before any watchdog arms. Nothing recovers it but an operator.
+///
+/// So this one condition is bounded. Exhausting the budget fails the startup
+/// rather than starting the epoch: the process exits, and its supervisor
+/// restarts it into whatever epoch the chain has actually reached, where the
+/// anchor resolves. That preserves "never start without the verified handoff
+/// data" — the node still does not enter the epoch — while turning an
+/// unrecoverable spin into a self-healing restart. Every other not-ready
+/// condition (cert absent, outputs missing) stays unbounded, because for those
+/// waiting is what makes them resolvable.
+const ANCHOR_COMMITTEE_RESOLVE_ATTEMPTS: u32 = 24;
+const ANCHOR_COMMITTEE_RESOLVE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How often a blocked prepare-then-start barrier re-states what it is still
+/// missing. On the boot path this warn and the `handoff_prepare_waiting` gauge
+/// are the ONLY operator-facing signals: the admin server, the uptime metric
+/// and both watchdogs all come up after node startup returns, which a blocked
+/// boot barrier delays.
+const BARRIER_STALL_WARN_INTERVAL: Duration = Duration::from_secs(10);
+
 impl AnchorCommittee {
+    /// Failures log at debug: the barrier's own periodic warn reports
+    /// `have_signing_committee=false`, and the bounded caller reports the
+    /// give-up at error, so a per-attempt warn inside a retry loop would be
+    /// pure noise.
     async fn resolve(&self, anchor_epoch: EpochId) -> Option<Arc<Committee>> {
         match self {
             Self::Held(committee) => Some(committee.clone()),
@@ -3646,17 +3718,23 @@ impl AnchorCommittee {
                         Some(Arc::new(committee))
                     }
                     Err(error) => {
-                        warn!(
+                        debug!(
                             ?error,
                             anchor_epoch,
-                            "prepare-then-start: failed to resolve the anchor epoch's committee; \
-                             the barrier cannot verify the handoff cert without it and will retry"
+                            "prepare-then-start: failed to resolve the anchor epoch's committee"
                         );
                         None
                     }
                 }
             }
         }
+    }
+
+    /// `true` for the boot path's chain-backed resolution, which is the only
+    /// variant that can fail and therefore the only one the attempt budget
+    /// applies to.
+    fn is_bounded(&self) -> bool {
+        matches!(self, Self::Resolved { .. })
     }
 }
 
@@ -3674,7 +3752,8 @@ enum AnchorOutcome {
     FailedClosed,
 }
 
-/// How the prepare-then-start barrier ended.
+/// How the prepare-then-start barrier ended. Only `Ready` permits the caller
+/// to start the epoch's components.
 enum HandoffBarrierOutcome {
     /// The epoch's full verified handoff data is local — start the epoch's
     /// components.
@@ -3685,6 +3764,11 @@ enum HandoffBarrierOutcome {
     /// shutdown forwarder it would otherwise rely on is not subscribed until
     /// `start_with_mode` returns and the signal would be dropped.
     FailedClosed,
+    /// The anchor epoch's committee could not be resolved within the attempt
+    /// budget, so the certificate cannot be verified at all. Boot path only —
+    /// see `ANCHOR_COMMITTEE_RESOLVE_ATTEMPTS` for why this one condition is
+    /// bounded and why the answer is to fail startup rather than keep waiting.
+    AnchorCommitteeUnresolved,
 }
 
 /// Ensures the cross-epoch trust anchor for the epoch being entered is
@@ -3784,13 +3868,14 @@ async fn prepare_handoff_anchor(
                     anchor_epoch,
                     error = ?e,
                     "prepare-then-start: the locally-persisted handoff cert FAILED \
-                     re-verification. For a next_committee_pubkey_set_hash mismatch the \
-                     likeliest cause is NOT a corrupt DB: the committee is named by consensus \
-                     key, so any member that ROTATED its consensus key at this boundary is \
-                     named differently by the epoch that signed the cert and by this one — \
-                     check for a recent set_next_epoch_consensus_pubkey_bytes. A tampered or \
-                     corrupted local handoff-cert DB is the remaining explanation. Halting the \
-                     node (fail-closed) rather than anchoring the epoch on an unverified cert."
+                     re-verification. Only two things reach this branch: the cert attests a \
+                     different epoch than the one being anchored, or its signatures do not \
+                     reach a stake quorum in the epoch-{anchor_epoch} committee. (A \
+                     next_committee_pubkey_set_hash mismatch does NOT — that is advisory and \
+                     verification proceeds past it.) So suspect a tampered or corrupted local \
+                     handoff-cert DB, or a wrong view of the committee that signed it. Halting \
+                     the node (fail-closed) rather than anchoring the epoch on an unverified \
+                     cert."
                 );
                 ctx.signal_fail_closed();
                 AnchorOutcome::FailedClosed
@@ -3938,15 +4023,24 @@ async fn wait_for_handoff_data_ready(
     }
     let started_at = std::time::Instant::now();
     let mut retries: u64 = 0;
+    // The stall breakdown is emitted on a WALL-CLOCK cadence, not every Nth
+    // retry. One iteration is a second while the barrier is only waiting on
+    // blobs, but up to the anchor fetch's whole attempt budget (five minutes)
+    // when no peer is serving the cert — which is exactly when an operator
+    // needs the breakdown, and is the case where a per-retry cadence would
+    // stretch the interval to the better part of an hour.
+    let mut last_warn_at = std::time::Instant::now();
 
     // The verified anchor is obtained ONCE and reused across iterations: the
     // cert is immutable for the epoch, so re-fetching/re-verifying its
     // committee signatures every second would be pure waste (and on the fetch
     // path, a per-second P2P hammering of converging peers). The signing
     // committee is cached for the same reason — on the boot path resolving it
-    // can cost a chain read.
+    // costs a chain read.
     let mut anchor_cert: Option<CertifiedHandoffAttestation> = None;
     let mut signing_committee: Option<Arc<Committee>> = None;
+    let mut committee_resolve_attempts: u32 = 0;
+    let mut last_committee_resolve_at: Option<std::time::Instant> = None;
     loop {
         // TESTS ONLY (`NodeConfig::withhold_handoff_anchor_for_testing`):
         // hold the anchor back so a test can observe a validator declining to
@@ -3967,8 +4061,39 @@ async fn wait_for_handoff_data_ready(
         // condition 2 reads. `Unavailable` means the anchor is not yet
         // confirmed (propagation lag) — re-attempt next iteration.
         if !withheld && anchor_cert.is_none() {
-            if signing_committee.is_none() {
+            // Resolving the signing committee can cost a chain read, so space
+            // the attempts rather than issuing one per barrier iteration, and
+            // give up after the budget when the resolution is the chain-backed
+            // one — the only failure the barrier cannot wait out.
+            if signing_committee.is_none()
+                && last_committee_resolve_at
+                    .is_none_or(|at| at.elapsed() >= ANCHOR_COMMITTEE_RESOLVE_INTERVAL)
+            {
+                last_committee_resolve_at = Some(std::time::Instant::now());
+                committee_resolve_attempts += 1;
                 signing_committee = anchor_committee.resolve(anchor_epoch).await;
+                if signing_committee.is_none()
+                    && anchor_committee.is_bounded()
+                    && committee_resolve_attempts >= ANCHOR_COMMITTEE_RESOLVE_ATTEMPTS
+                {
+                    error!(
+                        next_epoch,
+                        anchor_epoch,
+                        attempts = committee_resolve_attempts,
+                        "prepare-then-start: could not resolve the epoch-{anchor_epoch} committee \
+                         from the local committee store or from chain, so the handoff certificate \
+                         cannot be verified at all. The likeliest cause is that the chain has \
+                         advanced past epoch {next_epoch} since this process read it at boot — \
+                         the chain-read fallback only serves the previous committee while the \
+                         on-chain epoch is exactly {anchor_epoch}+1. Failing startup rather than \
+                         entering the epoch unanchored; a restart will boot into the epoch the \
+                         chain has actually reached."
+                    );
+                    if let Some(telemetry) = &telemetry {
+                        telemetry.handoff_prepare_waiting.set(0);
+                    }
+                    return HandoffBarrierOutcome::AnchorCommitteeUnresolved;
+                }
             }
             if let Some(committee) = &signing_committee {
                 match prepare_handoff_anchor(
@@ -4049,9 +4174,11 @@ async fn wait_for_handoff_data_ready(
                 .await;
         }
 
-        // Surface the breakdown roughly every 10s so a hang is never silent
-        // on a dashboard or in the logs.
-        if retries.is_multiple_of(10) {
+        // Surface the breakdown at least every 10 SECONDS so a hang is never
+        // silent on a dashboard or in the logs. Wall-clock rather than every
+        // Nth retry: see `last_warn_at`.
+        if last_warn_at.elapsed() >= BARRIER_STALL_WARN_INTERVAL {
+            last_warn_at = std::time::Instant::now();
             let (cert_network_key_items, missing_key_ids, unmapped_cert_keys) = match &cert {
                 Some(cert) => {
                     let total = cert
@@ -4357,10 +4484,12 @@ fn max_tx_per_checkpoint(_: &ProtocolConfig) -> usize {
 /// unmapped key rather than installing anything for it, and once the
 /// background derivation registers the mapping, adoption re-applies the same
 /// cert-digest gate and refuses a local output that contradicts the
-/// certificate. The barrier still guarantees the certificate itself is local,
-/// which is what arms that gate. The cost of passing is liveness, not
-/// safety — the key's sessions park until the stranded-key recovery fills it
-/// (see `specs/handoff.md`), which is exactly what happens today.
+/// certificate. And where the barrier did not manage to persist the
+/// certificate at all (the insert only warns on failure), adoption REJECTS a
+/// reconfigured key outright rather than adopting it cert-less. The cost of
+/// passing is liveness, not safety — the key's sessions park until the
+/// stranded-key recovery fills it (see `specs/handoff.md`), which is exactly
+/// what happens today.
 fn all_cert_network_key_outputs_held_locally(
     cert: &CertifiedHandoffAttestation,
     local_dkg_digests: &BTreeMap<ObjectID, [u8; 32]>,

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -3383,11 +3383,18 @@ impl IkaNode {
                     // the reconfiguration loop instead of starting the epoch's
                     // components on it — consensus is already torn down at
                     // this point, so the node is deliberately inert from here.
+                    //
+                    // Matched as "not Ready" rather than on the contradicted
+                    // variant alone so no future outcome can start the epoch by
+                    // default. Only that variant is reachable here: the anchor
+                    // committee is HELD (the outgoing store's own), so the
+                    // resolution this arm's sibling reports on cannot fail.
                     error!(
                         next_epoch,
-                        "prepare-then-start: refusing to enter epoch {next_epoch}; leaving the \
+                        "prepare-then-start: the cross-epoch anchor for epoch {next_epoch} is \
+                         CONTRADICTED; refusing to enter the epoch and leaving the \
                          reconfiguration loop with consensus down. The node has been signalled to \
-                         shut down."
+                         shut down (the barrier logged which contradiction)."
                     );
                     return Ok(());
                 }
@@ -3477,9 +3484,11 @@ impl IkaNode {
                     ) {
                         error!(
                             next_epoch,
-                            "prepare-then-start: refusing to promote this node into the epoch \
-                             {next_epoch} committee; leaving the reconfiguration loop. The node \
-                             has been signalled to shut down."
+                            "prepare-then-start: the cross-epoch anchor for epoch \
+                             {next_epoch} is CONTRADICTED; refusing to promote this node into \
+                             that committee and leaving the reconfiguration loop. The node has \
+                             been signalled to shut down (the barrier logged which \
+                             contradiction)."
                         );
                         return Ok(());
                     }

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -2988,15 +2988,19 @@ impl IkaNode {
                                             prior_epoch,
                                             error = ?e,
                                             "the locally-persisted handoff cert FAILED \
-                                             re-verification at epoch start — the local \
-                                             handoff-cert DB is tampered or corrupted — \
-                                             but for a next_committee_pubkey_set_hash \
-                                             mismatch, suspect first a member that rotated \
-                                             its consensus key at this boundary (v6 names \
-                                             the committee by consensus key), or the \
-                                             one-off v5->v6 identity flip. \
-                                             Halting the node (fail-closed) rather than \
-                                             anchoring the epoch on an unverified cert."
+                                             re-verification at epoch start. Only two \
+                                             things reach this branch: the cert attests a \
+                                             different epoch than the prior epoch \
+                                             {prior_epoch} this joiner expected, or its \
+                                             signatures do not reach a stake quorum in the \
+                                             epoch-{prior_epoch} committee. (A \
+                                             next_committee_pubkey_set_hash mismatch does \
+                                             NOT — that is advisory and verification \
+                                             proceeds past it.) So suspect a tampered or \
+                                             corrupted local handoff-cert DB, or a wrong \
+                                             view of the committee that signed it. Halting \
+                                             the node (fail-closed) rather than anchoring \
+                                             the epoch on an unverified cert."
                                         );
                                         let _ = fail_closed_shutdown.send(None);
                                         return;

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -2855,13 +2855,22 @@ impl IkaNode {
                     // bootstrap already chain-reads consensus pubkeys from) so
                     // bootstrap can still run.
                     None => match fetch_previous_committee(&sui_client, prior_epoch).await {
-                        Ok(committee) => {
+                        Ok(Some(committee)) => {
                             info!(
                                 prior_epoch,
                                 "prior committee absent locally; chain-read it for joiner \
                                  bootstrap from validator_set.previous_committee"
                             );
                             Some(Arc::new(committee))
+                        }
+                        Ok(None) => {
+                            info!(
+                                prior_epoch,
+                                "chain holds no committee for the prior epoch — this network's \
+                                 first off-chain epoch is the current one, so no handoff cert \
+                                 exists for {prior_epoch} and there is nothing to bootstrap"
+                            );
+                            None
                         }
                         Err(error) => {
                             warn!(
@@ -3693,37 +3702,54 @@ const ANCHOR_COMMITTEE_RESOLVE_INTERVAL: Duration = Duration::from_secs(5);
 /// boot barrier delays.
 const BARRIER_STALL_WARN_INTERVAL: Duration = Duration::from_secs(10);
 
+/// What resolving the anchor epoch's committee produced.
+enum AnchorCommitteeResolution {
+    /// The committee that signed the anchor epoch's handoff certificate.
+    Resolved(Arc<Committee>),
+    /// The chain says NO committee preceded the epoch being entered: this
+    /// network's first off-chain epoch is the current one, so the anchor epoch
+    /// never ran, no certificate was ever minted for it, and none ever will
+    /// be. Genesis-equivalent — the barrier has nothing to wait for and must
+    /// not block. Distinct from `Unavailable` because it is a chain ANSWER,
+    /// and waiting on it is a permanent wedge rather than a delay.
+    NoPredecessorEpoch,
+    /// Not answerable this attempt — a chain read failed, or the chain has
+    /// moved past the epoch whose predecessor we are asking about.
+    Unavailable,
+}
+
 impl AnchorCommittee {
     /// Failures log at debug: the barrier's own periodic warn reports
     /// `have_signing_committee=false`, and the bounded caller reports the
     /// give-up at error, so a per-attempt warn inside a retry loop would be
     /// pure noise.
-    async fn resolve(&self, anchor_epoch: EpochId) -> Option<Arc<Committee>> {
+    async fn resolve(&self, anchor_epoch: EpochId) -> AnchorCommitteeResolution {
         match self {
-            Self::Held(committee) => Some(committee.clone()),
+            Self::Held(committee) => AnchorCommitteeResolution::Resolved(committee.clone()),
             Self::Resolved {
                 committee_store,
                 sui_client,
             } => {
                 if let Ok(Some(committee)) = committee_store.get_committee(&anchor_epoch) {
-                    return Some(committee);
+                    return AnchorCommitteeResolution::Resolved(committee);
                 }
                 match fetch_previous_committee(sui_client, anchor_epoch).await {
-                    Ok(committee) => {
+                    Ok(Some(committee)) => {
                         info!(
                             anchor_epoch,
                             "prepare-then-start: anchor committee absent locally; chain-read it \
                              from validator_set.previous_committee"
                         );
-                        Some(Arc::new(committee))
+                        AnchorCommitteeResolution::Resolved(Arc::new(committee))
                     }
+                    Ok(None) => AnchorCommitteeResolution::NoPredecessorEpoch,
                     Err(error) => {
                         debug!(
                             ?error,
                             anchor_epoch,
                             "prepare-then-start: failed to resolve the anchor epoch's committee"
                         );
-                        None
+                        AnchorCommitteeResolution::Unavailable
                     }
                 }
             }
@@ -4071,7 +4097,35 @@ async fn wait_for_handoff_data_ready(
             {
                 last_committee_resolve_at = Some(std::time::Instant::now());
                 committee_resolve_attempts += 1;
-                signing_committee = anchor_committee.resolve(anchor_epoch).await;
+                match anchor_committee.resolve(anchor_epoch).await {
+                    AnchorCommitteeResolution::Resolved(committee) => {
+                        signing_committee = Some(committee);
+                    }
+                    // No epoch preceded this one off-chain, so no certificate
+                    // was ever minted for `anchor_epoch` and none ever will
+                    // be. This is the genesis case one epoch along: a network
+                    // whose validators come up for the first time already at
+                    // epoch 1 has exactly this shape. Blocking would wedge
+                    // every validator on the network's own first epoch, so
+                    // pass — loudly, because on an established network this
+                    // would mean the chain lost its previous committee.
+                    AnchorCommitteeResolution::NoPredecessorEpoch => {
+                        if let Some(telemetry) = &telemetry {
+                            telemetry.handoff_prepare_waiting.set(0);
+                        }
+                        info!(
+                            next_epoch,
+                            anchor_epoch,
+                            "prepare-then-start: the chain holds no committee for epoch \
+                             {anchor_epoch}, so no handoff certificate exists for it and none \
+                             ever will — this network's first off-chain epoch is \
+                             {next_epoch}. Entering it without a cross-epoch anchor, the same \
+                             as entering epoch 0 at genesis."
+                        );
+                        return HandoffBarrierOutcome::Ready;
+                    }
+                    AnchorCommitteeResolution::Unavailable => {}
+                }
                 if signing_committee.is_none()
                     && anchor_committee.is_bounded()
                     && committee_resolve_attempts >= ANCHOR_COMMITTEE_RESOLVE_ATTEMPTS

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -9,7 +9,7 @@ use anemo_tower::trace::DefaultOnFailure;
 use anemo_tower::trace::TraceLayer;
 use anyhow::{Result, anyhow};
 use arc_swap::ArcSwap;
-use prometheus::Registry;
+use prometheus::{IntCounterVec, Registry};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt;
 use std::path::PathBuf;
@@ -64,7 +64,13 @@ use ika_core::dwallet_checkpoints::{
 use ika_core::epoch::committee_store::CommitteeStore;
 use ika_core::epoch::consensus_store_pruner::ConsensusStorePruner;
 use ika_core::epoch::epoch_metrics::EpochMetrics;
+use ika_core::epoch_tasks::joiner_bootstrap_verifier::{
+    BootstrapOutcome, BootstrapRetryConfig, CertVerifier, JoinerBootstrapVerifier,
+    P2pHandoffCertSource,
+};
 use ika_core::storage::RocksDbStore;
+use ika_core::sui_connector::pubkey_provider_updater::fetch_previous_committee;
+use ika_core::validator_metadata::{next_committee_pubkey_set, verify_joiner_bootstrap_cert};
 use ika_network::discovery::TrustedPeerChangeEvent;
 use ika_network::{discovery, state_sync};
 use ika_protocol_config::{ProtocolConfig, ProtocolVersion};
@@ -1366,7 +1372,64 @@ impl IkaNode {
                  validator mode; validator duties will not start"
             );
         }
+        // Set up before the boot barrier below so the barrier can signal a
+        // fail-closed halt on it. Nothing subscribes until this function
+        // returns, which is exactly why the barrier ALSO reports the halt to
+        // its caller here (see `HandoffBarrierOutcome::FailedClosed`).
+        let (shutdown_channel, _) = broadcast::channel::<Option<RunWithRange>>(1);
+
         let validator_components = if mode.is_validator() && is_committee_member {
+            // Prepare-then-start barrier on the BOOT path: a process starting
+            // (or restarting) straight into an epoch reaches consensus and MPC
+            // through here, not through the reconfiguration seam, so without
+            // this it could enter consensus and take NOA presign demands
+            // naming a network key it holds no verified material for. Blocking
+            // here — before `construct_validator_components`, which is what
+            // spawns consensus — is the boot-path equivalent of blocking
+            // before the seam's `start_epoch_specific_validator_components`.
+            //
+            // The epoch's handoff anchor is the PREVIOUS epoch's certificate,
+            // and this process holds no store for that epoch, so the signing
+            // committee is resolved from the local committee store or from
+            // chain. Entering epoch 0 has no predecessor to be handed off
+            // from — the chain-true no-cert genesis epoch — and is skipped on
+            // the same `>= 1` test the joiner bootstrap uses.
+            if epoch_store.epoch() >= 1 {
+                let barrier = HandoffBarrierContext {
+                    p2p_network: p2p_network.clone(),
+                    perpetual_tables: perpetual_tables.clone(),
+                    shutdown_channel_tx: shutdown_channel.clone(),
+                    bootstrap_outcomes: ika_node_metrics.joiner_bootstrap_outcomes_total.clone(),
+                    telemetry: validator_metrics
+                        .as_ref()
+                        .map(|metrics| metrics.telemetry.clone()),
+                    withhold_anchor_for: config.withhold_handoff_anchor_for_testing,
+                };
+                let anchor_committee = AnchorCommittee::Resolved {
+                    committee_store: state.committee_store().clone(),
+                    sui_client: sui_client.clone(),
+                };
+                if matches!(
+                    wait_for_handoff_data_ready(
+                        &barrier,
+                        epoch_store.epoch() - 1,
+                        &anchor_committee,
+                        &epoch_peer_ids(&epoch_store),
+                        &epoch_store,
+                    )
+                    .await,
+                    HandoffBarrierOutcome::FailedClosed
+                ) {
+                    // The shutdown signal the barrier sent has no subscriber
+                    // this early, so halt by failing the start instead: the
+                    // node runner exits the process on a start error.
+                    return Err(anyhow!(
+                        "cross-epoch handoff anchor for epoch {} is contradicted; refusing to \
+                         start validator components (fail-closed)",
+                        epoch_store.epoch() - 1
+                    ));
+                }
+            }
             let components = Self::construct_validator_components(
                 config.clone(),
                 state.clone(),
@@ -1395,9 +1458,6 @@ impl IkaNode {
         } else {
             None
         };
-
-        // setup shutdown channel
-        let (shutdown_channel, _) = broadcast::channel::<Option<RunWithRange>>(1);
 
         // Per-epoch authority store directories grow unbounded without
         // pruning, and everything later epochs depend on lives in the
@@ -2723,8 +2783,28 @@ impl IkaNode {
             // the E-1 handoff cert (signed by the E-1 committee, pinning
             // the handoff into E). Fetch it from current-committee peers
             // and verify it (epoch-bound, prior committee, next-committee
-            // pubkey-set hash). Surfaces a tampered/wrong bootstrap; does
-            // not halt on failure.
+            // pubkey-set hash).
+            //
+            // For a VALIDATOR this is now a no-op re-check: every path that
+            // starts a validator's epoch components blocks on the
+            // prepare-then-start barrier first, and the barrier anchors this
+            // same epoch inline, so by the time this task runs the cert is
+            // already persisted and the outputs installed — it re-verifies
+            // and returns. It is kept because it is NOT redundant off the
+            // validator paths: a process that runs this loop without ever
+            // constructing validator components — one whose key is in the
+            // committee while the process is not in validator mode, or a
+            // fullnode following the epoch — never reaches the barrier, and
+            // this is what keeps its handoff cert and off-chain network-key
+            // overlay populated (and, when its key is in the committee,
+            // servable to peers still fetching). The barrier NEVER waits on
+            // this task: it runs from inside the epoch's own run loop, which
+            // is after the barrier by construction.
+            //
+            // A contradicted anchor (peers served certs and none verified, or
+            // a persisted cert that no longer verifies) halts the node
+            // fail-closed, the same as in the barrier; absence alone only
+            // warns.
             let joiner_bootstrap_handle = if cur_epoch_store.epoch() >= 1 {
                 use ika_core::epoch_tasks::joiner_bootstrap_verifier::{
                     BootstrapOutcome, BootstrapRetryConfig, CertVerifier, JoinerBootstrapVerifier,
@@ -3255,14 +3335,25 @@ impl IkaNode {
                 // so only it prepares. A node leaving the committee
                 // (validator last epoch, not this one) must not block on
                 // handoff data it will never use.
-                if self.state.is_validator(&new_epoch_store) {
-                    self.wait_for_handoff_data_ready(
-                        next_epoch,
-                        cur_epoch_store.epoch(),
-                        &cur_epoch_store,
-                        &new_epoch_store,
+                if self.state.is_validator(&new_epoch_store)
+                    && matches!(
+                        wait_for_handoff_data_ready(
+                            &HandoffBarrierContext::from_node(&self),
+                            cur_epoch_store.epoch(),
+                            // The epoch we are leaving IS the anchor epoch,
+                            // so its committee is in hand.
+                            &AnchorCommittee::Held(cur_epoch_store.committee().clone()),
+                            &epoch_peer_ids(&cur_epoch_store),
+                            &new_epoch_store,
+                        )
+                        .await,
+                        HandoffBarrierOutcome::FailedClosed
                     )
-                    .await;
+                {
+                    // The cross-epoch anchor is contradicted and the node has
+                    // been signalled to halt. Leave the reconfiguration loop
+                    // instead of starting the epoch's components on it.
+                    return Ok(());
                 }
 
                 if self.state.is_validator(&new_epoch_store) {
@@ -3327,6 +3418,29 @@ impl IkaNode {
 
                 if self.mode.is_validator() && is_committee_member {
                     info!("Promoting the node from fullnode to validator, starting grpc server");
+
+                    // Prepare-then-start barrier, same contract as the
+                    // continuing-validator seam above: a node promoted INTO
+                    // the committee needs the epoch's verified handoff data
+                    // before its MPC components exist, and it is the node
+                    // LEAST likely to already hold it — it computed none of
+                    // the outputs itself. The epoch it is leaving is the
+                    // anchor epoch even though this node was not in that
+                    // committee: the store still carries the committee the
+                    // cert was signed by and the peers that serve it.
+                    if matches!(
+                        wait_for_handoff_data_ready(
+                            &HandoffBarrierContext::from_node(&self),
+                            cur_epoch_store.epoch(),
+                            &AnchorCommittee::Held(cur_epoch_store.committee().clone()),
+                            &epoch_peer_ids(&cur_epoch_store),
+                            &new_epoch_store,
+                        )
+                        .await,
+                        HandoffBarrierOutcome::FailedClosed
+                    ) {
+                        return Ok(());
+                    }
 
                     Some(
                         Self::construct_validator_components(
@@ -3415,469 +3529,6 @@ impl IkaNode {
         new_epoch_store
     }
 
-    /// Ensures the cross-epoch trust anchor for the epoch we are entering
-    /// is locally present + verified, fetching it inline if it is not.
-    ///
-    /// Every validator anchors the epoch it enters (`anchor_epoch + 1`) on
-    /// the `anchor_epoch` handoff cert — the cert the `anchor_epoch`
-    /// committee produced, pinning the handoff into `anchor_epoch + 1` (it
-    /// certifies the network-key output digests the new epoch inherits and
-    /// binds the hash of the new committee's pubkey set). A continuing
-    /// validator that crossed quorum at `anchor_epoch`'s EndOfPublish has
-    /// already persisted this cert; for anyone missing it (a joiner, or a
-    /// continuing validator that didn't observe quorum) it must be
-    /// fetched + verified + persisted here.
-    ///
-    /// This is the synchronous, inline-awaited sibling of the
-    /// `joiner_bootstrap_handle` task spawned at epoch start: that task
-    /// anchors the *prior* epoch and runs in the *next* loop iteration,
-    /// which is too late for the prepare-then-start barrier at the
-    /// reconfigure seam (the barrier would deadlock waiting on a cert that
-    /// nothing fetches until after the barrier). So the barrier calls this
-    /// directly for `anchor_epoch = cur_epoch`.
-    ///
-    /// `anchor_epoch` here is the *current* epoch, so the committee that
-    /// signed the cert is the one we are still in (`cur_epoch_store`'s
-    /// committee) and whose consensus pubkeys come from the current active
-    /// validator set — no chain read of a departed prior committee is
-    /// needed (unlike the prior-epoch joiner-bootstrap path).
-    ///
-    /// REDUNDANT VERIFICATION (defense in depth): a handoff cert is
-    /// verified TWICE in its lifetime. The first verification is in the
-    /// bootstrap fetch path, before the cert is ever written to the local
-    /// DB. The second is HERE, when the cert is *consumed* to anchor the
-    /// new epoch — a persisted cert is ALWAYS re-verified against the
-    /// signing committee before it is allowed to anchor, so a corrupted or
-    /// tampered local handoff-cert DB cannot silently anchor an epoch on a
-    /// cert that no longer verifies. The same `verify` closure backs both
-    /// the persisted-cert re-check and the fetch path's per-candidate
-    /// verification.
-    ///
-    /// Returns `Some(cert)` — the verified anchor cert — iff one is locally
-    /// present afterward, so the caller can read the output digests it
-    /// certifies without a second DB read. Returns `None` when the anchor
-    /// is not yet confirmed (no peer served a cert within the attempt
-    /// budget — propagation lag, re-attempt) OR after fail-closing (halts
-    /// the node via the shutdown channel) when a persisted cert fails
-    /// re-verification (tampered/corrupted DB), or when peers served certs
-    /// but none verified against the signing committee — a genuine
-    /// cross-epoch trust-anchor mismatch (a possible eclipse), not
-    /// something to limp past.
-    async fn prepare_handoff_anchor(
-        &self,
-        anchor_epoch: EpochId,
-        cur_epoch_store: &AuthorityPerEpochStore,
-        new_epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> Option<CertifiedHandoffAttestation> {
-        use ika_core::epoch_tasks::joiner_bootstrap_verifier::{
-            BootstrapOutcome, BootstrapRetryConfig, CertVerifier, JoinerBootstrapVerifier,
-            P2pHandoffCertSource,
-        };
-        use ika_core::validator_metadata::{
-            next_committee_pubkey_set, verify_joiner_bootstrap_cert,
-        };
-        use ika_types::sui::epoch_start_system::EpochStartSystemTrait;
-
-        // Build the verification closure FIRST so it can re-verify a
-        // persisted cert as well as back the fetch path. The signing
-        // committee is the one we are still in: `anchor_epoch` is
-        // `cur_epoch`, and `cur_epoch_store.committee()` is exactly that
-        // committee. Its members' consensus pubkeys are fixed at
-        // registration and are in the current active validator set.
-        let signing_committee = cur_epoch_store.committee().as_ref().clone();
-        // The cert pins the hash of the committee being handed into —
-        // the epoch we are entering, whose committee is `new_epoch_store`'s.
-        let expected_next = next_committee_pubkey_set(new_epoch_store.committee());
-        let peer_ids: Vec<anemo::PeerId> = cur_epoch_store
-            .epoch_start_state()
-            .get_authority_names_to_peer_ids()
-            .into_values()
-            .collect();
-
-        // The signing committee carries its members' consensus keys, so it
-        // serves as the cert verifier's consensus-pubkey provider directly.
-        let verify: CertVerifier = Arc::new(move |cert| {
-            verify_joiner_bootstrap_cert(
-                cert,
-                anchor_epoch,
-                &signing_committee,
-                &signing_committee,
-                expected_next.iter().copied(),
-            )
-        });
-
-        // SECOND verification (the first was before this cert was written
-        // to the DB in the bootstrap path): a persisted cert must NOT
-        // silently anchor an epoch — re-verify it now. A tampered or
-        // corrupted local handoff-cert DB fails here and fail-closes
-        // rather than anchoring the new epoch on a cert that no longer
-        // verifies against the signing committee.
-        if let Some(persisted) = new_epoch_store
-            .get_certified_handoff_attestation(anchor_epoch)
-            .ok()
-            .flatten()
-        {
-            return match verify(&persisted) {
-                Ok(()) => {
-                    // Holding the cert does NOT imply holding the network-key
-                    // outputs it certifies: a lagging validator can adopt the
-                    // cert from a buffered peer-signature quorum (see
-                    // `quorum_attestation_in_buffer`) without ever computing or
-                    // caching those outputs. The barrier's condition 2 requires
-                    // every certified reconfiguration output held locally, so
-                    // fetch + cache them now (idempotent — a no-op when already
-                    // present). Without this a cert-but-no-outputs validator
-                    // blocks at the barrier forever, never enters the epoch, and
-                    // never publishes its mpc_data — wedging the next
-                    // reconfiguration's committee assembly at sub-full coverage.
-                    install_joiner_network_key_outputs(
-                        &persisted,
-                        &self.p2p_network,
-                        &peer_ids,
-                        new_epoch_store,
-                    )
-                    .await;
-                    Some(persisted)
-                }
-                Err(e) => {
-                    error!(
-                        anchor_epoch,
-                        error = ?e,
-                        "prepare-then-start: the locally-persisted handoff cert FAILED \
-                         re-verification. For a next_committee_pubkey_set_hash mismatch the \
-                         likeliest cause is NOT a corrupt DB: at protocol v6 the committee is \
-                         named by consensus key, so any member that ROTATED its consensus key \
-                         at this boundary is named differently by the epoch that signed the \
-                         cert and by this one — check for a recent \
-                         set_next_epoch_consensus_pubkey_bytes. The one-off v5->v6 identity \
-                         flip produces the same mismatch. A tampered or corrupted local \
-                         handoff-cert DB is the remaining explanation. Halting the node \
-                         (fail-closed) rather than anchoring the epoch on an unverified cert."
-                    );
-                    let _ = self.shutdown_channel_tx.send(None);
-                    None
-                }
-            };
-        }
-
-        // Absent from the DB — fetch + verify + persist + install.
-        info!(
-            anchor_epoch,
-            "prepare-then-start: anchor cert for the epoch being entered is not held locally; \
-             fetching + verifying it inline from peers before starting MPC"
-        );
-
-        let source = Arc::new(P2pHandoffCertSource::new(
-            self.p2p_network.clone(),
-            peer_ids.clone(),
-        ));
-        let verifier = JoinerBootstrapVerifier::new(
-            anchor_epoch,
-            source,
-            verify,
-            BootstrapRetryConfig {
-                retry_interval: Duration::from_secs(10),
-                max_attempts: 30,
-            },
-        );
-
-        match verifier.run().await {
-            BootstrapOutcome::Verified(cert) => {
-                self.metrics
-                    .joiner_bootstrap_outcomes_total
-                    .with_label_values(&["verified"])
-                    .inc();
-                // Persist the verified anchor so network-key
-                // instantiation can read it locally and this node can
-                // serve it to peers still fetching.
-                if let Err(e) = self
-                    .state
-                    .perpetual_tables()
-                    .insert_certified_handoff_attestation(anchor_epoch, &cert)
-                {
-                    warn!(error = ?e, anchor_epoch, "failed to persist anchor handoff cert");
-                }
-                install_joiner_network_key_outputs(
-                    &cert,
-                    &self.p2p_network,
-                    &peer_ids,
-                    new_epoch_store,
-                )
-                .await;
-                Some(*cert)
-            }
-            BootstrapOutcome::Rejected => {
-                self.metrics
-                    .joiner_bootstrap_outcomes_total
-                    .with_label_values(&["rejected"])
-                    .inc();
-                // Fail-closed: peers served certs but NONE verified
-                // against the signing committee — a genuine cross-epoch
-                // trust-anchor mismatch (a wrong committee view, or every
-                // reachable peer serving certs for the wrong committee, a
-                // possible eclipse). Refuse to participate on a broken
-                // anchor: halt so an operator investigates rather than
-                // silently entering the epoch on an unverified handoff.
-                error!(
-                    anchor_epoch,
-                    "prepare-then-start: cross-epoch anchor REJECTED — halting the node \
-                     (fail-closed). Investigate a wrong committee view or peers serving certs \
-                     for the wrong committee (possible eclipse)."
-                );
-                let _ = self.shutdown_channel_tx.send(None);
-                None
-            }
-            // No peer served a cert within the attempt budget
-            // (propagation lag) — the anchor is unconfirmed, not
-            // contradicted. The barrier will re-attempt.
-            BootstrapOutcome::Unavailable => {
-                self.metrics
-                    .joiner_bootstrap_outcomes_total
-                    .with_label_values(&["unavailable"])
-                    .inc();
-                None
-            }
-        }
-    }
-
-    /// Prepare-then-start barrier: blocks until the full handoff data for
-    /// the epoch being entered (`next_epoch`) is locally present AND
-    /// verified, then returns so the new epoch's MPC components may start.
-    ///
-    /// WHY THIS EXISTS: without it, the new epoch's MPC components start
-    /// immediately at the reconfigure seam while the network-key handoff
-    /// data still arrives asynchronously. A validator can then begin
-    /// epoch-N signing with STALE (epoch N-1) network-key shares, and
-    /// threshold sign rounds fail with `FailedToAdvanceMPC(InvalidParameters)`.
-    /// Starting the epoch stale is never acceptable, so this blocks
-    /// INDEFINITELY (no timeout): a stuck validator that is visibly not
-    /// signing is strictly safer than one signing with the wrong shares.
-    ///
-    /// The barrier waits on two conditions, both grounded in off-chain data
-    /// (the verified handoff cert + this validator's local outputs) — no
-    /// chain state, and no dependency on the chain-fed `network_keys_receiver`:
-    ///   1. The cross-epoch trust anchor (the `cur_epoch` handoff cert) is
-    ///      locally present + verified — `prepare_handoff_anchor` returns it,
-    ///      fetching it inline if missing.
-    ///   2. Every network-key output item the cert certifies —
-    ///      `NetworkReconfigurationOutput` AND `NetworkDkgOutput` — is held
-    ///      locally with a digest matching the cert. The cert's single
-    ///      `epoch` field scopes the whole handoff, so there is no per-key
-    ///      epoch to check — only per-key presence: reconfiguration outputs
-    ///      in this validator's epoch-keyed digest slice (keyed by
-    ///      `cur_epoch`, the reconfiguration session's epoch), DKG outputs in
-    ///      the NEW epoch store's merged view (empty per-epoch table → the
-    ///      perpetual canonical mirror — the value the installer repairs; the
-    ///      outgoing store's per-epoch table is exactly what the end-of-epoch
-    ///      hydration may have poisoned, issue #1852). A continuing validator
-    ///      caches its own MPC output; `prepare_handoff_anchor` and the
-    ///      per-retry installer fetch + cache missing/mismatching outputs
-    ///      from peers. See `all_cert_network_key_outputs_held_locally`.
-    async fn wait_for_handoff_data_ready(
-        &self,
-        next_epoch: EpochId,
-        cur_epoch: EpochId,
-        cur_epoch_store: &AuthorityPerEpochStore,
-        new_epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) {
-        info!(
-            next_epoch,
-            "prepare-then-start: awaiting full verified handoff data for epoch {next_epoch} \
-             before starting MPC"
-        );
-        // Present in validator mode, which is the only mode that reaches this
-        // barrier; the families are not registered anywhere else.
-        let telemetry = self.validator_telemetry.clone();
-        if let Some(telemetry) = &telemetry {
-            telemetry.handoff_prepare_waiting.set(1);
-        }
-        let started_at = std::time::Instant::now();
-        let mut retries: u64 = 0;
-
-        // The verified anchor is obtained ONCE and reused across iterations:
-        // the cert is immutable for the epoch, so re-fetching/re-verifying its
-        // committee signatures every second would be pure waste (and on the
-        // fetch path, a per-second P2P hammering of converging peers).
-        let mut anchor_cert: Option<CertifiedHandoffAttestation> = None;
-        loop {
-            // Condition 1: the cross-epoch trust anchor — the `cur_epoch`
-            // handoff cert — is present + verified. `prepare_handoff_anchor`
-            // returns it (re-verified) when already held, fetches + verifies
-            // + persists it inline when missing, and also fetches + caches
-            // the certified outputs this node is missing into the local
-            // digest slice condition 2 reads. `None` means the anchor is not
-            // yet confirmed (propagation lag) — re-attempt next iteration.
-            if anchor_cert.is_none() {
-                anchor_cert = self
-                    .prepare_handoff_anchor(cur_epoch, cur_epoch_store, new_epoch_store)
-                    .await;
-            }
-            let cert = anchor_cert.as_ref();
-
-            // Condition 2: every network-key output the cert certifies —
-            // reconfiguration AND DKG — is held locally with a digest
-            // matching the cert. Grounded entirely in the verified cert (the
-            // off-chain anchor) and this validator's own digest slices — no
-            // chain state, and no per-key epoch (the cert's single epoch
-            // scopes the whole handoff). A read error is treated as
-            // not-ready (empty slice); the periodic WARN below surfaces a
-            // persistent failure.
-            //
-            // The reconfiguration slice is keyed by the reconfiguration
-            // session's epoch (`cur_epoch`) on the outgoing store. The DKG
-            // digests are read from the NEW epoch store deliberately: its
-            // per-epoch table is empty at entry, so the merged view is the
-            // perpetual canonical mirror — the exact value the installer
-            // repairs. Reading them from the outgoing store would consult
-            // its per-epoch table first, which is precisely what the
-            // end-of-epoch hydration pass may have poisoned (the issue
-            // #1852 clobber variant), and the repaired perpetual value
-            // would never win — deadlocking this barrier.
-            let local_reconfiguration_digests = cur_epoch_store
-                .get_network_reconfiguration_output_digests_for_epoch(cur_epoch)
-                .unwrap_or_default();
-            let local_dkg_digests = new_epoch_store
-                .get_network_dkg_output_digests()
-                .unwrap_or_default();
-            let ready = cert.is_some_and(|cert| {
-                all_cert_network_key_outputs_held_locally(
-                    cert,
-                    &local_dkg_digests,
-                    &local_reconfiguration_digests,
-                )
-            });
-
-            if ready {
-                let elapsed = started_at.elapsed();
-                if let Some(telemetry) = &telemetry {
-                    telemetry.handoff_prepare_waiting.set(0);
-                    telemetry
-                        .handoff_prepare_duration_seconds
-                        .observe(elapsed.as_secs_f64());
-                }
-                info!(
-                    next_epoch,
-                    "prepare-then-start: epoch {next_epoch} handoff data ready+verified after \
-                     {}s, {retries} retries; starting MPC",
-                    elapsed.as_secs()
-                );
-                return;
-            }
-
-            retries += 1;
-            if let Some(telemetry) = &telemetry {
-                telemetry.handoff_prepare_retries_total.inc();
-            }
-
-            // Anchor held but some certified output still missing locally:
-            // retry fetching JUST the missing ones (the local-presence
-            // precheck inside skips everything already held, so this is not
-            // a refetch of held blobs).
-            if let Some(cert) = cert {
-                let peer_ids: Vec<anemo::PeerId> = cur_epoch_store
-                    .epoch_start_state()
-                    .get_authority_names_to_peer_ids()
-                    .into_values()
-                    .collect();
-                install_joiner_network_key_outputs(
-                    cert,
-                    &self.p2p_network,
-                    &peer_ids,
-                    new_epoch_store,
-                )
-                .await;
-            }
-
-            // Surface the breakdown roughly every 10s so a hang is never
-            // silent on a dashboard or in the logs.
-            if retries.is_multiple_of(10) {
-                let (cert_network_key_items, missing_key_ids, unmapped_cert_keys) = match &cert {
-                    Some(cert) => {
-                        let total = cert
-                            .attestation
-                            .items
-                            .iter()
-                            .filter(|(item, _)| {
-                                matches!(
-                                    item,
-                                    HandoffItemKey::NetworkReconfigurationOutput { .. }
-                                        | HandoffItemKey::NetworkDkgOutput { .. }
-                                )
-                            })
-                            .count();
-                        let missing: Vec<ObjectID> = cert
-                            .attestation
-                            .items
-                            .iter()
-                            .filter_map(|(item, digest)| {
-                                // Cert keys by NetworkKeyId; local digests by
-                                // ObjectID — translate via the temporary map.
-                                let (key_id, local_digests) = match item {
-                                    HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
-                                        (key_id, &local_reconfiguration_digests)
-                                    }
-                                    HandoffItemKey::NetworkDkgOutput { key_id } => {
-                                        (key_id, &local_dkg_digests)
-                                    }
-                                    HandoffItemKey::ValidatorMpcData { .. } => return None,
-                                };
-                                let object_id =
-                                    ika_core::network_key_id_mapping::object_id_for(key_id)?;
-                                (local_digests.get(&object_id) != Some(digest)).then_some(object_id)
-                            })
-                            .collect();
-                        // Cert keys with NO ObjectID mapping (this validator
-                        // never instantiated the key and it is not seeded)
-                        // are exactly the keys the gate can never satisfy,
-                        // yet the translation above drops them from
-                        // `missing` — report them separately so an
-                        // unmapped-key wedge no longer reads as
-                        // `missing_locally=0`. The MPC service's adoption
-                        // pass derives and registers the mapping in the
-                        // background; this state should clear on its own.
-                        // A key with both a DKG and a reconfiguration item
-                        // would list twice — dedup via the ordered set.
-                        let unmapped: BTreeSet<NetworkKeyId> = cert
-                            .attestation
-                            .items
-                            .iter()
-                            .filter_map(|(item, _)| match item {
-                                HandoffItemKey::NetworkReconfigurationOutput { key_id }
-                                | HandoffItemKey::NetworkDkgOutput { key_id }
-                                    if ika_core::network_key_id_mapping::object_id_for(key_id)
-                                        .is_none() =>
-                                {
-                                    Some(*key_id)
-                                }
-                                _ => None,
-                            })
-                            .collect();
-                        let unmapped: Vec<NetworkKeyId> = unmapped.into_iter().collect();
-                        (total, missing, unmapped)
-                    }
-                    None => (0, Vec::new(), Vec::new()),
-                };
-                warn!(
-                    next_epoch,
-                    cur_epoch,
-                    have_cert = cert.is_some(),
-                    cert_network_key_items,
-                    missing_locally = missing_key_ids.len(),
-                    missing_key_ids = ?missing_key_ids,
-                    unmapped_cert_keys = ?unmapped_cert_keys,
-                    retries,
-                    "prepare-then-start: still awaiting full verified handoff data for epoch \
-                     {next_epoch}"
-                );
-            }
-
-            // Re-check after 1s. No timeout — block indefinitely
-            // (safety-first: never start the epoch without the verified
-            // handoff outputs the cert certifies).
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-    }
-
     pub fn get_config(&self) -> &NodeConfig {
         &self.config
     }
@@ -3894,6 +3545,598 @@ impl IkaNode {
         self.sim_state
             .sim_safe_mode_expected
             .store(new_value, Ordering::Relaxed);
+    }
+}
+
+/// The anemo peer ids of an epoch's committee — who the barrier asks for the
+/// handoff certificate and the network-key output blobs it certifies.
+fn epoch_peer_ids(epoch_store: &AuthorityPerEpochStore) -> Vec<PeerId> {
+    epoch_store
+        .epoch_start_state()
+        .get_authority_names_to_peer_ids()
+        .into_values()
+        .collect()
+}
+
+/// The process-level handles the prepare-then-start barrier needs, whichever
+/// path entered it.
+///
+/// Assembled from the live `IkaNode` on the reconfiguration and
+/// fullnode-to-validator promotion paths, and from the locals in
+/// `start_with_mode` on the boot path — there the barrier has to run BEFORE
+/// the validator components are constructed, and constructing them is part of
+/// producing the node, so no `IkaNode` exists yet to hang a method off.
+struct HandoffBarrierContext {
+    p2p_network: Network,
+    perpetual_tables: Arc<AuthorityPerpetualTables>,
+    /// Fail-closed halt signal for a CONTRADICTED anchor. On the boot path it
+    /// has no subscriber yet (the forwarder is installed only once
+    /// `start_with_mode` returns), which is why the barrier also reports the
+    /// halt to its caller — see [`HandoffBarrierOutcome::FailedClosed`].
+    shutdown_channel_tx: broadcast::Sender<Option<RunWithRange>>,
+    bootstrap_outcomes: IntCounterVec,
+    /// `None` outside validator mode, where these families are deliberately
+    /// not registered at all; every barrier caller is in validator mode.
+    telemetry: Option<Arc<ValidatorTelemetryMetrics>>,
+    /// TESTS ONLY — `NodeConfig::withhold_handoff_anchor_for_testing`.
+    withhold_anchor_for: Option<Duration>,
+}
+
+impl HandoffBarrierContext {
+    /// The two paths that run inside `monitor_reconfiguration` build the
+    /// context from the running node.
+    fn from_node(node: &IkaNode) -> Self {
+        Self {
+            p2p_network: node.p2p_network.clone(),
+            perpetual_tables: node.state.perpetual_tables(),
+            shutdown_channel_tx: node.shutdown_channel_tx.clone(),
+            bootstrap_outcomes: node.metrics.joiner_bootstrap_outcomes_total.clone(),
+            telemetry: node.validator_telemetry.clone(),
+            withhold_anchor_for: node.config.withhold_handoff_anchor_for_testing,
+        }
+    }
+
+    /// Halt the node: the cross-epoch anchor is contradicted, so refuse to
+    /// participate rather than limp. A send with no subscriber is not an
+    /// error to log over — the boot path has none by construction and turns
+    /// the returned `FailedClosed` into a startup failure instead.
+    fn signal_fail_closed(&self) {
+        let _ = self.shutdown_channel_tx.send(None);
+    }
+}
+
+/// How the barrier obtains the committee that SIGNED the anchor epoch's
+/// handoff certificate: every signature on the certificate is verified
+/// against it, and its members are the peers asked to serve the certificate.
+enum AnchorCommittee {
+    /// The outgoing epoch store's own committee. Available whenever the node
+    /// is crossing a reconfiguration seam — continuing validator or promoted
+    /// fullnode alike — because the epoch it is leaving IS the anchor epoch.
+    Held(Arc<Committee>),
+    /// Resolved on the boot path, where this process holds no store for the
+    /// anchor epoch: the local committee store if this node followed that
+    /// epoch, else `validator_set.previous_committee` from chain. This is the
+    /// joiner bootstrap's own resolution, reused. A resolution failure leaves
+    /// the barrier not-ready and it retries — it never lets the epoch start
+    /// on an unverifiable anchor.
+    Resolved {
+        committee_store: Arc<CommitteeStore>,
+        sui_client: Arc<SuiConnectorClient>,
+    },
+}
+
+impl AnchorCommittee {
+    async fn resolve(&self, anchor_epoch: EpochId) -> Option<Arc<Committee>> {
+        match self {
+            Self::Held(committee) => Some(committee.clone()),
+            Self::Resolved {
+                committee_store,
+                sui_client,
+            } => {
+                if let Ok(Some(committee)) = committee_store.get_committee(&anchor_epoch) {
+                    return Some(committee);
+                }
+                match fetch_previous_committee(sui_client, anchor_epoch).await {
+                    Ok(committee) => {
+                        info!(
+                            anchor_epoch,
+                            "prepare-then-start: anchor committee absent locally; chain-read it \
+                             from validator_set.previous_committee"
+                        );
+                        Some(Arc::new(committee))
+                    }
+                    Err(error) => {
+                        warn!(
+                            ?error,
+                            anchor_epoch,
+                            "prepare-then-start: failed to resolve the anchor epoch's committee; \
+                             the barrier cannot verify the handoff cert without it and will retry"
+                        );
+                        None
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// What one attempt at obtaining the verified anchor certificate produced.
+enum AnchorOutcome {
+    /// The verified certificate for the anchor epoch, now persisted locally.
+    Anchored(Box<CertifiedHandoffAttestation>),
+    /// Not obtainable this attempt — no peer served one within the attempt
+    /// budget, or the signing committee is not resolvable yet. Absence, not
+    /// contradiction: retry.
+    Unavailable,
+    /// Contradicted: peers served certificates and none verified, or the
+    /// locally persisted one no longer verifies. The node has been signalled
+    /// to halt.
+    FailedClosed,
+}
+
+/// How the prepare-then-start barrier ended.
+enum HandoffBarrierOutcome {
+    /// The epoch's full verified handoff data is local — start the epoch's
+    /// components.
+    Ready,
+    /// The cross-epoch anchor is contradicted. The node has been signalled to
+    /// halt and the caller MUST NOT start the epoch's components. The boot
+    /// path additionally turns this into a startup error, because the
+    /// shutdown forwarder it would otherwise rely on is not subscribed until
+    /// `start_with_mode` returns and the signal would be dropped.
+    FailedClosed,
+}
+
+/// Ensures the cross-epoch trust anchor for the epoch being entered is
+/// locally present + verified, fetching it inline if it is not.
+///
+/// Every validator anchors the epoch it enters (`anchor_epoch + 1`) on the
+/// `anchor_epoch` handoff cert — the cert the `anchor_epoch` committee
+/// produced, pinning the handoff into `anchor_epoch + 1` (it certifies the
+/// network-key output digests the new epoch inherits and binds the hash of
+/// the new committee's pubkey set). A continuing validator that crossed
+/// quorum at `anchor_epoch`'s EndOfPublish has already persisted this cert;
+/// for anyone missing it — a joiner, a continuing validator that didn't
+/// observe quorum, or a process that just booted into the epoch — it must be
+/// fetched + verified + persisted here.
+///
+/// This is the synchronous, inline-awaited sibling of the
+/// `joiner_bootstrap_handle` task spawned at epoch start: that task anchors
+/// the same epoch but runs from inside the epoch's own run loop, which is too
+/// late for a barrier that has to finish BEFORE the epoch's components start
+/// (the barrier would deadlock waiting on a cert that nothing fetches until
+/// after the barrier). So the barrier never waits on that task and always
+/// fetches inline.
+///
+/// `signing_committee` is the `anchor_epoch` committee: on a reconfiguration
+/// seam it is the outgoing epoch store's committee, and on the boot path it
+/// is resolved from the local committee store or from chain (see
+/// [`AnchorCommittee`]). It doubles as the cert verifier's consensus-pubkey
+/// provider, because committee members carry their consensus keys.
+///
+/// REDUNDANT VERIFICATION (defense in depth): a handoff cert is verified
+/// TWICE in its lifetime. The first verification is in the fetch path, before
+/// the cert is ever written to the local DB. The second is HERE, when the
+/// cert is *consumed* to anchor the new epoch — a persisted cert is ALWAYS
+/// re-verified against the signing committee before it is allowed to anchor,
+/// so a corrupted or tampered local handoff-cert DB cannot silently anchor an
+/// epoch on a cert that no longer verifies. The same `verify` closure backs
+/// both the persisted-cert re-check and the fetch path's per-candidate
+/// verification.
+async fn prepare_handoff_anchor(
+    ctx: &HandoffBarrierContext,
+    anchor_epoch: EpochId,
+    signing_committee: &Committee,
+    peer_ids: &[PeerId],
+    new_epoch_store: &Arc<AuthorityPerEpochStore>,
+) -> AnchorOutcome {
+    // Build the verification closure FIRST so it can re-verify a persisted
+    // cert as well as back the fetch path.
+    let signing_committee = signing_committee.clone();
+    // The cert pins the hash of the committee being handed into — the epoch
+    // we are entering, whose committee is `new_epoch_store`'s.
+    let expected_next = next_committee_pubkey_set(new_epoch_store.committee());
+    let verify: CertVerifier = Arc::new(move |cert| {
+        verify_joiner_bootstrap_cert(
+            cert,
+            anchor_epoch,
+            &signing_committee,
+            &signing_committee,
+            expected_next.iter().copied(),
+        )
+    });
+
+    // SECOND verification (the first was before this cert was written to the
+    // DB in the fetch path): a persisted cert must NOT silently anchor an
+    // epoch — re-verify it now. A tampered or corrupted local handoff-cert DB
+    // fails here and fail-closes rather than anchoring the new epoch on a
+    // cert that no longer verifies against the signing committee.
+    if let Some(persisted) = new_epoch_store
+        .get_certified_handoff_attestation(anchor_epoch)
+        .ok()
+        .flatten()
+    {
+        return match verify(&persisted) {
+            Ok(()) => {
+                // Holding the cert does NOT imply holding the network-key
+                // outputs it certifies: a lagging validator can adopt the
+                // cert from a buffered peer-signature quorum (see
+                // `quorum_attestation_in_buffer`) without ever computing or
+                // caching those outputs, and a validator that just booted
+                // into the epoch may hold neither. The barrier's condition 2
+                // requires every certified output held locally, so fetch +
+                // cache them now (idempotent — a no-op when already present).
+                // Without this a cert-but-no-outputs validator blocks at the
+                // barrier forever, never enters the epoch, and never
+                // publishes its mpc_data — wedging the next
+                // reconfiguration's committee assembly at sub-full coverage.
+                install_joiner_network_key_outputs(
+                    &persisted,
+                    &ctx.p2p_network,
+                    peer_ids,
+                    new_epoch_store,
+                )
+                .await;
+                AnchorOutcome::Anchored(Box::new(persisted))
+            }
+            Err(e) => {
+                error!(
+                    anchor_epoch,
+                    error = ?e,
+                    "prepare-then-start: the locally-persisted handoff cert FAILED \
+                     re-verification. For a next_committee_pubkey_set_hash mismatch the \
+                     likeliest cause is NOT a corrupt DB: the committee is named by consensus \
+                     key, so any member that ROTATED its consensus key at this boundary is \
+                     named differently by the epoch that signed the cert and by this one — \
+                     check for a recent set_next_epoch_consensus_pubkey_bytes. A tampered or \
+                     corrupted local handoff-cert DB is the remaining explanation. Halting the \
+                     node (fail-closed) rather than anchoring the epoch on an unverified cert."
+                );
+                ctx.signal_fail_closed();
+                AnchorOutcome::FailedClosed
+            }
+        };
+    }
+
+    // Absent from the DB — fetch + verify + persist + install.
+    info!(
+        anchor_epoch,
+        "prepare-then-start: anchor cert for the epoch being entered is not held locally; \
+         fetching + verifying it inline from peers before starting MPC"
+    );
+
+    let source = Arc::new(P2pHandoffCertSource::new(
+        ctx.p2p_network.clone(),
+        peer_ids.to_vec(),
+    ));
+    let verifier = JoinerBootstrapVerifier::new(
+        anchor_epoch,
+        source,
+        verify,
+        BootstrapRetryConfig {
+            retry_interval: Duration::from_secs(10),
+            max_attempts: 30,
+        },
+    );
+
+    match verifier.run().await {
+        BootstrapOutcome::Verified(cert) => {
+            ctx.bootstrap_outcomes
+                .with_label_values(&["verified"])
+                .inc();
+            // Persist the verified anchor so network-key instantiation can
+            // read it locally and this node can serve it to peers still
+            // fetching.
+            if let Err(e) = ctx
+                .perpetual_tables
+                .insert_certified_handoff_attestation(anchor_epoch, &cert)
+            {
+                warn!(error = ?e, anchor_epoch, "failed to persist anchor handoff cert");
+            }
+            install_joiner_network_key_outputs(&cert, &ctx.p2p_network, peer_ids, new_epoch_store)
+                .await;
+            AnchorOutcome::Anchored(cert)
+        }
+        BootstrapOutcome::Rejected => {
+            ctx.bootstrap_outcomes
+                .with_label_values(&["rejected"])
+                .inc();
+            // Fail-closed: peers served certs but NONE verified against the
+            // signing committee — a genuine cross-epoch trust-anchor mismatch
+            // (a wrong committee view, or every reachable peer serving certs
+            // for the wrong committee, a possible eclipse). Refuse to
+            // participate on a broken anchor: halt so an operator
+            // investigates rather than silently entering the epoch on an
+            // unverified handoff.
+            error!(
+                anchor_epoch,
+                "prepare-then-start: cross-epoch anchor REJECTED — halting the node \
+                 (fail-closed). Investigate a wrong committee view or peers serving certs \
+                 for the wrong committee (possible eclipse)."
+            );
+            ctx.signal_fail_closed();
+            AnchorOutcome::FailedClosed
+        }
+        // No peer served a cert within the attempt budget (propagation lag) —
+        // the anchor is unconfirmed, not contradicted. The barrier
+        // re-attempts.
+        BootstrapOutcome::Unavailable => {
+            ctx.bootstrap_outcomes
+                .with_label_values(&["unavailable"])
+                .inc();
+            AnchorOutcome::Unavailable
+        }
+    }
+}
+
+/// Prepare-then-start barrier: blocks until the full handoff data for the
+/// epoch being entered (`new_epoch_store`'s epoch) is locally present AND
+/// verified, then returns so that epoch's MPC components may start.
+///
+/// WHY THIS EXISTS: without it, the new epoch's MPC components start
+/// immediately while the network-key handoff data still arrives
+/// asynchronously. A validator can then begin epoch-N signing with STALE
+/// (epoch N-1) network-key shares, and threshold sign rounds fail with
+/// `FailedToAdvanceMPC(InvalidParameters)`. Starting the epoch stale is never
+/// acceptable, so this blocks INDEFINITELY (no timeout): a stuck validator
+/// that is visibly not signing is strictly safer than one signing with the
+/// wrong shares.
+///
+/// EVERY path that starts a validator's epoch-specific components goes
+/// through here first — the continuing validator at a reconfiguration seam,
+/// a fullnode promoted into the committee at a boundary, and a process
+/// booting (or rebooting) into an epoch. The only skip is the epoch that has
+/// no predecessor to be handed off from: entering epoch 0 at genesis, which
+/// the boot caller filters out the same way the joiner bootstrap does.
+///
+/// The barrier waits on two conditions, both grounded in off-chain data (the
+/// verified handoff cert + this validator's local outputs) — no chain state
+/// beyond resolving the signing committee on the boot path, and no dependency
+/// on the chain-fed `network_keys_receiver`:
+///   1. The cross-epoch trust anchor (the `anchor_epoch` handoff cert) is
+///      locally present + verified — `prepare_handoff_anchor` returns it,
+///      fetching it inline if missing.
+///   2. Every network-key output item the cert certifies —
+///      `NetworkReconfigurationOutput` AND `NetworkDkgOutput` — is held
+///      locally with a digest matching the cert. The cert's single `epoch`
+///      field scopes the whole handoff, so there is no per-key epoch to
+///      check — only per-key presence. BOTH digest sources are read from the
+///      store for the epoch being ENTERED, which is the only store a booting
+///      process has: the reconfiguration digests come from the epoch-keyed
+///      PERPETUAL slice (keyed by `anchor_epoch`, the reconfiguration
+///      session's own epoch), which is shared process-wide and so reads
+///      identically through any epoch store; the DKG digests come from the
+///      merged view, whose per-epoch table is empty at entry so the value is
+///      the perpetual canonical mirror — the exact value the installer
+///      repairs. Reading the DKG digests from an outgoing store instead would
+///      consult ITS per-epoch table first, which is precisely what the
+///      end-of-epoch hydration pass may have poisoned (the issue #1852
+///      clobber variant), and the repaired perpetual value would never win —
+///      deadlocking this barrier. A continuing validator caches its own MPC
+///      output; `prepare_handoff_anchor` and the per-retry installer fetch +
+///      cache missing/mismatching outputs from peers. See
+///      `all_cert_network_key_outputs_held_locally`.
+async fn wait_for_handoff_data_ready(
+    ctx: &HandoffBarrierContext,
+    anchor_epoch: EpochId,
+    anchor_committee: &AnchorCommittee,
+    peer_ids: &[PeerId],
+    new_epoch_store: &Arc<AuthorityPerEpochStore>,
+) -> HandoffBarrierOutcome {
+    let next_epoch = new_epoch_store.epoch();
+    info!(
+        next_epoch,
+        anchor_epoch,
+        "prepare-then-start: awaiting full verified handoff data for epoch {next_epoch} \
+         before starting MPC"
+    );
+    // Present in validator mode, which is the only mode that reaches this
+    // barrier; the families are not registered anywhere else.
+    let telemetry = ctx.telemetry.clone();
+    if let Some(telemetry) = &telemetry {
+        telemetry.handoff_prepare_waiting.set(1);
+    }
+    let started_at = std::time::Instant::now();
+    let mut retries: u64 = 0;
+
+    // The verified anchor is obtained ONCE and reused across iterations: the
+    // cert is immutable for the epoch, so re-fetching/re-verifying its
+    // committee signatures every second would be pure waste (and on the fetch
+    // path, a per-second P2P hammering of converging peers). The signing
+    // committee is cached for the same reason — on the boot path resolving it
+    // can cost a chain read.
+    let mut anchor_cert: Option<CertifiedHandoffAttestation> = None;
+    let mut signing_committee: Option<Arc<Committee>> = None;
+    loop {
+        // TESTS ONLY (`NodeConfig::withhold_handoff_anchor_for_testing`):
+        // hold the anchor back so a test can observe a validator declining to
+        // start its epoch components without it. This suppresses only the
+        // ACQUISITION of the handoff data — the readiness predicate below
+        // still evaluates real local state, and reads not-ready because the
+        // anchor is absent, exactly as it would under prolonged propagation
+        // lag.
+        let withheld = ctx
+            .withhold_anchor_for
+            .is_some_and(|withhold| started_at.elapsed() < withhold);
+
+        // Condition 1: the cross-epoch trust anchor — the `anchor_epoch`
+        // handoff cert — is present + verified. `prepare_handoff_anchor`
+        // returns it (re-verified) when already held, fetches + verifies +
+        // persists it inline when missing, and also fetches + caches the
+        // certified outputs this node is missing into the local digest slices
+        // condition 2 reads. `Unavailable` means the anchor is not yet
+        // confirmed (propagation lag) — re-attempt next iteration.
+        if !withheld && anchor_cert.is_none() {
+            if signing_committee.is_none() {
+                signing_committee = anchor_committee.resolve(anchor_epoch).await;
+            }
+            if let Some(committee) = &signing_committee {
+                match prepare_handoff_anchor(
+                    ctx,
+                    anchor_epoch,
+                    committee,
+                    peer_ids,
+                    new_epoch_store,
+                )
+                .await
+                {
+                    AnchorOutcome::Anchored(cert) => anchor_cert = Some(*cert),
+                    AnchorOutcome::Unavailable => {}
+                    AnchorOutcome::FailedClosed => {
+                        if let Some(telemetry) = &telemetry {
+                            telemetry.handoff_prepare_waiting.set(0);
+                        }
+                        return HandoffBarrierOutcome::FailedClosed;
+                    }
+                }
+            }
+        }
+        let cert = anchor_cert.as_ref();
+
+        // Condition 2: every network-key output the cert certifies —
+        // reconfiguration AND DKG — is held locally with a digest matching
+        // the cert. Grounded entirely in the verified cert (the off-chain
+        // anchor) and this validator's own digest slices — no chain state,
+        // and no per-key epoch (the cert's single epoch scopes the whole
+        // handoff). A read error is treated as not-ready (empty slice); the
+        // periodic WARN below surfaces a persistent failure.
+        //
+        // Both slices are read from the store for the epoch being entered —
+        // see this function's doc for why the DKG digests in particular must
+        // not come from an outgoing store.
+        let local_reconfiguration_digests = new_epoch_store
+            .get_network_reconfiguration_output_digests_for_epoch(anchor_epoch)
+            .unwrap_or_default();
+        let local_dkg_digests = new_epoch_store
+            .get_network_dkg_output_digests()
+            .unwrap_or_default();
+        let ready = cert.is_some_and(|cert| {
+            all_cert_network_key_outputs_held_locally(
+                cert,
+                &local_dkg_digests,
+                &local_reconfiguration_digests,
+            )
+        });
+
+        if ready {
+            let elapsed = started_at.elapsed();
+            if let Some(telemetry) = &telemetry {
+                telemetry.handoff_prepare_waiting.set(0);
+                telemetry
+                    .handoff_prepare_duration_seconds
+                    .observe(elapsed.as_secs_f64());
+            }
+            info!(
+                next_epoch,
+                "prepare-then-start: epoch {next_epoch} handoff data ready+verified after \
+                 {}s, {retries} retries; starting MPC",
+                elapsed.as_secs()
+            );
+            return HandoffBarrierOutcome::Ready;
+        }
+
+        retries += 1;
+        if let Some(telemetry) = &telemetry {
+            telemetry.handoff_prepare_retries_total.inc();
+        }
+
+        // Anchor held but some certified output still missing locally: retry
+        // fetching JUST the missing ones (the local-presence precheck inside
+        // skips everything already held, so this is not a refetch of held
+        // blobs).
+        if let Some(cert) = cert.filter(|_| !withheld) {
+            install_joiner_network_key_outputs(cert, &ctx.p2p_network, peer_ids, new_epoch_store)
+                .await;
+        }
+
+        // Surface the breakdown roughly every 10s so a hang is never silent
+        // on a dashboard or in the logs.
+        if retries.is_multiple_of(10) {
+            let (cert_network_key_items, missing_key_ids, unmapped_cert_keys) = match &cert {
+                Some(cert) => {
+                    let total = cert
+                        .attestation
+                        .items
+                        .iter()
+                        .filter(|(item, _)| {
+                            matches!(
+                                item,
+                                HandoffItemKey::NetworkReconfigurationOutput { .. }
+                                    | HandoffItemKey::NetworkDkgOutput { .. }
+                            )
+                        })
+                        .count();
+                    let missing: Vec<ObjectID> = cert
+                        .attestation
+                        .items
+                        .iter()
+                        .filter_map(|(item, digest)| {
+                            // Cert keys by NetworkKeyId; local digests by
+                            // ObjectID — translate via the temporary map.
+                            let (key_id, local_digests) = match item {
+                                HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
+                                    (key_id, &local_reconfiguration_digests)
+                                }
+                                HandoffItemKey::NetworkDkgOutput { key_id } => {
+                                    (key_id, &local_dkg_digests)
+                                }
+                                HandoffItemKey::ValidatorMpcData { .. } => return None,
+                            };
+                            let object_id =
+                                ika_core::network_key_id_mapping::object_id_for(key_id)?;
+                            (local_digests.get(&object_id) != Some(digest)).then_some(object_id)
+                        })
+                        .collect();
+                    // Cert keys with NO ObjectID mapping (this validator
+                    // never instantiated the key and it is not one of the
+                    // compiled-in deployed keys) are keys the barrier can
+                    // neither check nor install, so they do NOT hold the gate
+                    // closed — see `all_cert_network_key_outputs_held_locally`
+                    // for why that is safe. Report them anyway: they are the
+                    // keys whose sessions will park after start until the
+                    // stranded-key recovery fills them. A key with both a DKG
+                    // and a reconfiguration item would list twice — dedup via
+                    // the ordered set.
+                    let unmapped: BTreeSet<NetworkKeyId> = cert
+                        .attestation
+                        .items
+                        .iter()
+                        .filter_map(|(item, _)| match item {
+                            HandoffItemKey::NetworkReconfigurationOutput { key_id }
+                            | HandoffItemKey::NetworkDkgOutput { key_id }
+                                if ika_core::network_key_id_mapping::object_id_for(key_id)
+                                    .is_none() =>
+                            {
+                                Some(*key_id)
+                            }
+                            _ => None,
+                        })
+                        .collect();
+                    let unmapped: Vec<NetworkKeyId> = unmapped.into_iter().collect();
+                    (total, missing, unmapped)
+                }
+                None => (0, Vec::new(), Vec::new()),
+            };
+            warn!(
+                next_epoch,
+                anchor_epoch,
+                have_cert = cert.is_some(),
+                have_signing_committee = signing_committee.is_some(),
+                cert_network_key_items,
+                missing_locally = missing_key_ids.len(),
+                missing_key_ids = ?missing_key_ids,
+                unmapped_cert_keys = ?unmapped_cert_keys,
+                retries,
+                withheld_for_testing = withheld,
+                "prepare-then-start: still awaiting full verified handoff data for epoch \
+                 {next_epoch}"
+            );
+        }
+
+        // Re-check after 1s. No timeout — block indefinitely (safety-first:
+        // never start the epoch without the verified handoff outputs the cert
+        // certifies).
+        tokio::time::sleep(Duration::from_secs(1)).await;
     }
 }
 
@@ -4094,6 +4337,30 @@ fn max_tx_per_checkpoint(_: &ProtocolConfig) -> usize {
 /// permanent. `ValidatorMpcData` items are not gated (they feed the mpc_data
 /// freeze, a separate plane). A cert with no network-key items is trivially
 /// ready on this condition.
+///
+/// UNMAPPED CERT KEYS DO NOT BLOCK. The certificate names keys by
+/// `NetworkKeyId` while every local slice and cache is keyed by `ObjectID`,
+/// and the translation between them is a process-global map holding the
+/// deployed keys as compiled-in constants plus whatever this PROCESS has
+/// instantiated or derived. A key outside the constants that this process has
+/// not touched — every fresh localnet/CI DKG, seen by a joiner or by a
+/// just-restarted validator — has no entry, and the barrier can do nothing
+/// about it: the installer cannot cache bytes under an unknown `ObjectID`,
+/// and the derivation that would register one runs from the MPC manager's
+/// adoption pass, which does not exist until this barrier releases. Blocking
+/// would be a guaranteed deadlock, so an unmapped item is passed and reported
+/// (`unmapped_cert_keys` on the barrier's periodic warn).
+///
+/// That is safe, because the hazard this barrier exists to prevent is
+/// entering an epoch holding STALE key material, and the guard against it for
+/// an unmapped key sits downstream and stays armed: adoption DEFERS an
+/// unmapped key rather than installing anything for it, and once the
+/// background derivation registers the mapping, adoption re-applies the same
+/// cert-digest gate and refuses a local output that contradicts the
+/// certificate. The barrier still guarantees the certificate itself is local,
+/// which is what arms that gate. The cost of passing is liveness, not
+/// safety — the key's sessions park until the stranded-key recovery fills it
+/// (see `specs/handoff.md`), which is exactly what happens today.
 fn all_cert_network_key_outputs_held_locally(
     cert: &CertifiedHandoffAttestation,
     local_dkg_digests: &BTreeMap<ObjectID, [u8; 32]>,
@@ -4104,8 +4371,9 @@ fn all_cert_network_key_outputs_held_locally(
         .iter()
         .all(|(item, cert_digest)| match item {
             HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
-                // Cert keys by NetworkKeyId; local digests by ObjectID.
-                ika_core::network_key_id_mapping::object_id_for(key_id).is_some_and(|object_id| {
+                // Cert keys by NetworkKeyId; local digests by ObjectID. An
+                // unmapped key passes — see the doc above.
+                ika_core::network_key_id_mapping::object_id_for(key_id).is_none_or(|object_id| {
                     local_reconfiguration_digests.get(&object_id) == Some(cert_digest)
                 })
             }
@@ -4122,7 +4390,7 @@ fn all_cert_network_key_outputs_held_locally(
             // leaving a poisoned validator wedged permanently.
             HandoffItemKey::NetworkDkgOutput { key_id } => {
                 ika_core::network_key_id_mapping::object_id_for(key_id)
-                    .is_some_and(|object_id| local_dkg_digests.get(&object_id) == Some(cert_digest))
+                    .is_none_or(|object_id| local_dkg_digests.get(&object_id) == Some(cert_digest))
             }
             HandoffItemKey::ValidatorMpcData { .. } => true,
         })
@@ -4248,6 +4516,31 @@ mod tests {
         assert!(all_cert_network_key_outputs_held_locally(
             &dkg_only,
             &canonical,
+            &BTreeMap::new()
+        ));
+
+        // A cert key with NO ObjectID mapping — never instantiated in this
+        // process and not one of the compiled-in deployed keys — reads READY
+        // even with nothing held locally. The barrier can neither check nor
+        // install such a key (the installer has no ObjectID to cache under,
+        // and the derivation that would register one runs from the adoption
+        // pass, which does not exist until the barrier releases), so blocking
+        // on it would deadlock every joiner and every restart on a network
+        // whose keys are outside the seed. Adoption's own cert-digest gate is
+        // what keeps this safe: it defers an unmapped key and, once the
+        // mapping lands, refuses any local output contradicting the cert.
+        let unmapped = cert_with_reconfiguration_items(vec![(network_key_id(200), [3u8; 32])]);
+        assert!(all_cert_network_key_outputs_held_locally(
+            &unmapped,
+            &BTreeMap::new(),
+            &BTreeMap::new()
+        ));
+        // Registering the mapping arms the gate for that same key: now the
+        // missing local output DOES hold the barrier closed.
+        ika_core::network_key_id_mapping::register(key_id(200), network_key_id(200));
+        assert!(!all_cert_network_key_outputs_held_locally(
+            &unmapped,
+            &BTreeMap::new(),
             &BTreeMap::new()
         ));
     }

--- a/crates/ika-swarm-config/src/node_config_builder.rs
+++ b/crates/ika-swarm-config/src/node_config_builder.rs
@@ -15,6 +15,7 @@ use ika_config::node::{
     default_end_of_epoch_broadcast_channel_capacity,
 };
 use std::path::PathBuf;
+use std::time::Duration;
 use sui_types::base_types::ObjectID;
 
 use ika_config::p2p::{P2pConfig, SeedPeer, StateSyncConfig};
@@ -62,6 +63,11 @@ pub struct ValidatorConfigBuilder {
     /// dir (`file://…`) gives the pusher the same verified fallback the
     /// public chains get from their public checkpoint stores.
     sui_checkpoint_archive_url: Option<String>,
+    /// Override for `NodeConfig.withhold_handoff_anchor_for_testing` — makes
+    /// this validator's prepare-then-start barrier report the epoch's handoff
+    /// certificate as unobtainable for the given duration, so a test can prove
+    /// the validator declines to start its epoch components without it.
+    withhold_handoff_anchor_for_testing: Option<Duration>,
 }
 
 impl ValidatorConfigBuilder {
@@ -126,6 +132,14 @@ impl ValidatorConfigBuilder {
 
     pub fn with_sui_checkpoint_archive_url(mut self, url: String) -> Self {
         self.sui_checkpoint_archive_url = Some(url);
+        self
+    }
+
+    /// TESTS ONLY: hold this validator's handoff anchor back for `withhold`
+    /// after it enters the prepare-then-start barrier. See
+    /// `NodeConfig::withhold_handoff_anchor_for_testing`.
+    pub fn with_withhold_handoff_anchor_for_testing(mut self, withhold: Duration) -> Self {
+        self.withhold_handoff_anchor_for_testing = Some(withhold);
         self
     }
 
@@ -258,6 +272,7 @@ impl ValidatorConfigBuilder {
             authority_db_retention_epochs: None,
             authority_db_pruner_period_secs: None,
             max_mpc_computation_cores: self.max_mpc_computation_cores,
+            withhold_handoff_anchor_for_testing: self.withhold_handoff_anchor_for_testing,
         }
     }
 
@@ -510,6 +525,7 @@ impl FullnodeConfigBuilder {
             authority_db_pruner_period_secs: None,
             // Fullnodes/notifiers don't run validator MPC computations.
             max_mpc_computation_cores: None,
+            withhold_handoff_anchor_for_testing: None,
         }
     }
 }

--- a/crates/ika-test-cluster/src/lib.rs
+++ b/crates/ika-test-cluster/src/lib.rs
@@ -47,6 +47,7 @@ use ika_types::messages_dwallet_mpc::{IkaNetworkConfig, SessionIdentifier, Sessi
 use ika_types::supported_protocol_versions::SupportedProtocolVersions;
 use rand::rngs::OsRng;
 use std::sync::atomic::{AtomicU16, Ordering};
+use std::time::Duration;
 use sui_keys::key_derive::generate_new_key;
 use sui_swarm_config::genesis_config::ValidatorGenesisConfigBuilder;
 use sui_swarm_config::network_config_builder::ConfigBuilder;
@@ -234,6 +235,19 @@ impl IkaTestCluster {
     /// boundary (the same lifecycle the bootstrap path drives for the
     /// initial set). Caller is responsible for `wait_for_epoch` after.
     pub async fn add_joiner_validator(&mut self) -> Result<JoinerHandle> {
+        self.add_joiner_validator_withholding_handoff_anchor(None)
+            .await
+    }
+
+    /// Like [`Self::add_joiner_validator`], but the joiner's
+    /// prepare-then-start barrier reports the epoch's handoff certificate as
+    /// unobtainable for `withhold` after it enters the barrier — so a test can
+    /// prove a node promoted from fullnode to validator declines to start its
+    /// epoch components until its handoff data is actually there.
+    pub async fn add_joiner_validator_withholding_handoff_anchor(
+        &mut self,
+        withhold: Option<Duration>,
+    ) -> Result<JoinerHandle> {
         // The joiner's ports are probed when the initialization config is
         // built here, but only bound by `spawn_new_node` after the whole
         // candidate→stake→add transaction sequence — a multi-second window
@@ -333,6 +347,9 @@ impl IkaTestCluster {
         let mut joiner_builder = ValidatorConfigBuilder::new();
         if let Some(path) = &self.ocs_sui_genesis_path {
             joiner_builder = joiner_builder.with_sui_genesis(path.clone());
+        }
+        if let Some(withhold) = withhold {
+            joiner_builder = joiner_builder.with_withhold_handoff_anchor_for_testing(withhold);
         }
         let validator_config = joiner_builder.build(
             &joiner_init,
@@ -1167,6 +1184,12 @@ pub struct IkaTestClusterBuilder {
     /// default (mirrored validators get the direct validators' peer ids
     /// pinned).
     automatic_mirror_peers: bool,
+    /// TESTS ONLY: every validator's prepare-then-start barrier reports the
+    /// epoch's handoff certificate as unobtainable for this long after it
+    /// enters the barrier. Used to prove that entering epoch 0 at genesis
+    /// skips the barrier entirely — there is no predecessor epoch to be
+    /// handed off from — while a later boundary honours the withhold.
+    withhold_handoff_anchor: Option<Duration>,
 }
 
 /// Cross-process mutex for the port-sensitive boot window. The Sui and
@@ -1225,6 +1248,7 @@ impl IkaTestClusterBuilder {
             sui_state_direct_count: None,
             peer_only_mirrored: false,
             automatic_mirror_peers: false,
+            withhold_handoff_anchor: None,
         }
     }
 
@@ -1308,6 +1332,14 @@ impl IkaTestClusterBuilder {
     /// equal `num_validators`. Use this to model a gradual upgrade scenario
     /// where some validators support a newer max than others. When unset,
     /// every validator gets `SupportedProtocolVersions::SYSTEM_DEFAULT`.
+    /// TESTS ONLY: hold every validator's handoff anchor back for `withhold`
+    /// after it enters the prepare-then-start barrier. See
+    /// `NodeConfig::withhold_handoff_anchor_for_testing`.
+    pub fn with_withhold_handoff_anchor(mut self, withhold: Duration) -> Self {
+        self.withhold_handoff_anchor = Some(withhold);
+        self
+    }
+
     pub fn with_per_validator_supported_protocol_versions(
         mut self,
         per_validator_versions: Vec<SupportedProtocolVersions>,
@@ -1552,6 +1584,9 @@ impl IkaTestClusterBuilder {
                     .with_supported_protocol_versions(supported_versions);
                 if let Some(path) = &ocs_sui_genesis_path {
                     builder = builder.with_sui_genesis(path.clone());
+                }
+                if let Some(withhold) = self.withhold_handoff_anchor {
+                    builder = builder.with_withhold_handoff_anchor_for_testing(withhold);
                 }
                 // Validators at index >= direct_count read through the relay.
                 if let Some(direct_count) = direct_count

--- a/crates/ika-test-cluster/src/lib.rs
+++ b/crates/ika-test-cluster/src/lib.rs
@@ -1184,12 +1184,6 @@ pub struct IkaTestClusterBuilder {
     /// default (mirrored validators get the direct validators' peer ids
     /// pinned).
     automatic_mirror_peers: bool,
-    /// TESTS ONLY: every validator's prepare-then-start barrier reports the
-    /// epoch's handoff certificate as unobtainable for this long after it
-    /// enters the barrier. Used to prove that entering epoch 0 at genesis
-    /// skips the barrier entirely — there is no predecessor epoch to be
-    /// handed off from — while a later boundary honours the withhold.
-    withhold_handoff_anchor: Option<Duration>,
 }
 
 /// Cross-process mutex for the port-sensitive boot window. The Sui and
@@ -1248,7 +1242,6 @@ impl IkaTestClusterBuilder {
             sui_state_direct_count: None,
             peer_only_mirrored: false,
             automatic_mirror_peers: false,
-            withhold_handoff_anchor: None,
         }
     }
 
@@ -1325,14 +1318,6 @@ impl IkaTestClusterBuilder {
     /// version (e.g. v4) supported by `SupportedProtocolVersions::SYSTEM_DEFAULT`.
     pub fn with_protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
         self.protocol_version = Some(protocol_version);
-        self
-    }
-
-    /// TESTS ONLY: hold every validator's handoff anchor back for `withhold`
-    /// after it enters the prepare-then-start barrier. See
-    /// `NodeConfig::withhold_handoff_anchor_for_testing`.
-    pub fn with_withhold_handoff_anchor(mut self, withhold: Duration) -> Self {
-        self.withhold_handoff_anchor = Some(withhold);
         self
     }
 
@@ -1584,9 +1569,6 @@ impl IkaTestClusterBuilder {
                     .with_supported_protocol_versions(supported_versions);
                 if let Some(path) = &ocs_sui_genesis_path {
                     builder = builder.with_sui_genesis(path.clone());
-                }
-                if let Some(withhold) = self.withhold_handoff_anchor {
-                    builder = builder.with_withhold_handoff_anchor_for_testing(withhold);
                 }
                 // Validators at index >= direct_count read through the relay.
                 if let Some(direct_count) = direct_count

--- a/crates/ika-test-cluster/src/lib.rs
+++ b/crates/ika-test-cluster/src/lib.rs
@@ -1328,10 +1328,6 @@ impl IkaTestClusterBuilder {
         self
     }
 
-    /// Per-validator `SupportedProtocolVersions` overrides — vector length must
-    /// equal `num_validators`. Use this to model a gradual upgrade scenario
-    /// where some validators support a newer max than others. When unset,
-    /// every validator gets `SupportedProtocolVersions::SYSTEM_DEFAULT`.
     /// TESTS ONLY: hold every validator's handoff anchor back for `withhold`
     /// after it enters the prepare-then-start barrier. See
     /// `NodeConfig::withhold_handoff_anchor_for_testing`.
@@ -1340,6 +1336,10 @@ impl IkaTestClusterBuilder {
         self
     }
 
+    /// Per-validator `SupportedProtocolVersions` overrides — vector length must
+    /// equal `num_validators`. Use this to model a gradual upgrade scenario
+    /// where some validators support a newer max than others. When unset,
+    /// every validator gets `SupportedProtocolVersions::SYSTEM_DEFAULT`.
     pub fn with_per_validator_supported_protocol_versions(
         mut self,
         per_validator_versions: Vec<SupportedProtocolVersions>,

--- a/crates/ika-test-cluster/tests/handoff_barrier_start_paths.rs
+++ b/crates/ika-test-cluster/tests/handoff_barrier_start_paths.rs
@@ -1,0 +1,319 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! The prepare-then-start barrier on the two epoch-start paths that are not
+//! the continuing-validator reconfiguration seam.
+//!
+//! A validator must hold the previous epoch's verified handoff certificate —
+//! and every network-key output it certifies — before it starts the epoch's
+//! consensus and MPC components. Without that it can enter consensus, take
+//! demands naming a network key it has no verified material for, and sign
+//! with stale shares. The barrier that enforces it used to be wired into one
+//! path only; these tests cover the other two.
+//!
+//! - `test_boot_into_epoch_waits_for_handoff_data`: a validator restarted
+//!   mid-epoch, with its handoff anchor held back. It must not finish
+//!   starting — and therefore cannot have started consensus, which is spawned
+//!   during startup — until the anchor is available, and must then rejoin and
+//!   carry the network through another epoch boundary.
+//!
+//! - `test_promoted_joiner_waits_for_handoff_data`: a fullnode promoted into
+//!   the committee at a boundary, with its handoff anchor held back. Same
+//!   contract, entered from the promotion branch instead of the boot path.
+//!   This is the node with the strongest claim on the barrier: it computed
+//!   none of the epoch's outputs itself, so it starts holding nothing.
+//!
+//! - `test_genesis_boot_does_not_wait_for_handoff_data`: entering epoch 0 has
+//!   no predecessor epoch to be handed off from, so the barrier is skipped
+//!   there. Every validator boots with the anchor held back for ten minutes
+//!   and the cluster still comes up.
+//!
+//! The hold-back is `NodeConfig::withhold_handoff_anchor_for_testing`: for
+//! that long after the barrier is entered, the barrier reports the anchor as
+//! not obtainable and fetches nothing — the same benign propagation-lag
+//! outcome it already retries on. It suppresses only the ACQUISITION of the
+//! handoff data; the readiness predicate keeps evaluating real local state.
+//!
+//! `#[tokio::test(flavor = "multi_thread")]` per `dev-docs/conventions/simtest.md`:
+//! the hold-back is a wall-clock window, not a message ordering, so there is
+//! no scheduling nondeterminism for `#[sim_test]` to control.
+
+use ika_node::IkaNodeHandle;
+use ika_test_cluster::{IkaTestCluster, IkaTestClusterBuilder, poll_until, wait_for_node_epoch};
+use ika_types::crypto::AuthorityName;
+use prometheus::proto::MetricType;
+use std::time::{Duration, Instant};
+
+/// How long each test holds a node's handoff anchor back. Long enough that a
+/// node which ignored the barrier would be observably up and in consensus
+/// well inside the window, short enough not to stretch the epochs around it.
+const WITHHOLD: Duration = Duration::from_secs(30);
+
+/// An `IkaNodeHandle` holds a STRONG `Arc<IkaNode>`, which keeps the node's
+/// RocksDB open. A handle still alive when its node restarts makes the
+/// respawn die on the held store lock. Acquire handles on demand, scoped to
+/// one statement — never across a `stop()`/`start()`.
+fn node_handle(cluster: &IkaTestCluster, name: &AuthorityName) -> IkaNodeHandle {
+    cluster
+        .swarm
+        .node(name)
+        .expect("validator node exists for the configured name")
+        .get_node_handle()
+        .expect("validator node is running")
+}
+
+/// Sum of a single-series counter or gauge in this node's own Prometheus
+/// registry (each in-process node registers into a registry of its own, so
+/// these readings are per-validator). Absent family reads as 0 — the families
+/// are registered at process start in validator mode, so 0 means "registered
+/// and never moved", which is exactly the vacuous-pass case the assertions
+/// below are looking for.
+fn metric_value(handle: &IkaNodeHandle, name: &str) -> f64 {
+    handle.with(|node| {
+        node.registry_service_for_testing()
+            .default_registry()
+            .gather()
+            .iter()
+            .filter(|family| family.name() == name)
+            .flat_map(|family| {
+                family
+                    .get_metric()
+                    .iter()
+                    .map(|metric| (family.get_field_type(), metric))
+            })
+            .map(|(kind, metric)| match kind {
+                MetricType::COUNTER => metric.get_counter().value(),
+                MetricType::GAUGE => metric.get_gauge().value(),
+                // For the barrier's duration histogram the interesting figure
+                // is the total time observed, not a bucket count.
+                MetricType::HISTOGRAM => metric.get_histogram().get_sample_sum(),
+                _ => 0.0,
+            })
+            .sum()
+    })
+}
+
+/// Barrier poll iterations this node has spent waiting for handoff data. The
+/// barrier re-checks once a second, so a node held back for `WITHHOLD` must
+/// show at least a large fraction of that many.
+fn barrier_retries(handle: &IkaNodeHandle) -> f64 {
+    metric_value(handle, "ika_handoff_prepare_retries_total")
+}
+
+/// 1 while the barrier is blocking this node's epoch components, 0 otherwise.
+fn barrier_waiting(handle: &IkaNodeHandle) -> f64 {
+    metric_value(handle, "ika_handoff_prepare_waiting")
+}
+
+/// Wall-clock seconds this node has spent inside completed barrier waits.
+fn barrier_seconds(handle: &IkaNodeHandle) -> f64 {
+    metric_value(handle, "ika_handoff_prepare_duration_seconds")
+}
+
+/// A 1s-per-iteration barrier held for `WITHHOLD` should log roughly
+/// `WITHHOLD` retries. Assert against a floor well below that so a slow CI
+/// host (where each iteration's peer fetch costs more than the sleep) still
+/// passes, while a node that never entered the barrier — the pre-fix
+/// behaviour, and the vacuous pass this guards — reads 0 and fails.
+fn min_expected_retries() -> f64 {
+    (WITHHOLD.as_secs() / 3) as f64
+}
+
+/// The epoch the tests strike. Epoch 0's close mints the first handoff
+/// certificate, so from epoch 1 onward there is a real anchor to withhold.
+const STRUCK_EPOCH: u64 = 1;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_boot_into_epoch_waits_for_handoff_data() {
+    telemetry_subscribers::init_for_testing();
+
+    let cluster = IkaTestClusterBuilder::new()
+        .with_num_validators(4)
+        .with_epoch_duration_ms(30_000)
+        .build()
+        .await
+        .expect("ika test cluster failed to boot");
+
+    let names = cluster.validator_names.clone();
+    let restarted = names[3];
+    for name in &names {
+        wait_for_node_epoch(&node_handle(&cluster, name), STRUCK_EPOCH).await;
+    }
+
+    // Restart the validator with its handoff anchor held back. Consensus for
+    // the epoch is spawned from inside node startup, so a node that starts
+    // its epoch components without the anchor finishes booting immediately —
+    // and the barrier is what makes startup wait instead.
+    let node = cluster.swarm.node(&restarted).expect("validator exists");
+    node.stop();
+    node.config().withhold_handoff_anchor_for_testing = Some(WITHHOLD);
+    tracing::info!(
+        withhold_secs = WITHHOLD.as_secs(),
+        "restarting the validator with its handoff anchor withheld",
+    );
+    let started_at = Instant::now();
+    node.start().await.expect("validator failed to restart");
+    let boot_elapsed = started_at.elapsed();
+
+    assert!(
+        boot_elapsed >= WITHHOLD,
+        "the restarted validator finished booting in {boot_elapsed:?}, before its withheld \
+         handoff anchor could possibly be available ({WITHHOLD:?}) — it started its epoch's \
+         consensus and MPC components without the verified handoff data for the epoch",
+    );
+
+    // The wait has to be the barrier's, not incidental boot slowness: the
+    // barrier's own retry counter is what separates the two.
+    let retries = barrier_retries(&node_handle(&cluster, &restarted));
+    assert!(
+        retries >= min_expected_retries(),
+        "the restarted validator recorded only {retries} prepare-then-start barrier retries \
+         over a {WITHHOLD:?} hold — it did not block in the barrier, so the {boot_elapsed:?} \
+         boot was slow for some other reason",
+    );
+    assert_eq!(
+        barrier_waiting(&node_handle(&cluster, &restarted)),
+        0.0,
+        "the restarted validator is up but still reports itself blocked in the \
+         prepare-then-start barrier",
+    );
+    tracing::info!(
+        boot_secs = boot_elapsed.as_secs(),
+        retries,
+        "restarted validator released from the barrier and started its epoch components",
+    );
+
+    // It rejoined for real: the network crosses another boundary with it,
+    // which it can only do by contributing to the reconfiguration MPC with
+    // the network-key material the barrier made it wait for. A validator that
+    // had started on stale or absent shares stalls here.
+    for name in &names {
+        wait_for_node_epoch(&node_handle(&cluster, name), STRUCK_EPOCH + 1).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_promoted_joiner_waits_for_handoff_data() {
+    telemetry_subscribers::init_for_testing();
+
+    let mut cluster = IkaTestClusterBuilder::new()
+        .with_num_validators(4)
+        .with_epoch_duration_ms(30_000)
+        .build()
+        .await
+        .expect("ika test cluster failed to boot");
+
+    let names = cluster.validator_names.clone();
+    for name in &names {
+        wait_for_node_epoch(&node_handle(&cluster, name), STRUCK_EPOCH).await;
+    }
+
+    // A true joiner: it was in no prior committee, so it computed none of the
+    // epoch's network-key outputs and starts holding nothing. It boots as a
+    // non-committee node and is promoted at the next boundary.
+    let joiner = cluster
+        .add_joiner_validator_withholding_handoff_anchor(Some(WITHHOLD))
+        .await
+        .expect("failed to add the joiner validator");
+    let joiner_name = joiner.authority_name();
+
+    // The promotion branch runs the barrier before it constructs the
+    // joiner's validator components, so the gauge going to 1 IS the promotion
+    // reaching the barrier. Without the barrier on that path it never moves,
+    // and this poll is what fails.
+    poll_until(
+        Duration::from_secs(300),
+        "the promoted joiner to enter the prepare-then-start barrier",
+        || {
+            cluster
+                .swarm
+                .node(&joiner_name)
+                .and_then(|node| node.get_node_handle())
+                .filter(|handle| barrier_waiting(handle) == 1.0)
+                .map(|_| ())
+        },
+    )
+    .await;
+    tracing::info!("promoted joiner is blocked in the prepare-then-start barrier");
+
+    poll_until(
+        Duration::from_secs(300),
+        "the promoted joiner to be released from the prepare-then-start barrier",
+        || {
+            cluster
+                .swarm
+                .node(&joiner_name)
+                .and_then(|node| node.get_node_handle())
+                .filter(|handle| barrier_waiting(handle) == 0.0)
+                .map(|_| ())
+        },
+    )
+    .await;
+
+    let waited = barrier_seconds(&node_handle(&cluster, &joiner_name));
+    assert!(
+        waited >= WITHHOLD.as_secs_f64(),
+        "the promoted joiner spent {waited}s in the prepare-then-start barrier but its handoff \
+         anchor was withheld for {}s — it was released before its handoff data could be there",
+        WITHHOLD.as_secs(),
+    );
+    let retries = barrier_retries(&node_handle(&cluster, &joiner_name));
+    assert!(
+        retries >= min_expected_retries(),
+        "the promoted joiner recorded only {retries} prepare-then-start barrier retries over a \
+         {WITHHOLD:?} hold",
+    );
+
+    // Promotion completed on the far side of the barrier and the joiner is a
+    // working committee member: the whole committee, joiner included, crosses
+    // another boundary, which needs the joiner's share of the reconfiguration
+    // MPC computed against the key material the barrier waited for.
+    let joiner_epoch =
+        node_handle(&cluster, &joiner_name).with(|node| node.current_epoch_for_testing());
+    for name in names.iter().chain(std::iter::once(&joiner_name)) {
+        wait_for_node_epoch(&node_handle(&cluster, name), joiner_epoch + 1).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_genesis_boot_does_not_wait_for_handoff_data() {
+    telemetry_subscribers::init_for_testing();
+
+    // Entering epoch 0 has no predecessor epoch to be handed off from — the
+    // chain-true no-cert genesis epoch — so the boot barrier is skipped
+    // there. Every validator is configured to hold its anchor back for ten
+    // minutes: if the skip were missing, boot would block in the barrier for
+    // the whole window (with nothing to anchor on even after it, since no
+    // epoch precedes 0) and the cluster would never come up.
+    let cluster = IkaTestClusterBuilder::new()
+        .with_num_validators(4)
+        // Long enough that the first boundary — where the barrier legitimately
+        // engages and WOULD honour the hold-back — cannot fire while the
+        // genesis-boot assertions below run.
+        .with_epoch_duration_ms(600_000)
+        .with_withhold_handoff_anchor(Duration::from_secs(600))
+        .build()
+        .await
+        .expect("ika test cluster failed to boot at genesis with the handoff anchor withheld");
+
+    for name in &cluster.validator_names {
+        let handle = node_handle(&cluster, name);
+        assert_eq!(
+            handle.with(|node| node.current_epoch_for_testing()),
+            0,
+            "the cluster left the genesis epoch before the genesis-skip assertions ran",
+        );
+        assert_eq!(
+            barrier_waiting(&handle),
+            0.0,
+            "a validator booting into the genesis epoch is blocked in the prepare-then-start \
+             barrier — epoch 0 has no predecessor to be handed off from and must skip it",
+        );
+        assert_eq!(
+            barrier_retries(&handle),
+            0.0,
+            "a validator booting into the genesis epoch spent barrier retries waiting for a \
+             handoff certificate that no epoch could have produced",
+        );
+    }
+}

--- a/crates/ika-test-cluster/tests/handoff_barrier_start_paths.rs
+++ b/crates/ika-test-cluster/tests/handoff_barrier_start_paths.rs
@@ -23,12 +23,15 @@
 //!   This is the node with the strongest claim on the barrier: it computed
 //!   none of the epoch's outputs itself, so it starts holding nothing.
 //!
-//! - `test_genesis_boot_does_not_wait_for_handoff_data`: entering epoch 0 has
-//!   no predecessor epoch to be handed off from, so the barrier is skipped
-//!   there. Every validator boots with the anchor held back for ten minutes
-//!   and the cluster still comes up.
+//! - `test_boot_without_a_predecessor_epoch_does_not_wait`: a network whose
+//!   validators come up for the first time already at epoch 1 has no epoch-0
+//!   committee and no epoch-0 certificate — the anchor cannot exist. The
+//!   barrier must read that off the chain and enter anyway rather than wait
+//!   for something that will never arrive, which would keep the whole
+//!   committee from starting.
 //!
-//! The hold-back is `NodeConfig::withhold_handoff_anchor_for_testing`: for
+//! The hold-back the first two use is
+//! `NodeConfig::withhold_handoff_anchor_for_testing`: for
 //! that long after the barrier is entered, the barrier reports the anchor as
 //! not obtainable and fetches nothing — the same benign propagation-lag
 //! outcome it already retries on. It suppresses only the ACQUISITION of the
@@ -286,44 +289,51 @@ async fn test_promoted_joiner_waits_for_handoff_data() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_genesis_boot_does_not_wait_for_handoff_data() {
+async fn test_boot_without_a_predecessor_epoch_does_not_wait() {
     telemetry_subscribers::init_for_testing();
 
-    // Entering epoch 0 has no predecessor epoch to be handed off from — the
-    // chain-true no-cert genesis epoch — so the boot barrier is skipped
-    // there. Every validator is configured to hold its anchor back for ten
-    // minutes: if the skip were missing, boot would block in the barrier for
-    // the whole window (with nothing to anchor on even after it, since no
-    // epoch precedes 0) and the cluster would never come up.
+    // A network's validators come up for the first time already at epoch 1:
+    // the on-chain initialization advances the system before any validator
+    // process exists. So epoch 0 never ran off-chain, minted no handoff
+    // certificate, and never will — the barrier's anchor for the epoch these
+    // validators are entering does not and cannot exist.
+    //
+    // The barrier has to read that off the chain (`validator_set
+    // .previous_committee` empty while the on-chain epoch matches) and enter
+    // anyway. Treating it as a failed read instead blocks the barrier on
+    // something that can never arrive, and — because the boot barrier runs
+    // inside node startup — every validator fails to start. That is not
+    // hypothetical: it is what the `restart_spectator` upgrade-test scenario
+    // caught on this branch, with the whole committee refusing to boot.
+    //
+    // The assertion is that the barrier did not spin AT ALL. A cluster that
+    // boots is necessary but not sufficient — the counters are what say the
+    // barrier answered immediately rather than waiting something out.
     let cluster = IkaTestClusterBuilder::new()
         .with_num_validators(4)
-        // Long enough that the first boundary — where the barrier legitimately
-        // engages and WOULD honour the hold-back — cannot fire while the
-        // genesis-boot assertions below run.
         .with_epoch_duration_ms(600_000)
-        .with_withhold_handoff_anchor(Duration::from_secs(600))
         .build()
         .await
-        .expect("ika test cluster failed to boot at genesis with the handoff anchor withheld");
+        .expect(
+            "the cluster must boot when the epoch being entered has no predecessor epoch to be \
+             handed off from",
+        );
 
     for name in &cluster.validator_names {
         let handle = node_handle(&cluster, name);
         assert_eq!(
-            handle.with(|node| node.current_epoch_for_testing()),
-            0,
-            "the cluster left the genesis epoch before the genesis-skip assertions ran",
-        );
-        assert_eq!(
             barrier_waiting(&handle),
             0.0,
-            "a validator booting into the genesis epoch is blocked in the prepare-then-start \
-             barrier — epoch 0 has no predecessor to be handed off from and must skip it",
+            "a validator entering an epoch with no predecessor is blocked in the \
+             prepare-then-start barrier, waiting for a handoff certificate that no epoch \
+             could have produced",
         );
         assert_eq!(
             barrier_retries(&handle),
             0.0,
-            "a validator booting into the genesis epoch spent barrier retries waiting for a \
-             handoff certificate that no epoch could have produced",
+            "a validator entering an epoch with no predecessor spent barrier retries before \
+             starting — the chain says outright that no committee preceded this epoch, so the \
+             barrier had nothing to wait for and should not have polled once",
         );
     }
 }

--- a/crates/ika-test-cluster/tests/handoff_barrier_start_paths.rs
+++ b/crates/ika-test-cluster/tests/handoff_barrier_start_paths.rs
@@ -230,24 +230,52 @@ async fn test_promoted_joiner_waits_for_handoff_data() {
         .expect("failed to add the joiner validator");
     let joiner_name = joiner.authority_name();
 
-    // The promotion branch runs the barrier before it constructs the
-    // joiner's validator components, so the gauge going to 1 IS the promotion
-    // reaching the barrier. Without the barrier on that path it never moves,
-    // and this poll is what fails.
+    // The epoch the joiner is promoted INTO: `request_add_validator` takes
+    // effect at the next boundary, so it is one past the chain's epoch now.
+    // Every barrier observation below is pinned to it, and that pinning is
+    // the whole point of this test. The joiner keeps its hold-back
+    // configured for its whole life, so one boundary later it produces a
+    // byte-identical 30s barrier signature as an ORDINARY CONTINUING
+    // validator on the reconfigure seam — a path that was already covered
+    // before this change. Without the epoch pin the test passes on that
+    // signature and says nothing at all about the promotion path.
+    let promotion_epoch = cluster
+        .current_epoch_from_chain()
+        .await
+        .expect("chain epoch is readable")
+        + 1;
+    let joiner_epoch =
+        |handle: &IkaNodeHandle| handle.with(|node| node.current_epoch_for_testing());
+    assert!(
+        joiner_epoch(&node_handle(&cluster, &joiner_name)) < promotion_epoch,
+        "the epoch boundary passed while the joiner was being added, so the epoch it is \
+         promoted into is not the one this test pinned",
+    );
+
+    // The promotion branch runs the barrier before it constructs the joiner's
+    // validator components, so the gauge reading 1 AT THE PROMOTION EPOCH is
+    // the promotion reaching the barrier. Without the barrier on that path it
+    // never moves at that epoch, and this poll is what fails.
     poll_until(
         Duration::from_secs(300),
-        "the promoted joiner to enter the prepare-then-start barrier",
+        "the promoted joiner to enter the prepare-then-start barrier for the epoch it is \
+         promoted into",
         || {
             cluster
                 .swarm
                 .node(&joiner_name)
                 .and_then(|node| node.get_node_handle())
-                .filter(|handle| barrier_waiting(handle) == 1.0)
+                .filter(|handle| {
+                    barrier_waiting(handle) == 1.0 && joiner_epoch(handle) == promotion_epoch
+                })
                 .map(|_| ())
         },
     )
     .await;
-    tracing::info!("promoted joiner is blocked in the prepare-then-start barrier");
+    tracing::info!(
+        promotion_epoch,
+        "promoted joiner is blocked in the prepare-then-start barrier",
+    );
 
     poll_until(
         Duration::from_secs(300),
@@ -257,7 +285,9 @@ async fn test_promoted_joiner_waits_for_handoff_data() {
                 .swarm
                 .node(&joiner_name)
                 .and_then(|node| node.get_node_handle())
-                .filter(|handle| barrier_waiting(handle) == 0.0)
+                .filter(|handle| {
+                    barrier_waiting(handle) == 0.0 && joiner_epoch(handle) == promotion_epoch
+                })
                 .map(|_| ())
         },
     )

--- a/crates/ika-test-cluster/tests/handoff_barrier_start_paths.rs
+++ b/crates/ika-test-cluster/tests/handoff_barrier_start_paths.rs
@@ -121,7 +121,17 @@ fn min_expected_retries() -> f64 {
 
 /// The epoch the tests strike. Epoch 0's close mints the first handoff
 /// certificate, so from epoch 1 onward there is a real anchor to withhold.
+///
+/// The restart test strikes epoch 2 rather than 1 so the anchor epoch is one
+/// this validator CROSSED while running, which puts the anchor committee in
+/// its local committee store. Committees are written there by reconfiguration
+/// only, so at epoch 1 the anchor (epoch 0) would be absent and the barrier
+/// would fall back to reading `validator_set.previous_committee` from chain —
+/// which only serves while the on-chain epoch is exactly anchor + 1. With
+/// epochs this short the boundary can land inside the restart window, and the
+/// test would then be measuring that race rather than the barrier.
 const STRUCK_EPOCH: u64 = 1;
+const RESTART_STRUCK_EPOCH: u64 = 2;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_boot_into_epoch_waits_for_handoff_data() {
@@ -137,7 +147,7 @@ async fn test_boot_into_epoch_waits_for_handoff_data() {
     let names = cluster.validator_names.clone();
     let restarted = names[3];
     for name in &names {
-        wait_for_node_epoch(&node_handle(&cluster, name), STRUCK_EPOCH).await;
+        wait_for_node_epoch(&node_handle(&cluster, name), RESTART_STRUCK_EPOCH).await;
     }
 
     // Restart the validator with its handoff anchor held back. Consensus for
@@ -188,7 +198,7 @@ async fn test_boot_into_epoch_waits_for_handoff_data() {
     // the network-key material the barrier made it wait for. A validator that
     // had started on stale or absent shares stalls here.
     for name in &names {
-        wait_for_node_epoch(&node_handle(&cluster, name), STRUCK_EPOCH + 1).await;
+        wait_for_node_epoch(&node_handle(&cluster, name), RESTART_STRUCK_EPOCH + 1).await;
     }
 }
 

--- a/dev-docs/plans/handoff-barrier-escape-and-pure-close-gate.md
+++ b/dev-docs/plans/handoff-barrier-escape-and-pure-close-gate.md
@@ -139,6 +139,16 @@ the next epoch via the fallback and signing works — validated per
 
 ## Item 2 — barrier on ALL consensus-start paths
 
+> **DONE.** The barrier now runs on the fullnode→validator promotion and
+> process-startup paths as well as the reconfigure seam; `specs/handoff.md`
+> describes the shipped behavior (the three paths, the generalized inputs,
+> the genesis and unmapped-key carve-outs). It landed WITHOUT item 1, so the
+> ordering note at the end of this item stands as an accepted risk rather
+> than a satisfied prerequisite: the indefinite block now applies to a
+> restarting or joining validator too. Items 1 and 3 remain deferred, item 1
+> still subject to the re-derivation the banner at the top of this file
+> demands.
+
 **Problem.** `wait_for_handoff_data_ready` runs only on the
 continuing-validator reconfigure path (lib.rs:2816). Two consensus-start
 paths skip it:

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -258,26 +258,87 @@ next epoch inherits.
    blindly — defense against local DB tampering/corruption), then
    re-installs certified outputs (idempotent: locally-present digests
    skip the fetch).
-2. **Prepare-then-start barrier (reconfiguration seam)**: before
-   entering epoch E+1, the validator blocks until the FULL verified
-   handoff data for epoch E is local: the certificate (fetched and
-   verified via the same verifier, anchored once per barrier entry) and
-   every certified network-key output blob — reconfiguration outputs
-   AND the canonical DKG outputs. Holding the certificate
-   does NOT imply holding the outputs (a lagging validator can adopt
-   the certificate from a buffered signature quorum without ever
-   computing the outputs), so the barrier installs missing outputs by
-   digest. This is what prevents stale-share `InvalidParameters`
-   signing failures after the boundary. The DKG items are part of the
-   readiness predicate deliberately: a local mirror whose digest
-   contradicts the certificate (the hydration-clobber shape below) can
-   only be repaired here — the installer fetches the cert-pinned bytes
-   from peers and re-caches them, and it only runs while the gate reads
-   not-ready. When the gate skipped DKG items, a poisoned mirror passed
-   the barrier instantly every epoch and stayed wedged permanently. The
-   DKG digests are read from the NEW epoch store (empty per-epoch table
-   → perpetual mirror), never the outgoing store, whose per-epoch table
+2. **Prepare-then-start barrier (every path that starts a validator's
+   epoch components)**: before entering epoch E+1, the validator blocks
+   until the FULL verified handoff data for epoch E is local: the
+   certificate (fetched and verified via the same verifier, anchored once
+   per barrier entry) and every certified network-key output blob —
+   reconfiguration outputs AND the canonical DKG outputs. Holding the
+   certificate does NOT imply holding the outputs (a lagging validator
+   can adopt the certificate from a buffered signature quorum without
+   ever computing the outputs; a joiner or a freshly-booted process may
+   hold neither), so the barrier installs missing outputs by digest.
+   This is what prevents stale-share `InvalidParameters` signing failures
+   after the boundary. The DKG items are part of the readiness predicate
+   deliberately: a local mirror whose digest contradicts the certificate
+   (the hydration-clobber shape below) can only be repaired here — the
+   installer fetches the cert-pinned bytes from peers and re-caches them,
+   and it only runs while the gate reads not-ready. When the gate skipped
+   DKG items, a poisoned mirror passed the barrier instantly every epoch
+   and stayed wedged permanently.
+
+   THE THREE PATHS. Everything that starts a validator's epoch-specific
+   components blocks here first, and nothing else does:
+   - the CONTINUING validator at the reconfiguration seam, before it
+     restarts consensus and the MPC service for the new epoch;
+   - the FULLNODE PROMOTED into the committee at a boundary, before its
+     validator components are constructed. This is the node with the
+     weakest starting position — it computed none of the epoch's outputs,
+     so it typically enters the barrier holding nothing;
+   - the process BOOTING (or rebooting) straight into an epoch, before
+     the same construction. Consensus startup is spawned from inside
+     that construction, so the barrier is what keeps a restarting
+     validator out of consensus until its key material is verified and
+     local.
+
+   INPUTS (all four, on every path). The anchor epoch — the epoch being
+   entered, minus one. That epoch's committee, which signed the
+   certificate and whose members serve it. Those members' peer ids. And
+   the epoch store for the epoch being ENTERED, which is where both
+   digest sources are read and where fetched outputs are cached. On the
+   two reconfiguration paths the anchor epoch's committee and peers come
+   straight from the outgoing epoch store. A booting process has no store
+   for the anchor epoch, so it resolves that committee from the local
+   committee store, falling back to `validator_set.previous_committee` on
+   chain — the joiner bootstrap's own resolution. A committee that cannot
+   be resolved leaves the barrier not-ready and it retries; that is
+   absence, never a licence to start unanchored.
+
+   Both digest sources are read from the store for the epoch being
+   ENTERED, the only store a booting process has. That costs nothing on
+   the reconfiguration paths: the reconfiguration digests live in the
+   epoch-keyed PERPETUAL slice (keyed by the reconfiguration session's
+   own epoch), which is process-wide and reads identically through any
+   epoch store. For the DKG digests it is load-bearing: read through the
+   entering store, its per-epoch table is empty and the merged view is
+   the perpetual canonical mirror — the value the installer repairs. Read
+   through an outgoing store, that store's per-epoch table wins, and it
    is exactly what the end-of-epoch hydration may have poisoned.
+
+   SKIPS. A node LEAVING the committee does not prepare — it will never
+   use the data. Entering epoch 0 at genesis is skipped: no predecessor
+   epoch exists to be handed off from (the same `epoch >= 1` test the
+   joiner bootstrap uses). Nothing else is exempt.
+
+   FAIL-CLOSED. A contradicted anchor — peers served certificates and
+   none verified, or a locally persisted one that no longer verifies —
+   halts the node on every path, and the caller does not start the
+   epoch's components. On the boot path the shutdown-signal subscriber is
+   not installed until node startup returns, so the barrier also reports
+   the halt to its caller, which fails the startup; the node runner exits
+   the process on a start failure, so the outcome is the same halt.
+
+   The block is indefinite by design and that has not changed — but it
+   now applies to more nodes: an epoch whose certificate was minted on no
+   validator (see
+   `dev-docs/plans/handoff-barrier-escape-and-pure-close-gate.md`) wedges
+   a restarting or joining validator too, not only a continuing one. A
+   validator visibly not signing remains the accepted trade against one
+   signing with the wrong shares. The operator-facing signals are the same
+   on all three paths — the `handoff_prepare_waiting` gauge, the
+   `handoff_prepare_retries_total` counter and the every-tenth-retry
+   warn — and they work on the boot path because the metrics server
+   starts before node startup runs.
 3. **Network-key adoption (steady state)**: each epoch, locally-held
    network-key outputs are adopted into the instantiation set only if
    their digests match the prior epoch's certificate
@@ -328,12 +389,17 @@ next epoch inherits.
      (joiner / cold start): an overlay entry with NO blobs at all for a
      key DKG'd in a PRIOR epoch, on a validator that holds nothing for
      it. The producer cache can never fill (this validator never
-     computed the key's outputs) and the cert-pinned blob install
-     (barrier) covers only continuing validators today, so adoption
-     flags the key for the syncer's chain-sourced read instead of
-     skipping it forever. (Until issue #1751 removed the migration
-     chain-read fallback, that fallback covered this shape implicitly;
-     the `v140_churn` scenario's mirrored joiner caught the regression.)
+     computed the key's outputs), and the cert-pinned blob install
+     (barrier) now runs on every start path but still cannot reach THIS
+     key: the certificate names keys by `NetworkKeyId`, the caches are
+     keyed by `ObjectID`, and a key this process has never instantiated
+     that is not one of the compiled-in deployed keys has no translation
+     between the two — the barrier passes it rather than deadlocking on
+     it (see the barrier section). So adoption flags the key for the
+     syncer's chain-sourced read instead of skipping it forever. (Until
+     issue #1751 removed the migration chain-read fallback, that fallback
+     covered this shape implicitly; the `v140_churn` scenario's mirrored
+     joiner caught the regression.)
      A key DKG'd THIS epoch is excluded — the healthy fresh-key
      bootstrap window. Second (mid-epoch restart, issue #1852). Once this
      epoch's reconfiguration completes, the off-chain copy of a key's
@@ -444,20 +510,22 @@ next epoch inherits.
    empty (shrunken) carry-forward map that would diverge this validator's
    frozen set from its peers'. An empty map is returned only for the
    chain-true no-cert epoch (genesis; historically also the v3→v4
-   boundary epochs). CAVEAT: the committee-uniformity of that empty-map case rests
-   on invariant 5 holding on EVERY consensus-start path; today the
-   barrier is wired only into the continuing-validator reconfigure path
-   (joiner-promotion and cold startup are pending — see
-   `dev-docs/plans/handoff-barrier-escape-and-pure-close-gate.md`), so
-   a joiner racing its bootstrap fetch can still freeze absent-cert.
-   The read-error flavor of the fork is closed; the absent-cert flavor
-   closes with the barrier wiring.
+   boundary epochs). The committee-uniformity of that empty-map case rests
+   on invariant 5 holding on EVERY consensus-start path, which it now does:
+   the barrier is wired into all three, so a validator cannot reach the
+   freeze without the prior epoch's certificate — a joiner can no longer
+   race its bootstrap fetch and freeze absent-cert. Both flavors of that
+   fork (read error and absent cert) are closed.
 5. The barrier guarantee: no validator participates in epoch E+1
    sessions without locally holding the verified epoch-E handoff
-   artifacts. Currently enforced on the continuing-validator
-   reconfigure path; extending it to the fullnode→validator promotion
-   and cold-startup consensus-start paths is planned work (see the
-   plan referenced in invariant 4).
+   artifacts. Enforced on all three paths that start a validator's
+   epoch-specific components — the continuing-validator reconfigure
+   seam, fullnode→validator promotion, and process startup into an
+   epoch — with two carve-outs, both stated in the barrier section:
+   entering epoch 0 at genesis (no predecessor epoch to be handed off
+   from), and a certified key with no local `NetworkKeyId → ObjectID`
+   translation, which the barrier cannot check or install and which
+   adoption's own cert-digest gate covers instead.
 
 Code anchors: `crates/ika-types/src/handoff.rs` (types),
 `crates/ika-core/src/handoff_cert.rs` (aggregation + verification),

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -390,9 +390,13 @@ next epoch inherits.
    validator visibly not signing remains the accepted trade against one
    signing with the wrong shares. The operator-facing signals are the same
    on all three paths — the `handoff_prepare_waiting` gauge, the
-   `handoff_prepare_retries_total` counter and the every-tenth-retry
-   warn — and they work on the boot path because the metrics server
-   starts before node startup runs.
+   `handoff_prepare_retries_total` counter, and a warn that re-states what
+   is still missing every ten SECONDS of wall clock (not every Nth retry:
+   one retry is a second while only blobs are missing, but as long as the
+   anchor fetch's whole attempt budget when no peer is serving the
+   certificate, which is exactly when the breakdown is needed) — and they
+   work on the boot path because the metrics server starts before node
+   startup runs.
 3. **Network-key adoption (steady state)**: each epoch, locally-held
    network-key outputs are adopted into the instantiation set only if
    their digests match the prior epoch's certificate

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -293,16 +293,34 @@ next epoch inherits.
 
    INPUTS (all four, on every path). The anchor epoch — the epoch being
    entered, minus one. That epoch's committee, which signed the
-   certificate and whose members serve it. Those members' peer ids. And
-   the epoch store for the epoch being ENTERED, which is where both
-   digest sources are read and where fetched outputs are cached. On the
-   two reconfiguration paths the anchor epoch's committee and peers come
-   straight from the outgoing epoch store. A booting process has no store
-   for the anchor epoch, so it resolves that committee from the local
-   committee store, falling back to `validator_set.previous_committee` on
-   chain — the joiner bootstrap's own resolution. A committee that cannot
-   be resolved leaves the barrier not-ready and it retries; that is
-   absence, never a licence to start unanchored.
+   certificate and against which every signature on it is verified. A set
+   of peers to ask for the certificate and the blobs. And the epoch store
+   for the epoch being ENTERED, which is where both digest sources are
+   read and where fetched outputs are cached.
+
+   On the two reconfiguration paths the anchor epoch's committee and its
+   peers come straight from the outgoing epoch store. A booting process
+   has no store for the anchor epoch: it resolves that committee from the
+   local committee store, falling back to
+   `validator_set.previous_committee` on chain (the joiner bootstrap's own
+   resolution), and it asks the ENTERING committee's peers — the set it
+   can actually dial — exactly as the joiner bootstrap does.
+
+   That chain fallback is the ONE not-ready condition the barrier does not
+   wait out indefinitely, and the reason is that waiting cannot fix it:
+   the fallback refuses to serve `validator_set.previous_committee` unless
+   the on-chain epoch is exactly `anchor_epoch + 1` (otherwise it would
+   hand back a committee for the wrong epoch), while the barrier's
+   `anchor_epoch` is fixed at boot. Once the chain crosses the next
+   boundary the condition is false forever, and a booting node cannot
+   re-read the chain — the reconfiguration loop, the admin server and both
+   watchdogs all start after node startup returns, which a blocked boot
+   barrier delays. So the boot path gives up on that one condition after a
+   bounded number of spaced attempts and FAILS STARTUP: the process exits
+   without entering the epoch, and its supervisor restarts it into
+   whichever epoch the chain has actually reached, where the anchor
+   resolves. Every other not-ready condition stays unbounded, because for
+   those, waiting is what makes them resolvable.
 
    Both digest sources are read from the store for the epoch being
    ENTERED, the only store a booting process has. That costs nothing on

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -338,6 +338,19 @@ next epoch inherits.
    epoch exists to be handed off from (the same `epoch >= 1` test the
    joiner bootstrap uses).
 
+   Genesis is not always epoch 0, though, and the boot path has to handle
+   that. A network can bring its validators up for the first time already
+   at epoch 1 — the on-chain initialization advances the system before any
+   validator process exists — and then epoch 0 never ran off-chain, minted
+   no certificate, and never will. The chain says so directly:
+   `validator_set.previous_committee` is EMPTY while the on-chain epoch
+   matches. That is an ANSWER, not a failed read, and the barrier treats it
+   as the genesis skip one epoch along — enter without a cross-epoch
+   anchor, logged loudly, because on an established network the same
+   reading would mean the chain lost its previous committee. Conflating it
+   with a failed read wedges every validator on the network's own first
+   epoch.
+
    One certified ITEM is also exempt, and it has to be. The certificate
    names keys by `NetworkKeyId`; every local digest slice and blob cache
    is keyed by `ObjectID`. The translation is a process-global map holding

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -574,6 +574,9 @@ Code anchors: `crates/ika-types/src/handoff.rs` (types),
 (EndOfPublish V2 processing, deferred close, epoch-keyed digest slice),
 `crates/ika-core/src/epoch_tasks/handoff_signature_sender.rs`,
 `crates/ika-core/src/epoch_tasks/joiner_bootstrap_verifier.rs`,
-`crates/ika-node/src/lib.rs` (bootstrap at epoch start +
-prepare-then-start barrier), `crates/ika-core/src/dwallet_mpc/mpc_manager.rs`
+`crates/ika-node/src/lib.rs` (bootstrap at epoch start, and the
+prepare-then-start barrier — `wait_for_handoff_data_ready`,
+`prepare_handoff_anchor`, `all_cert_network_key_outputs_held_locally`,
+`AnchorCommittee`, and its three call sites),
+`crates/ika-core/src/dwallet_mpc/mpc_manager.rs`
 (`adopt_cert_verified_keys`).

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -336,7 +336,30 @@ next epoch inherits.
    SKIPS. A node LEAVING the committee does not prepare — it will never
    use the data. Entering epoch 0 at genesis is skipped: no predecessor
    epoch exists to be handed off from (the same `epoch >= 1` test the
-   joiner bootstrap uses). Nothing else is exempt.
+   joiner bootstrap uses).
+
+   One certified ITEM is also exempt, and it has to be. The certificate
+   names keys by `NetworkKeyId`; every local digest slice and blob cache
+   is keyed by `ObjectID`. The translation is a process-global map holding
+   the deployed keys as compiled-in constants plus whatever this PROCESS
+   has instantiated or derived. A key outside the constants that this
+   process has not touched — every fresh localnet/CI DKG, seen by a joiner
+   or by a just-restarted validator — has no entry, and the barrier can do
+   nothing about it: the installer has no `ObjectID` to cache bytes under,
+   and the derivation that would register one runs from the MPC manager's
+   adoption pass, which does not exist until the barrier releases. So an
+   unmapped item passes the readiness predicate and is reported instead
+   (`unmapped_cert_keys` on the periodic warn). That does not admit stale
+   shares: adoption DEFERS an unmapped key rather than installing anything
+   for it, and once the background derivation registers the mapping it
+   re-applies the same cert-digest gate and refuses a local output that
+   contradicts the certificate. The barrier's own contribution — the
+   certificate being local — is what arms that gate. The cost is liveness:
+   the key's sessions park until the stranded-key recovery fills them.
+   Blocking instead would deadlock every joiner and every restart on a
+   network whose keys are outside the constants.
+
+   Nothing else is exempt.
 
    FAIL-CLOSED. A contradicted anchor — peers served certificates and
    none verified, or a locally persisted one that no longer verifies —

--- a/dev-docs/specs/internal-presign-pool.md
+++ b/dev-docs/specs/internal-presign-pool.md
@@ -103,10 +103,17 @@ measured three independent mechanisms in the current code:
 - **the epoch-start fill window.** Every epoch's manager starts with an empty
   adopted-key set and answers "no signing key" until its first
   blob-complete overlay entry lands. Any stagger between validators — at
-  least one 5s syncer tick at every epoch boundary, longer for a restarting
-  or joining validator — leaves one validator holding a key while a peer
-  holds none. This one needs only a single network key to occur, so it
-  applies to mainnet and testnet as they run today;
+  least one 5s syncer tick at every epoch boundary — leaves one validator
+  holding a key while a peer holds none. This one needs only a single
+  network key to occur, so it applies to mainnet and testnet as they run
+  today. A restarting or joining validator used to lag arbitrarily further,
+  because nothing held it back from starting its epoch components before
+  its handoff data arrived; the prepare-then-start barrier now runs on those
+  paths too (`handoff.md`), so it enters the epoch with the certified key
+  material already local and only the same one-tick overlay stagger remains.
+  What the barrier does NOT bound is a certified key it cannot translate to
+  a local `ObjectID` — the stranded-key shape, which still fills from the
+  syncer's chain read after start;
 - **per-key overlay incompleteness.** The overlay is assembled per validator
   from chain metadata plus locally cached blobs. An entry whose blobs are
   still empty is skipped at adoption, and the recovery path is a chain read


### PR DESCRIPTION
## What this changes, in plain words

A validator's network-key shares are handed from one epoch's committee to the
next through a **handoff certificate**: a quorum-signed record naming, by
digest, exactly which key material the next epoch inherits. A validator that
starts signing for an epoch before it holds that certificate — and the key
blobs the certificate names — signs with the *previous* epoch's shares. The
threshold rounds then fail with `FailedToAdvanceMPC(InvalidParameters)`, and
in the meantime the validator is in consensus taking work it cannot do.

The **prepare-then-start barrier** exists to prevent exactly that: before a
validator starts an epoch's consensus and MPC components, it blocks until the
previous epoch's certificate is local and verified and every key output that
certificate pins is held locally with a matching digest. It fetches whatever is
missing from committee peers while it waits, and it never gives up and starts
anyway.

Until now the barrier was wired into **one** of the three places that start
those components: a continuing validator crossing a reconfiguration boundary.
The other two were not:

- a **fullnode promoted into the committee** at a boundary — the node with the
  weakest starting position, since it computed none of the epoch's outputs and
  typically holds nothing;
- a **process booting or restarting straight into an epoch** — consensus
  startup is spawned from inside node startup, so a restarting validator went
  into consensus immediately and picked up its key material afterwards, on a
  background 5-second tick.

This wires the barrier into both. Same block, same fail-closed semantics, same
operator-facing signals.

## Mechanism

The barrier needed four things it previously took from the outgoing epoch's
store, which a booting process does not have. It now takes them explicitly:

1. **the anchor epoch** — the epoch being entered, minus one;
2. **that epoch's committee** — every signature on the certificate is verified
   against it, and its members are the peers asked to serve it. On the two
   reconfiguration paths it is the outgoing store's own committee. On the boot
   path it is resolved from the local committee store, falling back to
   `validator_set.previous_committee` on chain — the resolution the joiner
   bootstrap already uses. A committee that will not resolve leaves the barrier
   not-ready and it retries;
3. **those members' peer ids**;
4. **the epoch store being ENTERED**, where both digest sources are read and
   fetched blobs are cached.

Reading both digest sources through the entering store is a no-op for the
existing path — reconfiguration digests live in the process-wide epoch-keyed
perpetual slice and read identically through any store — and is required for
the DKG digests, which must come from the entering store's merged view (its
per-epoch table is empty, so the value is the perpetual canonical mirror the
installer repairs) rather than an outgoing store's per-epoch table, which is
what the end-of-epoch hydration can poison.

`prepare_handoff_anchor` and `wait_for_handoff_data_ready` moved from
`impl IkaNode` methods to free functions over a `HandoffBarrierContext`,
because the boot-path barrier has to run *before* the `IkaNode` exists — it
runs before `construct_validator_components`, and constructing those components
is part of producing the node.

## One relaxation, and why it is safe

The certificate names keys by `NetworkKeyId`; every local cache is keyed by
`ObjectID`. The translation is a process-global map holding the deployed
mainnet/testnet keys as compiled-in constants plus whatever this *process* has
instantiated. A key outside those constants that this process has not touched —
every fresh localnet/CI DKG, seen by a joiner or by a just-restarted
validator — has no entry, and the barrier can do nothing about it: the
installer has no `ObjectID` to cache bytes under, and the derivation that
registers one runs from the MPC manager's adoption pass, which does not exist
until the barrier releases. Blocking on such a key would have been a guaranteed
deadlock on exactly the two paths this PR adds.

So `all_cert_network_key_outputs_held_locally` now passes an unmapped item and
reports it (`unmapped_cert_keys` on the barrier's periodic warn) instead of
holding the gate closed. That does not admit stale shares: adoption
**defers** an unmapped key rather than installing anything for it
(`mpc_manager.rs`, the unmapped-key branch), and once the background derivation
registers the mapping, adoption re-applies the same cert-digest gate and
refuses a local output contradicting the certificate. The barrier still
guarantees the certificate itself is local, which is what arms that gate. The
cost is liveness, not safety — the key's sessions park until the stranded-key
recovery fills them, which is what happens today.

## Skips and fail-closed

A node **leaving** the committee does not prepare. Entering **epoch 0** at
genesis is skipped — no predecessor epoch exists to be handed off from — on the
same `epoch >= 1` test the joiner bootstrap uses. Nothing else is exempt.

A **contradicted** anchor (peers served certificates and none verified, or a
persisted one that no longer verifies) halts the node on every path and the
caller does not start the epoch's components. On the boot path the shutdown
signal has no subscriber yet — the forwarder is installed only once node
startup returns — so the barrier also reports the halt to its caller, which
fails the startup; the node runner exits the process on a start failure, so the
outcome is the same halt.

## The spawned joiner-bootstrap task: kept

It is not fully subsumed. For a validator it is now a no-op re-check: the
barrier anchored the same epoch inline before any component started, so the
task finds the certificate persisted, re-verifies it, and returns. But it also
runs on nodes that never construct validator components — a process whose key
is in the committee while the process is not in validator mode, and fullnodes
following the epoch — and that is what keeps their handoff certificate and
off-chain network-key overlay populated. Removing it would change fullnode
behaviour, which is outside this change. The barrier never waits on it: it
fetches inline, because that task runs from inside the epoch's own run loop,
which is after the barrier by construction.

## Accepted risk, stated plainly

`dev-docs/plans/handoff-barrier-escape-and-pure-close-gate.md` lists this work
as its item 2 and says to land it *with or after* item 1, the barrier's
cert-less escape, because these are two new indefinite-block exposures. This
lands without item 1, deliberately: item 1 relaxes the block-forever safety
gate and carries its own review cycle, and its central premise is flagged in
that document as needing re-derivation. The consequence is real and is now
documented in the spec — an epoch whose certificate was minted on no validator
wedges a restarting or joining validator too, not only a continuing one. The
same trade the barrier has always made: a validator visibly not signing beats a
validator signing with the wrong shares.

## Tests

New: `crates/ika-test-cluster/tests/handoff_barrier_start_paths.rs`, three
`#[tokio::test(flavor = "multi_thread")]` cluster tests (the hold-back is a
wall-clock window, not a message ordering, so there is nothing for `#[sim_test]`
to control — per `dev-docs/conventions/simtest.md`).

The hold-back is a new `serde(skip)` `NodeConfig` field,
`withhold_handoff_anchor_for_testing`, in the same family as
`supported_protocol_versions`: unreadable from any config file. For that long
after the barrier is entered, the barrier reports the anchor as not obtainable
and fetches nothing — the benign propagation-lag outcome it already retries
on. It suppresses only the *acquisition* of the handoff data; the readiness
predicate keeps evaluating real local state.

**`test_boot_into_epoch_waits_for_handoff_data`** — a validator restarted
mid-epoch with its handoff anchor held back. Consensus is spawned from inside
node startup, so a node that starts its epoch components without the anchor
finishes booting immediately; the assertion is that startup takes at least as
long as the hold-back, backed by the barrier's own retry counter (so a boot
that was merely slow for another reason does not pass) and by the waiting gauge
reading 0 afterwards. Then the whole committee, restarted validator included,
crosses another epoch boundary — which it can only do by contributing to the
reconfiguration MPC with the key material the barrier made it wait for.

**`test_promoted_joiner_waits_for_handoff_data`** — a true joiner (in no prior
committee, so it computed none of the epoch's outputs and starts holding
nothing) promoted at a boundary with its anchor held back. The promotion branch
runs the barrier before it constructs validator components, so the waiting
gauge going to 1 IS the promotion reaching the barrier. The test waits for that,
then for the release, then asserts the recorded barrier duration is at least the
hold-back — and finally that the joiner carries the committee through another
boundary.

**`test_boot_without_a_predecessor_epoch_does_not_wait`** — a cluster whose
validators come up for the first time already at epoch 1 boots, with the
waiting gauge and retry counter both untouched: the barrier read "no committee
preceded this epoch" off the chain and entered immediately. This started life
as a genesis/epoch-0 test and had to be retargeted — neither cluster harness
ever boots a validator at epoch 0, so the `epoch >= 1` guard is never what
decides, and the skip that does fire is this one.

**Fault validation** (per `dev-docs/playbooks/test-testing.md`): each test was
run against correct code, then again with a one-token fault at the site it
guards, in release — the profile CI uses. The exit code is not the assertion;
the predicted log evidence is, and it is quoted below.

*Boot path.* Control: the restarted validator blocks and then starts, on the
nose —

```
prepare-then-start: awaiting full verified handoff data for epoch 2 ... anchor_epoch=1
prepare-then-start: still awaiting full verified handoff data for epoch 2 ... have_cert=false
prepare-then-start: still awaiting full verified handoff data for epoch 2 ... have_cert=false
prepare-then-start: epoch 2 handoff data ready+verified after 30s, 30 retries; starting MPC
test result: ok. 1 passed; 0 failed ... finished in 180.49s
```

Fault: the boot-path barrier call replaced with `if false` — the pre-fix
cold-start behaviour. The RIGHT assertion fired, and not marginally:

```
panicked at handoff_barrier_start_paths.rs:168:
the restarted validator finished booting in 118.553584ms, before its withheld
handoff anchor could possibly be available (30s) — it started its epoch's
consensus and MPC components without the verified handoff data for the epoch
test result: FAILED. 0 passed; 1 failed
```

118ms against a 30s hold-back. The specificity control is in the surrounding
log: `IkaNode started!`, then the MPC service running
("No last read consensus round, cannot perform cryptographic computation") and
"submitting capabilities to consensus" — the validator went straight into
consensus and MPC without its handoff data, which is the production symptom.
No barrier line appears for it; the only barrier lines in that run are the
unfaulted reconfiguration seam's (`ready+verified after 0s, 0 retries`).

*No-predecessor skip.* Control: the cluster boots and the barrier does not
poll once —

```
prepare-then-start: awaiting full verified handoff data for epoch 1 ... anchor_epoch=0
prepare-then-start: the chain holds no committee for epoch 0, so no handoff
certificate exists for it and none ever will — this network's first off-chain
epoch is 1. Entering it without a cross-epoch anchor, the same as entering
epoch 0 at genesis.
test result: ok. 1 passed; 0 failed ... finished in 32.62s
```

Fault: the chain's "no committee preceded this epoch" answer read as a failed
read again — literally the regression `restart_spectator` caught. Every
validator hangs on an anchor that cannot exist and then refuses to start:

```
44 × prepare-then-start: still awaiting full verified handoff data for epoch 1
     ... anchor_epoch=0 have_cert=false have_signing_committee=false
could not resolve the epoch-0 committee that signed this epoch's handoff
certificate; refusing to start validator components without a verifiable
cross-epoch anchor
test result: FAILED. 0 passed; 1 failed ... finished in 149.81s
```

*Promotion path.* Control: the promoted joiner blocks at the epoch it is
promoted INTO —

```
prepare-then-start: awaiting full verified handoff data for epoch 2 ... anchor_epoch=1
prepare-then-start: still awaiting full verified handoff data for epoch 2 ... have_cert=false
prepare-then-start: epoch 2 handoff data ready+verified after 30s, 30 retries; starting MPC
test result: ok. 1 passed; 0 failed ... finished in 140.72s
```

Fault: the promotion barrier short-circuited so it never runs.

```
timed out after 300s waiting for: the promoted joiner to enter the
prepare-then-start barrier for the epoch it is promoted into
test result: FAILED. 0 passed; 1 failed ... finished in 327.27s
```

The specificity control is that `Promoting the node from fullnode to validator`
still appears in the faulted run — the joiner WAS promoted, just without the
barrier, so the timeout means "no barrier at promotion" and not "never
promoted".

That epoch pin exists because the first version of this test passed WITH the
fault. The joiner keeps its hold-back for its whole life, so one boundary
after promotion it produces a byte-identical 30s barrier signature as an
ordinary continuing validator on the reconfigure seam — a path that was
already covered before this change. Control and fault differed only in when:
30s entering epoch 2 (the promotion) versus 30s entering epoch 3 (the next
seam). Without the pin the test accepted the latter and said nothing about
the promotion path at all.


Every fault was reverted; `grep -r "TEST-TESTING FAULT" crates` is empty and
the working tree is clean.

## Consensus review

The `consensus-reviewer` agent (`.claude/agents/consensus-reviewer.md`) was run
adversarially over the diff. Findings and what was done about each:

**H1 — the boot barrier could become permanently unsatisfiable. FIXED
(commit 2).** The chain fallback refuses to serve
`validator_set.previous_committee` unless the on-chain epoch is exactly
`anchor_epoch + 1`, and the barrier's `anchor_epoch` is fixed at boot. A node
that was down across the whole anchor epoch (so its committee store lacks it)
and whose boot straddles the next boundary would spin at 1 Hz forever, inside
`start_with_mode` — before the reconfiguration loop that would re-read the
chain, before the admin server, and before either watchdog arms. Nothing but
an operator could have recovered it. That one condition is now bounded (24
attempts, 5s apart) and exhausting it FAILS STARTUP: the node still does not
enter the epoch, and a supervised restart boots into the epoch the chain has
actually reached, where the anchor resolves. Every other not-ready condition
stays unbounded, because for those waiting is what makes them resolvable.

**M1 — the boot block ran with a frozen peer dial set. FIXED (commit 2).** The
trusted-peer refresh loop was spawned after the node was assembled, i.e. after
the boot barrier. It now starts before it, so a long boot block is not pinned
to the single trusted-peer publish made at network setup. (The barrier's own
peer list is the epoch's committee and does not change within the epoch.)

**M2 — the stall warn could be ~50 minutes apart in the case it exists for.
FIXED (commit 2).** It fired every 10th retry; one retry is a second while only
blobs are missing, but up to the anchor fetch's whole 300s attempt budget when
no peer is serving the certificate. It is now a wall-clock 10s cadence.

**M3 — the reconfiguration paths' fail-closed early return was unlogged at the
exit point. FIXED (commit 2).** The originating error still logged, but the
loop exit itself did not, so in an embedded host with no shutdown subscriber
(the in-process test swarm) it left an inert node with nothing at the exit.
Both sites now log at error before returning.

**L1 — unthrottled 1 Hz warn plus 1 Hz chain RPC in the resolve-failure loop.
FIXED (commit 2).** Resolution attempts are now spaced 5s apart and bounded,
per-attempt failures log at debug, and the periodic barrier warn already
carries `have_signing_committee`.

**L2 — the fail-closed error text named a cause the code rules out. FIXED
(commit 2).** A `next_committee_pubkey_set_hash` mismatch is advisory in
`verify_joiner_bootstrap_cert` (it warns and proceeds), so it cannot reach the
re-verification failure branch. The message now names the two things that can:
an epoch mismatch, or signatures short of quorum.

**L3 / L4 — doc-comment placement and an overstated safety claim. FIXED
(commit 2).**

**Confirmed by the review, not changed:**

- The unmapped-key relaxation is safe. The reviewer traced the whole chain:
  the barrier passes an unmapped item; adoption defers it before every
  adoption branch; the deferral retries every tick; `register` writes both map
  directions under one lock so the barrier's miss implies adoption's miss; and
  once registered, adoption re-applies the cert-digest gate against the same
  certificate the barrier anchored. No stale key material can be admitted.
- Reading the reconfiguration digests through the entering epoch store is
  exactly equivalent — that accessor delegates solely to the process-wide
  epoch-keyed perpetual slice, and `perpetual_tables_for_handoff` is installed
  on both stores before the relevant read.
- No cascade deadlock on the boot path: everything the barrier needs is
  upstream of it, and a node blocked at the barrier still serves certificates
  to peers from perpetual storage, so a blocked peer does not starve others.
- No torn state at the promotion call site: the barrier only touches
  `epoch()`, `committee()` and `epoch_start_state()`, none of which go through
  the terminated store's `tables()`, and there is no concurrent writer to the
  entering store at either call site.
- The test-only config field is `serde(skip)` and reaches only the barrier's
  acquisition step.

**Lenses reported clean:** consensus determinism (the barrier produces no
consensus-visible value), epoch-close lock gating (untouched), batch loops
(every per-item guard `continue`s), no silent skips, parameter-set agreement.
Everything the review found landed in liveness symmetry.

## Verification

`cargo clippy --all-targets --all-features -- -D warnings` (ci.yaml's exact
invocation) is green on every commit here, along with the msim/simtest clippy
job that regular clippy never compiles.

- `cargo test --release -p ika-node --lib` — 39/39, including the extended
  `all_cert_network_key_outputs_held_locally_cases` (the unmapped-key arm, and
  that registering the mapping arms the gate for that same key).
- `ika-core` `dwallet_mpc::integration_tests::network_key_adoption` on CI —
  7/7, including `unmapped_cert_referenced_key_defers_and_spawns_derivation`,
  which is the downstream guard the unmapped-key relaxation leans on.
- Upgrade-test `restart_spectator` — PASSES. This is the one that matters most
  for the boot path: real, separately-compiled validator processes against a
  real localnet, one of them restarted mid-epoch, with a freshly-DKG'd network
  key that is NOT in the compiled-in `NetworkKeyId` seeds — so it exercises the
  boot barrier and the unmapped-key relaxation together. It is also what caught
  the genesis-is-not-always-epoch-0 defect.
- Upgrade-test `v140_churn` — FAILS on this branch, at
  `expect_network_key_output_converged`: validator 0's metrics endpoint saw 3
  of a required 4 output observations for one reconfiguration session. Its own
  log says `MPC output reached quorum` for that same session three seconds
  earlier, so the outputs converged and the shortfall is in the observation
  count, not the protocol. Every barrier in that run — all five validators,
  including the mirrored joiner's promotion into epoch 4 — completed in `0s, 0
  retries`, so nothing was held back by this change. A `v140_churn` baseline
  run on `main` is in flight to attribute it; there is no recent baseline on
  `main` because the `v131_*` → `v140_*` retarget postdates the last green run
  of that family. **Do not merge until that baseline reports.**
- Upgrade-test `v140_rollout` — PASSES. The deployed-release compatibility
  gate (and this PR's default upgrade-test scenario): a mixed committee of
  v1.4.0 and current binaries reshares to byte-identical outputs with zero
  malicious reports.
- Test Cluster suite — no run has yet completed on this branch's head; the
  queued ones were on superseded commits and were cancelled. All three new
  tests were run locally in release, which is the profile that job uses, but
  a green suite run on the head commit is still owed before merge.


## Follow-ups the review recommends (not blockers)

Neither is required for this change to be correct; both are worth their own
work, and the second would make this change's guarantee stronger than it is.

**The boot path's fail-closed exit is invisible to the alerts that should
catch it.** `AnchorCommitteeUnresolved` exits the process from inside node
startup, before the `uptime` metric is ever registered, and the barrier
clears `handoff_prepare_waiting` before returning. So a node crash-looping on
an unresolvable anchor trips neither the restart-loop alert nor
`ika-handoff-barrier-stuck`; the only rule that fires is the 1h
committee-downtime one, which names the wrong cause. The exit is correct — a
supervised restart is the recovery — but it should be attributable. Registering
the uptime metric before startup, or exporting a distinct counter at that
return, would do it.

**The no-stale-shares guarantee is structural, not defensive.** Today it holds
because no stale share pool survives into a new epoch's manager and requests
park in three level-triggered places — it is a property of the surrounding
construction, and nothing local rejects a share carrying the wrong epoch. An
epoch stamp on `validator_decryption_key_shares`, checked the way the VSS
cache already checks `derived_for_epoch`, would make the guarantee local and
testable in isolation instead of resting on the whole assembly staying the way
it is.

## Docs

- `dev-docs/specs/handoff.md` — the barrier section is rewritten for the three
  paths, the generalized inputs, the skips and the fail-closed behaviour;
  invariants 4 and 5 lose the "pending" caveat; the stranded-key note says what
  the barrier now covers and what it still cannot reach.
- `dev-docs/specs/internal-presign-pool.md` — the epoch-start fill window no
  longer cites unbounded restart/joiner lag; only the one-overlay-tick stagger
  remains, with the unmapped-key exception called out.
- `dev-docs/plans/handoff-barrier-escape-and-pure-close-gate.md` — item 2
  marked done, with the note that it landed without item 1 and that items 1 and
  3 remain deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
