### PR TITLE
chore: bump version to 1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-classgroups-types"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "bcs 0.2.1",
  "class_groups",
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "bcs 0.2.1",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "bcs 0.2.1",
@@ -5081,7 +5081,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-rng"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "commitment",
  "fastcrypto",
@@ -6871,7 +6871,7 @@ dependencies = [
 
 [[package]]
 name = "ika"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -6915,7 +6915,7 @@ dependencies = [
 
 [[package]]
 name = "ika-archival"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -7086,7 +7086,7 @@ dependencies = [
 
 [[package]]
 name = "ika-node"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7157,7 +7157,7 @@ dependencies = [
 
 [[package]]
 name = "ika-proxy"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -7310,7 +7310,7 @@ dependencies = [
 
 [[package]]
 name = "ika-test-cluster"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -7393,7 +7393,7 @@ dependencies = [
 
 [[package]]
 name = "ika-upgrade-test"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "bcs 0.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 [workspace.package]
 # This version string will be inherited by ika-core, ika-node, ika-tools, and ika crates.
-version = "1.4.0"
+version = "1.4.1"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/sdk/ika-wasm/Cargo.lock
+++ b/sdk/ika-wasm/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-centralized-party"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "bcs 0.2.1",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "dwallet-mpc-types"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "bcs 0.2.1",


### PR DESCRIPTION
Workspace version 1.4.0 → 1.4.1, with the two lockfiles' workspace-member entries updated (`cargo update --workspace`; no dependency moved). Same shape as #2088.

Release-readiness on main at the time of this bump (all on 236fe25c48 or later, 2026-09-03): CI, TS CI, Integration Tests (default scope), Test Cluster full suite, TS Integration, Simtest, and Upgrade Test with every scenario — all green.

After merge: tag the merged commit `release/mainnet-v1.4.1` and `release/testnet-v1.4.1`; `release.yaml` validates the tag version against `ika-node`'s crate version and builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)