### PR TITLE
ci(integration): exclude the swarm-booting crates from scope=all

### DIFF
--- a/.github/workflows/integration-tests-ci.yaml
+++ b/.github/workflows/integration-tests-ci.yaml
@@ -2,7 +2,15 @@ name: Integration Tests CI
 
 # Manually triggered. Runs the Rust dwallet-MPC integration tests (real
 # class-groups crypto, in-process consensus harness) on the `ika-k8s-large`
-# self-hosted runner. `scope: all` widens to the entire workspace test suite.
+# self-hosted runner. `scope: all` widens to the workspace test suite MINUS
+# the two crates whose tests start a Sui localnet: `ika-test-cluster` and
+# `ika-upgrade-test`. Those run under plain `cargo test` as several tests
+# in one process, each booting a Sui swarm, and collide on ports (the first
+# ever `all` run, 33750543127, died in sui-swarm with "Address already in
+# use"). They have their own workflows that give each test its own process:
+# `test-cluster.yaml` (nextest, profile `cluster`) and `upgrade-test.yaml`
+# (one scenario per job). `all` is therefore "every workspace test that can
+# share a process", not "every test in the repository".
 
 on:
   workflow_dispatch:
@@ -126,7 +134,10 @@ jobs:
           FEATURES="test-utils"
           if [ "$USE_MOCKS" = "true" ]; then FEATURES="test-utils,dwallet-mpc-unsafe-mock"; fi
           if [ "$SCOPE" = "all" ]; then
-            cargo test --release --workspace --features "$FEATURES" --color=always --no-run
+            # See the header: the swarm-booting crates cannot run in-process.
+            cargo test --release --workspace \
+              --exclude ika-test-cluster --exclude ika-upgrade-test \
+              --features "$FEATURES" --color=always --no-run
           else
             cargo test -p ika-core --lib --release --features "$FEATURES" --color=always --no-run
           fi
@@ -147,7 +158,12 @@ jobs:
           FEATURES="test-utils"
           if [ "$USE_MOCKS" = "true" ]; then FEATURES="test-utils,dwallet-mpc-unsafe-mock"; fi
           if [ "$SCOPE" = "all" ]; then
-            time cargo test --release --workspace --features "$FEATURES" --color=always -- \
+            # Same exclusions as the build step (see the header). Keep the two
+            # lists identical: a crate built here but not run, or run but not
+            # built, is a silent gap either way.
+            time cargo test --release --workspace \
+              --exclude ika-test-cluster --exclude ika-upgrade-test \
+              --features "$FEATURES" --color=always -- \
               $THREADS --nocapture 2>&1 | tee rust-tests.log
           else
             FILTER="dwallet_mpc::integration_tests"

--- a/.github/workflows/integration-tests-ci.yaml
+++ b/.github/workflows/integration-tests-ci.yaml
@@ -3,14 +3,37 @@ name: Integration Tests CI
 # Manually triggered. Runs the Rust dwallet-MPC integration tests (real
 # class-groups crypto, in-process consensus harness) on the `ika-k8s-large`
 # self-hosted runner. `scope: all` widens to the workspace test suite MINUS
