### PR TITLE
test(metrics): compose SuiClientMetrics into the per-mode export pins

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -311,22 +311,56 @@ jobs:
           # would go silent; `ika_dwallet_mpc_self_malicious_total`, whose
           # zero would stop meaning anything) and one added unnoticed.
           #
-          # All four run here, not just the validator pin (#2124). The whole
-          # point of the set is the DIFFERENCE between modes, and the notifier
-          # and fullnode pins are the only two that see one side of it — with
-          # only the validator pin gated, a family leaking onto the notifier
-          # (ika #2051, the regression these exist for) reached main
-          # unremarked. The fourth is the negative pin: it composes a notifier
-          # with `SuiClientMetrics` omitted and asserts the comparison reports
-          # its families as gone, so the three positive pins cannot quietly
-          # degrade into asserting nothing.
+          # Only the validator pin is named here, deliberately: this step is
+          # #2119's gate and must not depend on a step named for other work.
+          # The full per-mode set (this test included) runs in the step below,
+          # so the one overlapping test executes twice — a second ~0.01s run
+          # against an already-built binary.
+          cargo test -p ika-node --lib -- --exact \
+            metrics::per_mode_registration::a_validator_exports_every_family \
+            | tee "$RUNNER_TEMP/seed-rotation-metric-pins.log"
+          grep -qE '^test result: ok\. 1 passed' "$RUNNER_TEMP/seed-rotation-metric-pins.log"
+      - name: Per-mode metric export pins (#2106, #2124)
+        # What each `NodeMode` registers, per family. Same reason as the steps
+        # around it: `Cargo Test Check` is otherwise compile-only and is the
+        # ONLY PR job that executes ika-node's tests, so a test not named here
+        # never runs on a PR. The notifier and fullnode pins were in exactly
+        # that position until #2124 — and they are the only two that see one
+        # side of a per-mode DIFFERENCE, which is to say a family leaking onto
+        # a mode that does not drive it (ika #2051, the regression the whole
+        # set exists for) had no PR gate at all.
+        #
+        # Two of the five are controls on the comparison itself, one per
+        # direction: `missing` (compose a notifier with `SuiClientMetrics`
+        # omitted) and `unexpected` (diff the notifier against its own list
+        # with the `ika_sui_client_*` names removed). Without them the three
+        # positive pins can degrade into asserting nothing — every one of them
+        # only ever requires both halves to be EMPTY.
+        #
+        # SCOPE, so nobody reads more into a green run than is there: the
+        # tests compose the start sequence's constructors BY HAND into their
+        # own registry. Nothing checks that composition against
+        # `IkaNode::start_with_mode`. A mode gate applied at the real call
+        # site, or a struct added to the start sequence and not to the
+        # composition, is invisible to every test in this step. Closing that
+        # needs a booted-node `/metrics` scrape per mode, which lives in
+        # ika-test-cluster, not here.
+        #
+        # Debug profile: five registry builds, no MPC crypto, no I/O.
+        run: |
+          set -o pipefail
           cargo test -p ika-node --lib -- --exact \
             metrics::per_mode_registration::a_validator_exports_every_family \
             metrics::per_mode_registration::a_notifier_exports_only_the_families_it_drives \
             metrics::per_mode_registration::a_fullnode_exports_only_the_families_it_drives \
             metrics::per_mode_registration::omitting_the_sui_client_metrics_reports_them_missing \
-            | tee "$RUNNER_TEMP/seed-rotation-metric-pins.log"
-          grep -qE '^test result: ok\. 4 passed' "$RUNNER_TEMP/seed-rotation-metric-pins.log"
+            metrics::per_mode_registration::a_family_the_notifier_list_does_not_name_is_reported_unexpected \
+            | tee "$RUNNER_TEMP/per-mode-metric-pins.log"
+          # cargo exits 0 when a name filter matches nothing, so a renamed test
+          # would silently disable this gate. Require the exact count: unlike a
+          # `[1-9][0-9]*` floor, this also catches renaming SOME of the pins.
+          # Bump the number when adding one.
+          grep -qE '^test result: ok\. 5 passed' "$RUNNER_TEMP/per-mode-metric-pins.log"
       - name: Deprecated on-chain mpc_data placeholder pins
         # What a candidate registers in the deprecated on-chain
         # `mpc_data_bytes` field is a byte-format contract (#2119): exactly

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -310,10 +310,23 @@ jobs:
           # being exported (`ika_dwallet_mpc_seed_identity_state`, whose alert
           # would go silent; `ika_dwallet_mpc_self_malicious_total`, whose
           # zero would stop meaning anything) and one added unnoticed.
+          #
+          # All four run here, not just the validator pin (#2124). The whole
+          # point of the set is the DIFFERENCE between modes, and the notifier
+          # and fullnode pins are the only two that see one side of it — with
+          # only the validator pin gated, a family leaking onto the notifier
+          # (ika #2051, the regression these exist for) reached main
+          # unremarked. The fourth is the negative pin: it composes a notifier
+          # with `SuiClientMetrics` omitted and asserts the comparison reports
+          # its families as gone, so the three positive pins cannot quietly
+          # degrade into asserting nothing.
           cargo test -p ika-node --lib -- --exact \
             metrics::per_mode_registration::a_validator_exports_every_family \
+            metrics::per_mode_registration::a_notifier_exports_only_the_families_it_drives \
+            metrics::per_mode_registration::a_fullnode_exports_only_the_families_it_drives \
+            metrics::per_mode_registration::omitting_the_sui_client_metrics_reports_them_missing \
             | tee "$RUNNER_TEMP/seed-rotation-metric-pins.log"
-          grep -qE '^test result: ok\. 1 passed' "$RUNNER_TEMP/seed-rotation-metric-pins.log"
+          grep -qE '^test result: ok\. 4 passed' "$RUNNER_TEMP/seed-rotation-metric-pins.log"
       - name: Deprecated on-chain mpc_data placeholder pins
         # What a candidate registers in the deprecated on-chain
         # `mpc_data_bytes` field is a byte-format contract (#2119): exactly

--- a/crates/ika-node/src/metrics.rs
+++ b/crates/ika-node/src/metrics.rs
@@ -414,12 +414,41 @@ ika_counter_2 1"
 /// gauges it never drives — at values indistinguishable from a healthy
 /// validator's (ika #2051). Registration now follows the subsystems each mode
 /// actually runs, and these lists are what pins it.
+///
+/// # Deliberately mode-independent
+///
+/// A family in all three lists is not an oversight. `ika_sui_client_*` comes
+/// from [`ika_sui_client::metrics::SuiClientMetrics`], which every mode
+/// constructs on the exported registry in one unconditional line of
+/// `IkaNode::start_with_mode`, because every mode really does talk to Sui: a
+/// notifier runs a read/write `SuiClient` to push checkpoints, and a fullnode
+/// runs the connector stack's read client. There is no subsystem behind those
+/// families that a mode can decline to run, so "absence is the correct signal"
+/// has nothing to say about them and they stay everywhere.
+///
+/// The same holds for the protocol-version gauges (`ika_binary_*`,
+/// `ika_configured_*`, `ika_supported_protocol_version_*`) and
+/// `ika_reconfig_phase`: properties of the running binary, or of a watchdog
+/// every mode arms. See "A process registers only the families it drives" in
+/// `dev-docs/conventions/metrics.md`.
 #[cfg(test)]
 mod per_mode_registration {
     use super::IkaNodeMetrics;
     use crate::ValidatorModeMetrics;
     use ika_config::NodeMode;
     use prometheus::Registry;
+
+    /// Whether the composition registers [`SuiClientMetrics`] — flipped only
+    /// by `omitting_the_sui_client_metrics_reports_them_missing`, which is
+    /// what proves the pins would actually catch that struct being gated
+    /// behind a mode.
+    ///
+    /// [`SuiClientMetrics`]: ika_sui_client::metrics::SuiClientMetrics
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum SuiClient {
+        Registered,
+        Omitted,
+    }
 
     /// The ika-side metric structs the start sequence registers in `mode`,
     /// composed into one registry, returning the family names the endpoint
@@ -431,11 +460,33 @@ mod per_mode_registration {
     /// literal, vec or not, is covered instead by
     /// `scripts/check-metric-names.sh`.
     ///
+    /// Three of the six `ika_sui_client_*` families are exactly that case and
+    /// are therefore absent from all three lists below — not dropped, just not
+    /// served until something observes them: `ika_sui_client_sui_rpc_errors`,
+    /// `ika_sui_client_sui_response_errors_total` and
+    /// `ika_sui_client_chain_blob_reads` are label vecs whose children are
+    /// only created at an increment site. Seeding them would mean a hand-kept
+    /// list of `method` (and `method`×`kind`) values, which
+    /// `SuiClientMetrics` documents as the thing it deliberately does not do;
+    /// the two vecs that DO have a zero baseline
+    /// (`ika_sui_client_rate_limited_errors_total`,
+    /// `ika_sui_client_sui_node_info`) are pre-materialized at construction
+    /// and are pinned, so gating the whole struct behind a mode still shows up
+    /// here.
+    ///
     /// The families left out of this composition are mode-independent (the
-    /// anemo/quinn network, rocksdb, archive and pruner families) or already
-    /// mode-gated elsewhere (the host telemetry in `node_runner`), so none of
-    /// them can move a per-mode difference.
+    /// anemo/quinn network, rocksdb via `DBMetrics::init`, the mysten runtime
+    /// families via `mysten_metrics::init_metrics`, archive and pruner) or
+    /// already mode-gated elsewhere (the host telemetry in `node_runner`), so
+    /// none of them can move a per-mode difference. `NodeConfigMetrics` is
+    /// unconditional in the start sequence too and is absent here because it
+    /// registers nothing at all — it is an empty struct with a no-op
+    /// `record_metrics`.
     fn exported_families(mode: NodeMode) -> Vec<String> {
+        composed_families(mode, SuiClient::Registered)
+    }
+
+    fn composed_families(mode: NodeMode, sui_client: SuiClient) -> Vec<String> {
         let registry = Registry::new();
 
         // Registered by every mode, each internally registering only the
@@ -447,6 +498,14 @@ mod per_mode_registration {
         let _ocs = ika_core::sui_connector::ocs_metrics::OcsMetrics::new(&registry);
         let _proof_provider = ika_network::proof_provider::ProofProviderMetrics::new(&registry);
         let _node = IkaNodeMetrics::new(&registry);
+
+        // Mode-independent by construction: `IkaNode::start_with_mode` builds
+        // this one on `registry_service.default_registry()` before it branches
+        // on the mode at all, so the notifier's and fullnode's `/metrics`
+        // carry it too (ika #2124).
+        if sui_client == SuiClient::Registered {
+            let _sui_client = ika_sui_client::metrics::SuiClientMetrics::new(&registry);
+        }
 
         // Registered only where the subsystems behind them run: the MPC
         // service, the checkpoint builders and the validator telemetry, plus
@@ -469,11 +528,25 @@ mod per_mode_registration {
         names
     }
 
+    /// `(no longer exported, newly exported)` for `actual` against a pinned
+    /// list — the comparison `assert_families` renders, factored out so a test
+    /// can assert on the report itself rather than on a panic message.
+    fn diff_families(actual: &[String], expected: &[&str]) -> (Vec<String>, Vec<String>) {
+        let missing = expected
+            .iter()
+            .filter(|name| !actual.iter().any(|found| found == *name))
+            .map(|name| (*name).to_string())
+            .collect();
+        let unexpected = actual
+            .iter()
+            .filter(|found| !expected.contains(&found.as_str()))
+            .cloned()
+            .collect();
+        (missing, unexpected)
+    }
+
     fn assert_families(mode: NodeMode, expected: &[&str]) {
-        let actual = exported_families(mode);
-        let expected: Vec<String> = expected.iter().map(|name| name.to_string()).collect();
-        let missing: Vec<&String> = expected.iter().filter(|n| !actual.contains(n)).collect();
-        let unexpected: Vec<&String> = actual.iter().filter(|n| !expected.contains(n)).collect();
+        let (missing, unexpected) = diff_families(&exported_families(mode), expected);
         assert!(
             missing.is_empty() && unexpected.is_empty(),
             "{mode} export set changed.\n  no longer exported: {missing:?}\n  newly exported: \
@@ -637,6 +710,10 @@ mod per_mode_registration {
         "ika_split_brain_dwallet_checkpoint_forks",
         "ika_split_brain_system_checkpoint_forks",
         "ika_stranded_network_key_missing_from_registry_read_condition_active",
+        // Mode-independent: every mode constructs `SuiClientMetrics`.
+        "ika_sui_client_rate_limited_errors_total",
+        "ika_sui_client_sui_node_info",
+        "ika_sui_client_sui_node_info_last_success_unixtime",
         "ika_sui_connector_chain_active_system_sessions_count",
         "ika_sui_connector_chain_active_user_sessions_count",
         "ika_sui_connector_chain_dwallet_checkpoint_writer_lag",
@@ -705,6 +782,11 @@ mod per_mode_registration {
         "ika_protocol_upgrade_supporting_stake",
         "ika_reconfig_phase",
         "ika_stranded_network_key_missing_from_registry_read_condition_active",
+        // Mode-independent: a notifier runs a read/write `SuiClient` of its
+        // own, so it exports the same uplink telemetry a validator does.
+        "ika_sui_client_rate_limited_errors_total",
+        "ika_sui_client_sui_node_info",
+        "ika_sui_client_sui_node_info_last_success_unixtime",
         "ika_sui_connector_dwallet_checkpoint_sequence",
         "ika_sui_connector_dwallet_checkpoint_write_requests_total",
         "ika_sui_connector_dwallet_checkpoint_writes_failure_total",
@@ -759,6 +841,11 @@ mod per_mode_registration {
         "ika_protocol_upgrade_supporting_stake",
         "ika_reconfig_phase",
         "ika_stranded_network_key_missing_from_registry_read_condition_active",
+        // Mode-independent: the connector stack's read client is a real
+        // `SuiClient`, so a fullnode's uplink telemetry is the validator's.
+        "ika_sui_client_rate_limited_errors_total",
+        "ika_sui_client_sui_node_info",
+        "ika_sui_client_sui_node_info_last_success_unixtime",
         "ika_supported_protocol_version_max",
         "ika_supported_protocol_version_min",
     ];
@@ -776,5 +863,32 @@ mod per_mode_registration {
     #[test]
     fn a_fullnode_exports_only_the_families_it_drives() {
         assert_families(NodeMode::Fullnode, FULLNODE_FAMILIES);
+    }
+
+    /// The pins are only worth their maintenance if they FAIL on the
+    /// regression they exist for. Composing a notifier without
+    /// `SuiClientMetrics` — the shape of gating that struct behind
+    /// `mode.is_validator()`, which is what #2124 found the pins could not
+    /// see — must report its families as no longer exported, and must not
+    /// disturb anything else.
+    #[test]
+    fn omitting_the_sui_client_metrics_reports_them_missing() {
+        let gated = composed_families(NodeMode::Notifier, SuiClient::Omitted);
+        let (missing, unexpected) = diff_families(&gated, NOTIFIER_FAMILIES);
+
+        assert_eq!(
+            missing,
+            vec![
+                "ika_sui_client_rate_limited_errors_total".to_string(),
+                "ika_sui_client_sui_node_info".to_string(),
+                "ika_sui_client_sui_node_info_last_success_unixtime".to_string(),
+            ],
+            "gating SuiClientMetrics behind a mode must be reported as families that stopped \
+             being exported"
+        );
+        assert!(
+            unexpected.is_empty(),
+            "omitting SuiClientMetrics must not add a family: {unexpected:?}"
+        );
     }
 }

--- a/crates/ika-node/src/metrics.rs
+++ b/crates/ika-node/src/metrics.rs
@@ -431,6 +431,29 @@ ika_counter_2 1"
 /// `ika_reconfig_phase`: properties of the running binary, or of a watchdog
 /// every mode arms. See "A process registers only the families it drives" in
 /// `dev-docs/conventions/metrics.md`.
+///
+/// # What these pins do NOT cover
+///
+/// `exported_families` mirrors `IkaNode::start_with_mode` **by hand**: it
+/// builds its own registry and calls the same constructors itself. Nothing
+/// checks the mirror against the real call site, in either direction.
+///
+/// So a mode gate applied at the CALL SITE is invisible here. Swap
+/// `SuiClientMetrics::new` for a `new_for_mode` in `lib.rs` — leaving `new`
+/// in place for ika-proxy and the test constructors — and the notifier's and
+/// fullnode's real `/metrics` lose the `ika_sui_client_*` families while
+/// every test in this module stays green. Nothing about that is specific to
+/// `SuiClientMetrics`: every constructor composed below carries the same gap,
+/// and a struct added to the start sequence and not added here is simply
+/// unpinned.
+///
+/// Read the lists, then, as pinning WHAT EACH COMPOSED STRUCT REGISTERS PER
+/// MODE — a real and previously unpinned property (ika #2051 was a
+/// registration bug) — and not as a proof about the served endpoint. The only
+/// thing that would close the gap is a different test: boot each mode and
+/// scrape its `/metrics` (ika-test-cluster's reach, not this module's). Until
+/// that exists, keeping the composition in step with `lib.rs` is a review
+/// obligation, not a checked one.
 #[cfg(test)]
 mod per_mode_registration {
     use super::IkaNodeMetrics;
@@ -439,9 +462,12 @@ mod per_mode_registration {
     use prometheus::Registry;
 
     /// Whether the composition registers [`SuiClientMetrics`] — flipped only
-    /// by `omitting_the_sui_client_metrics_reports_them_missing`, which is
-    /// what proves the pins would actually catch that struct being gated
-    /// behind a mode.
+    /// by `omitting_the_sui_client_metrics_reports_them_missing`, which shows
+    /// the comparison reports the loss rather than tolerating it.
+    ///
+    /// That is a claim about THIS composition, not about `lib.rs`: a gate
+    /// applied at the real call site never reaches this switch. See "What
+    /// these pins do NOT cover" on the module.
     ///
     /// [`SuiClientMetrics`]: ika_sui_client::metrics::SuiClientMetrics
     #[derive(Clone, Copy, PartialEq, Eq)]
@@ -462,17 +488,30 @@ mod per_mode_registration {
     ///
     /// Three of the six `ika_sui_client_*` families are exactly that case and
     /// are therefore absent from all three lists below — not dropped, just not
-    /// served until something observes them: `ika_sui_client_sui_rpc_errors`,
-    /// `ika_sui_client_sui_response_errors_total` and
-    /// `ika_sui_client_chain_blob_reads` are label vecs whose children are
-    /// only created at an increment site. Seeding them would mean a hand-kept
-    /// list of `method` (and `method`×`kind`) values, which
-    /// `SuiClientMetrics` documents as the thing it deliberately does not do;
-    /// the two vecs that DO have a zero baseline
-    /// (`ika_sui_client_rate_limited_errors_total`,
-    /// `ika_sui_client_sui_node_info`) are pre-materialized at construction
-    /// and are pinned, so gating the whole struct behind a mode still shows up
-    /// here.
+    /// served until something observes them:
+    /// `ika_sui_client_sui_rpc_errors{method}`,
+    /// `ika_sui_client_sui_response_errors_total{method,kind}` and
+    /// `ika_sui_client_chain_blob_reads{method}` are label vecs whose children
+    /// are only created at an increment site.
+    ///
+    /// Only ONE of the three is unseeded by a documented decision:
+    /// `sui_response_errors_total`, whose "No zero baseline" note on
+    /// `SuiClientMetrics` argues that its `method`×`kind` cross product is
+    /// knowable only to the increment sites, and explicitly contrasts itself
+    /// with the seeded `sui_rate_limited_errors`. `sui_rpc_errors` and
+    /// `chain_blob_reads` are unseeded by inheritance — nobody ever wrote them
+    /// a baseline. Their `method` sets are closed, so seeding them IS
+    /// possible; it changes what a healthy node exports and what an alert on
+    /// them means, which is a metrics-semantics call this pin work does not
+    /// make.
+    ///
+    /// The three that are pinned survive for two different reasons. Two are
+    /// pre-materialized at construction:
+    /// `ika_sui_client_rate_limited_errors_total` seeds both `signal` children
+    /// at 0, `ika_sui_client_sui_node_info` seeds its `unknown` child at 1.
+    /// The third, `ika_sui_client_sui_node_info_last_success_unixtime`, is a
+    /// plain unlabelled `IntGauge` — there are no children to materialize, so
+    /// `gather()` always returns it.
     ///
     /// The families left out of this composition are mode-independent (the
     /// anemo/quinn network, rocksdb via `DBMetrics::init`, the mysten runtime
@@ -865,30 +904,75 @@ mod per_mode_registration {
         assert_families(NodeMode::Fullnode, FULLNODE_FAMILIES);
     }
 
-    /// The pins are only worth their maintenance if they FAIL on the
-    /// regression they exist for. Composing a notifier without
+    /// The three `ika_sui_client_*` families, which both controls below move
+    /// across the comparison in one direction or the other.
+    const SUI_CLIENT_FAMILIES: &[&str] = &[
+        "ika_sui_client_rate_limited_errors_total",
+        "ika_sui_client_sui_node_info",
+        "ika_sui_client_sui_node_info_last_success_unixtime",
+    ];
+
+    /// Control for the `missing` half. Composing a notifier without
     /// `SuiClientMetrics` — the shape of gating that struct behind
     /// `mode.is_validator()`, which is what #2124 found the pins could not
     /// see — must report its families as no longer exported, and must not
     /// disturb anything else.
+    ///
+    /// Scoped to this composition. A gate at the `lib.rs` call site is a
+    /// different failure and this test cannot see it either; see "What these
+    /// pins do NOT cover" on the module.
     #[test]
     fn omitting_the_sui_client_metrics_reports_them_missing() {
         let gated = composed_families(NodeMode::Notifier, SuiClient::Omitted);
         let (missing, unexpected) = diff_families(&gated, NOTIFIER_FAMILIES);
 
+        let expected_missing: Vec<String> =
+            SUI_CLIENT_FAMILIES.iter().map(|n| n.to_string()).collect();
         assert_eq!(
-            missing,
-            vec![
-                "ika_sui_client_rate_limited_errors_total".to_string(),
-                "ika_sui_client_sui_node_info".to_string(),
-                "ika_sui_client_sui_node_info_last_success_unixtime".to_string(),
-            ],
+            missing, expected_missing,
             "gating SuiClientMetrics behind a mode must be reported as families that stopped \
              being exported"
         );
         assert!(
             unexpected.is_empty(),
             "omitting SuiClientMetrics must not add a family: {unexpected:?}"
+        );
+    }
+
+    /// Control for the `unexpected` half, which nothing else exercises: every
+    /// other test here can only ever assert it is EMPTY, so replacing its
+    /// computation with `Vec::new()` would leave them all green — and a family
+    /// leaking onto a mode that does not drive it is the direction ika #2051
+    /// actually failed in.
+    ///
+    /// Diff the real notifier composition against its pinned list with the
+    /// `ika_sui_client_*` names removed: those three must come back as newly
+    /// exported, and nothing must come back as lost.
+    #[test]
+    fn a_family_the_notifier_list_does_not_name_is_reported_unexpected() {
+        let trimmed: Vec<&str> = NOTIFIER_FAMILIES
+            .iter()
+            .copied()
+            .filter(|name| !SUI_CLIENT_FAMILIES.contains(name))
+            .collect();
+        assert_eq!(
+            trimmed.len(),
+            NOTIFIER_FAMILIES.len() - SUI_CLIENT_FAMILIES.len(),
+            "the notifier list must actually name every ika_sui_client_* family for this control \
+             to mean anything"
+        );
+
+        let (missing, unexpected) = diff_families(&exported_families(NodeMode::Notifier), &trimmed);
+
+        let expected_unexpected: Vec<String> =
+            SUI_CLIENT_FAMILIES.iter().map(|n| n.to_string()).collect();
+        assert_eq!(
+            unexpected, expected_unexpected,
+            "a family exported but absent from the pinned list must be reported as newly exported"
+        );
+        assert!(
+            missing.is_empty(),
+            "trimming the list must not make anything look lost: {missing:?}"
         );
     }
 }

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -444,9 +444,27 @@ Three boundaries on the rule:
   runs the connector stack's read client — so `SuiClientMetrics` is constructed
   on the exported registry in one unconditional line of
   `IkaNode::start_with_mode`, before the mode branch. There is no subsystem
-  behind those families for a mode to decline, so a `sui_rpc_errors` of 0 on a
-  notifier is a real observation and not the "healthy validator" illusion the
-  rule exists to prevent. Do not gate this struct behind a mode.
+  behind those families for a mode to decline, so the "healthy validator"
+  illusion the rule exists to prevent cannot arise here. Do not gate this
+  struct behind a mode.
+
+  These families are **not node-only**: `ika-proxy` constructs the same struct
+  on its own registry (`crates/ika-proxy/src/main.rs`) for its own Sui client,
+  so `ika_sui_client_*` is served by the proxy's endpoint as well as by every
+  node's. Nothing in the metric distinguishes them — only the scrape target
+  does — so a fleet query over these families must be scoped to the node job
+  before it is read as a per-validator uplink rate.
+
+  Note also that most of these families have **no zero baseline on any mode**.
+  `ika_sui_client_sui_rpc_errors`, `..._sui_response_errors_total` and
+  `..._chain_blob_reads` are unseeded label vecs: a healthy node exports **no
+  series at all** for them, not a series at 0. Any rate alert on them must
+  treat absence as zero rather than as a missing target — which matters most
+  for `sui_rpc_errors`, the epoch-boundary boot-wedge lead indicator in
+  [`../playbooks/production-alerts.md`](../playbooks/production-alerts.md).
+  Only `..._rate_limited_errors_total` (both `signal` children seeded at 0),
+  `..._sui_node_info` (the `unknown` child at 1) and the unlabelled
+  `..._sui_node_info_last_success_unixtime` are present from process start.
 
 When a family stays on a mode that looks wrong for it, check what actually
 spawns its writer before "fixing" it. `ika_dwallet_mpc_data_blob_fetch_total`
@@ -459,20 +477,38 @@ about those subsystems, not about their metrics.
 The per-mode sets are pinned by `per_mode_registration` in
 `crates/ika-node/src/metrics.rs`, which composes the same constructors the
 start sequence uses and asserts the gathered family names for each mode. All
-four of its tests run on PR CI, in the `Cargo Test Check` job.
+five of its tests — three per-mode lists plus one control on each half of the
+comparison — run on PR CI, in the `Cargo Test Check` job's "Per-mode metric
+export pins" step.
 
-The pins' domain is `gather()`, what `/metrics` actually serves, so a label vec
+**What the pins do not reach.** The composition mirrors
+`IkaNode::start_with_mode` by hand, and nothing checks the mirror against it.
+A mode gate applied at the real call site, or a metric struct added to the
+start sequence and not to the composition, is invisible to all five tests. The
+pins constrain what each composed constructor registers per mode; they are not
+a statement about the served endpoint. Closing that would take a booted-node
+`/metrics` scrape per mode in `ika-test-cluster`, which does not exist today —
+so keeping the composition in step with `lib.rs` is a review obligation.
+
+**Their domain is `gather()`**, what `/metrics` actually serves, so a label vec
 with no children at construction is legitimately absent from all three lists:
 `ika_sui_client_sui_rpc_errors`, `ika_sui_client_sui_response_errors_total` and
-`ika_sui_client_chain_blob_reads` first appear at their increment site. That is
-not a hole in the pin — the two `SuiClientMetrics` vecs that DO carry a zero
-baseline are pre-materialized and pinned, so gating the struct behind a mode
-still fails the comparison, which is what
-`omitting_the_sui_client_metrics_reports_them_missing` asserts directly. Adding
-a family to a mode-independent struct without pre-materializing it is a choice
-about the zero baseline (see "No zero baseline" on `sui_response_errors_total`),
-not a way to stay out of the pins; `scripts/check-metric-names.sh` covers every
-registered literal either way.
+`ika_sui_client_chain_blob_reads` first appear at their increment site. An
+unseeded family is therefore genuinely outside the pins, and whether to seed
+one is a decision about its zero baseline (see "No zero baseline" on
+`sui_response_errors_total`, which argues it for that family's `method`×`kind`
+cross product specifically — the other two are unseeded by inheritance, and
+their closed `method` sets could be seeded).
+
+`scripts/check-metric-names.sh` is the complementary gate but a different one.
+It enforces exactly four things over every literal metric name in `crates/`:
+the `ika_` prefix (or membership of the frozen legacy allowlist); an explicit
+registry at the registration site, never prometheus's process-global default;
+no `ika`-prefixed registry re-exporting foreign metrics; and that the name
+appears in the generated inventory below — in both directions, so a removed
+metric left in the inventory fails too. It says nothing about which mode
+exports a family, and nothing about whether a family is ever gathered, which is
+why an unseeded vec passes it while sitting outside the per-mode pins.
 
 ## Validator host telemetry
 

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -455,7 +455,7 @@ Three boundaries on the rule:
   does — so a fleet query over these families must be scoped to the node job
   before it is read as a per-validator uplink rate.
 
-  Note also that most of these families have **no zero baseline on any mode**.
+  Note also that three of the six families have **no zero baseline on any mode**.
   `ika_sui_client_sui_rpc_errors`, `..._sui_response_errors_total` and
   `..._chain_blob_reads` are unseeded label vecs: a healthy node exports **no
   series at all** for them, not a series at 0. Any rate alert on them must

--- a/dev-docs/conventions/metrics.md
+++ b/dev-docs/conventions/metrics.md
@@ -428,7 +428,7 @@ family, and a family is not "suppressed to zero", it simply is not there:
   unconditional and a mis-classified family costs one lost observation on one
   role rather than a panic.
 
-Two boundaries on the rule:
+Three boundaries on the rule:
 
 - **`uptime{process=...}` and the process-level basics stay in every mode.**
   The protocol-version gauges (`ika_binary_max_protocol_version` and friends)
@@ -439,6 +439,14 @@ Two boundaries on the rule:
   a family from a validator breaks dashboards that already read it, which is a
   separate change with its own blast radius; this rule removes families only
   from processes that never drove them.
+- **`ika_sui_client_*` is mode-independent, deliberately.** Every mode talks to
+  Sui — a notifier runs a read/write `SuiClient` to push checkpoints, a fullnode
+  runs the connector stack's read client — so `SuiClientMetrics` is constructed
+  on the exported registry in one unconditional line of
+  `IkaNode::start_with_mode`, before the mode branch. There is no subsystem
+  behind those families for a mode to decline, so a `sui_rpc_errors` of 0 on a
+  notifier is a real observation and not the "healthy validator" illusion the
+  rule exists to prevent. Do not gate this struct behind a mode.
 
 When a family stays on a mode that looks wrong for it, check what actually
 spawns its writer before "fixing" it. `ika_dwallet_mpc_data_blob_fetch_total`
@@ -450,7 +458,21 @@ about those subsystems, not about their metrics.
 
 The per-mode sets are pinned by `per_mode_registration` in
 `crates/ika-node/src/metrics.rs`, which composes the same constructors the
-start sequence uses and asserts the gathered family names for each mode.
+start sequence uses and asserts the gathered family names for each mode. All
+four of its tests run on PR CI, in the `Cargo Test Check` job.
+
+The pins' domain is `gather()`, what `/metrics` actually serves, so a label vec
+with no children at construction is legitimately absent from all three lists:
+`ika_sui_client_sui_rpc_errors`, `ika_sui_client_sui_response_errors_total` and
+`ika_sui_client_chain_blob_reads` first appear at their increment site. That is
+not a hole in the pin — the two `SuiClientMetrics` vecs that DO carry a zero
+baseline are pre-materialized and pinned, so gating the struct behind a mode
+still fails the comparison, which is what
+`omitting_the_sui_client_metrics_reports_them_missing` asserts directly. Adding
+a family to a mode-independent struct without pre-materializing it is a choice
+about the zero baseline (see "No zero baseline" on `sui_response_errors_total`),
+not a way to stay out of the pins; `scripts/check-metric-names.sh` covers every
+registered literal either way.
 
 ## Validator host telemetry
 


### PR DESCRIPTION
## What

`exported_families()` in `crates/ika-node/src/metrics.rs` — the basis of the `per_mode_registration` pins from #2106 — composed six ika-side metric structs and never `SuiClientMetrics`. But `IkaNode::start_with_mode` builds that one on the exported registry in a single unconditional line (`crates/ika-node/src/lib.rs:419`), *before* it branches on the mode. So every `ika_sui_client_*` family was genuinely served by validator, notifier and fullnode alike while sitting outside the pins' domain entirely.

Consequence, as #2124 states it: the pins could not catch a per-mode regression in that family in either direction, and #2106's "byte-identical validator export set" claim only ever held over the composed structs, not over the real `/metrics`.

This composes it, regenerates the three lists from the real registries, documents the mode-independence, and adds a control on each half of the comparison.

## Family counts, before → after

| Mode | Before | After | Added |
|---|---|---|---|
| Validator | 180 | 183 | the three below |
| Notifier | 51 | 54 | the three below |
| Fullnode | 40 | 43 | the three below |

The same three families, identically, in all three lists:

```
ika_sui_client_rate_limited_errors_total
ika_sui_client_sui_node_info
ika_sui_client_sui_node_info_last_success_unixtime
```

Names were taken from the tests' own `newly exported:` report, not hand-typed.

## Why identical across modes is correct

Every mode talks to Sui — the notifier runs a read/write `SuiClient` to push checkpoints, the fullnode runs the connector stack's read client. There is no subsystem behind those families for a mode to decline, so "absence is the correct signal" (the ika #2051 rule) has nothing to say about them. That is now stated in the `per_mode_registration` module doc and added to `dev-docs/conventions/metrics.md` as a third boundary on the rule, so the duplication does not get "fixed" later.

`ika-proxy` also constructs `SuiClientMetrics` on its own registry, so these families are not node-only — noted in the conventions doc, since a fleet query over them must be scoped to the node job.

## The three families that are NOT in the lists

`ika_sui_client_sui_rpc_errors{method}`, `ika_sui_client_sui_response_errors_total{method,kind}` and `ika_sui_client_chain_blob_reads{method}` are label vecs with no children at construction, so `gather()` — the pins' domain, and what the endpoint actually serves — omits them until their first increment.

Only one of the three is unseeded by a *documented* decision: `sui_response_errors_total`, whose "No zero baseline" note argues its `method`×`kind` cross product is knowable only to the increment sites, explicitly contrasting itself with the seeded `sui_rate_limited_errors`. The other two are unseeded by inheritance — nobody ever wrote them a baseline — and their `method` sets are closed, so seeding them is possible; it changes what a healthy node exports and what an alert on them means, which this pin work does not decide. Recorded in both docs rather than left to read as an oversight.

The three that are pinned survive for two reasons: two are pre-materialized at construction (`rate_limited_errors_total` seeds both `signal` children at 0, `sui_node_info` seeds its `unknown` child at 1), and `sui_node_info_last_success_unixtime` is an unlabelled `IntGauge` with no children to materialize.

## Controls on the comparison

Both halves of the `missing`/`unexpected` report are now exercised, because neither was:

- `omitting_the_sui_client_metrics_reports_them_missing` — composes a notifier with `SuiClientMetrics` omitted and requires exactly those three families back as `missing`.
- `a_family_the_notifier_list_does_not_name_is_reported_unexpected` — diffs the real notifier composition against its pinned list with the three names removed and requires exactly those three back as `unexpected`. Before this, every test only ever asserted `unexpected.is_empty()`, so replacing that computation with `Vec::new()` kept all four green — and leak-onto-a-mode is the direction ika #2051 actually failed in.

Verified by mutation both ways: stubbing `unexpected` to empty fails only the second; stubbing `missing` fails only the first.

`assert_families`' comparison was factored into `diff_families` so the controls read the report rather than a panic string. Cost: one registry build each.

## What this does not cover

Stated here and in both docs so a green run is not read as more than it is.

**The composition mirrors `lib.rs` by hand, and nothing checks the mirror.** `composed_families` builds its own registry and calls the constructors itself; it never observes `crates/ika-node/src/lib.rs:419`. So a mode gate applied at the *real call site* — a `new_for_mode` in `IkaNode::start_with_mode` while `new` stays for ika-proxy and the test constructors — removes the families from the notifier's and fullnode's actual `/metrics` and leaves all five tests green. The same holds for any metric struct added to the start sequence and not added to the composition: it is simply unpinned.

This is a property of the per-mode pin design as introduced in #2106, not something this PR adds — but it bounds the claim. The pins constrain **what each composed constructor registers per mode**, a real and previously unpinned property; they are not a proof about the served endpoint.

The one real closure is a different kind of test: boot each mode and assert over its scraped `/metrics`, which belongs in `ika-test-cluster` and does not exist today. Offered as a possible follow-up, not opened as an issue. Until then, keeping the composition in step with `lib.rs` is a review obligation.

Deliberately **not** done: adding a `new_for_mode` to `SuiClientMetrics`. It is mode-independent by design.

## CI

The `per_mode_registration` tests move to their own step, **"Per-mode metric export pins (#2106, #2124)"**, exact count 5, same `set -o pipefail` / `tee` / `grep -qE` shape. They were previously gating #2124 work under a step named `Seed-rotation pins (#2119)`.

That step keeps the single `a_validator_exports_every_family` invocation it had, at its original count of 1, so #2119's gate does not depend on a step named for other work. The overlap costs one extra ~0.01s test run against an already-built binary.

Why this matters beyond tidiness: `Cargo Test Check` is the only PR job that executes ika-node's tests, and the notifier and fullnode pins were named nowhere — the two tests that see one side of a per-mode *difference* had no PR gate at all.

## Also checked

`NodeConfigMetrics` is the only other struct constructed unconditionally in `start_with_mode`. It registers nothing — empty struct, no-op `record_metrics` — so there is nothing to compose. Noted in the doc. `DBMetrics`/`mysten_metrics::init_metrics` were already covered by the existing "left out because mode-independent" note, now named there.

The conventions doc's description of `scripts/check-metric-names.sh` was corrected to what the script enforces: `ika_` prefix, explicit registry, no `ika`-prefixed vendored registry, and bidirectional agreement with the generated inventory — none of which is per-mode export.

## Verification

- `cargo fmt --all`
- `cargo clippy -p ika-node --all-targets --all-features -- -D warnings` — exit 0
- `cargo test -p ika-node --lib metrics::` — 15 passed
- Both CI step commands run verbatim locally: `1 passed` and `5 passed`, both greps match
- `scripts/check-metric-names.sh` — OK (340 literal)

Closes #2124

🤖 Generated with [Claude Code](https://claude.com/claude-code)
