### PR TITLE
ci: send the GitHub token proactively on dependency fetches, and verify it

### DIFF
--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -88,23 +88,33 @@ runs:
       # Turns the mechanism above into a gated invariant instead of a hope:
       # mimic the Move resolver (no global config, env channel only), trace
       # the HTTP exchange, and fail the job unless the FIRST request carries
-      # an Authorization header. Only a count is printed: the trace itself
-      # stays in the pipe (git redacts the header value anyway, but the
-      # token must never reach the log).
+      # an Authorization header. Runs from an empty directory on purpose:
+      # inside the checkout, actions/checkout's repo-local
+      # `http.extraheader` would authenticate the probe and hide a broken
+      # proactive path — and the resolver's `git clone` never sees that
+      # repo-local config (clone reads no enclosing repository), which is
+      # exactly the path that failed. Only counts and git's own (redacted)
+      # error lines are printed: the trace stays in a file that is deleted.
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         set -o pipefail
         rewrite="https://x-access-token:${GITHUB_TOKEN}@github.com/"
-        n=$(GIT_CONFIG_GLOBAL="" GIT_CONFIG_COUNT=2 \
-              GIT_CONFIG_KEY_0="url.${rewrite}.insteadOf" GIT_CONFIG_VALUE_0="https://github.com/" \
-              GIT_CONFIG_KEY_1="http.proactiveAuth" GIT_CONFIG_VALUE_1="basic" \
-              GIT_TRACE_CURL=1 GIT_TRACE_CURL_NO_DATA=1 GIT_TRACE_REDACT=1 \
-              git ls-remote https://github.com/MystenLabs/sui.git HEAD 2>&1 >/dev/null \
-            | grep -c '=> Send header: Authorization:' || true)
-        echo "Authorization headers sent during ls-remote: ${n}"
-        if [ "${n}" -lt 1 ]; then
-          echo "::error::git sent no Authorization header on a public GitHub fetch; dependency fetches would be anonymous and rate-limited per source address"
+        probe="$(mktemp -d)"
+        cd "${probe}"
+        rc=0
+        GIT_CONFIG_GLOBAL="" GIT_CONFIG_COUNT=2 \
+          GIT_CONFIG_KEY_0="url.${rewrite}.insteadOf" GIT_CONFIG_VALUE_0="https://github.com/" \
+          GIT_CONFIG_KEY_1="http.proactiveAuth" GIT_CONFIG_VALUE_1="basic" \
+          GIT_TRACE_CURL=1 GIT_TRACE_CURL_NO_DATA=1 GIT_TRACE_REDACT=1 \
+          git ls-remote https://github.com/MystenLabs/sui.git HEAD >/dev/null 2>trace.log || rc=$?
+        requests=$(grep -ci '=> Send header: GET ' trace.log || true)
+        auth=$(grep -ci '=> Send header: Authorization:' trace.log || true)
+        echo "probe ls-remote: exit=${rc} requests=${requests} authorization-headers=${auth}"
+        grep -i '^fatal:' trace.log | sed "s#${GITHUB_TOKEN}#<token>#g" | head -3 || true
+        rm -rf "${probe}"
+        if [ "${rc}" -ne 0 ] || [ "${auth}" -lt 1 ]; then
+          echo "::error::public GitHub fetch was not authenticated on its first request (exit=${rc}, authorization-headers=${auth}); dependency fetches would be anonymous and rate-limited per source address"
           exit 1
         fi

--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -58,11 +58,53 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+      #
+      # The credentials must be sent PROACTIVELY. Git only sends URL
+      # credentials after a 401 challenge, and GitHub's limit does not
+      # challenge: it completes the handshake and then returns a protocol
+      # error ("GitHub is temporarily limiting some unauthenticated
+      # downloads ... Please retry later or authenticate"), so with the
+      # rewrite alone the token was never sent and Upgrade Test run
+      # 33729120682 failed exactly like an anonymous clone.
+      # `http.proactiveAuth = basic` (git >= 2.46; older git ignores the key)
+      # sends the Authorization header on the first request. It is safe next
+      # to actions/checkout's own `http.extraheader` Authorization on this
+      # repo: curl replaces its generated header with the explicit one, so
+      # only one is sent. (An extraheader of our own instead would NOT be
+      # safe: GitHub answers a duplicated Authorization header with 400.)
       run: |
         rewrite="https://x-access-token:${GITHUB_TOKEN}@github.com/"
         git config --global url."${rewrite}".insteadOf "https://github.com/"
+        git config --global http.proactiveAuth basic
         {
-          echo "GIT_CONFIG_COUNT=1"
+          echo "GIT_CONFIG_COUNT=2"
           echo "GIT_CONFIG_KEY_0=url.${rewrite}.insteadOf"
           echo "GIT_CONFIG_VALUE_0=https://github.com/"
+          echo "GIT_CONFIG_KEY_1=http.proactiveAuth"
+          echo "GIT_CONFIG_VALUE_1=basic"
         } >> "$GITHUB_ENV"