-# the two crates whose tests start a Sui localnet: `ika-test-cluster` and
-# `ika-upgrade-test`. Those run under plain `cargo test` as several tests
-# in one process, each booting a Sui swarm, and collide on ports (the first
-# ever `all` run, 33750543127, died in sui-swarm with "Address already in
-# use"). They have their own workflows that give each test its own process:
-# `test-cluster.yaml` (nextest, profile `cluster`) and `upgrade-test.yaml`
-# (one scenario per job). `all` is therefore "every workspace test that can
-# share a process", not "every test in the repository".
+# `ika-test-cluster`, for two reasons that both matter:
+#
+# 1. Ports. Its tests boot a Sui swarm each, and under plain `cargo test`
+#    a binary's tests run concurrently in ONE process. The test ports come
+#    from `deterministic_port_base` (crates/ika-config/src/local_ip_utils.rs),
+#    which derives the block from NEXTEST_TEST_GLOBAL_SLOT and falls back to
+#    slot 0 without it — so every libtest thread draws base 9000 and the
+#    first cluster holds the ports for its whole test. Both `all` runs before
+#    this exclusion died that way in sui-swarm with "Address already in use":
+#    29056939247 (2026-07-09) and 33750543127 (2026-09-03, one test failed,
+#    two sibling swarms panicked). The cluster suite is covered by
+#    `test-cluster.yaml`, which runs it one process per test under nextest
+#    (profile `cluster`) so each test gets its own slot.
+# 2. Crypto. `ika-test-cluster` carries a self dev-dependency that enables
+#    `dwallet-mpc-unsafe-mock` (crates/ika-test-cluster/Cargo.toml). Under
+#    `--workspace`, dev-dependency features unify into the single `ika-core`
+#    build, so with the crate included EVERY test in the run — including the
+#    dwallet-MPC integration tests — used the INSECURE mock even with
+#    `use_mocks=false` (run 33750543127: ika-core lib in 761 s; excluded, run
+#    33768433944: 4180 s, matching the real-crypto `integration` scope).
+#    `scope: all` is real-crypto coverage only while this exclusion stands.
+#    Re-including the crate, e.g. by moving `all` onto nextest, silently
+#    re-mocks the whole workspace unless the self dev-dependency changes.
+#
+# `ika-upgrade-test` is NOT excluded: its scenario binaries return early
+# unless their RUN_* variable is set (they drive an external `sui` localnet
+# on fixed ports only under `upgrade-test.yaml`, one scenario per job), and
+# its 36 lib unit tests run nowhere else in CI.
+#
+# So `all` is "every workspace test that can share a process, with real
+# crypto"; the cluster suite must be dispatched separately.
 
 on:
   workflow_dispatch:
@@ -66,6 +89,9 @@ env:
 
 jobs:
   run-tests:
+    env:
+      # The one place the `all` exclusion is defined; both cargo steps use it.
+      ALL_SCOPE_EXCLUDES: "--exclude ika-test-cluster"
     name: Run ${{ inputs.scope }} tests
     runs-on: ika-k8s-large
     timeout-minutes: 180
@@ -130,13 +156,15 @@ jobs:
           # when green, and `time` in the run step covers test execution,
           # not rustc.
           # `use_mocks` layers the INSECURE deterministic mock on top of
-          # test-utils; default (off) is real crypto, byte-identical to before.
+          # test-utils; default (off) is real crypto for the `integration`
+          # scope, and for `all` only because `ika-test-cluster` is excluded
+          # (see the header: its self dev-dependency would unify the mock
+          # into ika-core for the whole run).
           FEATURES="test-utils"
           if [ "$USE_MOCKS" = "true" ]; then FEATURES="test-utils,dwallet-mpc-unsafe-mock"; fi
           if [ "$SCOPE" = "all" ]; then
-            # See the header: the swarm-booting crates cannot run in-process.
-            cargo test --release --workspace \
-              --exclude ika-test-cluster --exclude ika-upgrade-test \
+            # See the header for why `ika-test-cluster` is excluded.
+            cargo test --release --workspace $ALL_SCOPE_EXCLUDES \
               --features "$FEATURES" --color=always --no-run
           else
             cargo test -p ika-core --lib --release --features "$FEATURES" --color=always --no-run
@@ -158,11 +186,21 @@ jobs:
           FEATURES="test-utils"
           if [ "$USE_MOCKS" = "true" ]; then FEATURES="test-utils,dwallet-mpc-unsafe-mock"; fi
           if [ "$SCOPE" = "all" ]; then
