### PR TITLE
chore(upgrade-test): retarget the cross-binary gate to v1.4.1

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -32,8 +32,13 @@ name: Upgrade Test
 #                  v1.4.1 carries #2121 (the validator no longer reads the
 #                  deprecated on-chain mpc_data_bytes), #2120 (registration
 #                  writes a placeholder there), #2123 (prepare-then-start
-#                  handoff barrier) and the #2122 metric split, so those are
-#                  what a mixed committee now straddles.
+#                  handoff barrier) and the #2122 metric split, so both
+#                  sides of this gate are past all four — none of them is
+#                  straddled here; they are listed because the OLD side's
+#                  behaviour moved with them.
+#                  Immediately after a retarget, `main` == the OLD tag, so
+#                  the gate is a same-binary run; real cross-binary coverage
+#                  returns as `main` diverges.
 #                  v1.4.1 is post-#2074, so — as with the v1.4.0 gate it
 #                  replaces, and unlike the v1.3.1-based one before it — this
 #                  mixed committee shares ONE storage model. Crossing the
@@ -45,9 +50,7 @@ name: Upgrade Test
 #                  over the literal v1.4.1 committee, then a mirrored OCS
 #                  joiner folds into the reshared v1.4.1-origin key (4→5)
 #                  and a shrink reshare removes an original (5→4). Same OLD
-#                  defaults as v141_rollout. With v1.4.1 on the old side the
-#                  joiner's placeholder mpc_data registration is inert
-#                  (nothing reads the field), which it was not on v1.4.0.
+#                  defaults as v141_rollout.
 #   malicious_v141 — test-testing counterpart: honest literal-v1.4.1
 #                  committee + ONE current validator built with the
 #                  test-testing reconfiguration-message fault; honest

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -9,18 +9,18 @@ name: Upgrade Test
 # dev-docs/specs/cross-binary-upgrade.md).
 #
 # Manual dispatch can run any scenario. Relevant pull requests run only
-# `v140_rollout`, avoiding the full expensive matrix on unrelated changes.
+# `v141_rollout`, avoiding the full expensive matrix on unrelated changes.
 # (The v3/v4-era rehearsals — cross_binary, v118_*, v121_rollout — were
-# retired when protocol v3/v4 support was removed; v140_rollout is their
-# successor against the current v1.4.0 release.) Pick the scenario with
+# retired when protocol v3/v4 support was removed; v141_rollout is their
+# successor against the current v1.4.1 release.) Pick the scenario with
 # the `test` input:
 #
 #   smoke        — go/no-go plumbing: 4 same-binary processes reach epoch 2.
 #                  Needs only the current build. Fastest.
 #   workload     — full user DKG -> Presign -> Sign on-chain at genesis
 #                  protocol v7. Current build only.
-#   v140_rollout — the deployed-release compatibility gate: boot the literal
-#                  v1.4.0 release (deployed on mainnet AND testnet, which run
+#   v141_rollout — the deployed-release compatibility gate: boot the literal
+#                  v1.4.1 release (deployed on mainnet AND testnet, which run
 #                  protocol v7 — the only version either binary supports, so
 #                  the run genesises there),
 #                  upgrade exactly one validator to the current build,
@@ -28,24 +28,32 @@ name: Upgrade Test
 #                  zero malicious reports and per-authority output
 #                  byte-equality, then swap the rest and converge again — a
 #                  pure binary swap, no protocol transition. Defaults to
-#                  old_ref=release/mainnet-v1.4.0, old_bin_name=ika-validator.
-#                  v1.4.0 is post-#2074, so unlike the v1.3.1-based gate this
+#                  old_ref=release/mainnet-v1.4.1, old_bin_name=ika-validator.
+#                  v1.4.1 carries #2121 (the validator no longer reads the
+#                  deprecated on-chain mpc_data_bytes), #2120 (registration
+#                  writes a placeholder there), #2123 (prepare-then-start
+#                  handoff barrier) and the #2122 metric split, so those are
+#                  what a mixed committee now straddles.
+#                  v1.4.1 is post-#2074, so — as with the v1.4.0 gate it
+#                  replaces, and unlike the v1.3.1-based one before it — this
 #                  mixed committee shares ONE storage model. Crossing the
 #                  event-sourcing change is no longer covered by anything:
 #                  mid_epoch_rollback was the only scenario that did it and
 #                  was retired once v1.4.0 shipped (see
 #                  dev-docs/specs/event-sourced-epoch.md, "Rolling back").
-#   v140_churn   — v140_rollout's churn counterpart: full sequential swap
-#                  over the literal v1.4.0 committee, then a mirrored OCS
-#                  joiner folds into the reshared v1.4.0-origin key (4→5)
+#   v141_churn   — v141_rollout's churn counterpart: full sequential swap
+#                  over the literal v1.4.1 committee, then a mirrored OCS
+#                  joiner folds into the reshared v1.4.1-origin key (4→5)
 #                  and a shrink reshare removes an original (5→4). Same OLD
-#                  defaults as v140_rollout.
-#   malicious_v140 — test-testing counterpart: honest literal-v1.4.0
+#                  defaults as v141_rollout. With v1.4.1 on the old side the
+#                  joiner's placeholder mpc_data registration is inert
+#                  (nothing reads the field), which it was not on v1.4.0.
+#   malicious_v141 — test-testing counterpart: honest literal-v1.4.1
 #                  committee + ONE current validator built with the
 #                  test-testing reconfiguration-message fault; honest
 #                  validators must convict it and reshare without it
-#                  (committee dips to 3). Green = the v140 gates are not
-#                  vacuous. Same OLD defaults as v140_rollout.
+#                  (committee dips to 3). Green = the v141 gates are not
+#                  vacuous. Same OLD defaults as v141_rollout.
 #   wedged_drain — the #2102 wedged-but-alive drain gate: one validator's
 #                  MPC drain is parked (production-binary env hook) without
 #                  stopping its service, so its round channel fills, its
@@ -73,12 +81,12 @@ name: Upgrade Test
 # process during publish, so only ONE runs per job — `--test-threads=1`, one
 # `--test` target.
 #
-# The OLD binary for v140_rollout is built from `old_ref` in an isolated
+# The OLD binary for v141_rollout is built from `old_ref` in an isolated
 # `git worktree`, at that ref's OWN pinned toolchain (rustup honors the
 # worktree's rust-toolchain.toml). All binaries build with default features —
 # enforcement (enforce-minimum-cpu) is runtime-gated to validators on the ika
 # testnet/mainnet networks, so it is inert on the CI localnet (its ika
-# system object maps to Chain::Unknown), and v1.4.0 already carries the
+# system object maps to Chain::Unknown), and v1.4.1 already carries the
 # runtime gate.
 
 on:
@@ -175,7 +183,7 @@ on:
         description: "Scenario or comma-separated scenarios"
         type: string
         required: false
-        default: "v140_rollout"
+        default: "v141_rollout"
       candidate_sha:
         description: "Exact release-candidate commit SHA to check out and test"
         type: string
@@ -209,7 +217,7 @@ on:
         required: false
         default: false
       test_testing_fault:
-        description: "TEST ONLY: build a deliberately divergent candidate for v140_rollout"
+        description: "TEST ONLY: build a deliberately divergent candidate for v141_rollout"
         type: boolean
         required: false
         default: false
@@ -229,7 +237,7 @@ on:
         required: false
         default: ""
       old_ref:
-        description: "Git ref/tag/sha for the OLD binary (empty = per-scenario default; v140_rollout uses release/mainnet-v1.4.0)"
+        description: "Git ref/tag/sha for the OLD binary (empty = per-scenario default; v141_rollout uses release/mainnet-v1.4.1)"
         type: string
         required: false
         default: ""
@@ -239,7 +247,7 @@ on:
         required: false
         default: ""
       epoch_duration_ms:
-        description: "Override ika genesis epoch duration in ms (v140_rollout requires >=480000, wedged_drain >=1680000; empty = scenario default)"
+        description: "Override ika genesis epoch duration in ms (v141_rollout requires >=480000, wedged_drain >=1680000; empty = scenario default)"
         type: string
         required: false
         default: ""
@@ -264,7 +272,7 @@ on:
         required: false
         default: false
       test_testing_fault:
-        description: "TEST ONLY: build the current validator with the test-testing reconfiguration-message fault and run v140_rollout; the zero-malicious/convergence gate must fail."
+        description: "TEST ONLY: build the current validator with the test-testing reconfiguration-message fault and run v141_rollout; the zero-malicious/convergence gate must fail."
         type: boolean
         required: false
         default: false
@@ -303,10 +311,10 @@ jobs:
         env:
           # The default is the deployed-release compatibility gate, the one
           # scenario every relevant pull request and release candidate runs.
-          TEST: ${{ inputs.test || 'v140_rollout' }}
+          TEST: ${{ inputs.test || 'v141_rollout' }}
         run: |
           set -euo pipefail
-          ALL="smoke workload v140_rollout v140_churn malicious_v140 restart_spectator wedged_drain"
+          ALL="smoke workload v141_rollout v141_churn malicious_v141 restart_spectator wedged_drain"
           if [ "$TEST" = "all" ]; then
             SELECTED="$ALL"
           else
@@ -342,7 +350,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           # Full history + tags: the OLD binary is built from an arbitrary
-          # ref (e.g. the release/mainnet-v1.4.0 tag) via `git worktree add`.
+          # ref (e.g. the release/mainnet-v1.4.1 tag) via `git worktree add`.
           fetch-depth: 0
           # Resolve once at trigger time; never rebuild a moving branch head.
           ref: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
@@ -419,11 +427,11 @@ jobs:
           case "$TEST" in
             smoke)        RUN_FLAG=RUN_UPGRADE_SMOKE ;;
             workload)     RUN_FLAG=RUN_WORKLOAD_TEST ;;
-            v140_churn)   RUN_FLAG=RUN_V140_CHURN ;;
-            malicious_v140) RUN_FLAG=RUN_MALICIOUS_V140 ;;
+            v141_churn)   RUN_FLAG=RUN_V141_CHURN ;;
+            malicious_v141) RUN_FLAG=RUN_MALICIOUS_V141 ;;
             restart_spectator) RUN_FLAG=RUN_RESTART_SPECTATOR ;;
             wedged_drain) RUN_FLAG=RUN_WEDGED_DRAIN ;;
-            v140_rollout)   RUN_FLAG=RUN_V140_ROLLOUT ;;
+            v141_rollout)   RUN_FLAG=RUN_V141_ROLLOUT ;;
             *) echo "unknown test: $TEST" >&2; exit 1 ;;
           esac
           # Per-scenario OLD-binary defaults; explicit inputs override (an
@@ -431,15 +439,15 @@ jobs:
           OLD_REF="$IN_OLD_REF"
           OLD_BIN_NAME="$IN_OLD_BIN_NAME"
           case "$TEST" in
-            v140_churn | malicious_v140)
-              : "${OLD_REF:=release/mainnet-v1.4.0}"
+            v141_churn | malicious_v141)
+              : "${OLD_REF:=release/mainnet-v1.4.1}"
               : "${OLD_BIN_NAME:=ika-validator}"
               ;;