+
+    - name: Verify a public GitHub fetch is authenticated on its first request
+      # Turns the mechanism above into a gated invariant instead of a hope:
+      # mimic the Move resolver (no global config, env channel only), trace
+      # the HTTP exchange, and fail the job unless the FIRST request carries
+      # an Authorization header. Only a count is printed: the trace itself
+      # stays in the pipe (git redacts the header value anyway, but the
+      # token must never reach the log).
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -o pipefail
+        rewrite="https://x-access-token:${GITHUB_TOKEN}@github.com/"
+        n=$(GIT_CONFIG_GLOBAL="" GIT_CONFIG_COUNT=2 \
+              GIT_CONFIG_KEY_0="url.${rewrite}.insteadOf" GIT_CONFIG_VALUE_0="https://github.com/" \
+              GIT_CONFIG_KEY_1="http.proactiveAuth" GIT_CONFIG_VALUE_1="basic" \
+              GIT_TRACE_CURL=1 GIT_TRACE_CURL_NO_DATA=1 GIT_TRACE_REDACT=1 \
+              git ls-remote https://github.com/MystenLabs/sui.git HEAD 2>&1 >/dev/null \
+            | grep -c '=> Send header: Authorization:' || true)
+        echo "Authorization headers sent during ls-remote: ${n}"
+        if [ "${n}" -lt 1 ]; then
+          echo "::error::git sent no Authorization header on a public GitHub fetch; dependency fetches would be anonymous and rate-limited per source address"
+          exit 1
+        fi


### PR DESCRIPTION
## Problem

#2126 rewrote `github.com` URLs to carry the job token, but **git only sends URL credentials after a 401 challenge**, and GitHub's download limit does not challenge: it completes the handshake and returns a protocol error:

```
fatal: remote error: GitHub is temporarily limiting some unauthenticated downloads to protect the stability of the platform. Please retry later or authenticate.
```

So the token was never sent. Upgrade Test run [33729120682](https://github.com/dwallet-labs/ika/actions/runs/33729120682) on a branch that already carried #2126 failed exactly like an anonymous clone, in the Move dependency fetch inside `IkaTestClusterBuilder::build()`. The earlier green run on #2126 passed because the limit was not active at that moment, not because the fetch was authenticated.

Traced locally with `GIT_TRACE_CURL` under the resolver's own invocation (`GIT_CONFIG_GLOBAL=""`, env-channel config only):

| config | Authorization on first request |
|---|---|
| insteadOf rewrite only (#2126) | **none** |
| insteadOf + `http.proactiveAuth=basic` | sent |

## Fix

Set `http.proactiveAuth = basic` (git ≥ 2.46; the runner image has 2.55; older git ignores the key) through both channels: global config for cargo, `GIT_CONFIG_COUNT/KEY/VALUE` for the Move resolver.

Checked against GitHub that this coexists with `actions/checkout`'s own `http.extraheader` Authorization on this repo: curl sends only the explicit header, and `ls-remote` on `dwallet-labs/ika` succeeds with both configured. An `extraheader` of our own instead would **not** be safe: GitHub answers a duplicated `Authorization` header with `400 Duplicate header`.

## Verification, gated on every job

The composite action gains a step that mimics the resolver, traces one `ls-remote` against `MystenLabs/sui`, and fails the job unless the first request carries an `Authorization` header. Only the count is printed; the trace never reaches the log.

## Evidence

- The first version of the probe ran inside the checkout and reported `0` on every job ([CI 33734106955](https://github.com/dwallet-labs/ika/actions/runs/33734106955)): there, `actions/checkout`'s repo-local `http.extraheader` (an uppercase `AUTHORIZATION:`) authenticated the probe by the wrong mechanism and a case-sensitive count missed it. Reproduced locally. The probe now runs from an empty temp dir, which is also what the resolver's `git clone` sees (clone reads no enclosing repository).
- On head f2b17784d5 every PR CI job's probe reports `exit=0 requests=1 authorization-headers=2` ([CI 33734448787](https://github.com/dwallet-labs/ika/actions/runs/33734448787)).
- Test Cluster `-E binary(joiner)` on the same head: [33734440898](https://github.com/dwallet-labs/ika/actions/runs/33734440898), **10/10 passed**, probe `exit=0 requests=1 authorization-headers=2`, zero "limiting some unauthenticated downloads" / "could not read Username" lines in the log. The Move dependency clone of `MystenLabs/sui` inside `IkaTestClusterBuilder::build()` is the path that failed in 33729120682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