-            # Same exclusions as the build step (see the header). Keep the two
-            # lists identical: a crate built here but not run, or run but not
-            # built, is a silent gap either way.
-            time cargo test --release --workspace \
-              --exclude ika-test-cluster --exclude ika-upgrade-test \
+            # The exclusion is the only thing keeping swarm-booting tests out
+            # of this in-process run, and the failure it prevents is a
+            # 20-minute-deep abort. Fail fast if a crate outside the known set
+            # starts pulling a swarm library into its Cargo.toml.
+            known="crates/ika-swarm/Cargo.toml crates/ika-test-cluster/Cargo.toml crates/ika-upgrade-test/Cargo.toml crates/ika/Cargo.toml"
+            unexpected=""
+            for f in $(grep -lE '^(sui-swarm|ika-swarm)[a-z-]*(\.workspace)? *=' crates/*/Cargo.toml); do
+              case " $known " in *" $f "*) ;; *) unexpected="$unexpected $f" ;; esac
+            done
+            if [ -n "$unexpected" ]; then
+              echo "::error::new swarm dependents outside the scope=all exclusion list:$unexpected — their tests would collide on ports in-process; exclude them here or #[ignore] the swarm tests"
+              exit 1
+            fi
+            # $ALL_SCOPE_EXCLUDES is the job-level list the build step used.
+            time cargo test --release --workspace $ALL_SCOPE_EXCLUDES \
               --features "$FEATURES" --color=always -- \
               $THREADS --nocapture 2>&1 | tee rust-tests.log
           else

--- a/.github/workflows/integration-tests-ci.yaml
+++ b/.github/workflows/integration-tests-ci.yaml
@@ -12,8 +12,10 @@ name: Integration Tests CI
 #    slot 0 without it — so every libtest thread draws base 9000 and the
 #    first cluster holds the ports for its whole test. Both `all` runs before
 #    this exclusion died that way in sui-swarm with "Address already in use":
-#    29056939247 (2026-07-09) and 33750543127 (2026-09-03, one test failed,
-#    two sibling swarms panicked). The cluster suite is covered by
+#    29056939247 (2026-07-09) and 33750543127 (2026-09-03: one test failed —
+#    the five sui-node threads of its swarm died with EADDRINUSE and the
+#    test thread with RecvError; the binary's other two tests passed). The
+#    cluster suite is covered by
 #    `test-cluster.yaml`, which runs it one process per test under nextest
 #    (profile `cluster`) so each test gets its own slot.
 # 2. Crypto. `ika-test-cluster` carries a self dev-dependency that enables
@@ -90,8 +92,19 @@ env:
 jobs:
   run-tests:
     env:
-      # The one place the `all` exclusion is defined; both cargo steps use it.
+      # The one place the `all` exclusion is defined; both cargo steps and the
+      # guard use it.
       ALL_SCOPE_EXCLUDES: "--exclude ika-test-cluster"
+      # Crates that pull a swarm library but are SAFE in-process, and why.
+      # The guard step derives the excluded crates from ALL_SCOPE_EXCLUDES
+      # and treats only these as additionally allowed:
+      #   ika            — depends on ika-swarm for `ika start`; its tests
+      #                    never boot one (run 33768433944: 10 tests, ≤0.02 s)
+      #   ika-swarm      — its Swarm::launch tests are #[ignore]d
+      #   ika-upgrade-test — scenario binaries are RUN_*-gated no-ops
+      # Un-ignoring or un-gating any of those re-breaks scope=all with the
+      # guard silent: move the crate to ALL_SCOPE_EXCLUDES instead.
+      SAFE_SWARM_DEPENDENTS: "crates/ika/Cargo.toml crates/ika-swarm/Cargo.toml crates/ika-upgrade-test/Cargo.toml"
     name: Run ${{ inputs.scope }} tests
     runs-on: ika-k8s-large
     timeout-minutes: 180
@@ -146,6 +159,32 @@ jobs:
           nohup bash -c 'prev=$(grep usage_usec /sys/fs/cgroup/cpu.stat 2>/dev/null | awk "{print \$2}"); while true; do sleep 15; cur=$(grep usage_usec /sys/fs/cgroup/cpu.stat 2>/dev/null | awk "{print \$2}"); echo "$(date -u +%T) effective_cpus=$(( (cur - prev) / 15000000 )).$(( ((cur - prev) / 1500000) % 10 )) $(grep -E "nr_throttled|throttled_usec" /sys/fs/cgroup/cpu.stat 2>/dev/null | tr "\n" " ") load=$(cut -d" " -f1-3 /proc/loadavg)"; prev=$cur; done' > cpu-sampler.log 2>&1 &
           echo $! > cpu-sampler.pid
 
+      - name: Guard the scope=all exclusion
+        if: inputs.scope == 'all'
+        # Before the build, because the failure this prevents costs a full
+        # release build plus a 20-minute-deep test abort. A crate outside the
+        # excluded set and the safe list that pulls a swarm library — sui's
+        # `test-cluster`/`sui-node` (how ika-test-cluster boots its network)
+        # or `sui-swarm`/`ika-swarm` — would run its swarm tests in-process
+        # and collide on ports.
+        run: |
+          excluded=""
+          set -- $ALL_SCOPE_EXCLUDES
+          while [ $# -gt 0 ]; do
+            if [ "$1" = "--exclude" ]; then excluded="$excluded crates/$2/Cargo.toml"; shift; fi
+            shift
+          done
+          allowed="$excluded $SAFE_SWARM_DEPENDENTS"
+          unexpected=""
+          for f in $(grep -lE '^(sui-swarm|ika-swarm|test-cluster|sui-node)[a-z-]*(\.workspace)? *=' crates/*/Cargo.toml); do
+            case " $allowed " in *" $f "*) ;; *) unexpected="$unexpected $f" ;; esac
+          done
+          echo "excluded:$excluded; safe: $SAFE_SWARM_DEPENDENTS; swarm dependents found: $(grep -lE '^(sui-swarm|ika-swarm|test-cluster|sui-node)[a-z-]*(\.workspace)? *=' crates/*/Cargo.toml | tr '\n' ' ')"
+          if [ -n "$unexpected" ]; then
+            echo "::error::swarm dependents outside ALL_SCOPE_EXCLUDES and SAFE_SWARM_DEPENDENTS:$unexpected — their tests would collide on ports in-process; add them to ALL_SCOPE_EXCLUDES, or to SAFE_SWARM_DEPENDENTS with the reason they cannot boot a swarm under cargo test"
+            exit 1
+          fi
+
       - name: Build tests
         env:
           SCOPE: ${{ inputs.scope }}
