### PR TITLE
ci: authenticate public GitHub git fetches with the job token

### DIFF
--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -45,8 +45,24 @@ runs:
       # address, so every git fetch of github.com goes out with the job
       # token. The private-repo SSH rewrite above is a longer prefix, and git
       # applies the longest matching insteadOf, so it still wins for inkrypto.
+      #
+      # Two channels, because the Move package resolver (move_package_alt)
+      # runs git with GIT_CONFIG_GLOBAL="" and so never reads ~/.gitconfig:
+      # the global config covers cargo and hand-written git, and the same
+      # rewrite goes into the job environment as GIT_CONFIG_COUNT/KEY/VALUE,
+      # which git reads on every invocation regardless of config files and
+      # which the resolver does not strip (it unsets only the repo-locating
+      # GIT_* variables). Verified on Test Cluster run 33655947764: with the
+      # global config alone the cargo build step passed but the Move
+      # dependency clone inside the test still failed anonymously.
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        rewrite="https://x-access-token:${GITHUB_TOKEN}@github.com/"
+        git config --global url."${rewrite}".insteadOf "https://github.com/"
+        {
+          echo "GIT_CONFIG_COUNT=1"
+          echo "GIT_CONFIG_KEY_0=url.${rewrite}.insteadOf"
+          echo "GIT_CONFIG_VALUE_0=https://github.com/"
+        } >> "$GITHUB_ENV"

--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -1,10 +1,19 @@
 name: Setup SSH for private dependencies
-description: Configure SSH key and rewrite HTTPS to SSH for private repos
+description: >-
+  Configure the SSH deploy key and rewrite HTTPS to SSH for private repos;
+  authenticate every other GitHub HTTPS fetch with the job token.
 
 inputs:
   deploy-key:
     description: The SSH deploy key
     required: true
+  github-token:
+    description: >-
+      Token used to authenticate HTTPS git fetches of public GitHub
+      dependencies (cargo git deps and Move package deps). Defaults to the
+      job's GITHUB_TOKEN.
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: composite
@@ -23,3 +32,21 @@ runs:
       shell: bash
       run: |
         git config --global url."git@github.com:dwallet-labs/inkrypto".insteadOf "https://github.com/dwallet-labs/inkrypto"
+
+    - name: Authenticate public GitHub HTTPS fetches with the job token
+      # The self-hosted runners share one egress address. Cargo (with
+      # CARGO_NET_GIT_FETCH_WITH_CLI) and the Move package resolver fetch a
+      # dozen public git dependencies per fresh build, anonymously, and
+      # GitHub rate-limits anonymous git-over-HTTPS per source address: the
+      # symptom is `fatal: could not read Username for 'https://github.com'`
+      # (a 401 to an anonymous clone) followed by `the remote end hung up`,
+      # killing an 80-minute gate before any test body runs, on main as much
+      # as on a branch. Authenticated fetches are limited per token, not per
+      # address, so every git fetch of github.com goes out with the job
+      # token. The private-repo SSH rewrite above is a longer prefix, and git
+      # applies the longest matching insteadOf, so it still wins for inkrypto.
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"


### PR DESCRIPTION
## Problem

Every Rust-building workflow uses `.github/actions/setup-ssh`, which only rewrites the private `inkrypto` dependency to SSH. Cargo (with `CARGO_NET_GIT_FETCH_WITH_CLI`) and the Move package resolver fetch the public git dependencies anonymously over HTTPS. All self-hosted runners share one egress address, so GitHub's per-address limit on anonymous git-over-HTTPS hits whichever job needs a fresh fetch:

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: the remote end hung up unexpectedly
```

This fires in the build step, before any test body. On 2026-09-02 it failed the Upgrade Test gate and the Test Cluster suite repeatedly, on `main` (run 33650830572, both attempts) as well as on branches (33647250373 ×4, 33647258699), across `amnn/async-graphql`, `mystenmark/async-task`, `mystenlabs/anemo`, `MystenLabs/fastcrypto`, `RustCrypto/*` and others, while the cache-warm CI job kept passing because it fetched nothing.

## Fix

The composite action now also runs

```
git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
```

with the job's `GITHUB_TOKEN` (new optional `github-token` input, defaulting to `github.token`). Authenticated fetches are limited per token, not per source address. The `inkrypto` SSH rewrite is a longer prefix and git applies the longest matching `insteadOf`, so the private dependency path is unchanged.

## Evidence

Same cluster binary, same day, same runners, fresh pods each time:

| Head | Rewrite | Test Cluster `-E binary(joiner)` | Where it failed |
|---|---|---|---|
| `main` fe56f2e2c3 (baseline) | none | [33650830572](https://github.com/dwallet-labs/ika/actions/runs/33650830572) failure ×2 attempts | `Build test cluster`: cargo git deps, `could not read Username` |
| fe56f2e2c3 + global `insteadOf` only | global config | [33655947764](https://github.com/dwallet-labs/ika/actions/runs/33655947764) failure | build step **passed**; Move resolver clone inside the tests still anonymous (it runs git with `GIT_CONFIG_GLOBAL=""`) |
| 03bcc8a2d2 (this PR) | global + `GIT_CONFIG_COUNT/KEY/VALUE` env | [33657466161](https://github.com/dwallet-labs/ika/actions/runs/33657466161) **success**, 8 tests | — (zero `could not read Username` lines in the log) |

PR CI runs the action in every job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