-            v140_rollout)
+            v141_rollout)
               # OLD is the release the fleet is running; NEW is the candidate.
               # Both support protocol v7 only, so the boundary under test is a
               # pure binary swap.
-              : "${OLD_REF:=release/mainnet-v1.4.0}"
+              : "${OLD_REF:=release/mainnet-v1.4.1}"
               : "${OLD_BIN_NAME:=ika-validator}"
               ;;
           esac
@@ -475,7 +483,7 @@ jobs:
           # exists again — it is the run standing behind a version flip on a
           # live network, which is where mocked agreement is most misleading.
           case "$TEST_NAME" in
-            v140_rollout|v140_churn|malicious_v140)
+            v141_rollout|v141_churn|malicious_v141)
               if [ "$USE_MOCKS" = "true" ]; then
                 echo "$TEST_NAME is a cross-binary gate and must use real cryptography" >&2
                 exit 1
@@ -484,12 +492,12 @@ jobs:
           esac
           # ONE scenario, deliberately. The two rollout gates this condition
           # was originally written for are now a single one, and
-          # malicious_v140 is NOT a third: it builds its own faulty validator
+          # malicious_v141 is NOT a third: it builds its own faulty validator
           # (below) rather than taking it from this input, and it is expected
           # to PASS — the honest committee convicts the fault — whereas this
           # input is expected to make its run FAIL CLOSED.
-          if [ "$TEST_TESTING_FAULT" = "true" ] && [ "$TEST_NAME" != "v140_rollout" ]; then
-            echo "test_testing_fault is only supported by v140_rollout" >&2
+          if [ "$TEST_TESTING_FAULT" = "true" ] && [ "$TEST_NAME" != "v141_rollout" ]; then
+            echo "test_testing_fault is only supported by v141_rollout" >&2
             exit 1
           fi
           if [ "$TEST_TESTING_FAULT" = "true" ]; then
@@ -513,11 +521,11 @@ jobs:
           # testnet/mainnet networks, so it never fires on this localnet.
           cargo build --release $NODE_FEATURES $NODE_FAULT_FEATURES -p ika-node --bin ika-validator --bin ika-notifier
           cargo build --release -p ika --bin ika $IKA_FEATURES
-          if [ "$TEST_NAME" = "malicious_v140" ]; then
+          if [ "$TEST_NAME" = "malicious_v141" ]; then
             # The deliberately-faulty validator: current source with the
             # feature-gated reconfiguration-message fault compiled IN. Built
             # after the normal binaries and copied aside (the feature build
-            # overwrites target/release/ika-validator; malicious_v140 never
+            # overwrites target/release/ika-validator; malicious_v141 never
             # reads the honest current validator, so the overwrite is inert).
             cargo build --release --features test-testing -p ika-node --bin ika-validator
             cp target/release/ika-validator "$GITHUB_WORKSPACE/ika-validator-faulty"
@@ -526,7 +534,7 @@ jobs:
           cargo test --no-run --release -p ika-upgrade-test --test "$TEST_NAME"
 
       - name: Build OLD binary from ${{ env.OLD_REF }}
-        if: ${{ matrix.test == 'v140_rollout' || matrix.test == 'v140_churn' || matrix.test == 'malicious_v140' }}
+        if: ${{ matrix.test == 'v141_rollout' || matrix.test == 'v141_churn' || matrix.test == 'malicious_v141' }}
         run: |
           set -euo pipefail
           WT="$GITHUB_WORKSPACE/old-build"
@@ -548,7 +556,7 @@ jobs:
           echo "resolved OLD_REF=$OLD_REF to immutable commit $OLD_COMMIT"
           git worktree add --force --detach "$WT" "$OLD_COMMIT"
           # Build at the OLD ref's own toolchain (rustup reads the worktree's
-          # rust-toolchain.toml). Default features: v1.4.0's
+          # rust-toolchain.toml). Default features: v1.4.1's
           # enforce-minimum-cpu is runtime-gated (inert on the CI localnet),
           # matching its production build.
           ( cd "$WT" && cargo build --release -p ika-node --bin "$OLD_BIN_NAME" )
@@ -560,7 +568,7 @@ jobs:
       - name: Run ${{ matrix.test }}
         env:
           # smoke/workload read IKA_VALIDATOR_BIN/
-          # IKA_NOTIFIER_BIN/IKA_BIN; v140_rollout reads NEW_BIN/NOTIFIER_BIN/
+          # IKA_NOTIFIER_BIN/IKA_BIN; v141_rollout reads NEW_BIN/NOTIFIER_BIN/
           # OLD_BIN/IKA_BIN (OLD_BIN comes from the build step via
           # $GITHUB_ENV; unset for the others, which ignore it). Setting both
           # naming sets is harmless — each test reads only its own.
@@ -615,7 +623,7 @@ jobs:
           # quiet top-up loop can't prove resumption). The reduced-pool
           # override remains a resource concession for the lighter scenarios,
           # not compatibility evidence.
-          if [ "$TEST_NAME" = "v140_rollout" ] || [ "$TEST_NAME" = "restart_spectator" ]; then
+          if [ "$TEST_NAME" = "v141_rollout" ] || [ "$TEST_NAME" = "restart_spectator" ]; then
             unset IKA_ENABLE_SMALL_PRESIGN_POOLS
           fi
           mkdir -p "$UPGRADE_TEST_DIR"

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -906,7 +906,7 @@ async fn this_epoch_reconfiguration_output_is_skipped_and_current_epoch_output_r
 /// validators, so without intervention the key is never adopted. Adoption
 /// must flag it for the syncer's stranded-key chain read — the recovery that
 /// the removed v3→v4 chain-read fallback used to provide implicitly (caught