@@ -186,19 +225,6 @@ jobs:
           FEATURES="test-utils"
           if [ "$USE_MOCKS" = "true" ]; then FEATURES="test-utils,dwallet-mpc-unsafe-mock"; fi
           if [ "$SCOPE" = "all" ]; then
-            # The exclusion is the only thing keeping swarm-booting tests out
-            # of this in-process run, and the failure it prevents is a
-            # 20-minute-deep abort. Fail fast if a crate outside the known set
-            # starts pulling a swarm library into its Cargo.toml.
-            known="crates/ika-swarm/Cargo.toml crates/ika-test-cluster/Cargo.toml crates/ika-upgrade-test/Cargo.toml crates/ika/Cargo.toml"
-            unexpected=""
-            for f in $(grep -lE '^(sui-swarm|ika-swarm)[a-z-]*(\.workspace)? *=' crates/*/Cargo.toml); do
-              case " $known " in *" $f "*) ;; *) unexpected="$unexpected $f" ;; esac
-            done
-            if [ -n "$unexpected" ]; then
-              echo "::error::new swarm dependents outside the scope=all exclusion list:$unexpected — their tests would collide on ports in-process; exclude them here or #[ignore] the swarm tests"
-              exit 1
-            fi
             # $ALL_SCOPE_EXCLUDES is the job-level list the build step used.
             time cargo test --release --workspace $ALL_SCOPE_EXCLUDES \
               --features "$FEATURES" --color=always -- \

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -32,7 +32,11 @@ a nightly that dispatched only the `main` half is expected, not broken.
 ```bash
 # Rust dwallet-MPC integration tests (~48 tests, ~35 min at 4 threads).
 # Optional: test_filter (suffix after dwallet_mpc::integration_tests::),
-# rust_log, scope=all for the whole workspace.
+# rust_log. scope=all runs the workspace test suite under plain `cargo test`
+# EXCLUDING ika-test-cluster and ika-upgrade-test: their tests each boot a
+# Sui swarm and cannot share a process (in-process they collide on ports).
+# Those two are covered only by test-cluster.yaml and upgrade-test.yaml
+# below; scope=all is not a substitute for dispatching them.
 gh workflow run integration-tests-ci.yaml --ref <branch> \
   -f test_threads=4 [-f test_filter=network_dkg::test_network_dkg_full_flow]
 

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -30,10 +30,13 @@ a nightly that dispatched only the `main` half is expected, not broken.
 ## Dispatch commands
 
 ```bash
-# Rust dwallet-MPC integration tests (~48 tests, ~35 min at 4 threads).
+# Rust dwallet-MPC integration tests (107 tests, ~70 min test time / ~76 min
+# job at 4 threads, real crypto).
 # Optional: test_filter (suffix after dwallet_mpc::integration_tests::),
 # rust_log.
-#
+gh workflow run integration-tests-ci.yaml --ref <branch> \
+  -f test_threads=4 [-f test_filter=network_dkg::test_network_dkg_full_flow]
+
 # scope=all (manual only — the nightly dispatches the default scope) runs the
 # workspace test suite under plain `cargo test`, excluding ika-test-cluster:
 # its tests each boot a Sui swarm and, in one process, all draw port base
@@ -43,11 +46,10 @@ a nightly that dispatched only the `main` half is expected, not broken.
 # workspace silently ran on the mock. The cluster suite is covered by
 # test-cluster.yaml (and its sim_* tests by simtest.yaml); ika-upgrade-test
 # stays in (its scenarios are RUN_*-gated no-ops here; its lib tests run
-# nowhere else). scope=all is a strict superset of the default scope for
-# about 12 extra minutes (~80 min total at 4 threads).
+# nowhere else). scope=all is a strict superset of the default scope; the
+# measured cost before ika-upgrade-test was re-included was ~5 extra minutes
+# (76 min → 81 min job), to be re-measured with it in.
 gh workflow run integration-tests-ci.yaml --ref <branch> -f scope=all -f test_threads=4
-gh workflow run integration-tests-ci.yaml --ref <branch> \
-  -f test_threads=4 [-f test_filter=network_dkg::test_network_dkg_full_flow]
 
 # Cluster tests (in-process Sui+ika swarm tests via nextest,
 # process-per-test, ~35-40 min at 4 threads; 8-way OOMs the 96Gi pod).

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -32,11 +32,20 @@ a nightly that dispatched only the `main` half is expected, not broken.
 ```bash
 # Rust dwallet-MPC integration tests (~48 tests, ~35 min at 4 threads).
 # Optional: test_filter (suffix after dwallet_mpc::integration_tests::),
-# rust_log. scope=all runs the workspace test suite under plain `cargo test`
-# EXCLUDING ika-test-cluster and ika-upgrade-test: their tests each boot a
-# Sui swarm and cannot share a process (in-process they collide on ports).
-# Those two are covered only by test-cluster.yaml and upgrade-test.yaml
-# below; scope=all is not a substitute for dispatching them.
+# rust_log.
+#
+# scope=all (manual only — the nightly dispatches the default scope) runs the
+# workspace test suite under plain `cargo test`, excluding ika-test-cluster:
+# its tests each boot a Sui swarm and, in one process, all draw port base
+# 9000 (deterministic_port_base falls back to nextest slot 0). The exclusion
+# also keeps the crate's self dev-dependency on dwallet-mpc-unsafe-mock out
+# of the build, so scope=all is REAL crypto; with the crate in, the whole
+# workspace silently ran on the mock. The cluster suite is covered by
+# test-cluster.yaml (and its sim_* tests by simtest.yaml); ika-upgrade-test
+# stays in (its scenarios are RUN_*-gated no-ops here; its lib tests run
+# nowhere else). scope=all is a strict superset of the default scope for
+# about 12 extra minutes (~80 min total at 4 threads).
+gh workflow run integration-tests-ci.yaml --ref <branch> -f scope=all -f test_threads=4
 gh workflow run integration-tests-ci.yaml --ref <branch> \
   -f test_threads=4 [-f test_filter=network_dkg::test_network_dkg_full_flow]
 

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -46,9 +46,9 @@ gh workflow run integration-tests-ci.yaml --ref <branch> \
 # workspace silently ran on the mock. The cluster suite is covered by
 # test-cluster.yaml (and its sim_* tests by simtest.yaml); ika-upgrade-test
 # stays in (its scenarios are RUN_*-gated no-ops here; its lib tests run
-# nowhere else). scope=all is a strict superset of the default scope; the
-# measured cost before ika-upgrade-test was re-included was ~5 extra minutes
-# (76 min → 81 min job), to be re-measured with it in.
+# nowhere else). scope=all is a strict superset of the default scope for
+# about 11 extra minutes (87 min job vs 76 min, measured on run 33779055774
+# at 4 threads: 56 targets, 846 tests).
 gh workflow run integration-tests-ci.yaml --ref <branch> -f scope=all -f test_threads=4
 
 # Cluster tests (in-process Sui+ika swarm tests via nextest,


### PR DESCRIPTION
## Problem

`integration-tests-ci.yaml`'s `scope: all` ran `cargo test --release --workspace` under libtest, so the `ika-test-cluster` test binaries ran their tests concurrently in one process, each booting a Sui swarm. Every test draws its port block from `deterministic_port_base` (`crates/ika-config/src/local_ip_utils.rs`), which falls back to nextest slot 0 when `NEXTEST_TEST_GLOBAL_SLOT` is unset, so all of them get base 9000 and the first cluster holds the ports for its whole test. Both `all` runs to date died that way in sui-swarm with `Address already in use (os error 98)`: [29056939247](https://github.com/dwallet-labs/ika/actions/runs/29056939247) (2026-07-09) and [33750543127](https://github.com/dwallet-labs/ika/actions/runs/33750543127) (2026-09-03: one test failed, `test_promoted_joiner_waits_for_handoff_data` — the five sui-node threads of its swarm died with EADDRINUSE and the test thread with `RecvError`; the binary's other two tests passed). The same binaries pass one process per test in `test-cluster.yaml` (31/31 on [33679164808](https://github.com/dwallet-labs/ika/actions/runs/33679164808) and [33750546397](https://github.com/dwallet-labs/ika/actions/runs/33750546397), nextest profile `cluster`).

## Change

- `scope: all` builds and runs `--workspace --exclude ika-test-cluster` (one job-level `ALL_SCOPE_EXCLUDES`, used by both steps).
- **Side effect worth knowing, now documented in the header:** `ika-test-cluster` carries a self dev-dependency that enables `dwallet-mpc-unsafe-mock`; under `--workspace` that feature unified into the single `ika-core` build, so `scope=all` was running the entire workspace, integration tests included, on the INSECURE mock even with `use_mocks=false`. Excluding the crate makes `all` real crypto (the ika-core lib went from 761 s to 4180 s, matching the real-crypto `integration` scope). Re-including the crate later, e.g. by moving `all` onto nextest, would silently re-mock the workspace.
- `ika-upgrade-test` is **not** excluded: its scenario binaries return early unless their `RUN_*` variable is set (they drive an external `sui` localnet only under `upgrade-test.yaml`), and its 36 lib unit tests run nowhere else in CI.
- A guard step ahead of the build fails fast if a crate outside the excluded set (derived from `ALL_SCOPE_EXCLUDES`) and a separately named `SAFE_SWARM_DEPENDENTS` list (`ika`, `ika-swarm`, `ika-upgrade-test`, each with the reason it cannot boot a swarm under `cargo test`) starts pulling `sui-swarm`, `ika-swarm`, sui's `test-cluster` or `sui-node` into its `Cargo.toml` — the failure it prevents costs a full release build plus a 20-minute-deep test abort.
- `dev-docs/playbooks/ci-suites.md`: what `scope=all` covers, that it is real crypto only while the exclusion stands, that the nightly only ever dispatches the default scope, and the dispatch command with `-f scope=all`.
- The `integration` scope is untouched (`git diff origin/main...HEAD` touches only comments, the job env, the new guard step gated on `inputs.scope == 'all'`, and the `if [ "$SCOPE" = "all" ]` arms).

Why exclusion rather than switching `all` to nextest: the cluster suite already has a dedicated isolated workflow and takes ~21 min per run; and re-including the crate under any runner brings the mock feature back.

## Evidence

- Pre-fix `all`: [33750543127](https://github.com/dwallet-labs/ika/actions/runs/33750543127) failed (ports).
- `all` with `ika-test-cluster` and `ika-upgrade-test` excluded (first commit): [33768433944](https://github.com/dwallet-labs/ika/actions/runs/33768433944) **success**, 81 min, 46 test targets (27 binaries + 19 doc-test targets), 803 passed / 0 failed / 14 ignored. Five `panicked at` lines in the log: two `#[should_panic]` tests, one deliberately caught panic, and two pre-existing swallowed `Option::unwrap()` panics in background tasks of `ika-network`'s `discovery::tests::make_connection_to_seed_peer{,_with_peer_id}` (`discovery/mod.rs:551`) that report `ok` — not introduced here, worth its own fix.
- `all` with only `ika-test-cluster` excluded, guard step included (head f45e9a74af; the follow-up commit only edits the playbook): [33779055774](https://github.com/dwallet-labs/ika/actions/runs/33779055774) — **success**, 87 min job, 56 test targets, 846 passed / 0 failed / 15 ignored. Signature as required by the review: `ika_upgrade_test` lib 36 passed plus its 7 scenario binaries reporting `ok` as gated no-ops (with the `upgrade-test` bin target and one doc-test target: +10 targets over the previous run), no `ika_test_cluster` binary, ika-core lib in 4418 s (real crypto; the mocked run was 761 s), guard step silent with `excluded: crates/ika-test-cluster/Cargo.toml`. (33778415910 was the same dispatch on the previous head, cancelled as superseded.)
- `integration` (must be unchanged): [33768436905](https://github.com/dwallet-labs/ika/actions/runs/33768436905) — **success**, same command and the same result line as main's last green run [33753794040](https://github.com/dwallet-labs/ika/actions/runs/33753794040): `107 passed; 0 failed; 2 ignored; 452 filtered out`.

## Follow-up to consider (not in this PR)

`scope=all` is now a strict superset of the default scope; the measured extra cost is ~11 min (87 min job vs 76 min for the default scope, run 33779055774). It is the only CI job that executes ~450 ika-core unit tests, all doc-tests, and the `ika-node` / `ika-network` / `ika-config` tests (and all of `ika-sui-client`'s, beyond the pins `ci.yaml` runs). `scheduled-all-suites.yaml` could dispatch `-f scope=all` instead of the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