-/// live by the `v140_churn` scenario's mirrored joiner). A key DKG'd THIS
+/// live by the `v141_churn` scenario's mirrored joiner). A key DKG'd THIS
 /// epoch must NOT be flagged: that is the healthy fresh-key bootstrap window.
 #[tokio::test]
 async fn empty_overlay_for_prior_epoch_key_flags_stranded() {

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -906,7 +906,8 @@ async fn this_epoch_reconfiguration_output_is_skipped_and_current_epoch_output_r
 /// validators, so without intervention the key is never adopted. Adoption
 /// must flag it for the syncer's stranded-key chain read — the recovery that
 /// the removed v3→v4 chain-read fallback used to provide implicitly (caught
-/// live by the `v141_churn` scenario's mirrored joiner). A key DKG'd THIS
+/// live by the deployed-release churn scenario's mirrored joiner, then
+/// `v131_churn`). A key DKG'd THIS
 /// epoch must NOT be flagged: that is the healthy fresh-key bootstrap window.
 #[tokio::test]
 async fn empty_overlay_for_prior_epoch_key_flags_stranded() {

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_key_adoption.rs
@@ -906,8 +906,8 @@ async fn this_epoch_reconfiguration_output_is_skipped_and_current_epoch_output_r
 /// validators, so without intervention the key is never adopted. Adoption
 /// must flag it for the syncer's stranded-key chain read — the recovery that
 /// the removed v3→v4 chain-read fallback used to provide implicitly (caught
-/// live by the deployed-release churn scenario's mirrored joiner, then
-/// `v131_churn`). A key DKG'd THIS
+/// live by the deployed-release churn scenario's mirrored joiner — then
+/// `v125_churn`). A key DKG'd THIS
 /// epoch must NOT be flagged: that is the healthy fresh-key bootstrap window.
 #[tokio::test]
 async fn empty_overlay_for_prior_epoch_key_flags_stranded() {

--- a/crates/ika-swarm-config/src/sui_client.rs
+++ b/crates/ika-swarm-config/src/sui_client.rs
@@ -138,8 +138,9 @@ pub async fn fund_address_from_faucet(
 /// [`fund_address_from_faucet`] insufficient for gas-critical steps:
 /// the faucet executes its transfer asynchronously ("It can take up to 1
 /// minute to get the coin"), and a long-lived payer can arrive at a step
-/// with its earlier grants already burned down to dust (seen live in
-/// v141_churn: the publisher entered the join step with 0.199 SUI total
+/// with its earlier grants already burned down to dust (seen live in the
+/// deployed-release churn scenario, then `v131_churn`: the publisher entered
+/// the join step with 0.199 SUI total
 /// against a 5 SUI budget). Polling the summed gas-coin balance covers
 /// both.
 pub async fn ensure_sui_balance_from_faucet(

--- a/crates/ika-swarm-config/src/sui_client.rs
+++ b/crates/ika-swarm-config/src/sui_client.rs
@@ -139,10 +139,9 @@ pub async fn fund_address_from_faucet(
 /// the faucet executes its transfer asynchronously ("It can take up to 1
 /// minute to get the coin"), and a long-lived payer can arrive at a step
 /// with its earlier grants already burned down to dust (seen live in the
-/// deployed-release churn scenario, then `v131_churn`: the publisher entered
-/// the join step with 0.199 SUI total
-/// against a 5 SUI budget). Polling the summed gas-coin balance covers
-/// both.
+/// deployed-release churn scenario — then `v128_churn` — whose publisher
+/// entered the join step with 0.199 SUI total against a 5 SUI budget).
+/// Polling the summed gas-coin balance covers both.
 pub async fn ensure_sui_balance_from_faucet(
     context: &WalletContext,
     address: SuiAddress,

--- a/crates/ika-swarm-config/src/sui_client.rs
+++ b/crates/ika-swarm-config/src/sui_client.rs
@@ -139,7 +139,7 @@ pub async fn fund_address_from_faucet(
 /// the faucet executes its transfer asynchronously ("It can take up to 1
 /// minute to get the coin"), and a long-lived payer can arrive at a step
 /// with its earlier grants already burned down to dust (seen live in
-/// v140_churn: the publisher entered the join step with 0.199 SUI total
+/// v141_churn: the publisher entered the join step with 0.199 SUI total
 /// against a 5 SUI budget). Polling the summed gas-coin balance covers
 /// both.
 pub async fn ensure_sui_balance_from_faucet(
@@ -694,7 +694,7 @@ pub enum GenesisGlobalPresignConfig {
     /// routes workload presigns through the per-dWallet (targeted) path —
     /// the only coverage of that path, since a populated config makes it
     /// unreachable. The cross-binary malicious-party rehearsal
-    /// (`malicious_v140`) genesises with this.
+    /// (`malicious_v141`) genesises with this.
     Empty,
 }
 

--- a/crates/ika-upgrade-test/src/bin/upgrade-test.rs
+++ b/crates/ika-upgrade-test/src/bin/upgrade-test.rs
@@ -3,7 +3,7 @@
 
 //! CLI entry point for the cross-binary upgrade test harness.
 //!
-//! `dev` vs `tag:release/mainnet-v1.4.0` is the default example, not a baked-in constant —
+//! `dev` vs `tag:release/mainnet-v1.4.1` is the default example, not a baked-in constant —
 //! both sides are `--old` / `--new` binary specs (`path:` / `tag:` / `sha:` /
 //! `branch:`, or a bare value the resolver classifies).
 
@@ -22,7 +22,7 @@ struct Args {
     #[arg(long, default_value_t = 4)]
     validators: usize,
 
-    /// Old binary spec, e.g. `tag:release/mainnet-v1.4.0`.
+    /// Old binary spec, e.g. `tag:release/mainnet-v1.4.1`.
     #[arg(long)]
     old: String,
 
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
     let scenario = match args.scenario.as_str() {
         "rolling_majority_then_minority" => {
             // Proven-good config (originally from the retired
-            // `tests/cross_binary.rs`; `tests/v140_rollout.rs` uses the same
+            // `tests/cross_binary.rs`; `tests/v141_rollout.rs` uses the same
             // shape): long (10-min) epochs avoid the short-epoch sui_executor
             // wedge, the timeout covers a full long epoch per
             // `wait_for_epoch`, and the `set_buffer_stake(0)` before the

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -2127,7 +2127,7 @@ impl ClusterOfProcesses {
 
         // The publisher signs `stake_ika` below, and by this point in a long
         // scenario its bootstrap grants can be burned down to dust (the
-        // deployed-release churn scenario, then `v131_churn`, reached this
+        // deployed-release churn scenario — then `v128_churn` — reached this
         // step with 0.199 SUI total against the 5 SUI budget).
         // Top it up and wait for the grant to land before signing.
         ensure_sui_balance_from_faucet(

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -2126,8 +2126,9 @@ impl ClusterOfProcesses {
         .context("faucet-fund joiner")?;
 
         // The publisher signs `stake_ika` below, and by this point in a long
-        // scenario its bootstrap grants can be burned down to dust (v141_churn
-        // reached this step with 0.199 SUI total against the 5 SUI budget).
+        // scenario its bootstrap grants can be burned down to dust (the
+        // deployed-release churn scenario, then `v131_churn`, reached this
+        // step with 0.199 SUI total against the 5 SUI budget).
         // Top it up and wait for the grant to land before signing.
         ensure_sui_balance_from_faucet(
             &self.wallet,

--- a/crates/ika-upgrade-test/src/cluster.rs
+++ b/crates/ika-upgrade-test/src/cluster.rs
@@ -2126,7 +2126,7 @@ impl ClusterOfProcesses {
         .context("faucet-fund joiner")?;
 
         // The publisher signs `stake_ika` below, and by this point in a long
-        // scenario its bootstrap grants can be burned down to dust (v140_churn
+        // scenario its bootstrap grants can be burned down to dust (v141_churn
         // reached this step with 0.199 SUI total against the 5 SUI budget).
         // Top it up and wait for the grant to land before signing.
         ensure_sui_balance_from_faucet(

--- a/crates/ika-upgrade-test/src/lib.rs
+++ b/crates/ika-upgrade-test/src/lib.rs
@@ -4,7 +4,7 @@
 //! Out-of-process cross-binary upgrade test harness.
 //!
 //! Runs an Ika cluster on one machine with validators executing *real,
-//! separately-compiled* `ika-validator` binaries (e.g. `release/mainnet-v1.4.0` vs
+//! separately-compiled* `ika-validator` binaries (e.g. `release/mainnet-v1.4.1` vs
 //! `dev`), drives them across epoch boundaries, swaps binaries on individual
 //! validators mid-run, and asserts the upgrade invariants (protocol-version
 //! vote, reconfiguration MPC, session lifecycle, wire compat, on-disk compat).

--- a/crates/ika-upgrade-test/tests/malicious_v141.rs
+++ b/crates/ika-upgrade-test/tests/malicious_v141.rs
@@ -39,6 +39,12 @@
 //! `ika_dwallet_mpc_malicious_actors_count` gauge, which both releases
 //! export.
 //!
+//! **"Cross-binary" is nominal while `main` == the OLD tag.** Immediately
+//! after a retarget the honest and faulty binaries differ only by the
+//! `test-testing` feature, so this run gates the DETECTION path, not
+//! detection across two releases. The cross-binary half of the claim comes
+//! back as `main` diverges from v1.4.1.
+//!
 //! Opt-in, via `RUN_MALICIOUS_V141=1`:
 //!
 //! ```bash
@@ -83,7 +89,7 @@ async fn honest_committee_marks_faulty_current_validator_malicious() {
     // Honest reference binary: the literal v1.4.1 ika-validator.
     let honest = BinarySpec::Path(bin_from_env(
         "OLD_BIN",
-        "/tmp/ika-v141/target/release/ika-validator",
+        "/mnt/nvme0n1p1/v141-bins/ika-validator",
     ));
     // Deliberately-faulty current build (corrupts its reshare message),
     // produced by `cargo build --bin ika-validator --features test-testing`.

--- a/crates/ika-upgrade-test/tests/malicious_v141.rs
+++ b/crates/ika-upgrade-test/tests/malicious_v141.rs
@@ -4,7 +4,7 @@
 //! Cross-binary **malicious-party detection** rehearsal (test-testing) —
 //! the successor to the retired `malicious_cross_binary`.
 //!
-//! Boots a 4-validator committee on the HONEST literal v1.4.0 release
+//! Boots a 4-validator committee on the HONEST literal v1.4.1 release
 //! (deployed on both networks, protocol v7), lets it complete the genesis
 //! network DKG, then swaps **one** validator to a deliberately-FAULTY
 //! current build (`FAULTY_BIN`) that corrupts its outgoing reconfiguration
@@ -17,7 +17,7 @@
 //! --bin ika-validator --features test-testing`). The fault is compiled
 //! out of every normal build, so a plain release can never carry it.
 //!
-//! Expectation: the honest v1.4.0 validators must identify the faulty one as
+//! Expectation: the honest v1.4.1 validators must identify the faulty one as
 //! a malicious actor and reconfigure without it (committee dips to 3), so
 //! the network still reaches epoch 3. Detection is asserted
 //! **programmatically** by scraping the
@@ -26,24 +26,33 @@
 //! code alone is not the assertion: the network could reach epoch 3 without
 //! flagging anyone, which is exactly the vacuous-pass this guards against. A
 //! green run proves mixed-committee malicious detection against the deployed
-//! release is not vacuous — i.e. `v140_rollout`'s zero-malicious gate would
+//! release is not vacuous — i.e. `v141_rollout`'s zero-malicious gate would
 //! actually fire on a real divergence. This is NOT a production test; it
 //! validates the test infrastructure (see `.claude/skills/test-testing`).
 //!
-//! Opt-in, via `RUN_MALICIOUS_V140=1`:
+//! The honest reference moved from v1.4.0 to v1.4.1 with the rest of the
+//! deployed-release gates, so the convicting quorum now runs the post-#2121
+//! (no on-chain `mpc_data_bytes` read), post-#2123 (prepare-then-start
+//! handoff barrier) code that `v141_rollout` and `v141_churn` also boot.
+//! The fault itself is unchanged: it is injected into the CURRENT build's
+//! reconfiguration advance path, and the assertion remains the
+//! `ika_dwallet_mpc_malicious_actors_count` gauge, which both releases
+//! export.
+//!
+//! Opt-in, via `RUN_MALICIOUS_V141=1`:
 //!
 //! ```bash
 //! # Build the faulty binary via the feature (no source edit):
 //! cargo build --release -p ika-node --bin ika-validator --features test-testing
 //! cp target/release/ika-validator /tmp/ika-validator-FAULTY-RECONFIG
 //! # then run:
-//! RUN_MALICIOUS_V140=1 \
-//!   OLD_BIN=/path/to/ika-validator-v1.4.0 \
+//! RUN_MALICIOUS_V141=1 \
+//!   OLD_BIN=/path/to/ika-validator-v1.4.1 \
 //!   FAULTY_BIN=/tmp/ika-validator-FAULTY-RECONFIG \
 //!   NOTIFIER_BIN=target/release/ika-notifier \
 //!   IKA_BIN=target/release/ika \
 //!   SUI_BIN=$(which sui) \
-//!   cargo test --release -p ika-upgrade-test --test malicious_v140 -- --nocapture
+//!   cargo test --release -p ika-upgrade-test --test malicious_v141 -- --nocapture
 //! ```
 
 use std::path::PathBuf;
@@ -60,9 +69,9 @@ fn bin_from_env(var: &str, default: &str) -> PathBuf {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn honest_committee_marks_faulty_current_validator_malicious() {
-    if std::env::var("RUN_MALICIOUS_V140").is_err() {
+    if std::env::var("RUN_MALICIOUS_V141").is_err() {
         eprintln!(
-            "skipping: set RUN_MALICIOUS_V140=1 (needs OLD_BIN/FAULTY_BIN/NOTIFIER_BIN/IKA_BIN/SUI_BIN)"
+            "skipping: set RUN_MALICIOUS_V141=1 (needs OLD_BIN/FAULTY_BIN/NOTIFIER_BIN/IKA_BIN/SUI_BIN)"
         );
         return;
     }
@@ -71,10 +80,10 @@ async fn honest_committee_marks_faulty_current_validator_malicious() {
         .with_env()
         .init();
 
-    // Honest reference binary: the literal v1.4.0 ika-validator.
+    // Honest reference binary: the literal v1.4.1 ika-validator.
     let honest = BinarySpec::Path(bin_from_env(
         "OLD_BIN",
-        "/tmp/ika-v140/target/release/ika-validator",
+        "/tmp/ika-v141/target/release/ika-validator",
     ));
     // Deliberately-faulty current build (corrupts its reshare message),
     // produced by `cargo build --bin ika-validator --features test-testing`.
@@ -93,7 +102,7 @@ async fn honest_committee_marks_faulty_current_validator_malicious() {
         .to_path_buf();
 
     let base = PathBuf::from(
-        std::env::var("UPGRADE_TEST_DIR").unwrap_or_else(|_| "/tmp/ika-malicious-v140".to_string()),
+        std::env::var("UPGRADE_TEST_DIR").unwrap_or_else(|_| "/tmp/ika-malicious-v141".to_string()),
     );
     let _ = std::fs::remove_dir_all(&base);
 
@@ -118,7 +127,7 @@ async fn honest_committee_marks_faulty_current_validator_malicious() {
         .with_min_validator_count(3)
         .with_ika_cli(ika_cli)
         .with_genesis_global_presign_config(GenesisGlobalPresignConfig::Empty)
-        // Genesis network DKG on the all-honest v1.4.0 committee at v7.
+        // Genesis network DKG on the all-honest v1.4.1 committee at v7.
         .start_all(honest)
         .wait_for_epoch(2)
         // Swap ONE validator to the faulty current build — a mixed committee.
@@ -131,10 +140,10 @@ async fn honest_committee_marks_faulty_current_validator_malicious() {
         .expect_malicious_actors_at_least(&[3], 1)
         .run()
         .await
-        .expect("honest v1.4.0 committee should reconfigure past a faulty current validator");
+        .expect("honest v1.4.1 committee should reconfigure past a faulty current validator");
 
     tracing::info!(
-        "malicious-v140 PASSED: honest v1.4.0 committee reached epoch 3 AND recorded the \
+        "malicious-v141 PASSED: honest v1.4.1 committee reached epoch 3 AND recorded the \
          faulty current validator as malicious (asserted via the \
          ika_dwallet_mpc_malicious_actors_count gauge)"
     );

--- a/crates/ika-upgrade-test/tests/restart_spectator.rs
+++ b/crates/ika-upgrade-test/tests/restart_spectator.rs
@@ -9,7 +9,7 @@
 //! window — not merely stay consensus-healthy while peers absorb every
 //! session.
 //!
-//! This is the ingredient `v140_rollout` lacks: its binary swaps land minutes
+//! This is the ingredient `v141_rollout` lacks: its binary swaps land minutes
 //! from an epoch boundary and none of its gates assert per-validator top-up
 //! participation, so a restarted validator that silently re-mints
 //! already-completed internal-presign ordinals (the in-memory

--- a/crates/ika-upgrade-test/tests/v141_churn.rs
+++ b/crates/ika-upgrade-test/tests/v141_churn.rs
@@ -1,15 +1,15 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-//! Literal v1.4.0 upgrade rehearsal **with post-upgrade committee churn** —
+//! Literal v1.4.1 upgrade rehearsal **with post-upgrade committee churn** —
 //! the successor to the retired `v118_churn`/`cross_binary` churn coverage.
 //!
-//! Boot a 4-validator committee on the actual v1.4.0 release (deployed on
+//! Boot a 4-validator committee on the actual v1.4.1 release (deployed on
 //! mainnet AND testnet, protocol v7), sequentially swap **all validators** to
 //! the current build — then, on the now all-current committee:
 //!
 //! - **join a brand-new validator** (candidate → stake → activate) so the
-//!   next reshare encrypts the network key (originally DKG'd by v1.4.0's
+//!   next reshare encrypts the network key (originally DKG'd by v1.4.1's
 //!   binary) to a 5-member committee that includes a party which never held
 //!   it. The joiner boots peer-only `SuiStateMirrored`, reading verified Sui
 //!   state through the direct relay validators — the OCS joiner
@@ -19,22 +19,34 @@
 //!   committee 5 → 4 (the reshare-to-fewer-parties direction that only the
 //!   retired `cross_binary` exercised).
 //!
+//! The joiner phase is the part the v1.4.1 retarget most changes. On v1.4.0
+//! a newly registered validator's on-chain `mpc_data_bytes` was still READ by
+//! committee members, so a placeholder registration was a permanent,
+//! unrecoverable committee-build failure and activation order was
+//! load-bearing. v1.4.1 is post-#2121 (nothing reads the field) and
+//! post-#2120 (registration writes the placeholder), so both the booted
+//! committee and the joiner are on the same side of that change and the
+//! join is a plain reshare — see
+//! dev-docs/specs/validator-mpc-data-announcements.md. The joiner also
+//! exercises the prepare-then-start handoff barrier on promotion (#2123),
+//! which v1.4.0 did not run.
+//!
 //! The sequential replacement has transient mixed states but intentionally
-//! avoids an MPC boundary; real mixed-committee MPC is `v140_rollout`'s job.
+//! avoids an MPC boundary; real mixed-committee MPC is `v141_rollout`'s job.
 //! The OCS read topology splits at the swap: validators 0 and 1 stay direct
 //! (serving the relay), 2 and 3 flip to peer-only mirrored, and the joiner
 //! comes up mirrored — the topology the retired `cross_binary` exercised.
 //!
-//! Opt-in, via `RUN_V140_CHURN=1` (same binaries as `v140_rollout`):
+//! Opt-in, via `RUN_V141_CHURN=1` (same binaries as `v141_rollout`):
 //!
 //! ```bash
-//! RUN_V140_CHURN=1 \
-//!   OLD_BIN=/path/to/ika-validator-v1.4.0 \
+//! RUN_V141_CHURN=1 \
+//!   OLD_BIN=/path/to/ika-validator-v1.4.1 \
 //!   NEW_BIN=target/release/ika-validator \
 //!   NOTIFIER_BIN=target/release/ika-notifier \
 //!   IKA_BIN=target/release/ika \
 //!   SUI_BIN=$(which sui) \
-//!   cargo test --release -p ika-upgrade-test --test v140_churn -- --nocapture
+//!   cargo test --release -p ika-upgrade-test --test v141_churn -- --nocapture
 //! ```
 
 use std::path::PathBuf;
@@ -50,10 +62,10 @@ fn bin_from_env(var: &str, default: &str) -> PathBuf {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn v140_full_swap_then_committee_churn() {
-    if std::env::var("RUN_V140_CHURN").is_err() {
+async fn v141_full_swap_then_committee_churn() {
+    if std::env::var("RUN_V141_CHURN").is_err() {
         eprintln!(
-            "skipping: set RUN_V140_CHURN=1 \
+            "skipping: set RUN_V141_CHURN=1 \
              (needs OLD_BIN/NEW_BIN/NOTIFIER_BIN/IKA_BIN/SUI_BIN)"
         );
         return;
@@ -65,7 +77,7 @@ async fn v140_full_swap_then_committee_churn() {
 
     let old = BinarySpec::Path(bin_from_env(
         "OLD_BIN",
-        "/tmp/ika-v140/target/release/ika-validator",
+        "/tmp/ika-v141/target/release/ika-validator",
     ));
     let current = BinarySpec::Path(bin_from_env("NEW_BIN", "target/release/ika-validator"));
     let notifier = bin_from_env("NOTIFIER_BIN", "target/release/ika-notifier");
@@ -79,7 +91,7 @@ async fn v140_full_swap_then_committee_churn() {
         .to_path_buf();
     let base = PathBuf::from(
         std::env::var("UPGRADE_TEST_DIR")
-            .unwrap_or_else(|_| "/mnt/nvme0n1p1/tmp/ika-v140-churn".to_string()),
+            .unwrap_or_else(|_| "/mnt/nvme0n1p1/tmp/ika-v141-churn".to_string()),
     );
     let _ = std::fs::remove_dir_all(&base);
     let epoch_duration_ms = std::env::var("EPOCH_DURATION_MS")
@@ -88,7 +100,7 @@ async fn v140_full_swap_then_committee_churn() {
         .unwrap_or(600_000);
     assert!(
         epoch_duration_ms >= 480_000,
-        "the v1.4.0 churn scenario requires an epoch of at least 480000ms so the bounded sequential \
+        "the v1.4.1 churn scenario requires an epoch of at least 480000ms so the bounded sequential \
          restarts complete before the mid-epoch reconfiguration"
     );
 
@@ -109,13 +121,13 @@ async fn v140_full_swap_then_committee_churn() {
         .with_epoch_timeout(Duration::from_secs(1200))
         // OCS read topology: 0 and 1 stay direct (relay servers); 2, 3 and
         // the joiner run peer-only SuiStateMirrored through them. The split
-        // materializes at the swap; the v1.4.0 boot phase is all-direct.
+        // materializes at the swap; the v1.4.1 boot phase is all-direct.
         .with_direct_validators(&[0, 1])
         .with_ika_cli(ika_cli)
         // Deployed-faithful on-chain state (populated global-presign config).
         .with_genesis_global_presign_config(GenesisGlobalPresignConfig::Full)
-        // Boot the literal v1.4.0 committee at protocol v7; epoch 2
-        // guarantees the genesis network DKG (v1.4.0 binary) completed
+        // Boot the literal v1.4.1 committee at protocol v7; epoch 2
+        // guarantees the genesis network DKG (v1.4.1 binary) completed
         // before the swap.
         .start_all(old)
         .wait_for_epoch(2)
@@ -124,8 +136,8 @@ async fn v140_full_swap_then_committee_churn() {
         .expect_committee_size(4)
         .expect_protocol_version_at_least(7)
         // Sequentially swap every validator to the current build. The
-        // current binaries inherit the v1.4.0-written RocksDB state and
-        // reshare the v1.4.0-DKG'd network key. v1.4.0 is post-#2074, so
+        // current binaries inherit the v1.4.1-written RocksDB state and
+        // reshare the v1.4.1-DKG'd network key. v1.4.1 is post-#2074, so
         // that inheritance is now within ONE storage model — the durable
         // tables both binaries keep, not a fold-side set one writes and the
         // other does not. Crossing the event-sourcing change was
@@ -138,7 +150,7 @@ async fn v140_full_swap_then_committee_churn() {
         .expect_all_validators_healthy()
         .expect_committee_size(4)
         // ── Churn 1: grow 4 → 5 with a mirrored joiner. ────────────────────
-        // The reshare encrypts the v1.4.0-origin key to a committee
+        // The reshare encrypts the v1.4.1-origin key to a committee
         // including a party that never held it; the joiner installs the key
         // by the cert-pinned digest over the OCS mirrored path.
         .join_validator_mirrored(current)
@@ -161,7 +173,7 @@ async fn v140_full_swap_then_committee_churn() {
         .expect_network_key_output_converged(&current_observer)
         .expect_malicious_actors_exactly(&current_observer, 0)
         // The 5-member committee runs a full lifecycle against the reshared
-        // v1.4.0-origin network key.
+        // v1.4.1-origin network key.
         .run_workload("v7-with-joiner")
         .record_mpc_timings("v7-with-joiner")
         // ── Churn 2: shrink 5 → 4 by removing an original validator. ──────
@@ -190,11 +202,11 @@ async fn v140_full_swap_then_committee_churn() {
         .expect_log_line_absent("failed to submit an MPC output message to consensus")
         .run()
         .await
-        .expect("v1.4.0 -> current full-committee upgrade + committee churn in both directions");
+        .expect("v1.4.1 -> current full-committee upgrade + committee churn in both directions");
 
     tracing::info!(
-        "v1.4.0 churn PASSED: full binary swap over v1.4.0 state, a mirrored joiner folded \
-         into the reshared v1.4.0-origin key (4→5), and a shrink reshare (5→4) all converged \
+        "v1.4.1 churn PASSED: full binary swap over v1.4.1 state, a mirrored joiner folded \
+         into the reshared v1.4.1-origin key (4→5), and a shrink reshare (5→4) all converged \
          while serving a full user lifecycle"
     );
 }

--- a/crates/ika-upgrade-test/tests/v141_churn.rs
+++ b/crates/ika-upgrade-test/tests/v141_churn.rs
@@ -19,17 +19,12 @@
 //!   committee 5 → 4 (the reshare-to-fewer-parties direction that only the
 //!   retired `cross_binary` exercised).
 //!
-//! The joiner phase is the part the v1.4.1 retarget most changes. On v1.4.0
-//! a newly registered validator's on-chain `mpc_data_bytes` was still READ by
-//! committee members, so a placeholder registration was a permanent,
-//! unrecoverable committee-build failure and activation order was
-//! load-bearing. v1.4.1 is post-#2121 (nothing reads the field) and
-//! post-#2120 (registration writes the placeholder), so both the booted
-//! committee and the joiner are on the same side of that change and the
-//! join is a plain reshare — see
-//! dev-docs/specs/validator-mpc-data-announcements.md. The joiner also
-//! exercises the prepare-then-start handoff barrier on promotion (#2123),
-//! which v1.4.0 did not run.
+//! The joiner phase is unaffected by the retarget: all four validators are
+//! already swapped to the candidate before `join_validator_mirrored`, so no
+//! OLD binary is in the committee at join time, and the harness registers the
+//! joiner's real mpc_data via
+//! `ika_swarm_config::sui_client::request_add_validator_candidate` — not
+//! #2120's CLI placeholder.
 //!
 //! The sequential replacement has transient mixed states but intentionally
 //! avoids an MPC boundary; real mixed-committee MPC is `v141_rollout`'s job.
@@ -77,7 +72,7 @@ async fn v141_full_swap_then_committee_churn() {
 
     let old = BinarySpec::Path(bin_from_env(
         "OLD_BIN",
-        "/tmp/ika-v141/target/release/ika-validator",
+        "/mnt/nvme0n1p1/v141-bins/ika-validator",
     ));
     let current = BinarySpec::Path(bin_from_env("NEW_BIN", "target/release/ika-validator"));
     let notifier = bin_from_env("NOTIFIER_BIN", "target/release/ika-notifier");
@@ -137,10 +132,12 @@ async fn v141_full_swap_then_committee_churn() {
         .expect_protocol_version_at_least(7)
         // Sequentially swap every validator to the current build. The
         // current binaries inherit the v1.4.1-written RocksDB state and
-        // reshare the v1.4.1-DKG'd network key. v1.4.1 is post-#2074, so
-        // that inheritance is now within ONE storage model — the durable
-        // tables both binaries keep, not a fold-side set one writes and the
-        // other does not. Crossing the event-sourcing change was
+        // reshare the v1.4.1-DKG'd network key. v1.4.1, like the v1.4.0
+        // release it replaces here, is post-#2074, so that inheritance has
+        // been within ONE storage model since the 1.3.1 -> 1.4.0 retarget
+        // stopped crossing that boundary — the durable tables both binaries
+        // keep, not a fold-side set one writes and the other does not.
+        // Crossing the event-sourcing change was
         // `mid_epoch_rollback`'s job; that scenario was retired with v1.4.0
         // (#2077, #2064), so nothing exercises that crossing now.
         .stop_and_swap(&[0, 1, 2, 3], current.clone())

--- a/crates/ika-upgrade-test/tests/v141_rollout.rs
+++ b/crates/ika-upgrade-test/tests/v141_rollout.rs
@@ -18,9 +18,12 @@
 //! Sign lifecycle across two reshares and a full binary swap. That is the
 //! wire-no-op every candidate must be against the release the fleet is running.
 //!
-//! **What the mixed v1.4.1/candidate committee now exercises.** Retargeting
-//! from v1.4.0 moved the OLD side across everything that shipped in v1.4.1,
-//! so these are the behaviours a mixed committee straddles from here on:
+//! **What the retarget removes from this gate's reach.** Retargeting from
+//! v1.4.0 moved the OLD side across everything that shipped in v1.4.1, so
+//! each of the following is now identical on both sides and is no longer a
+//! difference this gate straddles. They are listed because the OLD side's
+//! behaviour moved with them, not because the mixed committee exercises a
+//! disagreement about them:
 //!
 //! - the validator no longer READS the deprecated on-chain `mpc_data_bytes`
 //!   (#2121, Part A of #2119), and a newly registered validator writes a

--- a/crates/ika-upgrade-test/tests/v141_rollout.rs
+++ b/crates/ika-upgrade-test/tests/v141_rollout.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
 //! Deployed-release rolling-upgrade rehearsal at protocol v7: the literal
-//! v1.4.0 release against the candidate build.
+//! v1.4.1 release against the candidate build.
 //!
-//! - **OLD** = the v1.4.0 `ika-validator` (built from the
-//!   `release/mainnet-v1.4.0` tag, deployed on mainnet AND testnet).
+//! - **OLD** = the v1.4.1 `ika-validator` (built from the
+//!   `release/mainnet-v1.4.1` tag, deployed on mainnet AND testnet).
 //! - **NEW** = the candidate build.
 //!
 //! `MIN_PROTOCOL_VERSION = MAX_PROTOCOL_VERSION = 7`, so both binaries support
@@ -18,32 +18,53 @@
 //! Sign lifecycle across two reshares and a full binary swap. That is the
 //! wire-no-op every candidate must be against the release the fleet is running.
 //!
+//! **What the mixed v1.4.1/candidate committee now exercises.** Retargeting
+//! from v1.4.0 moved the OLD side across everything that shipped in v1.4.1,
+//! so these are the behaviours a mixed committee straddles from here on:
+//!
+//! - the validator no longer READS the deprecated on-chain `mpc_data_bytes`
+//!   (#2121, Part A of #2119), and a newly registered validator writes a
+//!   placeholder into it (#2120). Both sides of this scenario are now past
+//!   that change, so the mixed phase no longer has one side decoding a field
+//!   the other side stubs — the compatibility hazard that made activation
+//!   order load-bearing on v1.4.0 (see
+//!   dev-docs/specs/validator-mpc-data-announcements.md);
+//! - per-epoch root-seed resolution with the optional previous-seed rotation
+//!   field (#2121) — both sides resolve the epoch's seed the same way;
+//! - the prepare-then-start handoff barrier on cold start and joiner
+//!   promotion (#2123), which both sides now run;
+//! - `ika_sui_client_sui_response_errors_total` split out of
+//!   `ika_sui_client_sui_rpc_errors` (#2122). This gate asserts on neither
+//!   family, so the split is inert here — it is listed because the OLD
+//!   side's metric surface changed with it.
+//!
 //! **What the storage model does to this gate's reach.** Against v1.3.1 the
 //! mixed phase also straddled the event-sourcing change (#2074): the OLD
 //! validators wrote per-round MPC tables and a `last_consensus_stats`
 //! watermark, the NEW ones kept that state in memory, and a green run said
 //! something about two committee members disagreeing about what is durable.
-//! v1.4.0 is post-#2074, so both sides of this scenario now share one storage
-//! model and that ingredient is GONE from here — the assertions below are
-//! unchanged and still gate wire and MPC-output agreement, but they no longer
-//! stand behind any claim about mixed storage models. NOTHING crosses that
-//! boundary any more: `mid_epoch_rollback` was the one scenario that did —
-//! pinned to `release/mainnet-v1.3.1`, the last release that reopens an epoch
-//! store expecting its own fold's tables to be there — and it was retired once
+//! v1.4.1 — like the v1.4.0 release it replaces here — is post-#2074, so both
+//! sides of this scenario share one storage model and that ingredient is GONE
+//! from here: the assertions below are unchanged and still gate wire and
+//! MPC-output agreement, but they no longer stand behind any claim about
+//! mixed storage models. NOTHING crosses that boundary any more:
+//! `mid_epoch_rollback` was the one scenario that did — pinned to
+//! `release/mainnet-v1.3.1`, the last release that reopens an epoch store
+//! expecting its own fold's tables to be there — and it was retired once
 //! v1.4.0 shipped and was validated in production (#2077, #2064). A future
 //! storage-model boundary needs a scenario built for it.
 //!
-//! Opt-in (real binaries + long-running), via `RUN_V140_ROLLOUT=1`:
+//! Opt-in (real binaries + long-running), via `RUN_V141_ROLLOUT=1`:
 //!
 //! ```bash
-//! # OLD_BIN: the v1.4.0 ika-validator; NEW_BIN: the candidate
-//! RUN_V140_ROLLOUT=1 \
-//!   OLD_BIN=/path/to/ika-validator-v1.4.0 \
+//! # OLD_BIN: the v1.4.1 ika-validator; NEW_BIN: the candidate
+//! RUN_V141_ROLLOUT=1 \
+//!   OLD_BIN=/path/to/ika-validator-v1.4.1 \
 //!   NEW_BIN=target/release/ika-validator \
 //!   NOTIFIER_BIN=target/release/ika-notifier \
 //!   IKA_BIN=target/release/ika \
 //!   SUI_BIN=$(which sui) \
-//!   cargo test --release -p ika-upgrade-test --test v140_rollout -- --nocapture
+//!   cargo test --release -p ika-upgrade-test --test v141_rollout -- --nocapture
 //! ```
 
 use std::path::PathBuf;
@@ -60,10 +81,10 @@ fn bin_from_env(var: &str, default: &str) -> PathBuf {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn v140_rollout_converges_across_binary_swap_at_v7() {
-    if std::env::var("RUN_V140_ROLLOUT").is_err() {
+async fn v141_rollout_converges_across_binary_swap_at_v7() {
+    if std::env::var("RUN_V141_ROLLOUT").is_err() {
         eprintln!(
-            "skipping: set RUN_V140_ROLLOUT=1 \
+            "skipping: set RUN_V141_ROLLOUT=1 \
              (needs OLD_BIN/NEW_BIN/NOTIFIER_BIN/IKA_BIN/SUI_BIN)"
         );
         return;
@@ -75,7 +96,7 @@ async fn v140_rollout_converges_across_binary_swap_at_v7() {
 
     let old = BinarySpec::Path(bin_from_env(
         "OLD_BIN",
-        "/mnt/nvme0n1p1/v140-bins/ika-validator",
+        "/mnt/nvme0n1p1/v141-bins/ika-validator",
     ));
     let current = BinarySpec::Path(bin_from_env("NEW_BIN", "target/release/ika-validator"));
     let notifier = bin_from_env("NOTIFIER_BIN", "target/release/ika-notifier");
@@ -89,7 +110,7 @@ async fn v140_rollout_converges_across_binary_swap_at_v7() {
         .to_path_buf();
     let base = PathBuf::from(
         std::env::var("UPGRADE_TEST_DIR")
-            .unwrap_or_else(|_| "/mnt/nvme0n1p1/tmp/ika-v140-rollout".to_string()),
+            .unwrap_or_else(|_| "/mnt/nvme0n1p1/tmp/ika-v141-rollout".to_string()),
     );
     let _ = std::fs::remove_dir_all(&base);
     let epoch_duration_ms = std::env::var("EPOCH_DURATION_MS")
@@ -98,7 +119,7 @@ async fn v140_rollout_converges_across_binary_swap_at_v7() {
         .unwrap_or(600_000);
     assert!(
         epoch_duration_ms >= 480_000,
-        "the v1.4.0 rollout requires an epoch of at least 480000ms so the bounded sequential \
+        "the v1.4.1 rollout requires an epoch of at least 480000ms so the bounded sequential \
          restarts complete before the mid-epoch reconfiguration"
     );
 
@@ -200,12 +221,12 @@ async fn v140_rollout_converges_across_binary_swap_at_v7() {
         .run()
         .await
         .expect(
-            "v1.4.0/candidate committee must converge across the mixed phase and the full binary \
+            "v1.4.1/candidate committee must converge across the mixed phase and the full binary \
              swap at protocol v7",
         );
 
     tracing::info!(
-        "v1.4.0 rollout PASSED: the mixed v1.4.0/candidate committee converged across two \
+        "v1.4.1 rollout PASSED: the mixed v1.4.1/candidate committee converged across two \
          reshares at v7, and the fully-upgraded committee converged and kept serving a full \
          user lifecycle at each stage"
     );

--- a/dev-docs/conventions/enforce-minimum-cpu.md
+++ b/dev-docs/conventions/enforce-minimum-cpu.md
@@ -42,7 +42,7 @@ When enforcing, startup asserts ≥ 16 cores and panics below that.
   the runtime gate, not for the ref the suite happens to target today.
   `.github/workflows/upgrade-test.yaml` is the opposite case and is also
   deliberate: its OLD build step passes NO feature flags, because the ref it
-  builds (v1.4.0) already carries the runtime gate and the CI localnet's ika
+  builds (v1.4.1) already carries the runtime gate and the CI localnet's ika
   system object maps to `Chain::Unknown`.
 - `IKA_PROTOCOL_CONFIG_CHAIN_OVERRIDE` (honored only when the real
   chain is `Unknown` — `ika-types/src/digests.rs`) makes a localnet

--- a/dev-docs/plans/archive/cross-binary-upgrade-testing.md
+++ b/dev-docs/plans/archive/cross-binary-upgrade-testing.md
@@ -2,10 +2,10 @@
 
 > ARCHIVED PLAN — built by #1727, then superseded. **The two tests its results
 > table names, `tests/cross_binary.rs` and `tests/v118_upgrade.rs`, were deleted
-> in #1895** (`0f2679799f`); the current scenarios are `v140_rollout`,
-> `v140_churn`, `malicious_v140`, `restart_spectator`, `smoke` and `workload`
-> (`mid_epoch_rollback` was added later and deleted again once v1.4.0
-> shipped). The contract is
+> in #1895** (`0f2679799f`); the current scenarios are `v141_rollout`,
+> `v141_churn`, `malicious_v141`, `restart_spectator`, `wedged_drain`,
+> `smoke` and `workload` (`mid_epoch_rollback` was added later and deleted
+> again once v1.4.0 shipped). The contract is
 > [`../../specs/cross-binary-upgrade.md`](../../specs/cross-binary-upgrade.md)
 > and the running procedure is
 > [`../../playbooks/ci-suites.md`](../../playbooks/ci-suites.md). Kept for the

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -151,6 +151,12 @@ retarget renames all of it in one change — the three test files, their
 spec. Leaving any of them behind is the failure the convention exists to
 make visible.
 
+Immediately after a retarget, `main` == the OLD tag, so the gate is a
+same-binary run; real cross-binary coverage returns as `main` diverges. The
+run that lands with the retarget itself therefore proves the plumbing — that
+the OLD binary builds from the new tag at its own toolchain and the renamed
+gate wires up end to end — not binary compatibility.
+
 There are no capability-pinned scenarios left, but the convention still
 holds and is worth stating: when a scenario's OLD side is pinned to a
 specific capability rather than to "whatever is deployed", say so at the pin

--- a/dev-docs/playbooks/ci-suites.md
+++ b/dev-docs/playbooks/ci-suites.md
@@ -81,7 +81,7 @@ gh run download <run-id> -n <artifact>   # localnet-logs / cluster-tests-log-<at
 (`crates/ika-upgrade-test/`) — real, separately-compiled `ika-validator`
 child processes against an external `sui` localnet. Manual dispatch remains
 available. Pull requests matching the workflow's `paths:` filter automatically
-run the `v140_rollout` deployed-release gate rather than the entire matrix.
+run the `v141_rollout` deployed-release gate rather than the entire matrix.
 **Read that filter in the workflow; do not paraphrase it here** — every
 paraphrase written so far has been wrong, and a wrong one hides gaps. The
 comment above the list states the rule the list follows: the `ika-validator`
@@ -113,7 +113,7 @@ v5 -> v6 flavor was retired at MIN = 6 and resurrected for v6 -> v7.
 > #1891).** It previously called this workflow with the candidate SHA and
 > blocked tag publication on `v118_mixed_rollout`; that job was removed, so
 > a release tag now builds, uploads and drafts **unconditionally**.
-> Validating a release candidate is a manual step: dispatch `v140_rollout`
+> Validating a release candidate is a manual step: dispatch `v141_rollout`
 > (the deployed-release compatibility gate) plus the cluster and
 > Rust-integration suites against the exact tagged SHA and record the runs
 > in the draft's Validation section (the notes scaffold prompts for it). A
@@ -134,21 +134,22 @@ version-transition gates, which were retargeted rather than dropped:
 (`v127_v7_upgrade` and the `protocol_version_transition` cluster test) —
 retired outright this time rather than retargeted, because MIN = MAX = 7
 leaves no boundary; see the note above on resurrecting them at v8. Their
-successors are `v140_rollout`/`v140_churn`/`malicious_v140`
+successors are `v141_rollout`/`v141_churn`/`malicious_v141`
 (below), which play the same mixed-committee gate against the CURRENTLY
-deployed release (v1.4.0, both networks, protocol v7) — a pure binary swap
+deployed release (v1.4.1, both networks, protocol v7) — a pure binary swap
 with no protocol transition. (Historical `cross_binary` 96 GiB runner-OOM
 forensics and its infra fix: this playbook's pre-#1751 history.)
 
 **Retarget the `v1XY_*` family whenever the deployed release moves.** The
 scenario names carry the OLD BINARY's release, not the protocol version,
 so that this maintenance is visible rather than silent: the set was
-`v125_*` against v1.2.5, then `v127_*`, then `v128_*`, then `v131_*`, and is
-now `v140_*` with `old_ref=release/mainnet-v1.4.0`. A retarget renames all of
-it in one change — the three test files, their `RUN_*` opt-in env gates,
-the workflow's scenario names, `RUN_FLAG` mapping, `old_ref` defaults and
-both guard lists below, plus this playbook and the spec. Leaving any of
-them behind is the failure the convention exists to make visible.
+`v125_*` against v1.2.5, then `v127_*`, then `v128_*`, then `v131_*`, then
+`v140_*`, and is now `v141_*` with `old_ref=release/mainnet-v1.4.1`. A
+retarget renames all of it in one change — the three test files, their
+`RUN_*` opt-in env gates, the workflow's scenario names, `RUN_FLAG` mapping,
+`old_ref` defaults and both guard lists below, plus this playbook and the
+spec. Leaving any of them behind is the failure the convention exists to
+make visible.
 
 There are no capability-pinned scenarios left, but the convention still
 holds and is worth stating: when a scenario's OLD side is pinned to a
@@ -166,8 +167,9 @@ was validated in production (#2077, #2064).
 
 Retargeting also costs the gate whatever the OLD side happened to bring
 beyond its version. The v1.3.1-based gate straddled the event-sourcing
-change by accident of timing; the v1.4.0-based one does not, because both
-sides are post-#2074. That used to be covered by the separately-pinned
+change by accident of timing; the v1.4.0-based one that replaced it did
+not, and neither does the current v1.4.1-based one, because on both of them
+each side is post-#2074. That used to be covered by the separately-pinned
 backward scenario; with that scenario retired, nothing covers it, and a
 future storage-model boundary needs a purpose-built gate rather than an
 inherited one.
@@ -180,7 +182,7 @@ superficially correct while the thing it tests changes underneath is
 worse than one that visibly goes stale.
 
 **Which gates must refuse mocks.** Every gate whose evidence is
-cross-binary agreement: `v140_rollout`, `v140_churn` and `malicious_v140` —
+cross-binary agreement: `v141_rollout`, `v141_churn` and `malicious_v141` —
 plus any transition gate, the moment one exists again. (The list and the
 workflow both dropped `mid_epoch_rollback` when that scenario was deleted;
 the workflow now guards exactly these three.) Mocked cryptography is deterministic, so two
@@ -200,7 +202,7 @@ accepting mocks.
 # scenario runs --test-threads=1 (each binds the fixed Sui localnet ports and
 # chdirs during publish, so only one can run per job). smoke, workload and
 # restart_spectator and wedged_drain need only the current build; the three
-# v140 gates also build `old_ref` in an isolated git worktree at that ref's
+# v141 gates also build `old_ref` in an isolated git worktree at that ref's
 # own toolchain.
 
 # Everything in parallel (default), or a subset:
@@ -214,11 +216,11 @@ gh workflow run upgrade-test.yaml --ref <branch> -f test=smoke
 gh workflow run upgrade-test.yaml --ref <branch> -f test=workload
 
 # THE DEPLOYED-RELEASE GATE (also the PR default, and the scenario to run
-# by hand on every release tag): boot the literal v1.4.0 release, upgrade
+# by hand on every release tag): boot the literal v1.4.1 release, upgrade
 # one validator to current, converge two mixed aggregated reshares
 # (per-authority byte-equality, zero malicious), then swap the rest.
-gh workflow run upgrade-test.yaml --ref <branch> -f test=v140_rollout
-#   override the old side:  -f old_ref=release/mainnet-v1.4.0 -f old_bin_name=ika-validator
+gh workflow run upgrade-test.yaml --ref <branch> -f test=v141_rollout
+#   override the old side:  -f old_ref=release/mainnet-v1.4.1 -f old_bin_name=ika-validator
 
 # THE PROTOCOL-UPGRADE GATE: none exists right now. MIN = MAX = 7, so there
 # is no boundary to cross, and both transition gates were retired with the v6
@@ -233,18 +235,18 @@ gh workflow run upgrade-test.yaml --ref <branch> -f test=v140_rollout
 # Test-test the gate with the compiled-in, feature-gated one-validator
 # reconfiguration-message fault. This run is expected to fail; its logs must
 # show the exact zero-malicious or output-convergence assertion firing.
-gh workflow run upgrade-test.yaml --ref <branch> -f test=v140_rollout -f test_testing_fault=true
+gh workflow run upgrade-test.yaml --ref <branch> -f test=v141_rollout -f test_testing_fault=true
 
 # The standalone test-testing counterpart (green = detection works): honest
-# v1.4.0 committee + one faulty current validator (built in-workflow with
+# v1.4.1 committee + one faulty current validator (built in-workflow with
 # --features test-testing); honest validators must convict it and reshare
 # without it (committee dips to 3).
-gh workflow run upgrade-test.yaml --ref <branch> -f test=malicious_v140
+gh workflow run upgrade-test.yaml --ref <branch> -f test=malicious_v141
 
-# v140_rollout's churn counterpart: full swap, then a mirrored OCS joiner
-# folds into the reshared v1.4.0-origin key (4→5) and a shrink reshare
+# v141_rollout's churn counterpart: full swap, then a mirrored OCS joiner
+# folds into the reshared v1.4.1-origin key (4→5) and a shrink reshare
 # removes an original validator (5→4).
-gh workflow run upgrade-test.yaml --ref <branch> -f test=v140_churn
+gh workflow run upgrade-test.yaml --ref <branch> -f test=v141_churn
 
 # The mid-epoch-restart gate (#1952). Current build only, but it runs at
 # production presign-pool sizing, so it is not a cheap scenario.
@@ -286,9 +288,9 @@ notifier + a validator committee:
 |---|---|---|
 | `smoke` | current only | process harness reaches epoch 2 |
 | `workload` | current only | user DKG → Presign → Sign completes on-chain |
-| `v140_rollout` | **one current + three literal v1.4.0**, then all swapped | mixed aggregated reshares converge byte-identically with zero malicious reports; the fully-swapped committee converges and keeps serving |
-| `v140_churn` | all swapped, then a mirrored joiner (4→5) and a removal (5→4) | the v1.4.0-origin key reshares to a party that never held it (OCS joiner trust-anchor path) and back down |
-| `malicious_v140` | three literal v1.4.0 + one FAULTY current (test-testing build) | honest committee convicts the faulty validator and reshares without it — detection is not vacuous |
+| `v141_rollout` | **one current + three literal v1.4.1**, then all swapped | mixed aggregated reshares converge byte-identically with zero malicious reports; the fully-swapped committee converges and keeps serving |
+| `v141_churn` | all swapped, then a mirrored joiner (4→5) and a removal (5→4) | the v1.4.1-origin key reshares to a party that never held it (OCS joiner trust-anchor path) and back down |
+| `malicious_v141` | three literal v1.4.1 + one FAULTY current (test-testing build) | honest committee convicts the faulty validator and reshares without it — detection is not vacuous |
 | `wedged_drain` | current only, ONE validator's MPC drain parked by env hook | the #2102 wedged-but-alive drain gate: with the drain stuck but the service alive, the fold parks on the full round channel and the commit-liveness watchdog HOLDS rather than exiting — blocked seconds climbing against a flat consumed round, depth pinned at capacity, silence held, committed-leader round still advancing, peers untouched; on release the drain resumes with no restart |
 | `restart_spectator` | current only, production presign-pool sizing | the #1952 mid-epoch-restart gate: a validator restarted far from a boundary, in an epoch with an established network key and ongoing internal-presign volume, resumes LIVE registry-driven top-up instantiation within the epoch — not merely staying consensus-healthy while peers absorb its sessions |
 
@@ -299,8 +301,8 @@ quota, a **96 GiB pod memory limit**, and no swap. Each idle `ika-validator`
 runs ≈7.5–8 GB RSS, so co-locating many validators approaches the pod limit —
 the deleted `cross_binary` scenario (5–6 validators) reproducibly OOM-killed
 the runner at that limit (`OOMKilled`/137; forensics in this playbook's
-pre-#1751 history). `v140_rollout` is 4-validator and fits comfortably;
-`v140_churn` peaks at 5 validators during its joiner phase — the same peak
+pre-#1751 history). `v141_rollout` is 4-validator and fits comfortably;
+`v141_churn` peaks at 5 validators during its joiner phase — the same peak
 as the retired `v118_churn`, which passed on these runners (the OOM death
 was specific to `cross_binary`'s heavier 5–6-validator multi-lifecycle
 profile).

--- a/dev-docs/playbooks/test-testing.md
+++ b/dev-docs/playbooks/test-testing.md
@@ -66,7 +66,7 @@ conclude from pass/fail alone.
 
 4. **Build only the binary that carries the fault, and name it.** A
    reference binary you can't edit (a fixed release like the literal
-   v1.4.0 build) cannot carry a producer fault — put the fault in the
+   v1.4.1 build) cannot carry a producer fault — put the fault in the
    **local** build and run it as the minority in an otherwise-honest
    committee. Build to a clearly-named artifact (`…-FAULTED` / `…-FAULTY-*`)
    so it's never mistaken for a real binary.
@@ -119,14 +119,14 @@ Property: in a mixed-binary committee, honest validators identify a
 validator that broadcasts a malformed contribution and reconfigure without
 it.
 
-Harness: `crates/ika-upgrade-test/tests/malicious_v140.rs`. It boots a
-4-validator committee on the HONEST literal v1.4.0 release, lets the genesis
+Harness: `crates/ika-upgrade-test/tests/malicious_v141.rs`. It boots a
+4-validator committee on the HONEST literal v1.4.1 release, lets the genesis
 network DKG finish, then swaps ONE validator to the `--features test-testing`
 build so it corrupts its outgoing reconfiguration message at the next epoch
 boundary.
 
 ```bash
-gh workflow run upgrade-test.yaml --ref <branch> -f test=malicious_v140
+gh workflow run upgrade-test.yaml --ref <branch> -f test=malicious_v141
 ```
 
 Outcome shape: **recoverable** — the honest validators exclude the faulty
@@ -146,8 +146,8 @@ wire incompatibility would have failed every cross-binary message and never
 reached quorum; had a *clean* swapped validator also been flagged, you would
 be measuring incompatibility, not detection.
 
-What a green `malicious_v140` buys you is the right to trust a different
-run: it shows `v140_rollout`'s zero-malicious gate would actually fire on a
+What a green `malicious_v141` buys you is the right to trust a different
+run: it shows `v141_rollout`'s zero-malicious gate would actually fire on a
 real divergence, rather than reading zero because nothing ever checks.
 
 ## Worked example — hard-fail: running the fault through the gate itself
@@ -157,10 +157,10 @@ detection test, inverts the outcome shape:
 
 ```bash
 gh workflow run upgrade-test.yaml --ref <branch> \
-  -f test=v140_rollout -f test_testing_fault=true
+  -f test=v141_rollout -f test_testing_fault=true
 ```
 
-`v140_rollout` requires mixed reshares to converge byte-identically with
+`v141_rollout` requires mixed reshares to converge byte-identically with
 ZERO malicious reports, so a faulty validator must break it. **This run is
 expected to FAIL**, and its logs must show the specific zero-malicious or
 output-convergence assertion firing. A green run here is the red flag: it

--- a/dev-docs/specs/cross-binary-upgrade.md
+++ b/dev-docs/specs/cross-binary-upgrade.md
@@ -191,13 +191,13 @@ of those rollouts completed on the deployed networks.
 
 Beyond the MIN-driven retirements, the mixed-committee family is retargeted
 whenever the DEPLOYED release moves — the scenario names carry the old
-binary's release (`v125_*` → `v127_*` → `v128_*` → `v131_*` → `v140_*`), so
-the maintenance is visible rather than silent. The current deployed-release
-gate is `tests/v140_rollout.rs`: the one-upgraded-validator mixed topology
-against the literal **v1.4.0** release at protocol v7. Both sides support v7
-and only v7, so the boundary under test is a pure binary swap. It is the
-PR-gating scenario and the one a release manager dispatches against every
-release tag.
+binary's release (`v125_*` → `v127_*` → `v128_*` → `v131_*` → `v140_*` →
+`v141_*`), so the maintenance is visible rather than silent. The current
+deployed-release gate is `tests/v141_rollout.rs`: the one-upgraded-validator
+mixed topology against the literal **v1.4.1** release at protocol v7. Both
+sides support v7 and only v7, so the boundary under test is a pure binary
+swap. It is the PR-gating scenario and the one a release manager dispatches
+against every release tag.
 
 **No scenario crosses the storage-model change any more.**
 `tests/mid_epoch_rollback.rs` was the one that did: it was deliberately kept
@@ -211,7 +211,7 @@ rollback safety net.
 
 Note what that leaves the forward gate standing on. The v1.3.1-based
 `v131_rollout` straddled the storage-model change by accident of timing;
-`v140_rollout` has both sides post-#2074 and stands behind wire and
+`v141_rollout` has both sides post-#2074 and stands behind wire and
 MPC-output agreement only. Nothing in it was weakened to get there, and that
 ingredient used to survive in the scenario pinned for it — but with that
 scenario retired it now lives nowhere in the matrix. Any future change that
@@ -228,8 +228,8 @@ drives them across epochs. The surviving scenarios (current build only):
   epoch 2 on the genesis epoch cadence.
 - `tests/workload.rs` — the session-lifecycle invariant: a full user
   DKG → Presign → Sign completing on-chain at genesis protocol v7.
-- `tests/v140_rollout.rs` — the current deployed-release compatibility gate:
-  boot the literal v1.4.0 release at genesis protocol v7, upgrade exactly one
+- `tests/v141_rollout.rs` — the current deployed-release compatibility gate:
+  boot the literal v1.4.1 release at genesis protocol v7, upgrade exactly one
   of four validators to the candidate, require two mixed
   network-key reshares to converge byte-identically with zero malicious
   reports and a served user lifecycle after each, then swap the remaining
@@ -246,20 +246,20 @@ drives them across epochs. The surviving scenarios (current build only):
   it independently the way a fleet does, while the in-process cluster test
   shares one such global across all four simulated validators and can only
   gate the vote arithmetic and the cross-epoch handoff path.
-- `tests/v140_churn.rs` — the churn counterpart: full sequential swap over
-  the literal v1.4.0 committee (on-disk RocksDB continuity), then a
-  peer-only-mirrored joiner folds into the reshared v1.4.0-origin key
+- `tests/v141_churn.rs` — the churn counterpart: full sequential swap over
+  the literal v1.4.1 committee (on-disk RocksDB continuity), then a
+  peer-only-mirrored joiner folds into the reshared v1.4.1-origin key
   (4→5, the OCS joiner trust-anchor path) and a shrink reshare removes an
   original validator (5→4).
-- `tests/malicious_v140.rs` — the test-testing counterpart: an honest
-  literal-v1.4.0 committee plus ONE current-build validator carrying the
+- `tests/malicious_v141.rs` — the test-testing counterpart: an honest
+  literal-v1.4.1 committee plus ONE current-build validator carrying the
   `test-testing`-gated reconfiguration-message fault (the hook lives in
   the main reconfiguration advance path in
   `crytographic_computation/mpc_computations.rs`); honest validators must
   convict it and reshare without it, asserted via the malicious-actors
   gauge. Green = the compatibility gates above are not vacuous. The
   workflow's `test_testing_fault` input runs the same fault through
-  `v140_rollout` itself (that run must fail closed); `malicious_v140` is
+  `v141_rollout` itself (that run must fail closed); `malicious_v141` is
   also directly dispatchable (the workflow builds the faulty binary).
 - **There is no BACKWARD direction in the matrix, and no scenario whose OLD
   side is pinned to a capability rather than to the deployed release.**

--- a/dev-docs/specs/event-sourced-epoch.md
+++ b/dev-docs/specs/event-sourced-epoch.md
@@ -885,7 +885,7 @@ What in-process coverage cannot reach, and belongs on CI or a cluster:
 
   The FORWARD direction across this change was covered by `v131_rollout` /
   `v131_churn` while v1.3.1 was the deployed release. Their successors
-  `v140_rollout` / `v140_churn` boot v1.4.0, which is itself post-#2074, so
+  `v141_rollout` / `v141_churn` boot v1.4.1, which is itself post-#2074, so
   they no longer put two storage models in one committee — they gate wire and
   MPC-output agreement between two event-sourced binaries. **Nothing now
   exercises a pre-#2074 binary sharing an epoch with a current one, in either

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -466,7 +466,7 @@ next epoch inherits.
      it (see the barrier section). So adoption flags the key for the
      syncer's chain-sourced read instead of skipping it forever. (Until
      issue #1751 removed the migration chain-read fallback, that fallback
-     covered this shape implicitly; the `v140_churn` scenario's mirrored
+     covered this shape implicitly; the `v141_churn` scenario's mirrored
      joiner caught the regression.)
      A key DKG'd THIS epoch is excluded — the healthy fresh-key
      bootstrap window. Second (mid-epoch restart, issue #1852). Once this

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -466,8 +466,8 @@ next epoch inherits.
      it (see the barrier section). So adoption flags the key for the
      syncer's chain-sourced read instead of skipping it forever. (Until
      issue #1751 removed the migration chain-read fallback, that fallback
-     covered this shape implicitly; the `v141_churn` scenario's mirrored
-     joiner caught the regression.)
+     covered this shape implicitly; the deployed-release churn scenario's
+     mirrored joiner — then `v131_churn` — caught the regression.)
      A key DKG'd THIS epoch is excluded — the healthy fresh-key
      bootstrap window. Second (mid-epoch restart, issue #1852). Once this
      epoch's reconfiguration completes, the off-chain copy of a key's

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -467,7 +467,7 @@ next epoch inherits.
      syncer's chain-sourced read instead of skipping it forever. (Until
      issue #1751 removed the migration chain-read fallback, that fallback
      covered this shape implicitly; the deployed-release churn scenario's
-     mirrored joiner — then `v131_churn` — caught the regression.)
+     mirrored joiner — then `v125_churn` — caught the regression.)
      A key DKG'd THIS epoch is excluded — the healthy fresh-key
      bootstrap window. Second (mid-epoch restart, issue #1852). Once this
      epoch's reconfiguration completes, the off-chain copy of a key's


### PR DESCRIPTION
## What

v1.4.1 is the release the fleet now runs — `release/mainnet-v1.4.1` and
`release/testnet-v1.4.1` both point at `e8848a5d45` — so the deployed-release
scenario family moves with it, per the convention in
`dev-docs/playbooks/ci-suites.md` ("Retarget the `v1XY_*` family whenever the
deployed release moves").

| before | after |
|---|---|
| `v140_rollout` | `v141_rollout` (PR-default gate) |
| `v140_churn` | `v141_churn` |
| `malicious_v140` | `malicious_v141` |
| `old_ref=release/mainnet-v1.4.0` | `old_ref=release/mainnet-v1.4.1` |

`old_bin_name` stays `ika-validator`.

Renamed in one sweep: the three test files (via `git mv`), their test
functions, the `RUN_V141_*` / `RUN_MALICIOUS_V141` opt-in env gates, and every
place in `upgrade-test.yaml` keyed on a scenario name — the `ALL` list, the
default `TEST`, the `RUN_FLAG` mapping, the per-scenario `OLD_REF` defaults,
the mocks-refusal guard, the `test_testing_fault` guard, the faulty-binary
build condition, the OLD-build step `if:`, the presign-pool carve-out, all
input descriptions and the header comment. Plus the spec, both playbooks, the
archived plan's pointer banner, and the scenario references in `ika-core`,
`ika-swarm-config` and the harness.

**No scenario logic or assertion changed** — only names and the OLD ref.

## Why this is safe

- **Protocol pin unchanged.** `MIN_PROTOCOL_VERSION = MAX_PROTOCOL_VERSION = 7`
  at both `release/mainnet-v1.4.0` and this HEAD, so the v7 genesis pin and the
  pure-binary-swap framing hold as written. No v1.4.0-specific assumption was
  found in any of the three scenarios.
- **No metric coupling to the #2122 rename.** The harness scrapes only
  `ika_dwallet_mpc_*`, `ika_consensus_*`, `ika_current_*`, `ika_output_info*`
  and `ika_validator_process_uptime_seconds`. It asserts on neither
  `ika_sui_client_sui_rpc_errors` nor the new
  `ika_sui_client_sui_response_errors_total`, so the split is inert here.
  #2106 (register metric families by `NodeMode`) likewise only *narrows*
  registration to the applicable mode — every family above is validator-mode.
- **The v1.4.0 ↔ v1.4.1 mix was already validated**: `v140_rollout` passed on
  the version-bump PR (#2131) and on `236fe25c48`'s release-prep run of every
  scenario (run 33750555978, all eight jobs green).

## What the retarget does to these gates' reach

Moving the OLD side from v1.4.0 to v1.4.1 carries it across #2121 (the
validator no longer reads the deprecated on-chain `mpc_data_bytes`), #2120
(registration writes a placeholder there), #2123 (the prepare-then-start
handoff barrier) and the #2122 metric split.

**Both sides of every one of these gates are now past all four**, so none of
them is straddled here — they are recorded because the OLD side's behaviour
moved with them, not because a mixed committee exercises a disagreement about
them. The scenario doc comments and the workflow header say exactly that.

The storage-model paragraph keeps its substance: v1.4.1, like the v1.4.0 gate
it replaces, is post-#2074, so both sides still share one storage model, and
the boundary stopped being crossed at the 1.3.1 → 1.4.0 retarget rather than
at this one. Nothing in the matrix crosses the event-sourcing change.

## Note on this PR's own gate run

HEAD of this branch is the `v1.4.1` tag commit plus these renames, so for *this
PR* OLD and NEW are the same code and `v141_rollout` is a same-binary run.
That is expected immediately after a retarget: the run's value here is proving
the plumbing — that the OLD binary builds from the v1.4.1 tag at its own
toolchain and the renamed gate wires up end to end. Real cross-binary coverage
returns as `main` diverges from v1.4.1. This limitation is now recorded
in-repo (workflow header + `ci-suites.md` next to the retarget rule), not just
here; `malicious_v141` carries the matching note that its "cross-binary"
framing is currently nominal.

## Evidence

All three scenarios green. Every job resolved the tag to the right immutable
commit and printed the anti-vacuous-pass assertion:

| run | scenario | result | duration |
|---|---|---|---|
| [33802980427](https://github.com/dwallet-labs/ika/actions/runs/33802980427) | `v141_rollout` (PR gate, default) | success | 73 min |
| [33802992319](https://github.com/dwallet-labs/ika/actions/runs/33802992319) | `v141_churn` | success | 74 min |
| [33802992319](https://github.com/dwallet-labs/ika/actions/runs/33802992319) | `malicious_v141` | success | 34 min |

Dispatched once as `-f test=v141_churn,malicious_v141`, confirming the `test`
input's comma list fans out to one matrix job per scenario.

OLD-build resolution, identical in all three jobs:

```
resolved OLD_REF=release/mainnet-v1.4.1 to immutable commit e8848a5d45b9233709f8354eed4c59c8b8591eec
built OLD binary: /home/runner/_work/ika/ika/old-build/target/release/ika-validator
```

Gate assertions (the `set -uo pipefail` step requires this exact line, so a
skipped test cannot pass):

```
v141_rollout   test result: ok. 1 passed; ... finished in 2950.22s
v141_churn     test result: ok. 1 passed; ... finished in 3146.25s
malicious_v141 test result: ok. 1 passed; ...  finished in 696.67s
```

Plus each scenario's own PASSED line — e.g. `v1.4.1 rollout PASSED: the mixed
v1.4.1/candidate committee converged across two reshares at v7`, and
`malicious-v141 PASSED: honest v1.4.1 committee reached epoch 3 AND recorded
the faulty current validator as malicious`.

Baselines from `236fe25c48`'s pre-bump run for comparison: rollout 71 min,
churn 74 min, malicious 44 min — no regression.

Local: `cargo fmt --all --check`, `clippy -p ika-upgrade-test --all-targets -D
warnings`, `cargo test -p ika-upgrade-test --lib` (36 passed), all three test
targets `--no-run`, workflow YAML parses with `v141_rollout` as the
`workflow_call` default, and the `RUN_FLAG` mapping cross-checked against the
`std::env::var("RUN_…")` gate each test actually reads.

The second commit is doc-only but touches paths in the workflow's `paths:`
filter, so it re-triggered the gate on `d4b49e5f2b`
([33810021860](https://github.com/dwallet-labs/ika/actions/runs/33810021860)).

## Residual `v1.4.0` references, and why each stays

These are history, not the current gate, and retargeting them would rewrite the
record:

- `dev-docs/specs/validator-mpc-data-announcements.md:105` — "On v1.4.0 … an
  activated placeholder member is … permanent". True of v1.4.0 and **false of
  v1.4.1** (post-#2121). Retargeting this would make it wrong.
- `docs/content/docs/cli/validator-commands.mdx:65,67` — the user-facing
  "v1.4.0 and earlier still read this field" compatibility statement. Same
  reason.
- `mid_epoch_rollback`'s retirement record — `cross-binary-upgrade.md:208,269-274`,
  `event-sourced-epoch.md:636-645,882-883`, `ci-suites.md:157,164,266-268`,
  `dev-docs/README.md:42`, `dev-docs/specs/README.md:30`. It was pinned to
  v1.3.1 and proved rollback safe *for the v1.4.0 release commit*.
- `.github/workflows/ci.yaml:151` and `scripts/check-rust-toolchain-consistency.sh:8`
  — the v1.4.0 release build's MSRV-drift failure.
- `crates/ika-proxy/src/sui_chain.rs:16`, `crates/ika-types/src/digests.rs:165`
  — the #2091 `ika-proxy` v1.4.0 crash-loop.
- The scenario-lineage lists in `cross-binary-upgrade.md:194` and
  `ci-suites.md:147`, which now read `… → v140_* → v141_*`.
- Third-party `1.4.0` versions in `Cargo.lock`, `Cargo.toml` (`expect-test`),
  `pnpm-lock.yaml` and the JS `package.json`s.

`git grep -nE 'v140_|RUN_V140|V140'` returns only those two lineage lines.

## Provenance fix (commits 2 and 3)

Four evidence-citing comments named whichever churn scenario was current when
they were last swept, so each retarget silently reassigned an observation to a
scenario that never produced it. Each now names the earliest instance the
comment names (verified with `git log -L<line>,<line>:<file>`), so the next
retarget stops rewriting history:

| site | first named | commit |
|---|---|---|
| `crates/ika-core/.../network_key_adoption.rs:909` | `v125_churn` | `0f2679799f` (#1895) |
| `dev-docs/specs/handoff.md:469` | `v125_churn` | `0f2679799f` (#1895) |
| `crates/ika-swarm-config/src/sui_client.rs:142` | `v128_churn` | `b207150d2f` (#1992) |
| `crates/ika-upgrade-test/src/cluster.rs:2130` | `v128_churn` | `b207150d2f` (#1992) |

The first pass at this pinned all four to `v131_churn` — wrong the same way
the original was, since `v131_churn` was itself a reassignment made by #2040
(`04d3987dd0`). All four now use the unambiguous em-dash apposition
("the deployed-release churn scenario — then `v125_churn` — caught the
regression") rather than a comma form that reads as two scenarios in sequence.

## One deliberate scope call

`dev-docs/plans/archive/cross-binary-upgrade-testing.md` is an archived plan,
but its banner explicitly names *the current scenarios* — leaving it would
assert something false. The previous retarget (#2097, `6389339c8f`) updated the
same line, so this follows that precedent. While rewriting the list I also
added `wedged_drain`, which it had been missing since #2118. The archived body
is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

