### PR TITLE
feat(noa): derive the NOA signing key from the handoff certificate

### DIFF
--- a/crates/ika-core/src/authority/authority_perpetual_tables.rs
+++ b/crates/ika-core/src/authority/authority_perpetual_tables.rs
@@ -8,6 +8,7 @@ use typed_store::traits::Map;
 
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
 use crate::sui_connector::verified_state_cache::VerifiedSnapshot;
+use dwallet_mpc_types::dwallet_mpc::NetworkKeyId;
 use ika_network::mpc_artifacts::mpc_data_blob_hash;
 use ika_types::handoff::CertifiedHandoffAttestation;
 use ika_types::messages_dwallet_mpc::SessionIdentifier;
@@ -51,6 +52,17 @@ pub struct AuthorityPerpetualTables {
     /// for, and skipping a single epoch can permanently break their
     /// ability to bootstrap.
     pub(crate) certified_handoff_attestations: DBMap<EpochId, CertifiedHandoffAttestation>,
+
+    /// `ObjectID -> NetworkKeyId` for every network encryption key this
+    /// process has translated — registered at instantiation or by the
+    /// background derivation, written here by the MPC manager, and loaded
+    /// into the process-global `network_key_id_mapping` at boot. The
+    /// mapping is content-derived and reconfiguration-invariant, so an
+    /// entry never changes. It exists so a restarting validator can
+    /// translate every certified key at the prepare-then-start barrier,
+    /// where the epoch's network-owned-address signing key is resolved,
+    /// instead of only after the key's re-instantiation.
+    pub(crate) network_key_ids_by_object_id: DBMap<ObjectID, NetworkKeyId>,
 
     /// Per-key map `network_key_id -> blob digest` for the network
     /// DKG output. Stable across epochs (a key's DKG output is
@@ -402,6 +414,28 @@ impl AuthorityPerpetualTables {
         &self,
     ) -> impl Iterator<Item = IkaResult<(EpochId, CertifiedHandoffAttestation)>> + '_ {
         self.certified_handoff_attestations
+            .safe_iter()
+            .map(|res| res.map_err(IkaError::from))
+    }
+
+    /// Records a network key's `ObjectID -> NetworkKeyId` translation.
+    /// Idempotent: the mapping never changes for a key.
+    pub fn insert_network_key_id_mapping(
+        &self,
+        object_id: ObjectID,
+        network_key_id: NetworkKeyId,
+    ) -> IkaResult {
+        self.network_key_ids_by_object_id
+            .insert(&object_id, &network_key_id)?;
+        Ok(())
+    }
+
+    /// Every persisted `ObjectID -> NetworkKeyId` translation — what the
+    /// node loads into `network_key_id_mapping` at boot.
+    pub fn iter_network_key_id_mappings(
+        &self,
+    ) -> impl Iterator<Item = IkaResult<(ObjectID, NetworkKeyId)>> + '_ {
+        self.network_key_ids_by_object_id
             .safe_iter()
             .map(|res| res.map_err(IkaError::from))
     }
@@ -828,6 +862,28 @@ mod tests {
             .collect();
         seen.sort();
         assert_eq!(seen, vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn network_key_id_mappings_round_trip() {
+        let (_dir, tables) = open_tables();
+        let first = (ObjectID::from_single_byte(1), NetworkKeyId([1u8; 32]));
+        let second = (ObjectID::from_single_byte(2), NetworkKeyId([2u8; 32]));
+        for (object_id, network_key_id) in [second, first] {
+            tables
+                .insert_network_key_id_mapping(object_id, network_key_id)
+                .unwrap();
+        }
+        // Re-inserting the same mapping is a no-op.
+        tables
+            .insert_network_key_id_mapping(first.0, first.1)
+            .unwrap();
+        let mut seen: Vec<_> = tables
+            .iter_network_key_id_mappings()
+            .map(|r| r.unwrap())
+            .collect();
+        seen.sort();
+        assert_eq!(seen, vec![first, second]);
     }
 
     #[tokio::test]

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -287,6 +287,11 @@ impl DWalletMPCService {
         // runs at all. Resolved per epoch by
         // `DWalletMPCService::verify_validator_keys`.
         seed_resolution: &EpochSeedResolution,
+        // This epoch's network-owned-address signing key, resolved by the
+        // prepare-then-start barrier from the prior epoch's handoff
+        // certificate (`network_owned_address_signing_key::select`); `None`
+        // when the epoch has none or this validator sits NOA signing out.
+        network_owned_address_signing_key_id: Option<ObjectID>,
     ) -> Self {
         let network_dkg_third_round_delay = protocol_config.network_dkg_third_round_delay();
 
@@ -336,6 +341,7 @@ impl DWalletMPCService {
             network_owned_address_sign_output_sender,
             max_mpc_computation_cores,
             stranded_network_keys,
+            network_owned_address_signing_key_id,
         );
         // Self-malicious diagnostic snapshots are mirrored to disk beside the
         // databases (NOT under `db_path()`/live, which is RocksDB-managed):
@@ -484,6 +490,7 @@ impl DWalletMPCService {
                 network_owned_address_sign_output_sender,
                 None,
                 Arc::new(ArcSwap::from_pointee(HashSet::new())),
+                None,
             ),
             exit: watch::channel(()).1,
             end_of_publish: false,
@@ -564,6 +571,18 @@ impl DWalletMPCService {
     #[allow(dead_code)]
     pub(crate) fn last_read_consensus_round(&self) -> Option<Round> {
         self.last_read_consensus_round
+    }
+
+    /// Sets the epoch's network-owned-address signing key the way the
+    /// prepare-then-start barrier would have handed it in at construction —
+    /// the harness DKGs its key after the service exists.
+    #[cfg(test)]
+    pub(crate) fn set_network_owned_address_signing_key_id_for_testing(
+        &mut self,
+        key_id: Option<ObjectID>,
+    ) {
+        self.dwallet_mpc_manager
+            .set_network_owned_address_signing_key_id_for_testing(key_id);
     }
 
     /// Shrinks the demand park bound so a test can reach it in a handful of
@@ -1190,7 +1209,7 @@ impl DWalletMPCService {
                 pending_requests = self.pending_network_owned_address_sign_requests.len(),
                 signing_key = ?self
                     .dwallet_mpc_manager
-                    .network_owned_address_signing_key_resolution(),
+                    .network_owned_address_signing_network_encryption_key_id(),
                 "network-owned-address sign requests waiting: presign not yet assigned \
                  in consensus order or signing key unavailable"
             );

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -80,6 +80,7 @@ use mpc::GuaranteedOutputDeliveryRoundResult;
 #[cfg(any(test, feature = "test-utils"))]
 use prometheus::Registry;
 use std::collections::{HashMap, HashSet};
+use std::mem;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use sui_types::base_types::ObjectID;
@@ -94,45 +95,6 @@ const READ_INTERVAL_MS: u64 = 20;
 const FIVE_KILO_BYTES: usize = 5 * 1024;
 
 pub const NETWORK_OWNED_ADDRESS_SIGN_CHANNEL_CAPACITY: usize = 1024;
-
-/// How many consensus rounds a network-owned-address presign demand may stay
-/// parked in the assignment drain before it is dropped.
-///
-/// A demand carries the network encryption key it was announced under, and the
-/// presign pool is keyed by that id, so a demand naming a key this validator
-/// holds no pool for cannot be assigned. It parks (kept in consensus-delivery
-/// order, retried every round) rather than being rejected, because honest
-/// validators do transiently hold different adopted key sets and a local
-/// reject would turn that lag into a permanent drop — the reasoning is in
-/// `dev-docs/specs/internal-presign-pool.md`. Without an upper bound, a demand
-/// naming a key NO validator will ever adopt parks for the rest of the epoch
-/// and blocks that epoch's NOA checkpoint finalization.
-///
-/// Rounds, not wall clock, so the drop decision is identical on every
-/// validator (see `DWalletMPCService::drain_consensus_rounds`).
-///
-/// The value is ~1 hour of mainnet consensus at ~19.5 rounds/s (the rate the
-/// catch-up gate is calibrated against — see `CATCH_UP_ENTER_GAP_ROUNDS`).
-/// That sits far above every window in which an honest validator can still be
-/// missing a key or its pool:
-/// - the network-key syncer re-merges the overlay every 5s (~100 rounds);
-/// - a restarting or joining validator recovers a stranded key by chain read
-///   and then instantiates class groups for it — minutes, so at most low tens
-///   of thousands of rounds;
-/// - a freshly adopted key's presign pool is filled by internal-presign MPC,
-///   again minutes.
-///
-/// And far below the epoch it has to fit inside: a 24h epoch is ~1.7M rounds,
-/// so the bound spends ~4% of an epoch waiting before giving up on a demand.
-///
-/// A compile-time constant is safe only while demands cannot reach the wire:
-/// announcements are gated on `noa_checkpoints()`, which is off on every live
-/// network, so no committee can currently be split across two values of it.
-/// Once that flag is on, changing this number is a consensus-affecting change
-/// — validators running different values would drop different demands — and
-/// it has to move into `ProtocolConfig`, where a change is version-gated
-/// rather than binary-driven.
-const NOA_PRESIGN_DEMAND_PARK_ROUNDS: u64 = 70_000;
 
 /// A consensus-agreed NOA presign demand waiting in the assignment drain,
 /// together with the consensus round that delivered it.
@@ -263,18 +225,18 @@ pub struct DWalletMPCService {
     buffered_noa_presign_demands: Vec<ConsensusNOAPresignDemand>,
     /// NOA sign presign demands agreed via consensus, drained in
     /// consensus-delivery order to assign each a presign (kept across rounds
-    /// when the pool is momentarily empty, up to
-    /// [`NOA_PRESIGN_DEMAND_PARK_ROUNDS`]).
+    /// while the signing key is not yet derived here or its pool is
+    /// momentarily empty, up to `noa_presign_demand_park_rounds`).
     agreed_noa_presign_demands_queue: Vec<ParkedNOAPresignDemand>,
     /// Digests of demands this validator has already announced this epoch, so it
     /// announces each demand at most once.
     announced_noa_demand_digests: HashSet<[u8; 32]>,
-    /// Consensus rounds a demand may stay parked before the drain drops it.
-    /// [`NOA_PRESIGN_DEMAND_PARK_ROUNDS`] in production; only tests override
-    /// it. The value is part of a consensus-uniform predicate, so every
-    /// validator must run the same one — it is deliberately NOT node
-    /// configuration.
-    noa_presign_demand_park_rounds: u64,
+    /// Consensus rounds a demand may stay parked before the drain drops it;
+    /// `None` never drops. Read from `ProtocolConfig`
+    /// (`noa_presign_demand_park_rounds`), so a change is version-gated: the
+    /// value is part of a consensus-uniform predicate, and validators running
+    /// different bounds would drop different demands. Only tests override it.
+    noa_presign_demand_park_rounds: Option<u64>,
     /// Receiver for sign outputs from MPC manager to route to NOA checkpoint handlers.
     network_owned_address_sign_output_receiver:
         tokio::sync::mpsc::Receiver<NetworkOwnedAddressSignOutput>,
@@ -337,6 +299,8 @@ impl DWalletMPCService {
         let schnorr_presign_second_round_delay = protocol_config
             .schnorr_presign_second_round_delay_as_option()
             .unwrap_or(0);
+        let noa_presign_demand_park_rounds =
+            protocol_config.noa_presign_demand_park_rounds_as_option();
 
         let max_mpc_computation_cores = node_config.max_mpc_computation_cores;
         // The seed for THIS epoch, not simply the configured one: during a
@@ -417,7 +381,7 @@ impl DWalletMPCService {
             buffered_noa_presign_demands: Vec::new(),
             agreed_noa_presign_demands_queue: Vec::new(),
             announced_noa_demand_digests: HashSet::new(),
-            noa_presign_demand_park_rounds: NOA_PRESIGN_DEMAND_PARK_ROUNDS,
+            noa_presign_demand_park_rounds,
             network_owned_address_sign_output_receiver,
             dwallet_checkpoint_handler,
             system_checkpoint_handler,
@@ -488,6 +452,9 @@ impl DWalletMPCService {
                 NETWORK_OWNED_ADDRESS_SIGN_CHANNEL_CAPACITY,
             );
 
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+        let noa_presign_demand_park_rounds =
+            protocol_config.noa_presign_demand_park_rounds_as_option();
         let service = DWalletMPCService {
             last_read_consensus_round: Some(0),
             // Integration tests always drive a participating validator; the
@@ -512,7 +479,7 @@ impl DWalletMPCService {
                 0,
                 DWalletMPCMetrics::new(&Registry::new()),
                 sui_data_receivers.clone(),
-                ProtocolConfig::get_for_max_version_UNSAFE(),
+                protocol_config.clone(),
                 epoch_store,
                 network_owned_address_sign_output_sender,
                 None,
@@ -524,7 +491,7 @@ impl DWalletMPCService {
             sui_data_requests: sui_data_receivers,
             name: authority_name,
             epoch: 1,
-            protocol_config: ProtocolConfig::get_for_max_version_UNSAFE(),
+            protocol_config,
             committee: Arc::new(committee),
             last_sent_idle_status: None,
             number_of_consensus_rounds: 0,
@@ -547,7 +514,7 @@ impl DWalletMPCService {
             buffered_noa_presign_demands: Vec::new(),
             agreed_noa_presign_demands_queue: Vec::new(),
             announced_noa_demand_digests: HashSet::new(),
-            noa_presign_demand_park_rounds: NOA_PRESIGN_DEMAND_PARK_ROUNDS,
+            noa_presign_demand_park_rounds,
             network_owned_address_sign_output_receiver: tokio::sync::mpsc::channel(
                 NETWORK_OWNED_ADDRESS_SIGN_CHANNEL_CAPACITY,
             )
@@ -600,12 +567,12 @@ impl DWalletMPCService {
     }
 
     /// Shrinks the demand park bound so a test can reach it in a handful of
-    /// rounds instead of [`NOA_PRESIGN_DEMAND_PARK_ROUNDS`]. Never call this
-    /// outside tests: validators that disagree on the bound disagree on which
-    /// demands were dropped.
+    /// rounds instead of the `ProtocolConfig` value. Never call this outside
+    /// tests: validators that disagree on the bound disagree on which demands
+    /// were dropped.
     #[cfg(test)]
     pub(crate) fn set_noa_presign_demand_park_rounds_for_testing(&mut self, rounds: u64) {
-        self.noa_presign_demand_park_rounds = rounds;
+        self.noa_presign_demand_park_rounds = Some(rounds);
     }
 
     #[cfg(test)]
@@ -1070,20 +1037,19 @@ impl DWalletMPCService {
 
         // Announce a presign demand for each pending request so every validator
         // assigns it a presign in the same consensus-delivery order (the drain
-        // in `drain_consensus_rounds`). Gated on `noa_checkpoints()`
-        // for wire safety — the `NOAPresignDemand` consensus kind must never
-        // reach a peer that predates it — and on the signing network key being
-        // known (the demand carries its id, and the presign pool is keyed by it;
-        // announcing before adoption would let validators disagree on the key).
-        // Announce each demand at most once; one the drain already resolved —
-        // assigned a presign, or dropped at the park bound — needs no
-        // (re-)announcement, and the resolution is durable, so this holds after
-        // a restart too. Do NOT pop/instantiate here.
-        if self.protocol_config.noa_checkpoints()
-            && let Some(network_encryption_key_id) = self
-                .dwallet_mpc_manager
-                .network_owned_address_signing_network_encryption_key_id()
-        {
+        // in `drain_consensus_rounds`). Gated on `noa_checkpoints()` for wire
+        // safety — the `NOAPresignDemand` consensus kind must never reach a
+        // peer that predates it — and on nothing else: the announcement
+        // carries only the demand identity. The network encryption key the
+        // presign is drawn under is not announced; every validator derives it
+        // from the prior epoch's handoff certificate at assignment time, so an
+        // announcement does not wait for this validator to have derived it (a
+        // demand sequenced before the derivation resolves simply parks in the
+        // drain). Announce each demand at most once; one the drain already
+        // resolved — assigned a presign, or dropped at the park bound — needs
+        // no (re-)announcement, and the resolution is durable, so this holds
+        // after a restart too. Do NOT pop/instantiate here.
+        if self.protocol_config.noa_checkpoints() {
             for request in &self.pending_network_owned_address_sign_requests {
                 let digest = request.demand_id.digest();
                 if self.announced_noa_demand_digests.contains(&digest) {
@@ -1116,7 +1082,6 @@ impl DWalletMPCService {
                     .push(ConsensusNOAPresignDemand {
                         authority: self.name,
                         demand_id: request.demand_id.clone(),
-                        network_encryption_key_id,
                     });
                 self.announced_noa_demand_digests.insert(digest);
             }
@@ -1223,6 +1188,9 @@ impl DWalletMPCService {
             self.last_noa_starvation_log = Some(Instant::now());
             warn!(
                 pending_requests = self.pending_network_owned_address_sign_requests.len(),
+                signing_key = ?self
+                    .dwallet_mpc_manager
+                    .network_owned_address_signing_key_resolution(),
                 "network-owned-address sign requests waiting: presign not yet assigned \
                  in consensus order or signing key unavailable"
             );
@@ -1367,7 +1335,6 @@ impl DWalletMPCService {
                 let tx = ConsensusTransaction::new_noa_presign_demand(
                     demand.authority,
                     demand.demand_id.clone(),
-                    demand.network_encryption_key_id,
                 );
                 if let Err(e) = self
                     .dwallet_submit_to_consensus
@@ -1377,6 +1344,161 @@ impl DWalletMPCService {
                     error!(error = ?e, consensus_round, "Failed to submit NOA presign demand; re-buffering for retry");
                     self.buffered_noa_presign_demands.push(demand);
                 }
+            }
+        }
+    }
+
+    /// Drains one parked NOA presign demand at `consensus_round` under the
+    /// epoch's network-owned-address signing key as this validator has derived
+    /// it (`None` while it has not), returning whether the demand stays in the
+    /// queue.
+    ///
+    /// With a key, `assign_presign_for_demand` is atomic + idempotent: it pops
+    /// a presign and records the assignment (raw presign + the key it was
+    /// drawn under) in ONE committed batch, or returns the existing resolution
+    /// without popping. The pop and the record MUST be one commit — a crash
+    /// between a self-committed pop and a separate record would let a re-drain
+    /// after a consensus-round replay pop a different presign than peers
+    /// assigned. `Assigned` (just now, or by an earlier drain) and `Evicted`
+    /// are both terminal — the demand leaves the queue; `PoolEmpty` parks it,
+    /// preserving order across rounds until the presign is generated or the
+    /// park bound expires; `Err` parks it for retry.
+    ///
+    /// Without a key nothing can be popped, but a demand this validator
+    /// already resolved in an earlier pass over the same rounds — a restart
+    /// replaying the epoch before the derivation's inputs have landed again —
+    /// must still leave the queue on its DURABLE resolution. Parking it
+    /// instead would let the replayed bound drop it a second time: the
+    /// eviction write is a no-op on a resolved demand, but the queue would
+    /// hold a demand whose sign already ran, and the drop would be counted
+    /// and logged as new. So the durable table is read first, and only an
+    /// unresolved demand parks.
+    ///
+    /// The algorithm comes from the demand IDENTITY, never from the
+    /// announcement: the consensus dedup key is the demand-id digest alone,
+    /// so the first announcement sequenced for a demand would otherwise
+    /// supply any payload field for the whole network while the honest
+    /// duplicates are dropped behind it. The key comes from the handoff
+    /// certificate for the same reason. Carrying neither is stronger than
+    /// validating either: an announcer with a different algorithm produces a
+    /// DIFFERENT identity — a demand no honest consumer looks up — and there
+    /// is no announced key left to substitute. The pool popped here therefore
+    /// cannot disagree with the session instantiated from the same id and the
+    /// same stored key.
+    ///
+    /// The park bound (`noa_presign_demand_park_rounds`, from
+    /// `ProtocolConfig`) is a liveness backstop, not a security control: it
+    /// is what stops a demand whose pool never fills — or whose key this
+    /// validator can never derive — from parking for the whole epoch and
+    /// blocking that epoch's NOA checkpoint finalization. No consensus-uniform
+    /// signal tells a pool that will never fill from one still filling, so the
+    /// bound drops both alike and is sized so no honest window comes near it;
+    /// `dev-docs/specs/internal-presign-pool.md` records the windows.
+    fn drain_parked_noa_presign_demand(
+        &self,
+        parked: &ParkedNOAPresignDemand,
+        consensus_round: Round,
+        signing_key: Option<ObjectID>,
+    ) -> bool {
+        let ParkedNOAPresignDemand {
+            demand,
+            delivered_at_consensus_round,
+        } = parked;
+        let outcome = match signing_key {
+            Some(network_encryption_key_id) => self.epoch_store.assign_presign_for_demand(
+                &PresignDemand::Noa {
+                    demand_id: demand.demand_id.clone(),
+                },
+                demand.demand_id.expected_signature_algorithm(),
+                network_encryption_key_id,
+            ),
+            None => self
+                .epoch_store
+                .noa_presign_demand_resolution(&demand.demand_id)
+                .map(|resolution| match resolution {
+                    Some(NoaPresignDemandResolution::Assigned {
+                        session_identifier,
+                        blending_index,
+                        presign,
+                        ..
+                    }) => PresignAssignmentOutcome::Assigned {
+                        session_identifier,
+                        blending_index,
+                        presign,
+                    },
+                    Some(NoaPresignDemandResolution::Evicted) => PresignAssignmentOutcome::Evicted,
+                    None => PresignAssignmentOutcome::PoolEmpty,
+                }),
+        };
+        match outcome {
+            Ok(PresignAssignmentOutcome::Assigned { .. }) => false,
+            // Dropped by an earlier round of this same stream and recorded
+            // durably, so this is a re-drain (a restart replaying the epoch's
+            // rounds). Terminal already: leave the store alone, and do not
+            // re-log or re-count what the original pass already reported.
+            Ok(PresignAssignmentOutcome::Evicted) => {
+                debug!(
+                    demand_id = ?demand.demand_id,
+                    demand_id_digest = hex::encode(demand.demand_id_digest()),
+                    "replayed a NOA presign demand that was already dropped at the park bound; \
+                     leaving it dropped"
+                );
+                false
+            }
+            Ok(PresignAssignmentOutcome::PoolEmpty) => {
+                let parked_rounds = consensus_round.saturating_sub(*delivered_at_consensus_round);
+                let Some(park_rounds) = self.noa_presign_demand_park_rounds else {
+                    return true;
+                };
+                if parked_rounds < park_rounds {
+                    return true;
+                }
+                // Record the drop DURABLY before dropping the demand from the
+                // queue. The pool is not rewound by a replay, so a drop kept
+                // only in memory would let a restart re-read this demand at
+                // its delivery round against a pool that filled after the drop
+                // and pop for a demand every peer abandoned. On a write error,
+                // keep the demand and retry next round — the same failure
+                // posture as an assignment error.
+                if let Err(e) = self.epoch_store.evict_noa_presign_demand(&demand.demand_id) {
+                    error!(
+                        error = ?e,
+                        demand_id = ?demand.demand_id,
+                        "failed to record a NOA presign demand's drop — keeping it parked for retry"
+                    );
+                    return true;
+                }
+                self.dwallet_mpc_metrics
+                    .noa_presign_demands_evicted_total
+                    .with_label_values(&[&format!(
+                        "{:?}",
+                        demand.demand_id.expected_signature_algorithm()
+                    )])
+                    .inc();
+                error!(
+                    demand_id = ?demand.demand_id,
+                    demand_id_digest = hex::encode(demand.demand_id_digest()),
+                    signing_key = ?signing_key,
+                    announcing_authority = ?demand.authority,
+                    delivered_at_consensus_round,
+                    eviction_consensus_round = consensus_round,
+                    parked_rounds,
+                    "dropping a NOA presign demand that stayed unassigned for the whole park \
+                     bound. This demand's sign will NOT happen in this epoch — either the \
+                     network-owned-address signing key was never derivable here (no handoff \
+                     certificate for the prior epoch, or a certified key this validator could \
+                     not translate or read chain metadata for), or its presign pool took longer \
+                     than the bound to fill"
+                );
+                false
+            }
+            Err(e) => {
+                ika_types::report_invariant_violation!(
+                    "noa_presign_assignment",
+                    error=?e,
+                    "failed to assign presign for NOA demand — keeping for retry"
+                );
+                true
             }
         }
     }
@@ -1949,22 +2071,28 @@ impl DWalletMPCService {
             //   (d) the presign pool is network-uniform (keyed by the
             //       consensus-assigned presign sequence), so popping in the same
             //       order yields the same presign per demand on every validator;
-            //   (e) a demand that stays unassigned is dropped on a predicate
-            //       built only from (a)-(d): its consensus delivery round, the
-            //       consensus round being drained, and whether the pool of
-            //       (a)-(d) could serve it. Nothing per-validator — not the
-            //       locally adopted key set, not the network-key overlay, not
-            //       wall clock — enters it, so every validator drops the same
-            //       demand at the same round. A drop decided on local state
-            //       would put back exactly the disagreement this queue exists
-            //       to remove.
+            //   (e) the network encryption key every presign is drawn under
+            //       is derived from the prior epoch's handoff certificate —
+            //       one value per epoch, identical on every validator that
+            //       has derived it — never announced and never read from the
+            //       locally adopted key set;
+            //   (f) a demand that stays unassigned is dropped on a predicate
+            //       built from its consensus delivery round, the consensus
+            //       round being drained, and whether the pool of (a)-(e)
+            //       could serve it. No wall clock enters it. The one
+            //       per-validator input is WHEN this validator finished
+            //       deriving (e): until then a demand parks here while a peer
+            //       that derived earlier may already have assigned it. The
+            //       bound still measures from the consensus delivery round,
+            //       so a late deriver that never resolves drops the demand at
+            //       the same round its peers would have.
             // `assign_presign_for_demand` is atomic + idempotent: it pops and
-            // records in one committed batch, and reports an already-resolved demand
-            // without popping again (so re-delivery, and a re-drain after a
-            // consensus-round replay, are both safe). Keeping a demand while the
-            // pool is empty (`PoolEmpty` => keep) preserves ordering across
-            // rounds until its presign is generated, up to
-            // `noa_presign_demand_park_rounds`. Both the queue and the
+            // records in one committed batch, and reports an already-resolved
+            // demand without popping again (so re-delivery, and a re-drain
+            // after a consensus-round replay, are both safe). Keeping a demand
+            // while the pool is empty or the signing key is not yet derived
+            // preserves ordering across rounds until its presign is generated,
+            // up to `noa_presign_demand_park_rounds`. Both the queue and the
             // resolution table it writes are per-epoch (the queue rebuilds
             // empty on the per-epoch service restart; the table is physically
             // dropped on epoch rotation), and so are the delivery rounds
@@ -1976,17 +2104,14 @@ impl DWalletMPCService {
             // outcomes are therefore written to the same durable per-demand
             // table, and the replay reads them instead of deciding again.
             //
-            // The assignment step reads ONLY the consensus-delivered demand
-            // queue and the consensus-generated presign pool — there is no
-            // wall-clock, channel-arrival-order, or local-instantiation-order
-            // input in it. That is the whole point: the bug this replaces
-            // popped presigns in local instantiation order, which diverged
-            // across a staggered restart. The `network_encryption_key_id` is
-            // carried IN the consensus-agreed demand (frozen at announce), and
-            // the sign later instantiates under that same key (stored with the
-            // assignment), so the key is fully consensus-uniform — it does not
-            // rest on the announce-time and instantiate-time key resolutions
-            // agreeing.
+            // The assignment step reads the consensus-delivered demand queue,
+            // the consensus-generated presign pool, and the certificate-derived
+            // signing key — there is no channel-arrival-order or
+            // local-instantiation-order input in it. That is the whole point:
+            // the bug this replaces popped presigns in local instantiation
+            // order, which diverged across a staggered restart. The sign later
+            // instantiates under the key stored with the assignment, so the
+            // assignment and the session cannot disagree on it.
             self.agreed_noa_presign_demands_queue.extend(
                 noa_presign_demand_messages
                     .into_iter()
@@ -1996,138 +2121,16 @@ impl DWalletMPCService {
                     }),
             );
             if !self.agreed_noa_presign_demands_queue.is_empty() {
-                let park_rounds = self.noa_presign_demand_park_rounds;
-                self.agreed_noa_presign_demands_queue.retain(|parked| {
-                    let ParkedNOAPresignDemand {
-                        demand,
-                        delivered_at_consensus_round,
-                    } = parked;
-                    // Atomic + idempotent (see `assign_presign_for_demand`): pops a
-                    // presign and records the assignment (raw presign + the
-                    // demand's network key id) in ONE committed batch, or
-                    // returns the existing assignment without popping. The pop
-                    // and the record MUST be one commit — a crash between a
-                    // self-committed pop and a separate record would let a
-                    // re-drain after a consensus-round replay pop a different
-                    // presign than peers assigned. `Assigned` (just now, or by
-                    // an earlier drain) and `Evicted` are both terminal — drop
-                    // from the queue; `PoolEmpty` => keep, preserving order
-                    // across rounds until the presign is generated or the park
-                    // bound expires; `Err` => keep for retry.
-                    // The algorithm comes from the demand IDENTITY, never from
-                    // the announcement: the consensus dedup key is the
-                    // demand-id digest alone, so the first announcement
-                    // sequenced for a demand would otherwise supply that field
-                    // for the whole network while the honest duplicates are
-                    // dropped behind it. Carrying no second copy is stronger
-                    // than comparing two: an announcer with a different
-                    // algorithm produces a DIFFERENT identity — a demand no
-                    // honest consumer looks up — and the pool popped here
-                    // cannot disagree with the session instantiated from the
-                    // same id.
-                    //
-                    // `network_encryption_key_id` is NOT derivable from the
-                    // identity (it is frozen at announce time on purpose, so
-                    // the assignment does not rest on the announce-time and
-                    // instantiate-time key resolutions agreeing), so it stays
-                    // announcer-supplied behind the same dedup key. It is
-                    // deliberately NOT validated against the locally adopted
-                    // key set: honest validators transiently hold different
-                    // adopted sets (every epoch start has such a window), so a
-                    // local reject would drop honest demands. A demand naming a
-                    // key this validator has no pool for therefore parks, in
-                    // order, and is retried every round — and is dropped only
-                    // once it has been parked for `park_rounds` consensus
-                    // rounds, which is what stops a demand naming a key nobody
-                    // will ever adopt from parking for the whole epoch and
-                    // blocking that epoch's NOA checkpoint finalization. The
-                    // bound cannot tell that case apart from a key still on its
-                    // way, because no consensus-uniform signal distinguishes
-                    // them; it is sized so that no honest window comes near it
-                    // (see `NOA_PRESIGN_DEMAND_PARK_ROUNDS`), and
-                    // `dev-docs/specs/internal-presign-pool.md` records why
-                    // parking-with-a-bound is the only safe shape here.
-                    match self.epoch_store.assign_presign_for_demand(
-                        &PresignDemand::Noa {
-                            demand_id: demand.demand_id.clone(),
-                        },
-                        demand.demand_id.expected_signature_algorithm(),
-                        demand.network_encryption_key_id,
-                    ) {
-                        Ok(PresignAssignmentOutcome::Assigned { .. }) => false,
-                        // Dropped by an earlier round of this same stream and
-                        // recorded durably, so this is a re-drain (a restart
-                        // replaying the epoch's rounds). Terminal already: leave
-                        // the store alone, and do not re-log or re-count what
-                        // the original pass already reported.
-                        Ok(PresignAssignmentOutcome::Evicted) => {
-                            debug!(
-                                demand_id = ?demand.demand_id,
-                                demand_id_digest = hex::encode(demand.demand_id_digest()),
-                                "replayed a NOA presign demand that was already dropped at the \
-                                 park bound; leaving it dropped"
-                            );
-                            false
-                        }
-                        Ok(PresignAssignmentOutcome::PoolEmpty) => {
-                            let parked_rounds =
-                                consensus_round.saturating_sub(*delivered_at_consensus_round);
-                            if parked_rounds < park_rounds {
-                                return true;
-                            }
-                            // Record the drop DURABLY before dropping the demand
-                            // from the queue. The pool is not rewound by a
-                            // replay, so a drop kept only in memory would let a
-                            // restart re-read this demand at its delivery round
-                            // against a pool that filled after the drop and pop
-                            // for a demand every peer abandoned. On a write
-                            // error, keep the demand and retry next round —
-                            // the same failure posture as an assignment error.
-                            if let Err(e) =
-                                self.epoch_store.evict_noa_presign_demand(&demand.demand_id)
-                            {
-                                error!(
-                                    error = ?e,
-                                    demand_id = ?demand.demand_id,
-                                    "failed to record a NOA presign demand's drop — keeping it \
-                                     parked for retry"
-                                );
-                                return true;
-                            }
-                            self.dwallet_mpc_metrics
-                                .noa_presign_demands_evicted_total
-                                .with_label_values(&[&format!(
-                                    "{:?}",
-                                    demand.demand_id.expected_signature_algorithm()
-                                )])
-                                .inc();
-                            error!(
-                                demand_id = ?demand.demand_id,
-                                demand_id_digest = hex::encode(demand.demand_id_digest()),
-                                network_encryption_key_id = ?demand.network_encryption_key_id,
-                                announcing_authority = ?demand.authority,
-                                delivered_at_consensus_round,
-                                eviction_consensus_round = consensus_round,
-                                parked_rounds,
-                                "dropping a NOA presign demand that stayed unassigned for the \
-                                 whole park bound: no presign pool exists for the network \
-                                 encryption key its announcement named. This demand's sign will \
-                                 NOT happen in this epoch — either the announcer named a key the \
-                                 network never adopts, or that key took longer than the bound to \
-                                 arrive"
-                            );
-                            false
-                        }
-                        Err(e) => {
-                            ika_types::report_invariant_violation!(
-                                "noa_presign_assignment",
-                                error=?e,
-                                "failed to assign presign for NOA demand — keeping for retry"
-                            );
-                            true
-                        }
-                    }
+                // Derived once per round: the answer is fixed for the epoch
+                // once it exists, and every parked demand draws under it.
+                let signing_key = self
+                    .dwallet_mpc_manager
+                    .network_owned_address_signing_network_encryption_key_id();
+                let mut queue = mem::take(&mut self.agreed_noa_presign_demands_queue);
+                queue.retain(|parked| {
+                    self.drain_parked_noa_presign_demand(parked, consensus_round, signing_key)
                 });
+                self.agreed_noa_presign_demands_queue = queue;
             }
 
             // Group checkpoint messages by chain.

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -3698,7 +3698,7 @@ mod tests {
             .iter()
             .map(|service| ConsensusGlobalPresignRequest {
                 authority: service.name,
-                request: request.clone(),
+                request,
             })
             .collect();
         deliver_and_drain(&mut services, &stores, payload).await;

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -3591,3 +3591,222 @@ impl DWalletMPCService {
         Ok(resolution)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dwallet_mpc::integration_tests::utils::{self, TestingAuthorityPerEpochStore};
+    use dwallet_mpc_types::dwallet_mpc::DWalletSignatureAlgorithm;
+    use ika_types::messages_dwallet_mpc::ConsensusGlobalPresignRequest;
+    use ika_types::noa_checkpoint::NOAPresignDemandId;
+
+    fn presign_demand(authority: AuthorityName, marker: u8) -> ConsensusNOAPresignDemand {
+        ConsensusNOAPresignDemand {
+            authority,
+            demand_id: NOAPresignDemandId::GrpcAttestation {
+                session_identifier: [marker; 32],
+                signature_algorithm: DWalletSignatureAlgorithm::EdDSA,
+            },
+        }
+    }
+
+    fn seed_presign_pools(stores: &[Arc<TestingAuthorityPerEpochStore>], key_id: ObjectID) {
+        for store in stores {
+            for (slot, marker) in [(0, 0x3Au8), (1, 0x3Bu8)] {
+                store
+                    .insert_presigns(
+                        DWalletSignatureAlgorithm::EdDSA,
+                        key_id,
+                        slot,
+                        SessionIdentifier::new(SessionType::InternalPresign, [marker; 32]),
+                        vec![vec![marker; 16]],
+                    )
+                    .expect("seed identical presign pools");
+            }
+        }
+    }
+
+    async fn deliver_and_drain(
+        services: &mut [DWalletMPCService],
+        stores: &[Arc<TestingAuthorityPerEpochStore>],
+        payload: ConsensusRoundPayload,
+    ) {
+        assert_eq!(services.len(), stores.len());
+        for (service, store) in services.iter_mut().zip(stores) {
+            store.deliver_round(payload.clone()).await;
+            service.drain_consensus_rounds().await;
+            assert_eq!(service.last_read_consensus_round, Some(payload.round));
+        }
+    }
+
+    fn assigned_presign(
+        store: &TestingAuthorityPerEpochStore,
+        demand_id: &NOAPresignDemandId,
+    ) -> NoaPresignDemandResolution {
+        let resolution = store
+            .noa_presign_demand_resolution(demand_id)
+            .expect("read demand resolution")
+            .expect("demand must be resolved");
+        assert!(
+            matches!(resolution, NoaPresignDemandResolution::Assigned { .. }),
+            "demand must receive a presign: {resolution:?}"
+        );
+        resolution
+    }
+
+    /// Skipping a NOA demand must not change the next global request's
+    /// checkpoint: both consumers draw from the same internal presign pool.
+    /// The two keyed validators are the control for the keyless validator.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn noa_keyless_validator_preserves_global_presign_checkpoint() {
+        let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
+        let (mut services, _senders, _collectors, stores, _notify, _requests, _outputs) =
+            utils::create_dwallet_mpc_services(3);
+        let key_id = ObjectID::random();
+        seed_presign_pools(&stores, key_id);
+        for service in &mut services[..2] {
+            service.set_network_owned_address_signing_key_id_for_testing(Some(key_id));
+        }
+
+        let demand = presign_demand(services[0].name, 1);
+        let mut payload = utils::empty_round_payload(1);
+        payload.noa_presign_demands.push(demand.clone());
+        deliver_and_drain(&mut services, &stores, payload).await;
+        assert_eq!(
+            assigned_presign(&stores[0], &demand.demand_id),
+            assigned_presign(&stores[1], &demand.demand_id),
+            "the keyed control validators must agree on the NOA assignment"
+        );
+        assert_eq!(
+            stores[2]
+                .noa_presign_demand_resolution(&demand.demand_id)
+                .unwrap(),
+            None,
+            "the validator without a signing key parks the NOA demand"
+        );
+
+        let request = GlobalPresignRequest {
+            session_identifier: SessionIdentifier::new(SessionType::User, [0x71; 32]),
+            session_sequence_number: 10,
+            presign_id: ObjectID::random(),
+            curve: DWalletCurve::Curve25519,
+            signature_algorithm: DWalletSignatureAlgorithm::EdDSA,
+            dwallet_network_encryption_key_id: key_id,
+        };
+        let mut payload = utils::empty_round_payload(2);
+        payload.global_presign_requests = services
+            .iter()
+            .map(|service| ConsensusGlobalPresignRequest {
+                authority: service.name,
+                request: request.clone(),
+            })
+            .collect();
+        deliver_and_drain(&mut services, &stores, payload).await;
+
+        let checkpoints: Vec<_> = stores
+            .iter()
+            .map(|store| {
+                let checkpoints = store.pending_checkpoints.lock().unwrap();
+                assert_eq!(
+                    checkpoints.len(),
+                    1,
+                    "the global request must emit a checkpoint"
+                );
+                checkpoints[0].clone()
+            })
+            .collect();
+        assert_eq!(checkpoints[0], checkpoints[1], "keyed checkpoint control");
+        assert_eq!(
+            checkpoints[0], checkpoints[2],
+            "a keyless validator must emit the same global-presign checkpoint as its peers"
+        );
+    }
+
+    /// A joiner may learn and persist its missing key mapping after entering
+    /// the epoch without a signing key. Reconstructing its service with the
+    /// now-resolvable key must not reuse a presign peers consumed before its
+    /// restart. Replay retains both the pool and the earlier eviction.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn noa_keyless_restart_preserves_later_noa_assignment() {
+        let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
+        let (committee, seeds, bundles) = utils::build_committee_with_random_seeds(3);
+        let (mut services, _senders, _collectors, stores, _notify, _requests, _outputs) =
+            utils::create_dwallet_mpc_services_with_committee_and_seeds(
+                committee.clone(),
+                seeds.clone(),
+                bundles.clone(),
+            );
+        let key_id = ObjectID::random();
+        seed_presign_pools(&stores, key_id);
+        for service in &mut services {
+            service.set_noa_presign_demand_park_rounds_for_testing(1);
+        }
+        for service in &mut services[..2] {
+            service.set_network_owned_address_signing_key_id_for_testing(Some(key_id));
+        }
+
+        let first_demand = presign_demand(services[0].name, 1);
+        let mut payload = utils::empty_round_payload(1);
+        payload.noa_presign_demands.push(first_demand.clone());
+        deliver_and_drain(&mut services, &stores, payload).await;
+        assert_eq!(
+            assigned_presign(&stores[0], &first_demand.demand_id),
+            assigned_presign(&stores[1], &first_demand.demand_id),
+            "the keyed control validators must agree before the restart"
+        );
+        deliver_and_drain(&mut services, &stores, utils::empty_round_payload(2)).await;
+        assert_eq!(
+            stores[2]
+                .noa_presign_demand_resolution(&first_demand.demand_id)
+                .unwrap(),
+            Some(NoaPresignDemandResolution::Evicted),
+            "the keyless validator reaches the park bound"
+        );
+        assert_eq!(
+            stores[2]
+                .presign_pool_size(DWalletSignatureAlgorithm::EdDSA, key_id)
+                .unwrap(),
+            2,
+            "the keyless validator retains the presign its peers consumed"
+        );
+
+        let authority = services[2].name;
+        let (mut restarted, _senders, _collector, _notify, _request, _output) =
+            utils::create_dwallet_mpc_service_over_epoch_store(
+                &authority,
+                committee,
+                seeds[&authority].clone(),
+                bundles,
+                stores[2].clone(),
+            );
+        // Supply the answer the barrier returns after reloading the newly
+        // persisted mapping, before the replacement service drains any round.
+        restarted.set_network_owned_address_signing_key_id_for_testing(Some(key_id));
+        restarted.set_noa_presign_demand_park_rounds_for_testing(1);
+        services[2] = restarted;
+        stores[2].replay_recorded_rounds().await;
+        services[2].drain_consensus_rounds().await;
+        assert_eq!(services[2].last_read_consensus_round, Some(2));
+        assert_eq!(
+            stores[2]
+                .noa_presign_demand_resolution(&first_demand.demand_id)
+                .unwrap(),
+            Some(NoaPresignDemandResolution::Evicted),
+            "replay must retain the original eviction"
+        );
+
+        let second_demand = presign_demand(services[0].name, 2);
+        let mut payload = utils::empty_round_payload(3);
+        payload.noa_presign_demands.push(second_demand.clone());
+        deliver_and_drain(&mut services, &stores, payload).await;
+        let assignments: Vec<_> = stores
+            .iter()
+            .map(|store| assigned_presign(store, &second_demand.demand_id))
+            .collect();
+        assert_eq!(assignments[0], assignments[1], "keyed assignment control");
+        assert_eq!(
+            assignments[0], assignments[2],
+            "a formerly keyless restart must assign the same presign as its peers"
+        );
+    }
+}

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/idle_status_voting.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/idle_status_voting.rs
@@ -1,6 +1,8 @@
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStoreTrait;
 use crate::dwallet_mpc::NetworkOwnedAddressSignRequest;
-use crate::dwallet_mpc::integration_tests::network_dkg::create_network_key_test;
+use crate::dwallet_mpc::integration_tests::network_dkg::{
+    create_network_key_test, create_noa_signing_network_key_test,
+};
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::{
     TEST_IDLE_SESSION_COUNT_THRESHOLD, build_test_state, create_test_protocol_config_guard,
@@ -527,9 +529,11 @@ async fn test_split_idle_status_vote_does_not_reach_consensus() {
         );
     }
 
-    // Create network key to enable internal presigns.
+    // Create network key to enable internal presigns, handed in as the
+    // epoch's NOA signing key the way the barrier would: the NOA signs
+    // below instantiate only under a signing key.
     let (consensus_round, _network_key_bytes, network_key_id) =
-        create_network_key_test(&mut test_state).await;
+        create_noa_signing_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
 
     // Fill the EdDSA presign pool (needed for the sign request).

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/mod.rs
@@ -23,5 +23,5 @@ mod seed_rotation_store;
 mod session;
 mod sign;
 mod threshold_not_reached;
-mod utils;
+pub(super) mod utils;
 mod validator_restart;

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg.rs
@@ -337,6 +337,26 @@ async fn test_reconfiguration_completes_with_partial_upcoming_keys() {
 pub(crate) async fn create_network_key_test(
     test_state: &mut IntegrationTestState,
 ) -> (Round, Vec<u8>, ObjectID) {
+    create_network_key_test_with_noa_signing_role(test_state, false).await
+}
+
+/// [`create_network_key_test`], with the new key handed to every validator as
+/// the epoch's network-owned-address (NOA) signing key BEFORE it is adopted —
+/// the order the prepare-then-start barrier guarantees in production, where
+/// the key is a constructor input and the first internal-presign top-up
+/// already runs under the NOA pool parameters. The harness DKGs the key in
+/// the epoch under test, so no barrier ran with it; production would name it
+/// one epoch later. Meaningful only with `noa_checkpoints` on.
+pub(crate) async fn create_noa_signing_network_key_test(
+    test_state: &mut IntegrationTestState,
+) -> (Round, Vec<u8>, ObjectID) {
+    create_network_key_test_with_noa_signing_role(test_state, true).await
+}
+
+async fn create_network_key_test_with_noa_signing_role(
+    test_state: &mut IntegrationTestState,
+    noa_signing_key: bool,
+) -> (Round, Vec<u8>, ObjectID) {
     for service in &mut test_state.dwallet_mpc_services {
         service
             .dwallet_mpc_manager_mut()
@@ -367,6 +387,11 @@ pub(crate) async fn create_network_key_test(
         key_id =
             Some(ObjectID::from_bytes(message.dwallet_network_encryption_key_id.clone()).unwrap());
         network_key_bytes.extend(message.public_output.clone())
+    }
+    if noa_signing_key {
+        for service in &mut test_state.dwallet_mpc_services {
+            service.set_network_owned_address_signing_key_id_for_testing(key_id);
+        }
     }
     test_state
         .sui_data_senders

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
@@ -29,12 +29,14 @@ use dwallet_mpc_types::dwallet_mpc::{
 use ika_types::message::{DWalletCheckpointMessageKind, MakeDWalletUserSecretKeySharesPublicOutput};
 use ika_types::noa_checkpoint::{NOACheckpointKindName, NOACheckpointTxRef, NOAPresignDemandId};
 use ika_types::messages_dwallet_mpc::{ConsensusNOAPresignDemand,
-    DWalletMPCOutput, DWalletMPCOutputReport, SessionIdentifier, SessionType,
+    DWalletMPCOutput, DWalletMPCOutputReport, DWalletNetworkEncryptionKeyData,
+    DWalletNetworkEncryptionKeyState, SessionIdentifier, SessionType,
 };
 use crate::validator_metadata::OffChainCommitteeBundles;
 use dwallet_rng::RootSeed;
 use ika_types::crypto::AuthorityName;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use itertools::Itertools;
 use sui_types::base_types::ObjectID;
 use tracing::info;
@@ -114,7 +116,7 @@ async fn network_owned_address_sign_flow(
     let mut test_state = build_test_state(4);
 
     // Create a network key (required for network-owned-address signing).
-    let (consensus_round, _network_key_bytes, encryption_key) =
+    let (consensus_round, network_key_bytes, encryption_key) =
         create_network_key_test(&mut test_state).await;
 
     info!(
@@ -122,6 +124,8 @@ async fn network_owned_address_sign_flow(
         consensus_round, encryption_key
     );
     test_state.consensus_round = consensus_round as usize;
+    // The signing key derives from the prior epoch's handoff certificate.
+    utils::certify_network_key_for_noa_signing(&test_state, encryption_key, &network_key_bytes);
 
     info!(
         ?curve,
@@ -481,9 +485,10 @@ async fn test_presign_pool_exhaustion_buffers_excess_sign_requests() {
     let mut test_state = build_test_state(4);
 
     // Create a network key (required for network-owned-address signing).
-    let (consensus_round, _network_key_bytes, encryption_key) =
+    let (consensus_round, network_key_bytes, encryption_key) =
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
+    utils::certify_network_key_for_noa_signing(&test_state, encryption_key, &network_key_bytes);
 
     // Fill the EdDSA presign pool.
     let start_round = test_state.consensus_round as u64;
@@ -702,9 +707,10 @@ async fn test_presign_assignment_is_consensus_ordered_not_local() {
     let mut test_state = build_test_state(4);
 
     // Create a network key and fill the EdDSA presign pool.
-    let (consensus_round, _network_key_bytes, encryption_key) =
+    let (consensus_round, network_key_bytes, encryption_key) =
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
+    utils::certify_network_key_for_noa_signing(&test_state, encryption_key, &network_key_bytes);
 
     let start_round = test_state.consensus_round as u64;
     let consensus_round = utils::advance_rounds_while_presign_pool_empty(
@@ -859,9 +865,10 @@ async fn test_late_instantiating_validator_preserves_buffered_sign_messages() {
 
     // Create a network key and fill the EdDSA presign pool so every validator
     // is able to instantiate the sign.
-    let (consensus_round, _network_key_bytes, encryption_key) =
+    let (consensus_round, network_key_bytes, encryption_key) =
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
+    utils::certify_network_key_for_noa_signing(&test_state, encryption_key, &network_key_bytes);
     let start_round = test_state.consensus_round as u64;
     let consensus_round = utils::advance_rounds_while_presign_pool_empty(
         &mut test_state,
@@ -1006,9 +1013,10 @@ async fn test_instantiation_normalizes_byzantine_native_placeholder() {
     let hash_scheme = DWalletHashScheme::SHA512;
 
     let mut test_state = build_test_state(4);
-    let (consensus_round, _network_key_bytes, encryption_key) =
+    let (consensus_round, network_key_bytes, encryption_key) =
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
+    utils::certify_network_key_for_noa_signing(&test_state, encryption_key, &network_key_bytes);
     let start_round = test_state.consensus_round as u64;
     let consensus_round = utils::advance_rounds_while_presign_pool_empty(
         &mut test_state,
@@ -1179,9 +1187,10 @@ async fn network_owned_address_vss_sign_flow(
     let mut test_state = build_test_state(4);
 
     // VSS sign requires a reconfigured network key.
-    let (consensus_round, _network_key_bytes, network_key_id) =
+    let (consensus_round, network_key_bytes, network_key_id) =
         create_reconfigured_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
+    utils::certify_network_key_for_noa_signing(&test_state, network_key_id, &network_key_bytes);
 
     info!(
         ?curve,
@@ -1333,9 +1342,10 @@ async fn test_noa_presign_demand_draws_from_the_pool_its_identity_names() {
     let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
 
     let mut test_state = build_test_state(4);
-    let (consensus_round, _network_key_bytes, network_key_id) =
+    let (consensus_round, network_key_bytes, network_key_id) =
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
+    utils::certify_network_key_for_noa_signing(&test_state, network_key_id, &network_key_bytes);
 
     // A checkpoint demand names its kind, and the kind fixes the algorithm.
     let demand_id = NOAPresignDemandId::Checkpoint {
@@ -1402,7 +1412,6 @@ async fn test_noa_presign_demand_draws_from_the_pool_its_identity_names() {
         .push(ConsensusNOAPresignDemand {
             authority: announcing_authority,
             demand_id: demand_id.clone(),
-            network_encryption_key_id: network_key_id,
         });
     test_state.epoch_stores[target]
         .deliver_round(demand_round_payload)
@@ -1453,8 +1462,8 @@ async fn test_noa_presign_demand_draws_from_the_pool_its_identity_names() {
     );
     assert_eq!(
         assigned_key_id, network_key_id,
-        "the announced network key is still authoritative — it is not derivable \
-         from the identity (the open half of #2019)"
+        "the assignment must record the key derived from the handoff certificate — \
+         the announcement carries none"
     );
     // No other pool may be reachable: the announcement carries no algorithm.
     assert_eq!(
@@ -1499,7 +1508,6 @@ fn checkpoint_demand_id(sequence_number: u64) -> NOAPresignDemandId {
 async fn deliver_noa_presign_demand(
     test_state: &mut IntegrationTestState,
     demand_id: &NOAPresignDemandId,
-    network_encryption_key_id: ObjectID,
 ) -> u64 {
     let announcing_authority = test_state
         .committee
@@ -1522,7 +1530,6 @@ async fn deliver_noa_presign_demand(
     payload.noa_presign_demands.push(ConsensusNOAPresignDemand {
         authority: announcing_authority,
         demand_id: demand_id.clone(),
-        network_encryption_key_id,
     });
     test_state.epoch_stores[PARK_TEST_TARGET]
         .deliver_round(payload)
@@ -1552,17 +1559,22 @@ async fn flow_consensus_rounds(test_state: &mut IntegrationTestState, rounds: us
         .await;
 }
 
-/// A demand announced under a network encryption key this validator has no
-/// presign pool for PARKS: it is neither assigned nor dropped, and stays in the
-/// queue in consensus-delivery order to be retried every round.
+/// A demand sequenced while this validator has not derived the epoch's
+/// network-owned-address signing key PARKS: it is neither assigned nor
+/// dropped, and stays in the queue in consensus-delivery order to be retried
+/// every round.
 ///
-/// Rejecting such a demand locally is unsafe — honest validators transiently
-/// hold different adopted network-key sets (issue #2019 measured the windows),
-/// so the announcement of a key this validator has not adopted yet is the
-/// normal case, not evidence of misbehavior.
+/// The key derives from the prior epoch's handoff certificate, and this
+/// harness hands the validator none, so nothing can be drawn for the whole
+/// test. Rejecting the demand instead would turn an honest lag into a
+/// permanent loss: WHEN a validator can derive the key is per-validator (a
+/// restarting or joining validator translates a certified key and reads its
+/// chain metadata after its peers do), and consensus deduplicates
+/// announcements on the demand id alone, so no corrected announcement could
+/// ever follow a reject.
 #[tokio::test]
 #[cfg(test)]
-async fn test_noa_presign_demand_parks_on_an_unrecognised_network_key() {
+async fn test_noa_presign_demand_parks_while_the_signing_key_is_not_derived() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
 
@@ -1571,12 +1583,11 @@ async fn test_noa_presign_demand_parks_on_an_unrecognised_network_key() {
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
 
-    // A key no validator in this test holds a pool for.
-    let unrecognised_key_id = ObjectID::random();
+    // No handoff certificate anywhere: no validator can derive a signing key.
     let demand_id = checkpoint_demand_id(1);
-    deliver_noa_presign_demand(&mut test_state, &demand_id, unrecognised_key_id).await;
+    deliver_noa_presign_demand(&mut test_state, &demand_id).await;
 
-    // Well short of the park bound, which is left at its production value.
+    // Well short of the park bound, which is left at its protocol value.
     flow_consensus_rounds(&mut test_state, 5).await;
 
     assert_eq!(
@@ -1584,8 +1595,8 @@ async fn test_noa_presign_demand_parks_on_an_unrecognised_network_key() {
             .noa_presign_demand_resolution(&demand_id)
             .expect("read resolution"),
         None,
-        "a parked demand has no resolution yet: no presign exists for the announced key, \
-         and the bound is nowhere near"
+        "a parked demand has no resolution yet: no signing key is derived, and the bound is \
+         nowhere near"
     );
     assert_eq!(
         test_state.dwallet_mpc_services[PARK_TEST_TARGET].parked_noa_presign_demand_count(),
@@ -1594,30 +1605,40 @@ async fn test_noa_presign_demand_parks_on_an_unrecognised_network_key() {
     );
 }
 
-/// A validator that is merely LAGGING adoption of the announced key assigns the
-/// demand as soon as that key's pool appears: the demand parked in the
-/// meantime, so nothing was lost.
+/// A validator that derives the signing key LATE assigns a demand sequenced
+/// before the derivation as soon as the key resolves, drawing from that key's
+/// pool: the demand parked in the meantime, so nothing was lost.
 ///
-/// This is the honest-skew case the park exists for. The assignment must record
-/// the ANNOUNCED key — the consensus-agreed one the presign was drawn under —
-/// not a key resolved locally at assignment time.
+/// This is the honest-lag case the park exists for. The assignment must
+/// record the DERIVED key — the one the presign was drawn under — so the sign
+/// later instantiates under exactly that key.
 #[tokio::test]
 #[cfg(test)]
-async fn test_noa_presign_demand_assigns_once_the_announced_key_pool_arrives() {
+async fn test_noa_presign_demand_assigns_once_the_signing_key_is_derived() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
 
     let mut test_state = build_test_state(4);
-    let (consensus_round, _network_key_bytes, _network_key_id) =
+    let (consensus_round, network_key_bytes, network_key_id) =
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
 
-    // The key the announcement names: adopted network-wide, but this validator
-    // has no pool for it yet.
-    let late_key_id = ObjectID::random();
+    // A recognizable presign at the head of the key's pool, seeded before any
+    // top-up batch can complete: slot 0 sorts before every slot the loop fills.
     let demand_id = checkpoint_demand_id(2);
     let derived_algorithm = demand_id.expected_signature_algorithm();
-    deliver_noa_presign_demand(&mut test_state, &demand_id, late_key_id).await;
+    const LATE_POOL_MARKER: u8 = 0x7C;
+    test_state.epoch_stores[PARK_TEST_TARGET]
+        .insert_presigns(
+            derived_algorithm,
+            network_key_id,
+            0,
+            SessionIdentifier::new(SessionType::InternalPresign, [LATE_POOL_MARKER; 32]),
+            vec![vec![LATE_POOL_MARKER; 16]],
+        )
+        .expect("seed the key's presign pool");
+
+    deliver_noa_presign_demand(&mut test_state, &demand_id).await;
 
     flow_consensus_rounds(&mut test_state, 3).await;
     assert_eq!(
@@ -1625,20 +1646,12 @@ async fn test_noa_presign_demand_assigns_once_the_announced_key_pool_arrives() {
             .noa_presign_demand_resolution(&demand_id)
             .expect("read resolution"),
         None,
-        "the demand cannot be resolved before its key's pool exists"
+        "the demand cannot be resolved before the signing key is derived, even with its \
+         pool full"
     );
 
-    // The lag resolves: the key's presign pool fills.
-    const LATE_POOL_MARKER: u8 = 0x7C;
-    test_state.epoch_stores[PARK_TEST_TARGET]
-        .insert_presigns(
-            derived_algorithm,
-            late_key_id,
-            0,
-            SessionIdentifier::new(SessionType::InternalPresign, [LATE_POOL_MARKER; 32]),
-            vec![vec![LATE_POOL_MARKER; 16]],
-        )
-        .expect("seed the late key's presign pool");
+    // The lag resolves: the handoff certificate naming the key lands.
+    utils::certify_network_key_for_noa_signing(&test_state, network_key_id, &network_key_bytes);
 
     flow_consensus_rounds(&mut test_state, 2).await;
 
@@ -1647,16 +1660,16 @@ async fn test_noa_presign_demand_assigns_once_the_announced_key_pool_arrives() {
             test_state.epoch_stores[PARK_TEST_TARGET]
                 .noa_presign_demand_resolution(&demand_id)
                 .expect("read resolution"),
-            "the parked demand once its key's pool arrives",
+            "the parked demand once the signing key is derived",
         );
     assert_eq!(
         presign_bytes,
         vec![LATE_POOL_MARKER; 16],
-        "the assignment must draw from the late key's pool"
+        "the assignment must draw from the derived key's pool"
     );
     assert_eq!(
-        assigned_key_id, late_key_id,
-        "the assignment must record the announced key, not a locally resolved one"
+        assigned_key_id, network_key_id,
+        "the assignment must record the derived key the presign was drawn under"
     );
     assert_eq!(
         test_state.dwallet_mpc_services[PARK_TEST_TARGET].parked_noa_presign_demand_count(),
@@ -1665,17 +1678,15 @@ async fn test_noa_presign_demand_assigns_once_the_announced_key_pool_arrives() {
     );
 }
 
-/// A demand naming a key that never gets a pool is dropped at the park bound —
-/// loudly, counted, and permanently for this epoch.
+/// A demand whose signing key is never derived here is dropped at the park
+/// bound — loudly, counted, and permanently for this epoch.
 ///
-/// This is the byzantine case: the consensus dedup key for an announcement is
-/// the demand-id digest alone, so a committee member announcing first pins the
-/// network encryption key for the whole network. Naming a key no validator will
-/// ever adopt would otherwise park the demand for the rest of the epoch and
-/// block that epoch's NOA checkpoint finalization.
-///
-/// The bound is measured in consensus rounds and the test shrinks it, so the
-/// drop is reachable without driving the production ~70k rounds.
+/// The bound is a liveness backstop: without it a demand sequenced in an
+/// epoch whose key never resolves on this validator (no handoff certificate,
+/// or a certified key it can never translate) would park for the rest of the
+/// epoch and block that epoch's NOA checkpoint finalization. It is measured in
+/// consensus rounds and the test shrinks it, so the drop is reachable without
+/// driving the protocol's ~70k rounds.
 #[tokio::test]
 #[cfg(test)]
 async fn test_noa_presign_demand_is_dropped_at_the_park_bound() {
@@ -1683,7 +1694,7 @@ async fn test_noa_presign_demand_is_dropped_at_the_park_bound() {
     let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
 
     let mut test_state = build_test_state(4);
-    let (consensus_round, _network_key_bytes, _network_key_id) =
+    let (consensus_round, network_key_bytes, network_key_id) =
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
 
@@ -1691,12 +1702,10 @@ async fn test_noa_presign_demand_is_dropped_at_the_park_bound() {
     test_state.dwallet_mpc_services[PARK_TEST_TARGET]
         .set_noa_presign_demand_park_rounds_for_testing(PARK_ROUNDS);
 
-    // A key nobody ever adopts, so no pool for it can ever appear.
-    let never_adopted_key_id = ObjectID::random();
+    // No certificate anywhere: the signing key stays underived past the bound.
     let demand_id = checkpoint_demand_id(3);
     let derived_algorithm = demand_id.expected_signature_algorithm();
-    let delivery_round =
-        deliver_noa_presign_demand(&mut test_state, &demand_id, never_adopted_key_id).await;
+    let delivery_round = deliver_noa_presign_demand(&mut test_state, &demand_id).await;
 
     // One more round than the bound, so the drain reaches
     // `round - delivery_round >= PARK_ROUNDS`.
@@ -1718,29 +1727,31 @@ async fn test_noa_presign_demand_is_dropped_at_the_park_bound() {
         "the drop must be counted"
     );
 
-    // A drop is terminal for this epoch, not starvation: a pool appearing for
-    // the announced key AFTER the bound changes nothing, because the demand is
-    // no longer in the queue to be retried.
+    // A drop is terminal for this epoch, not starvation: the signing key
+    // resolving and its pool filling AFTER the bound change nothing, because
+    // the demand is no longer in the queue to be retried.
     test_state.epoch_stores[PARK_TEST_TARGET]
         .insert_presigns(
             derived_algorithm,
-            never_adopted_key_id,
+            network_key_id,
             0,
             SessionIdentifier::new(SessionType::InternalPresign, [0x11; 32]),
             vec![vec![0x11; 16]],
         )
         .expect("seed a pool for the dropped demand's key");
+    utils::certify_network_key_for_noa_signing(&test_state, network_key_id, &network_key_bytes);
     flow_consensus_rounds(&mut test_state, 3).await;
     assert_eq!(
         test_state.epoch_stores[PARK_TEST_TARGET]
             .noa_presign_demand_resolution(&demand_id)
             .expect("read resolution"),
         Some(NoaPresignDemandResolution::Evicted),
-        "a dropped demand must stay dropped — durably — even once a pool for its key exists"
+        "a dropped demand must stay dropped — durably — even once its key derives and a pool \
+         for it exists"
     );
     assert_eq!(
         test_state.epoch_stores[PARK_TEST_TARGET]
-            .presign_pool_size(derived_algorithm, never_adopted_key_id)
+            .presign_pool_size(derived_algorithm, network_key_id)
             .expect("pool size"),
         1,
         "the dropped demand must not consume the pool that arrived after it"
@@ -1786,7 +1797,7 @@ async fn test_noa_presign_demand_is_dropped_at_the_park_bound() {
     );
     assert_eq!(
         test_state.epoch_stores[PARK_TEST_TARGET]
-            .presign_pool_size(derived_algorithm, never_adopted_key_id)
+            .presign_pool_size(derived_algorithm, network_key_id)
             .expect("pool size"),
         1,
         "the pool that arrived after the drop must still be untouched"
@@ -1877,16 +1888,19 @@ async fn restart_target_validator(
 ///
 /// The drain replays every consensus round of the epoch after a restart, and
 /// the presign pool is durable and NOT rewound with it. So a demand dropped at
-/// round R_e, whose announced key's pool only filled at some later round, is
-/// re-read at its delivery round against a pool that now holds a presign — and
-/// a drop recorded only in memory is gone, so the replayed drain would pop.
-/// That validator would then hold an assignment no peer has, and would consume
-/// a presign its peers pair with a DIFFERENT demand, diverging the
-/// demand-to-presign pairing for the rest of the epoch.
+/// round R_e, whose signing key only derived and whose pool only filled at
+/// some later round, is re-read at its delivery round against a pool that now
+/// holds a presign — and a drop recorded only in memory is gone, so the
+/// replayed drain would pop. That validator would then hold an assignment no
+/// peer has, and would consume a presign its peers pair with a DIFFERENT
+/// demand, diverging the demand-to-presign pairing for the rest of the epoch.
 ///
-/// Only the honest-lag drop can reach this shape (a key nobody ever adopts
-/// never gets a pool), which is exactly the case the bound deliberately
-/// treats the same as the byzantine one.
+/// Two restarts cover the two states a replayed drain can run in. The first
+/// replacement service holds no network-key overlay yet, so its drain runs
+/// with the key still underived: the replayed demand must leave the queue on
+/// its durable drop, neither parked again nor re-counted. The second is handed
+/// the overlay first, so its drain runs under a derived key against the full
+/// pool: the assignment step must report the drop rather than pop.
 #[tokio::test]
 #[cfg(test)]
 async fn test_restart_does_not_resurrect_a_dropped_noa_presign_demand() {
@@ -1894,7 +1908,7 @@ async fn test_restart_does_not_resurrect_a_dropped_noa_presign_demand() {
     let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
 
     let (mut test_state, seeds, bundles) = build_restartable_test_state();
-    let (consensus_round, _network_key_bytes, _network_key_id) =
+    let (consensus_round, network_key_bytes, network_key_id) =
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
 
@@ -1902,12 +1916,11 @@ async fn test_restart_does_not_resurrect_a_dropped_noa_presign_demand() {
     test_state.dwallet_mpc_services[PARK_TEST_TARGET]
         .set_noa_presign_demand_park_rounds_for_testing(PARK_ROUNDS);
 
-    // The announced key is adopted network-wide, but its pool arrives on this
-    // validator only after the bound has already elapsed.
-    let late_key_id = ObjectID::random();
+    // No certificate yet: the signing key cannot be derived, so the demand
+    // parks past the bound.
     let demand_id = checkpoint_demand_id(4);
     let derived_algorithm = demand_id.expected_signature_algorithm();
-    deliver_noa_presign_demand(&mut test_state, &demand_id, late_key_id).await;
+    deliver_noa_presign_demand(&mut test_state, &demand_id).await;
 
     flow_consensus_rounds(&mut test_state, PARK_ROUNDS as usize + 1).await;
     assert_eq!(
@@ -1916,20 +1929,24 @@ async fn test_restart_does_not_resurrect_a_dropped_noa_presign_demand() {
         "the demand must be dropped at the bound before the restart is simulated"
     );
 
-    // The lag resolves, too late: the key's pool fills AFTER the drop.
+    // The lag resolves, too late: the key's pool fills and the certificate
+    // naming the key lands AFTER the drop.
     const LATE_POOL_MARKER: u8 = 0x5E;
     test_state.epoch_stores[PARK_TEST_TARGET]
         .insert_presigns(
             derived_algorithm,
-            late_key_id,
+            network_key_id,
             0,
             SessionIdentifier::new(SessionType::InternalPresign, [LATE_POOL_MARKER; 32]),
             vec![vec![LATE_POOL_MARKER; 16]],
         )
-        .expect("seed the late key's presign pool");
+        .expect("seed the key's presign pool");
+    utils::certify_network_key_for_noa_signing(&test_state, network_key_id, &network_key_bytes);
 
-    // Restart: in-memory state is gone, the epoch store (rounds AND pool)
-    // survives, and the round cursor rewinds so every round is re-drained.
+    // First restart: in-memory state is gone, the epoch store (rounds, pool
+    // AND certificate) survives, and the round cursor rewinds so every round
+    // is re-drained — with the key still underived, because the replacement
+    // service's overlay starts empty.
     restart_target_validator(&mut test_state, &seeds, &bundles, PARK_ROUNDS).await;
     flow_consensus_rounds(&mut test_state, 3).await;
 
@@ -1941,8 +1958,50 @@ async fn test_restart_does_not_resurrect_a_dropped_noa_presign_demand() {
         "the replay must not assign a presign to a demand the bound already dropped"
     );
     assert_eq!(
+        test_state.dwallet_mpc_services[PARK_TEST_TARGET]
+            .dwallet_mpc_metrics()
+            .noa_presign_demands_evicted_total
+            .with_label_values(&[&format!("{derived_algorithm:?}")])
+            .get(),
+        0,
+        "a replayed drop is read from the durable table, not decided and counted again"
+    );
+    assert_eq!(
+        test_state.dwallet_mpc_services[PARK_TEST_TARGET].parked_noa_presign_demand_count(),
+        0,
+        "the dropped demand must not sit in the rebuilt queue either"
+    );
+
+    // Second restart, this time with the overlay in place before any round is
+    // drained, so the key derives and the replayed demand reaches the
+    // assignment step against the full pool.
+    restart_target_validator(&mut test_state, &seeds, &bundles, PARK_ROUNDS).await;
+    test_state.sui_data_senders[PARK_TEST_TARGET]
+        .network_keys_sender
+        .send(Arc::new(HashMap::from([(
+            network_key_id,
+            DWalletNetworkEncryptionKeyData {
+                id: network_key_id,
+                current_epoch: 1,
+                dkg_at_epoch: 1,
+                current_reconfiguration_public_output: vec![],
+                network_dkg_public_output: network_key_bytes.clone(),
+                state: DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration,
+            },
+        )])))
+        .expect("the restarted service holds the overlay receiver");
+    flow_consensus_rounds(&mut test_state, 3).await;
+
+    assert_eq!(
         test_state.epoch_stores[PARK_TEST_TARGET]
-            .presign_pool_size(derived_algorithm, late_key_id)
+            .noa_presign_demand_resolution(&demand_id)
+            .expect("read resolution"),
+        Some(NoaPresignDemandResolution::Evicted),
+        "the replay under a derived key must still report the drop"
+    );
+    assert_eq!(
+        test_state.epoch_stores[PARK_TEST_TARGET]
+            .presign_pool_size(derived_algorithm, network_key_id)
             .expect("pool size"),
         1,
         "the replay must not consume the presign that arrived after the drop"
@@ -1973,7 +2032,7 @@ async fn test_noa_presign_demand_is_inert_while_the_flag_is_off() {
     let _guard = utils::create_test_protocol_config_guard();
 
     let mut test_state = build_test_state(4);
-    let (consensus_round, _network_key_bytes, network_key_id) =
+    let (consensus_round, _network_key_bytes, _network_key_id) =
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
 
@@ -1987,7 +2046,6 @@ async fn test_noa_presign_demand_is_inert_while_the_flag_is_off() {
     let demand = ConsensusNOAPresignDemand {
         authority: announcing_authority,
         demand_id: demand_id.clone(),
-        network_encryption_key_id: network_key_id,
     };
 
     // One round carrying the demand, delivered over the real transport to the

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_owned_address_sign.rs
@@ -17,7 +17,8 @@ use crate::dwallet_mpc::NetworkOwnedAddressSignRequest;
 use crate::dwallet_mpc::crytographic_computation::mpc_computations::network_owned_address_sign_dkg_emulation::network_owned_address_sign_dkg_session_identifier;
 use crate::dwallet_mpc::mpc_session::{SessionComputationType, SessionStatus};
 use crate::dwallet_mpc::integration_tests::network_dkg::{
-    create_network_key_test, create_reconfigured_network_key_test,
+    create_network_key_test, create_noa_signing_network_key_test,
+    create_reconfigured_network_key_test,
 };
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::{
@@ -29,14 +30,12 @@ use dwallet_mpc_types::dwallet_mpc::{
 use ika_types::message::{DWalletCheckpointMessageKind, MakeDWalletUserSecretKeySharesPublicOutput};
 use ika_types::noa_checkpoint::{NOACheckpointKindName, NOACheckpointTxRef, NOAPresignDemandId};
 use ika_types::messages_dwallet_mpc::{ConsensusNOAPresignDemand,
-    DWalletMPCOutput, DWalletMPCOutputReport, DWalletNetworkEncryptionKeyData,
-    DWalletNetworkEncryptionKeyState, SessionIdentifier, SessionType,
+    DWalletMPCOutput, DWalletMPCOutputReport, SessionIdentifier, SessionType,
 };
 use crate::validator_metadata::OffChainCommitteeBundles;
 use dwallet_rng::RootSeed;
 use ika_types::crypto::AuthorityName;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 use itertools::Itertools;
 use sui_types::base_types::ObjectID;
 use tracing::info;
@@ -116,16 +115,14 @@ async fn network_owned_address_sign_flow(
     let mut test_state = build_test_state(4);
 
     // Create a network key (required for network-owned-address signing).
-    let (consensus_round, network_key_bytes, encryption_key) =
-        create_network_key_test(&mut test_state).await;
+    let (consensus_round, _network_key_bytes, encryption_key) =
+        create_noa_signing_network_key_test(&mut test_state).await;
 
     info!(
         "Network key created at consensus round {}, key_id: {:?}",
         consensus_round, encryption_key
     );
     test_state.consensus_round = consensus_round as usize;
-    // The signing key derives from the prior epoch's handoff certificate.
-    utils::certify_network_key_for_noa_signing(&test_state, encryption_key, &network_key_bytes);
 
     info!(
         ?curve,
@@ -485,10 +482,9 @@ async fn test_presign_pool_exhaustion_buffers_excess_sign_requests() {
     let mut test_state = build_test_state(4);
 
     // Create a network key (required for network-owned-address signing).
-    let (consensus_round, network_key_bytes, encryption_key) =
-        create_network_key_test(&mut test_state).await;
+    let (consensus_round, _network_key_bytes, encryption_key) =
+        create_noa_signing_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
-    utils::certify_network_key_for_noa_signing(&test_state, encryption_key, &network_key_bytes);
 
     // Fill the EdDSA presign pool.
     let start_round = test_state.consensus_round as u64;
@@ -707,10 +703,9 @@ async fn test_presign_assignment_is_consensus_ordered_not_local() {
     let mut test_state = build_test_state(4);
 
     // Create a network key and fill the EdDSA presign pool.
-    let (consensus_round, network_key_bytes, encryption_key) =
-        create_network_key_test(&mut test_state).await;
+    let (consensus_round, _network_key_bytes, encryption_key) =
+        create_noa_signing_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
-    utils::certify_network_key_for_noa_signing(&test_state, encryption_key, &network_key_bytes);
 
     let start_round = test_state.consensus_round as u64;
     let consensus_round = utils::advance_rounds_while_presign_pool_empty(
@@ -865,10 +860,9 @@ async fn test_late_instantiating_validator_preserves_buffered_sign_messages() {
 
     // Create a network key and fill the EdDSA presign pool so every validator
     // is able to instantiate the sign.
-    let (consensus_round, network_key_bytes, encryption_key) =
-        create_network_key_test(&mut test_state).await;
+    let (consensus_round, _network_key_bytes, encryption_key) =
+        create_noa_signing_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
-    utils::certify_network_key_for_noa_signing(&test_state, encryption_key, &network_key_bytes);
     let start_round = test_state.consensus_round as u64;
     let consensus_round = utils::advance_rounds_while_presign_pool_empty(
         &mut test_state,
@@ -1013,10 +1007,9 @@ async fn test_instantiation_normalizes_byzantine_native_placeholder() {
     let hash_scheme = DWalletHashScheme::SHA512;
 
     let mut test_state = build_test_state(4);
-    let (consensus_round, network_key_bytes, encryption_key) =
-        create_network_key_test(&mut test_state).await;
+    let (consensus_round, _network_key_bytes, encryption_key) =
+        create_noa_signing_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
-    utils::certify_network_key_for_noa_signing(&test_state, encryption_key, &network_key_bytes);
     let start_round = test_state.consensus_round as u64;
     let consensus_round = utils::advance_rounds_while_presign_pool_empty(
         &mut test_state,
@@ -1187,10 +1180,12 @@ async fn network_owned_address_vss_sign_flow(
     let mut test_state = build_test_state(4);
 
     // VSS sign requires a reconfigured network key.
-    let (consensus_round, network_key_bytes, network_key_id) =
+    let (consensus_round, _network_key_bytes, network_key_id) =
         create_reconfigured_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
-    utils::certify_network_key_for_noa_signing(&test_state, network_key_id, &network_key_bytes);
+    // The reconfigured-key helper DKGs without the NOA role; hand the key
+    // in the way the barrier would.
+    utils::select_network_key_for_noa_signing(&mut test_state, network_key_id);
 
     info!(
         ?curve,
@@ -1342,10 +1337,9 @@ async fn test_noa_presign_demand_draws_from_the_pool_its_identity_names() {
     let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
 
     let mut test_state = build_test_state(4);
-    let (consensus_round, network_key_bytes, network_key_id) =
-        create_network_key_test(&mut test_state).await;
+    let (consensus_round, _network_key_bytes, network_key_id) =
+        create_noa_signing_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
-    utils::certify_network_key_for_noa_signing(&test_state, network_key_id, &network_key_bytes);
 
     // A checkpoint demand names its kind, and the kind fixes the algorithm.
     let demand_id = NOAPresignDemandId::Checkpoint {
@@ -1559,22 +1553,18 @@ async fn flow_consensus_rounds(test_state: &mut IntegrationTestState, rounds: us
         .await;
 }
 
-/// A demand sequenced while this validator has not derived the epoch's
-/// network-owned-address signing key PARKS: it is neither assigned nor
-/// dropped, and stays in the queue in consensus-delivery order to be retried
-/// every round.
+/// A demand sequenced on a validator the barrier left WITHOUT a signing key
+/// this epoch PARKS: it is neither assigned nor dropped, and stays in the
+/// queue in consensus-delivery order to be retried every round.
 ///
-/// The key derives from the prior epoch's handoff certificate, and this
-/// harness hands the validator none, so nothing can be drawn for the whole
-/// test. Rejecting the demand instead would turn an honest lag into a
-/// permanent loss: WHEN a validator can derive the key is per-validator (a
-/// restarting or joining validator translates a certified key and reads its
-/// chain metadata after its peers do), and consensus deduplicates
-/// announcements on the demand id alone, so no corrected announcement could
-/// ever follow a reject.
+/// Nothing can be drawn on such a validator all epoch (the key is a
+/// constructor input), so the park ends only at the bound. Rejecting the
+/// demand instead would be wrong for the same reason it always was:
+/// consensus deduplicates announcements on the demand id alone, so no
+/// corrected announcement could ever follow a reject.
 #[tokio::test]
 #[cfg(test)]
-async fn test_noa_presign_demand_parks_while_the_signing_key_is_not_derived() {
+async fn test_noa_presign_demand_parks_on_a_validator_without_a_signing_key() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
 
@@ -1583,7 +1573,7 @@ async fn test_noa_presign_demand_parks_while_the_signing_key_is_not_derived() {
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
 
-    // No handoff certificate anywhere: no validator can derive a signing key.
+    // No signing key was handed in: this validator sits NOA signing out.
     let demand_id = checkpoint_demand_id(1);
     deliver_noa_presign_demand(&mut test_state, &demand_id).await;
 
@@ -1595,7 +1585,7 @@ async fn test_noa_presign_demand_parks_while_the_signing_key_is_not_derived() {
             .noa_presign_demand_resolution(&demand_id)
             .expect("read resolution"),
         None,
-        "a parked demand has no resolution yet: no signing key is derived, and the bound is \
+        "a parked demand has no resolution yet: there is no signing key, and the bound is \
          nowhere near"
     );
     assert_eq!(
@@ -1605,28 +1595,41 @@ async fn test_noa_presign_demand_parks_while_the_signing_key_is_not_derived() {
     );
 }
 
-/// A validator that derives the signing key LATE assigns a demand sequenced
-/// before the derivation as soon as the key resolves, drawing from that key's
-/// pool: the demand parked in the meantime, so nothing was lost.
+/// A demand delivered while the signing key's pool is still EMPTY parks, and
+/// is assigned as soon as the pool fills: nothing was lost in the meantime.
 ///
-/// This is the honest-lag case the park exists for. The assignment must
-/// record the DERIVED key — the one the presign was drawn under — so the sign
-/// later instantiates under exactly that key.
+/// This is the honest-lag case the park exists for now that the key itself
+/// is fixed for the epoch. The assignment must record the signing key — the
+/// one the presign was drawn under — so the sign later instantiates under
+/// exactly that key.
 #[tokio::test]
 #[cfg(test)]
-async fn test_noa_presign_demand_assigns_once_the_signing_key_is_derived() {
+async fn test_noa_presign_demand_assigns_once_its_pool_fills() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
 
     let mut test_state = build_test_state(4);
-    let (consensus_round, network_key_bytes, network_key_id) =
-        create_network_key_test(&mut test_state).await;
+    let (consensus_round, _network_key_bytes, network_key_id) =
+        create_noa_signing_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
 
-    // A recognizable presign at the head of the key's pool, seeded before any
-    // top-up batch can complete: slot 0 sorts before every slot the loop fills.
+    // Only the target's service runs in this test, so no top-up batch can
+    // complete and the key's pool stays empty until seeded below.
     let demand_id = checkpoint_demand_id(2);
     let derived_algorithm = demand_id.expected_signature_algorithm();
+    deliver_noa_presign_demand(&mut test_state, &demand_id).await;
+
+    flow_consensus_rounds(&mut test_state, 3).await;
+    assert_eq!(
+        test_state.epoch_stores[PARK_TEST_TARGET]
+            .noa_presign_demand_resolution(&demand_id)
+            .expect("read resolution"),
+        None,
+        "the demand cannot be resolved while the signing key's pool is empty"
+    );
+
+    // The lag resolves: the key's presign pool fills. Slot 0 sorts before
+    // every slot a top-up batch could fill.
     const LATE_POOL_MARKER: u8 = 0x7C;
     test_state.epoch_stores[PARK_TEST_TARGET]
         .insert_presigns(
@@ -1638,21 +1641,6 @@ async fn test_noa_presign_demand_assigns_once_the_signing_key_is_derived() {
         )
         .expect("seed the key's presign pool");
 
-    deliver_noa_presign_demand(&mut test_state, &demand_id).await;
-
-    flow_consensus_rounds(&mut test_state, 3).await;
-    assert_eq!(
-        test_state.epoch_stores[PARK_TEST_TARGET]
-            .noa_presign_demand_resolution(&demand_id)
-            .expect("read resolution"),
-        None,
-        "the demand cannot be resolved before the signing key is derived, even with its \
-         pool full"
-    );
-
-    // The lag resolves: the handoff certificate naming the key lands.
-    utils::certify_network_key_for_noa_signing(&test_state, network_key_id, &network_key_bytes);
-
     flow_consensus_rounds(&mut test_state, 2).await;
 
     let (_session_identifier, _blending_index, presign_bytes, assigned_key_id) =
@@ -1660,16 +1648,16 @@ async fn test_noa_presign_demand_assigns_once_the_signing_key_is_derived() {
             test_state.epoch_stores[PARK_TEST_TARGET]
                 .noa_presign_demand_resolution(&demand_id)
                 .expect("read resolution"),
-            "the parked demand once the signing key is derived",
+            "the parked demand once its pool fills",
         );
     assert_eq!(
         presign_bytes,
         vec![LATE_POOL_MARKER; 16],
-        "the assignment must draw from the derived key's pool"
+        "the assignment must draw from the signing key's pool"
     );
     assert_eq!(
         assigned_key_id, network_key_id,
-        "the assignment must record the derived key the presign was drawn under"
+        "the assignment must record the signing key the presign was drawn under"
     );
     assert_eq!(
         test_state.dwallet_mpc_services[PARK_TEST_TARGET].parked_noa_presign_demand_count(),
@@ -1678,23 +1666,17 @@ async fn test_noa_presign_demand_assigns_once_the_signing_key_is_derived() {
     );
 }
 
-/// A demand whose signing key is never derived here is dropped at the park
-/// bound — loudly, counted, and permanently for this epoch.
-///
-/// The bound is a liveness backstop: without it a demand sequenced in an
-/// epoch whose key never resolves on this validator (no handoff certificate,
-/// or a certified key it can never translate) would park for the rest of the
-/// epoch and block that epoch's NOA checkpoint finalization. It is measured in
-/// consensus rounds and the test shrinks it, so the drop is reachable without
-/// driving the protocol's ~70k rounds.
+/// A demand on a validator without a signing key this epoch is dropped at
+/// the park bound, and a pool for the key appearing afterwards changes
+/// nothing: the drop is terminal and the pool stays untouched.
 #[tokio::test]
 #[cfg(test)]
-async fn test_noa_presign_demand_is_dropped_at_the_park_bound() {
+async fn test_noa_presign_demand_without_a_signing_key_is_dropped_at_the_park_bound() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
 
     let mut test_state = build_test_state(4);
-    let (consensus_round, network_key_bytes, network_key_id) =
+    let (consensus_round, _network_key_bytes, network_key_id) =
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
 
@@ -1702,7 +1684,62 @@ async fn test_noa_presign_demand_is_dropped_at_the_park_bound() {
     test_state.dwallet_mpc_services[PARK_TEST_TARGET]
         .set_noa_presign_demand_park_rounds_for_testing(PARK_ROUNDS);
 
-    // No certificate anywhere: the signing key stays underived past the bound.
+    let demand_id = checkpoint_demand_id(5);
+    let derived_algorithm = demand_id.expected_signature_algorithm();
+    deliver_noa_presign_demand(&mut test_state, &demand_id).await;
+    flow_consensus_rounds(&mut test_state, PARK_ROUNDS as usize + 1).await;
+
+    assert_eq!(
+        test_state.epoch_stores[PARK_TEST_TARGET]
+            .noa_presign_demand_resolution(&demand_id)
+            .expect("read resolution"),
+        Some(NoaPresignDemandResolution::Evicted),
+        "without a signing key the demand is dropped once the bound elapses"
+    );
+
+    test_state.epoch_stores[PARK_TEST_TARGET]
+        .insert_presigns(
+            derived_algorithm,
+            network_key_id,
+            0,
+            SessionIdentifier::new(SessionType::InternalPresign, [0x22; 32]),
+            vec![vec![0x22; 16]],
+        )
+        .expect("seed a pool for the key");
+    flow_consensus_rounds(&mut test_state, 3).await;
+    assert_eq!(
+        test_state.epoch_stores[PARK_TEST_TARGET]
+            .presign_pool_size(derived_algorithm, network_key_id)
+            .expect("pool size"),
+        1,
+        "a validator without a signing key never draws from the pool"
+    );
+}
+
+/// A demand whose signing key's pool never fills is dropped at the park
+/// bound — loudly, counted, and permanently for this epoch.
+///
+/// The bound is a liveness backstop: without it a demand whose pool never
+/// fills would park for the rest of the epoch and block that epoch's NOA
+/// checkpoint finalization. It is measured in consensus rounds and the test
+/// shrinks it, so the drop is reachable without driving the protocol's ~70k
+/// rounds.
+#[tokio::test]
+#[cfg(test)]
+async fn test_noa_presign_demand_is_dropped_at_the_park_bound() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
+
+    let mut test_state = build_test_state(4);
+    let (consensus_round, _network_key_bytes, network_key_id) =
+        create_noa_signing_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+
+    const PARK_ROUNDS: u64 = 3;
+    test_state.dwallet_mpc_services[PARK_TEST_TARGET]
+        .set_noa_presign_demand_park_rounds_for_testing(PARK_ROUNDS);
+
+    // Only the target's service runs, so the key's pool never fills.
     let demand_id = checkpoint_demand_id(3);
     let derived_algorithm = demand_id.expected_signature_algorithm();
     let delivery_round = deliver_noa_presign_demand(&mut test_state, &demand_id).await;
@@ -1727,9 +1764,9 @@ async fn test_noa_presign_demand_is_dropped_at_the_park_bound() {
         "the drop must be counted"
     );
 
-    // A drop is terminal for this epoch, not starvation: the signing key
-    // resolving and its pool filling AFTER the bound change nothing, because
-    // the demand is no longer in the queue to be retried.
+    // A drop is terminal for this epoch, not starvation: the pool filling
+    // AFTER the bound changes nothing, because the demand is no longer in the
+    // queue to be retried.
     test_state.epoch_stores[PARK_TEST_TARGET]
         .insert_presigns(
             derived_algorithm,
@@ -1739,15 +1776,13 @@ async fn test_noa_presign_demand_is_dropped_at_the_park_bound() {
             vec![vec![0x11; 16]],
         )
         .expect("seed a pool for the dropped demand's key");
-    utils::certify_network_key_for_noa_signing(&test_state, network_key_id, &network_key_bytes);
     flow_consensus_rounds(&mut test_state, 3).await;
     assert_eq!(
         test_state.epoch_stores[PARK_TEST_TARGET]
             .noa_presign_demand_resolution(&demand_id)
             .expect("read resolution"),
         Some(NoaPresignDemandResolution::Evicted),
-        "a dropped demand must stay dropped — durably — even once its key derives and a pool \
-         for it exists"
+        "a dropped demand must stay dropped — durably — even once a pool for its key exists"
     );
     assert_eq!(
         test_state.epoch_stores[PARK_TEST_TARGET]
@@ -1888,19 +1923,19 @@ async fn restart_target_validator(
 ///
 /// The drain replays every consensus round of the epoch after a restart, and
 /// the presign pool is durable and NOT rewound with it. So a demand dropped at
-/// round R_e, whose signing key only derived and whose pool only filled at
-/// some later round, is re-read at its delivery round against a pool that now
-/// holds a presign — and a drop recorded only in memory is gone, so the
-/// replayed drain would pop. That validator would then hold an assignment no
-/// peer has, and would consume a presign its peers pair with a DIFFERENT
-/// demand, diverging the demand-to-presign pairing for the rest of the epoch.
+/// round R_e, whose pool only filled at some later round, is re-read at its
+/// delivery round against a pool that now holds a presign — and a drop
+/// recorded only in memory is gone, so the replayed drain would pop. That
+/// validator would then hold an assignment no peer has, and would consume a
+/// presign its peers pair with a DIFFERENT demand, diverging the
+/// demand-to-presign pairing for the rest of the epoch.
 ///
 /// Two restarts cover the two states a replayed drain can run in. The first
-/// replacement service holds no network-key overlay yet, so its drain runs
-/// with the key still underived: the replayed demand must leave the queue on
-/// its durable drop, neither parked again nor re-counted. The second is handed
-/// the overlay first, so its drain runs under a derived key against the full
-/// pool: the assignment step must report the drop rather than pop.
+/// replacement service is constructed without a signing key, so its drain
+/// runs keyless: the replayed demand must leave the queue on its durable drop,
+/// neither parked again nor re-counted. The second is handed the key, so its
+/// drain runs against the full pool: the assignment step must report the
+/// drop rather than pop.
 #[tokio::test]
 #[cfg(test)]
 async fn test_restart_does_not_resurrect_a_dropped_noa_presign_demand() {
@@ -1908,16 +1943,16 @@ async fn test_restart_does_not_resurrect_a_dropped_noa_presign_demand() {
     let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
 
     let (mut test_state, seeds, bundles) = build_restartable_test_state();
-    let (consensus_round, network_key_bytes, network_key_id) =
-        create_network_key_test(&mut test_state).await;
+    let (consensus_round, _network_key_bytes, network_key_id) =
+        create_noa_signing_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
 
     const PARK_ROUNDS: u64 = 3;
     test_state.dwallet_mpc_services[PARK_TEST_TARGET]
         .set_noa_presign_demand_park_rounds_for_testing(PARK_ROUNDS);
 
-    // No certificate yet: the signing key cannot be derived, so the demand
-    // parks past the bound.
+    // Only the target's service runs, so the key's pool stays empty and the
+    // demand parks past the bound.
     let demand_id = checkpoint_demand_id(4);
     let derived_algorithm = demand_id.expected_signature_algorithm();
     deliver_noa_presign_demand(&mut test_state, &demand_id).await;
@@ -1929,8 +1964,7 @@ async fn test_restart_does_not_resurrect_a_dropped_noa_presign_demand() {
         "the demand must be dropped at the bound before the restart is simulated"
     );
 
-    // The lag resolves, too late: the key's pool fills and the certificate
-    // naming the key lands AFTER the drop.
+    // The lag resolves, too late: the key's pool fills AFTER the drop.
     const LATE_POOL_MARKER: u8 = 0x5E;
     test_state.epoch_stores[PARK_TEST_TARGET]
         .insert_presigns(
@@ -1941,12 +1975,11 @@ async fn test_restart_does_not_resurrect_a_dropped_noa_presign_demand() {
             vec![vec![LATE_POOL_MARKER; 16]],
         )
         .expect("seed the key's presign pool");
-    utils::certify_network_key_for_noa_signing(&test_state, network_key_id, &network_key_bytes);
 
-    // First restart: in-memory state is gone, the epoch store (rounds, pool
-    // AND certificate) survives, and the round cursor rewinds so every round
-    // is re-drained — with the key still underived, because the replacement
-    // service's overlay starts empty.
+    // First restart: in-memory state is gone, the epoch store (rounds AND
+    // pool) survives, and the round cursor rewinds so every round is
+    // re-drained — keyless, because the replacement service is constructed
+    // without a signing key.
     restart_target_validator(&mut test_state, &seeds, &bundles, PARK_ROUNDS).await;
     flow_consensus_rounds(&mut test_state, 3).await;
 
@@ -1972,24 +2005,12 @@ async fn test_restart_does_not_resurrect_a_dropped_noa_presign_demand() {
         "the dropped demand must not sit in the rebuilt queue either"
     );
 
-    // Second restart, this time with the overlay in place before any round is
-    // drained, so the key derives and the replayed demand reaches the
-    // assignment step against the full pool.
+    // Second restart, this time handed the key before any round is drained,
+    // so the replayed demand reaches the assignment step against the full
+    // pool.
     restart_target_validator(&mut test_state, &seeds, &bundles, PARK_ROUNDS).await;
-    test_state.sui_data_senders[PARK_TEST_TARGET]
-        .network_keys_sender
-        .send(Arc::new(HashMap::from([(
-            network_key_id,
-            DWalletNetworkEncryptionKeyData {
-                id: network_key_id,
-                current_epoch: 1,
-                dkg_at_epoch: 1,
-                current_reconfiguration_public_output: vec![],
-                network_dkg_public_output: network_key_bytes.clone(),
-                state: DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration,
-            },
-        )])))
-        .expect("the restarted service holds the overlay receiver");
+    test_state.dwallet_mpc_services[PARK_TEST_TARGET]
+        .set_network_owned_address_signing_key_id_for_testing(Some(network_key_id));
     flow_consensus_rounds(&mut test_state, 3).await;
 
     assert_eq!(
@@ -1997,7 +2018,7 @@ async fn test_restart_does_not_resurrect_a_dropped_noa_presign_demand() {
             .noa_presign_demand_resolution(&demand_id)
             .expect("read resolution"),
         Some(NoaPresignDemandResolution::Evicted),
-        "the replay under a derived key must still report the drop"
+        "the replay under the key must still report the drop"
     );
     assert_eq!(
         test_state.epoch_stores[PARK_TEST_TARGET]

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/noa_checkpoint.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/noa_checkpoint.rs
@@ -18,15 +18,17 @@ use async_trait::async_trait;
 use dwallet_mpc_types::dwallet_mpc::DWalletSignatureAlgorithm;
 use ika_types::message::DWalletCheckpointMessageKind;
 use ika_types::messages_consensus::ConsensusTransactionKind;
-use ika_types::messages_dwallet_mpc::ConsensusNOAPresignDemand;
+use ika_types::messages_dwallet_mpc::{ConsensusNOAPresignDemand, SessionIdentifier, SessionType};
 use ika_types::messages_system_checkpoints::SystemCheckpointMessageKind;
 use ika_types::noa_checkpoint::{
     NOACheckpointKindName, NOACheckpointTxObservation, NOACheckpointTxRef, NOAPresignDemandId,
     SuiChainContext, SuiDWalletCheckpoint, SuiSystemCheckpoint,
 };
-use sui_types::base_types::ObjectID;
 use tracing::info;
 
+use crate::authority::authority_per_epoch_store::{
+    AuthorityPerEpochStoreTrait, NoaPresignDemandResolution,
+};
 use crate::dwallet_mpc::integration_tests::network_dkg::create_network_key_test;
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::{
@@ -42,7 +44,7 @@ use crate::noa_checkpoints::{NOAChainSubmitter, NOACheckpointHandler, TxExecutio
 async fn setup_noa_test_state() -> IntegrationTestState {
     let mut test_state = build_test_state(4);
 
-    let (consensus_round, _network_key_bytes, network_key_id) =
+    let (consensus_round, network_key_bytes, network_key_id) =
         create_network_key_test(&mut test_state).await;
 
     info!(
@@ -50,6 +52,9 @@ async fn setup_noa_test_state() -> IntegrationTestState {
         consensus_round, network_key_id
     );
     test_state.consensus_round = consensus_round as usize;
+    // The NOA signing key derives from the prior epoch's handoff certificate;
+    // hand every validator one naming the key.
+    utils::certify_network_key_for_noa_signing(&test_state, network_key_id, &network_key_bytes);
 
     let start_round = test_state.consensus_round as u64;
     let consensus_round = utils::advance_rounds_while_presign_pool_empty(
@@ -607,7 +612,6 @@ async fn test_noa_status_update_rebuffers_on_submit_failure() {
             tx_ref,
             retry_round: 0,
         },
-        network_encryption_key_id: ObjectID::random(),
     };
     service.buffer_noa_observation_for_testing(observation.clone());
     service.buffer_noa_presign_demand_for_testing(demand.clone());
@@ -667,4 +671,185 @@ async fn test_noa_status_update_rebuffers_on_submit_failure() {
         })
         .collect();
     assert_eq!(submitted_demands, vec![demand]);
+}
+
+// ── Test 6: a demand sequenced before the signing key is derived ─────────────
+
+/// Runs `rounds` consensus rounds through the services at `indices`, then one
+/// final iteration so the last round created is actually drained.
+async fn flow_consensus_rounds_on(
+    test_state: &mut IntegrationTestState,
+    indices: [usize; 2],
+    rounds: usize,
+) {
+    for _ in 0..rounds {
+        for index in indices {
+            test_state.dwallet_mpc_services[index]
+                .run_service_loop_iteration()
+                .await;
+        }
+        utils::send_advance_results_between_parties(
+            &test_state.committee,
+            &mut test_state.sent_consensus_messages_collectors,
+            &mut test_state.epoch_stores,
+            test_state.consensus_round as u64,
+        )
+        .await;
+        test_state.consensus_round += 1;
+    }
+    for index in indices {
+        test_state.dwallet_mpc_services[index]
+            .run_service_loop_iteration()
+            .await;
+    }
+}
+
+/// A demand sequenced while a validator has not yet derived the epoch's
+/// network-owned-address signing key parks, and once the derivation resolves
+/// it is assigned the SAME presign a peer that derived the key immediately
+/// assigned it.
+///
+/// Two validators receive the same demand in the same round over identical
+/// pools. The peer holds the prior epoch's handoff certificate from the start
+/// and assigns at delivery; the target holds none, parks, and assigns once it
+/// is handed the certificate. Their assignment tables must then match entry
+/// for entry: same presign, same blending index, same session, same key.
+#[tokio::test]
+#[cfg(test)]
+async fn test_noa_presign_demand_parked_on_an_underived_key_matches_the_peer_assignment() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
+
+    let mut test_state = build_test_state(4);
+    let (consensus_round, network_key_bytes, network_key_id) =
+        create_network_key_test(&mut test_state).await;
+    test_state.consensus_round = consensus_round as usize;
+
+    const TARGET: usize = 0;
+    const PEER: usize = 1;
+    let demand_id = NOAPresignDemandId::Checkpoint {
+        tx_ref: NOACheckpointTxRef {
+            kind_name: NOACheckpointKindName::SuiDWallet,
+            sequence_number: 7,
+            tx_index: 0,
+            epoch: 1,
+        },
+        retry_round: 0,
+    };
+    let algorithm = demand_id.expected_signature_algorithm();
+
+    // Identical pools with two slots each, so WHICH slot the drain takes is
+    // observable, seeded before any top-up batch can complete.
+    for index in [TARGET, PEER] {
+        for (slot, marker) in [(0u64, 0x3Au8), (1, 0x3B)] {
+            test_state.epoch_stores[index]
+                .insert_presigns(
+                    algorithm,
+                    network_key_id,
+                    slot,
+                    SessionIdentifier::new(SessionType::InternalPresign, [marker; 32]),
+                    vec![vec![marker; 16]],
+                )
+                .expect("seed the presign pool");
+        }
+    }
+
+    // Only the peer can derive the signing key from the start.
+    let (prior_epoch, certificate) =
+        utils::noa_signing_certificate(&test_state, network_key_id, &network_key_bytes);
+    test_state.epoch_stores[PEER]
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(prior_epoch, certificate.clone());
+
+    // The same demand reaches both validators in the same round: this round
+    // goes to everyone the usual way, then both get one more round carrying
+    // the demand.
+    let announcing_authority = test_state
+        .committee
+        .names()
+        .nth(2)
+        .copied()
+        .expect("committee has a third member");
+    let round = test_state.consensus_round as u64;
+    utils::send_advance_results_between_parties(
+        &test_state.committee,
+        &mut test_state.sent_consensus_messages_collectors,
+        &mut test_state.epoch_stores,
+        round,
+    )
+    .await;
+    for index in [TARGET, PEER] {
+        let mut payload = utils::empty_round_payload(round + 1);
+        payload.noa_presign_demands.push(ConsensusNOAPresignDemand {
+            authority: announcing_authority,
+            demand_id: demand_id.clone(),
+        });
+        test_state.epoch_stores[index].deliver_round(payload).await;
+    }
+    test_state.consensus_round += 2;
+
+    flow_consensus_rounds_on(&mut test_state, [TARGET, PEER], 3).await;
+
+    let peer_resolution = test_state.epoch_stores[PEER]
+        .noa_presign_demand_resolution(&demand_id)
+        .expect("read the peer's resolution");
+    assert!(
+        matches!(
+            peer_resolution,
+            Some(NoaPresignDemandResolution::Assigned { .. })
+        ),
+        "the peer derived the key at once and assigns at delivery, found {peer_resolution:?}"
+    );
+    assert_eq!(
+        test_state.epoch_stores[TARGET]
+            .noa_presign_demand_resolution(&demand_id)
+            .expect("read the target's resolution"),
+        None,
+        "the target cannot derive the key yet, so its demand parks"
+    );
+    assert_eq!(
+        test_state.dwallet_mpc_services[TARGET].parked_noa_presign_demand_count(),
+        1,
+        "the parked demand stays in the target's queue"
+    );
+
+    // The target's derivation input lands.
+    test_state.epoch_stores[TARGET]
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(prior_epoch, certificate);
+    flow_consensus_rounds_on(&mut test_state, [TARGET, PEER], 3).await;
+
+    let target_resolution = test_state.epoch_stores[TARGET]
+        .noa_presign_demand_resolution(&demand_id)
+        .expect("read the target's resolution");
+    assert_eq!(
+        target_resolution, peer_resolution,
+        "the parked demand must be assigned exactly what the peer assigned it"
+    );
+    assert!(
+        matches!(
+            target_resolution,
+            Some(NoaPresignDemandResolution::Assigned { network_encryption_key_id, .. })
+                if network_encryption_key_id == network_key_id
+        ),
+        "the assignment records the certificate-derived key, found {target_resolution:?}"
+    );
+    for index in [TARGET, PEER] {
+        assert_eq!(
+            test_state.dwallet_mpc_services[index].parked_noa_presign_demand_count(),
+            0,
+            "an assigned demand leaves the queue on validator {index}"
+        );
+        assert_eq!(
+            test_state.epoch_stores[index]
+                .presign_pool_size(algorithm, network_key_id)
+                .expect("pool size"),
+            1,
+            "exactly one slot is consumed on validator {index}"
+        );
+    }
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/noa_checkpoint.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/noa_checkpoint.rs
@@ -29,7 +29,9 @@ use tracing::info;
 use crate::authority::authority_per_epoch_store::{
     AuthorityPerEpochStoreTrait, NoaPresignDemandResolution,
 };
-use crate::dwallet_mpc::integration_tests::network_dkg::create_network_key_test;
+use crate::dwallet_mpc::integration_tests::network_dkg::{
+    create_network_key_test, create_noa_signing_network_key_test,
+};
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::{
     IntegrationTestState, build_test_state, create_test_protocol_config_guard,
@@ -44,17 +46,14 @@ use crate::noa_checkpoints::{NOAChainSubmitter, NOACheckpointHandler, TxExecutio
 async fn setup_noa_test_state() -> IntegrationTestState {
     let mut test_state = build_test_state(4);
 
-    let (consensus_round, network_key_bytes, network_key_id) =
-        create_network_key_test(&mut test_state).await;
+    let (consensus_round, _network_key_bytes, network_key_id) =
+        create_noa_signing_network_key_test(&mut test_state).await;
 
     info!(
         "Network key created at consensus round {}, key_id: {:?}",
         consensus_round, network_key_id
     );
     test_state.consensus_round = consensus_round as usize;
-    // The NOA signing key derives from the prior epoch's handoff certificate;
-    // hand every validator one naming the key.
-    utils::certify_network_key_for_noa_signing(&test_state, network_key_id, &network_key_bytes);
 
     let start_round = test_state.consensus_round as u64;
     let consensus_round = utils::advance_rounds_while_presign_pool_empty(
@@ -673,18 +672,18 @@ async fn test_noa_status_update_rebuffers_on_submit_failure() {
     assert_eq!(submitted_demands, vec![demand]);
 }
 
-// ── Test 6: a demand sequenced before the signing key is derived ─────────────
+// ── Test 6: the drain under the barrier-resolved signing key ─────────────────
 
 /// Runs `rounds` consensus rounds through the services at `indices`, then one
 /// final iteration so the last round created is actually drained.
 async fn flow_consensus_rounds_on(
     test_state: &mut IntegrationTestState,
-    indices: [usize; 2],
+    indices: &[usize],
     rounds: usize,
 ) {
     for _ in 0..rounds {
         for index in indices {
-            test_state.dwallet_mpc_services[index]
+            test_state.dwallet_mpc_services[*index]
                 .run_service_loop_iteration()
                 .await;
         }
@@ -698,35 +697,35 @@ async fn flow_consensus_rounds_on(
         test_state.consensus_round += 1;
     }
     for index in indices {
-        test_state.dwallet_mpc_services[index]
+        test_state.dwallet_mpc_services[*index]
             .run_service_loop_iteration()
             .await;
     }
 }
 
-/// A demand sequenced while a validator has not yet derived the epoch's
-/// network-owned-address signing key parks, and once the derivation resolves
-/// it is assigned the SAME presign a peer that derived the key immediately
-/// assigned it.
+/// Two validators holding the epoch's signing key assign the same demand the
+/// SAME presign, entry for entry; a third, which the barrier left without a
+/// key this epoch, parks the demand and never draws from the pool.
 ///
-/// Two validators receive the same demand in the same round over identical
-/// pools. The peer holds the prior epoch's handoff certificate from the start
-/// and assigns at delivery; the target holds none, parks, and assigns once it
-/// is handed the certificate. Their assignment tables must then match entry
-/// for entry: same presign, same blending index, same session, same key.
+/// All three receive the same demand in the same round over identical
+/// two-slot pools, so which slot the drain takes is observable. The keyed
+/// pair must agree exactly (same session, blending index, presign, key), and
+/// the keyless one must leave its pool untouched — it sits NOA signing out,
+/// it does not diverge.
 #[tokio::test]
 #[cfg(test)]
-async fn test_noa_presign_demand_parked_on_an_underived_key_matches_the_peer_assignment() {
+async fn test_noa_presign_demand_assignment_matches_across_keyed_validators() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let _guard = create_test_protocol_config_guard_with_noa_checkpoints();
 
     let mut test_state = build_test_state(4);
-    let (consensus_round, network_key_bytes, network_key_id) =
+    let (consensus_round, _network_key_bytes, network_key_id) =
         create_network_key_test(&mut test_state).await;
     test_state.consensus_round = consensus_round as usize;
 
-    const TARGET: usize = 0;
-    const PEER: usize = 1;
+    const KEYED: [usize; 2] = [0, 1];
+    const KEYLESS: usize = 2;
+    const ALL: [usize; 3] = [0, 1, 2];
     let demand_id = NOAPresignDemandId::Checkpoint {
         tx_ref: NOACheckpointTxRef {
             kind_name: NOACheckpointKindName::SuiDWallet,
@@ -738,9 +737,9 @@ async fn test_noa_presign_demand_parked_on_an_underived_key_matches_the_peer_ass
     };
     let algorithm = demand_id.expected_signature_algorithm();
 
-    // Identical pools with two slots each, so WHICH slot the drain takes is
-    // observable, seeded before any top-up batch can complete.
-    for index in [TARGET, PEER] {
+    // Identical pools with two slots each, seeded before any top-up batch
+    // can complete.
+    for index in ALL {
         for (slot, marker) in [(0u64, 0x3Au8), (1, 0x3B)] {
             test_state.epoch_stores[index]
                 .insert_presigns(
@@ -753,25 +752,20 @@ async fn test_noa_presign_demand_parked_on_an_underived_key_matches_the_peer_ass
                 .expect("seed the presign pool");
         }
     }
+    for index in KEYED {
+        test_state.dwallet_mpc_services[index]
+            .set_network_owned_address_signing_key_id_for_testing(Some(network_key_id));
+    }
 
-    // Only the peer can derive the signing key from the start.
-    let (prior_epoch, certificate) =
-        utils::noa_signing_certificate(&test_state, network_key_id, &network_key_bytes);
-    test_state.epoch_stores[PEER]
-        .certified_handoff_attestations
-        .lock()
-        .unwrap()
-        .insert(prior_epoch, certificate.clone());
-
-    // The same demand reaches both validators in the same round: this round
-    // goes to everyone the usual way, then both get one more round carrying
-    // the demand.
+    // The same demand reaches all three in the same round: this round goes
+    // to everyone the usual way, then each gets one more round carrying the
+    // demand.
     let announcing_authority = test_state
         .committee
         .names()
-        .nth(2)
+        .nth(3)
         .copied()
-        .expect("committee has a third member");
+        .expect("committee has a fourth member");
     let round = test_state.consensus_round as u64;
     utils::send_advance_results_between_parties(
         &test_state.committee,
@@ -780,7 +774,7 @@ async fn test_noa_presign_demand_parked_on_an_underived_key_matches_the_peer_ass
         round,
     )
     .await;
-    for index in [TARGET, PEER] {
+    for index in ALL {
         let mut payload = utils::empty_round_payload(round + 1);
         payload.noa_presign_demands.push(ConsensusNOAPresignDemand {
             authority: announcing_authority,
@@ -790,55 +784,30 @@ async fn test_noa_presign_demand_parked_on_an_underived_key_matches_the_peer_ass
     }
     test_state.consensus_round += 2;
 
-    flow_consensus_rounds_on(&mut test_state, [TARGET, PEER], 3).await;
+    flow_consensus_rounds_on(&mut test_state, &ALL, 3).await;
 
-    let peer_resolution = test_state.epoch_stores[PEER]
-        .noa_presign_demand_resolution(&demand_id)
-        .expect("read the peer's resolution");
+    let resolutions: Vec<_> = KEYED
+        .iter()
+        .map(|index| {
+            test_state.epoch_stores[*index]
+                .noa_presign_demand_resolution(&demand_id)
+                .expect("read resolution")
+        })
+        .collect();
     assert!(
         matches!(
-            peer_resolution,
-            Some(NoaPresignDemandResolution::Assigned { .. })
-        ),
-        "the peer derived the key at once and assigns at delivery, found {peer_resolution:?}"
-    );
-    assert_eq!(
-        test_state.epoch_stores[TARGET]
-            .noa_presign_demand_resolution(&demand_id)
-            .expect("read the target's resolution"),
-        None,
-        "the target cannot derive the key yet, so its demand parks"
-    );
-    assert_eq!(
-        test_state.dwallet_mpc_services[TARGET].parked_noa_presign_demand_count(),
-        1,
-        "the parked demand stays in the target's queue"
-    );
-
-    // The target's derivation input lands.
-    test_state.epoch_stores[TARGET]
-        .certified_handoff_attestations
-        .lock()
-        .unwrap()
-        .insert(prior_epoch, certificate);
-    flow_consensus_rounds_on(&mut test_state, [TARGET, PEER], 3).await;
-
-    let target_resolution = test_state.epoch_stores[TARGET]
-        .noa_presign_demand_resolution(&demand_id)
-        .expect("read the target's resolution");
-    assert_eq!(
-        target_resolution, peer_resolution,
-        "the parked demand must be assigned exactly what the peer assigned it"
-    );
-    assert!(
-        matches!(
-            target_resolution,
+            resolutions[0],
             Some(NoaPresignDemandResolution::Assigned { network_encryption_key_id, .. })
                 if network_encryption_key_id == network_key_id
         ),
-        "the assignment records the certificate-derived key, found {target_resolution:?}"
+        "a keyed validator assigns at delivery under the signing key, found {:?}",
+        resolutions[0]
     );
-    for index in [TARGET, PEER] {
+    assert_eq!(
+        resolutions[0], resolutions[1],
+        "the two keyed validators must bind the same presign to the demand"
+    );
+    for index in KEYED {
         assert_eq!(
             test_state.dwallet_mpc_services[index].parked_noa_presign_demand_count(),
             0,
@@ -852,4 +821,24 @@ async fn test_noa_presign_demand_parked_on_an_underived_key_matches_the_peer_ass
             "exactly one slot is consumed on validator {index}"
         );
     }
+
+    assert_eq!(
+        test_state.epoch_stores[KEYLESS]
+            .noa_presign_demand_resolution(&demand_id)
+            .expect("read resolution"),
+        None,
+        "the keyless validator parks the demand"
+    );
+    assert_eq!(
+        test_state.dwallet_mpc_services[KEYLESS].parked_noa_presign_demand_count(),
+        1,
+        "the parked demand stays in the keyless validator's queue"
+    );
+    assert_eq!(
+        test_state.epoch_stores[KEYLESS]
+            .presign_pool_size(algorithm, network_key_id)
+            .expect("pool size"),
+        2,
+        "the keyless validator never draws from the pool"
+    );
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/noa_signing_key_skew.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/noa_signing_key_skew.rs
@@ -1,202 +1,87 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-//! The network-owned-address (NOA) signing key is a pure function of the
-//! prior epoch's handoff certificate, fixed for the epoch: among the keys the
-//! certificate names, the one with the largest `dkg_at_epoch`, ties broken by
-//! the smaller `NetworkKeyId`
-//! (`DWalletMPCManager::network_owned_address_signing_key_resolution`).
+//! The network-owned-address (NOA) signing key is resolved by the
+//! prepare-then-start barrier from the prior epoch's handoff certificate
+//! (`dwallet_mpc::network_owned_address_signing_key::select`, whose rule is
+//! pinned in that module's own tests) and handed to the MPC manager as a
+//! fixed constructor input.
 //!
-//! It is deliberately NOT read from the locally adopted key set, whose
-//! contents differ between honest validators while their adoption lags (issue
-//! #2019 measured three such windows: the epoch-start fill window, per-key
-//! overlay incompleteness, and a handoff-certificate read error). These tests
-//! drive two managers at the same epoch with the SAME certificate and
-//! DIFFERENT adopted sets and assert the selector agrees; and they pin the
-//! all-or-nothing rule — a validator that cannot translate, or has no chain
-//! metadata for, one certified key answers `None` rather than choosing among
-//! the keys it can see.
-//!
-//! The selector reads the certificate from the epoch store, the translation
-//! from the process-global `network_key_id_mapping`, and `dkg_at_epoch` from
-//! the network-key overlay watch; the adopted set is driven separately through
-//! `adopt_cert_verified_keys`, exactly as the service does, so a test can hand
-//! the two managers the same watch value and different adoption inputs.
+//! These tests pin the manager's side of that contract: with
+//! `noa_checkpoints` on, its answer IS that input and never the locally
+//! adopted key set — whose contents differ between honest validators while
+//! their adoption lags (issue #2019 measured three such windows: the
+//! epoch-start fill window, per-key overlay incompleteness, and a
+//! handoff-certificate read error) — while the flag-off path keeps the
+//! adopted-set pool-role rule byte for byte.
 
+use crate::dwallet_mpc::dwallet_mpc_service::DWalletMPCService;
 use crate::dwallet_mpc::integration_tests::utils;
-use crate::dwallet_mpc::mpc_manager::NetworkOwnedAddressSigningKeyResolution;
 use crate::network_key_id_mapping;
 use dwallet_mpc_types::dwallet_mpc::NetworkKeyId;
-use ika_network::mpc_artifacts::mpc_data_blob_hash;
-use ika_types::handoff::{CertifiedHandoffAttestation, HandoffAttestation, HandoffItemKey};
 use ika_types::messages_dwallet_mpc::{
     DWalletNetworkEncryptionKeyData, DWalletNetworkEncryptionKeyState,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 use sui_types::base_types::ObjectID;
 
-/// A network key as the overlay serves it: metadata from chain, blob bytes
-/// from the local producer cache (empty when this validator has not cached /
-/// fetched them yet — adoption then skips the key, but the selector still
-/// reads `dkg_at_epoch`).
+/// A network key in its initial-DKG state as the overlay serves it: metadata
+/// from chain, the DKG blob from the local producer cache (empty when this
+/// validator has not cached it yet — adoption then skips the key).
 fn overlay_entry(
     key_id: ObjectID,
     current_epoch: u64,
-    dkg_at_epoch: u64,
     network_dkg_public_output: Vec<u8>,
-    current_reconfiguration_public_output: Vec<u8>,
-) -> DWalletNetworkEncryptionKeyData {
-    DWalletNetworkEncryptionKeyData {
-        id: key_id,
-        current_epoch,
-        dkg_at_epoch,
-        network_dkg_public_output,
-        current_reconfiguration_public_output,
-        state: DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted,
-    }
-}
-
-/// A key's inputs to one test: its Sui id, its content-derived id, and the
-/// blobs the overlay carries for it.
-struct TestKey {
-    object_id: ObjectID,
-    network_key_id: NetworkKeyId,
-    dkg_at_epoch: u64,
-    dkg: Vec<u8>,
-    reconfiguration: Vec<u8>,
-}
-
-impl TestKey {
-    /// A key whose `NetworkKeyId` is its `ObjectID`'s bytes — so ordering the
-    /// object ids orders the network key ids identically — registered in the
-    /// process-global mapping (adoption defers any key it cannot map).
-    fn registered(object_id: ObjectID, dkg_at_epoch: u64, tag: &str) -> Self {
-        let network_key_id = NetworkKeyId(object_id.into_bytes());
-        network_key_id_mapping::register(object_id, network_key_id);
-        Self {
-            object_id,
-            network_key_id,
-            dkg_at_epoch,
-            dkg: format!("{tag} dkg output").into_bytes(),
-            reconfiguration: format!("{tag} reconfiguration output").into_bytes(),
-        }
-    }
-
-    fn complete_entry(&self, epoch_id: u64) -> (ObjectID, DWalletNetworkEncryptionKeyData) {
-        (
-            self.object_id,
-            overlay_entry(
-                self.object_id,
-                epoch_id,
-                self.dkg_at_epoch,
-                self.dkg.clone(),
-                self.reconfiguration.clone(),
-            ),
-        )
-    }
-
-    /// Metadata present, blobs not yet cached locally.
-    fn blob_empty_entry(&self, epoch_id: u64) -> (ObjectID, DWalletNetworkEncryptionKeyData) {
-        (
-            self.object_id,
-            overlay_entry(self.object_id, epoch_id, self.dkg_at_epoch, vec![], vec![]),
-        )
-    }
-}
-
-/// Two keys whose id ordering is known.
-fn two_ordered_keys(dkg_at_epoch: u64) -> (TestKey, TestKey) {
-    let (a, b) = (ObjectID::random(), ObjectID::random());
-    let (low, high) = if a < b { (a, b) } else { (b, a) };
+) -> (ObjectID, DWalletNetworkEncryptionKeyData) {
     (
-        TestKey::registered(low, dkg_at_epoch, "low key"),
-        TestKey::registered(high, dkg_at_epoch, "high key"),
+        key_id,
+        DWalletNetworkEncryptionKeyData {
+            id: key_id,
+            current_epoch,
+            dkg_at_epoch: 0,
+            network_dkg_public_output,
+            current_reconfiguration_public_output: vec![],
+            state: DWalletNetworkEncryptionKeyState::NetworkDKGCompleted,
+        },
     )
 }
 
-/// A certificate naming `keys` — a DKG item and a reconfiguration item per
-/// key, digests over the blobs the overlays carry, so adoption's digest gate
-/// admits each key once its blobs are local.
-fn certificate_naming(prior_epoch: u64, keys: &[&TestKey]) -> CertifiedHandoffAttestation {
-    let mut items: Vec<_> = keys
-        .iter()
-        .flat_map(|key| {
-            [
-                (
-                    HandoffItemKey::NetworkDkgOutput {
-                        key_id: key.network_key_id,
-                    },
-                    mpc_data_blob_hash(&key.dkg),
-                ),
-                (
-                    HandoffItemKey::NetworkReconfigurationOutput {
-                        key_id: key.network_key_id,
-                    },
-                    mpc_data_blob_hash(&key.reconfiguration),
-                ),
-            ]
-        })
-        .collect();
-    items.sort_by(|(a, _), (b, _)| a.cmp(b));
-    CertifiedHandoffAttestation {
-        attestation: HandoffAttestation {
-            epoch: prior_epoch,
-            next_committee_pubkey_set_hash: [0u8; 32],
-            items,
-        },
-        signatures: vec![],
-    }
+/// Two keys whose id ordering is known, registered in the process-global
+/// mapping (adoption defers any key it cannot map).
+fn two_ordered_registered_keys() -> (ObjectID, ObjectID) {
+    let (a, b) = (ObjectID::random(), ObjectID::random());
+    let (low, high) = if a < b { (a, b) } else { (b, a) };
+    network_key_id_mapping::register(low, NetworkKeyId(low.into_bytes()));
+    network_key_id_mapping::register(high, NetworkKeyId(high.into_bytes()));
+    (low, high)
 }
 
-/// Two validators at the same epoch, with `noa_checkpoints` on.
+/// Two validators at the same epoch.
 struct TwoValidators {
-    services: Vec<crate::dwallet_mpc::dwallet_mpc_service::DWalletMPCService>,
-    senders: Vec<crate::SuiDataSenders>,
-    epoch_stores: Vec<Arc<utils::TestingAuthorityPerEpochStore>>,
+    services: Vec<DWalletMPCService>,
     epoch_id: u64,
-    prior_epoch: u64,
 }
 
 impl TwoValidators {
     fn build() -> Self {
-        let (services, senders, _collectors, epoch_stores, _notify, _requests, _outputs) =
+        let (services, _senders, _collectors, _epoch_stores, _notify, _requests, _outputs) =
             utils::create_dwallet_mpc_services(2);
         let epoch_id = services.first().expect("two services").epoch;
-        Self {
-            services,
-            senders,
-            epoch_stores,
-            epoch_id,
-            prior_epoch: epoch_id - 1,
-        }
+        Self { services, epoch_id }
     }
 
-    /// The certificate is network-uniform: every validator is handed the
-    /// same one.
-    fn install_certificate(&self, certificate: &CertifiedHandoffAttestation) {
-        for epoch_store in &self.epoch_stores {
-            epoch_store
-                .certified_handoff_attestations
-                .lock()
-                .unwrap()
-                .insert(self.prior_epoch, certificate.clone());
-        }
+    /// The barrier's answer, as it would have been handed in at
+    /// construction.
+    fn set_key(&mut self, index: usize, key_id: Option<ObjectID>) {
+        self.services[index].set_network_owned_address_signing_key_id_for_testing(key_id);
     }
 
-    /// Publishes `overlay` as validator `index`'s network-key watch value —
-    /// what the selector reads `dkg_at_epoch` from — and runs its adoption
-    /// pass over the same overlay.
-    fn publish_and_adopt(
+    fn adopt(
         &mut self,
         index: usize,
         overlay: &Arc<HashMap<ObjectID, DWalletNetworkEncryptionKeyData>>,
     ) {
-        self.senders[index]
-            .network_keys_sender
-            .send(overlay.clone())
-            .expect("the service holds the overlay receiver");
         self.services[index]
             .dwallet_mpc_manager_mut()
             .adopt_cert_verified_keys(overlay);
@@ -218,330 +103,145 @@ impl TwoValidators {
             .dwallet_mpc_manager()
             .network_owned_address_signing_network_encryption_key_id()
     }
-
-    fn resolution(&self, index: usize) -> NetworkOwnedAddressSigningKeyResolution {
-        self.services[index]
-            .dwallet_mpc_manager()
-            .network_owned_address_signing_key_resolution()
-    }
 }
 
-/// Two validators with the same certificate but different adopted sets — one
-/// holding both certified keys, the other only the higher-id one because the
-/// low key's blobs have not reached its local cache (adoption skips a
-/// blob-empty entry) — name the same key. Under the previous adopted-set rule
-/// this was the shape that diverged (issue #2019, per-key overlay
-/// incompleteness).
+/// Two validators handed the same key with different adopted sets — one
+/// holding both keys, the other only the higher-id one because the low key's
+/// blob has not reached its local cache — name the same key, including the
+/// one that has not adopted it. Under the previous adopted-set rule this was
+/// the shape that diverged (per-key overlay incompleteness).
 #[tokio::test]
-async fn same_certificate_with_different_adopted_sets_selects_the_same_key() {
+async fn same_key_input_with_different_adopted_sets_selects_the_same_key() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
     let mut validators = TwoValidators::build();
     let epoch_id = validators.epoch_id;
-
-    let (low, high) = two_ordered_keys(0);
-    validators.install_certificate(&certificate_naming(validators.prior_epoch, &[&low, &high]));
+    let (low, high) = two_ordered_registered_keys();
 
     let complete = Arc::new(HashMap::from([
-        low.complete_entry(epoch_id),
-        high.complete_entry(epoch_id),
+        overlay_entry(low, epoch_id, b"low key dkg output".to_vec()),
+        overlay_entry(high, epoch_id, b"high key dkg output".to_vec()),
     ]));
-    let low_blobs_missing = Arc::new(HashMap::from([
-        low.blob_empty_entry(epoch_id),
-        high.complete_entry(epoch_id),
+    let low_blob_missing = Arc::new(HashMap::from([
+        overlay_entry(low, epoch_id, vec![]),
+        overlay_entry(high, epoch_id, b"high key dkg output".to_vec()),
     ]));
-    validators.publish_and_adopt(0, &complete);
-    validators.publish_and_adopt(1, &low_blobs_missing);
-
+    validators.adopt(0, &complete);
+    validators.adopt(1, &low_blob_missing);
     // Control: the adopted sets really differ.
     assert_eq!(validators.adopted_keys(0), {
-        let mut both = vec![low.object_id, high.object_id];
+        let mut both = vec![low, high];
         both.sort();
         both
     });
-    assert_eq!(validators.adopted_keys(1), vec![high.object_id]);
+    assert_eq!(validators.adopted_keys(1), vec![high]);
 
-    // Both keys are certified with the same `dkg_at_epoch`, so the tie-break
-    // names the smaller id — on BOTH validators, including the one that has
-    // not adopted it.
+    // The barrier named the LOW key — the one validator two has not adopted.
+    validators.set_key(0, Some(low));
+    validators.set_key(1, Some(low));
+
     let (first, second) = (validators.selected_key(0), validators.selected_key(1));
     tracing::info!(?first, ?second, "selected NOA signing keys");
-    assert_eq!(first, Some(low.object_id));
+    assert_eq!(first, Some(low));
     assert_eq!(
         second,
-        Some(low.object_id),
-        "the selector must name the certified key even though this validator has not \
-         adopted it"
+        Some(low),
+        "the answer is the barrier's input, not a choice over the adopted set"
     );
-    assert_eq!(first, second);
 }
 
 /// A validator that has adopted NOTHING — every overlay entry still
-/// blob-empty, the epoch-start fill window of issue #2019 — names the same
-/// key as a peer that has adopted everything.
+/// blob-empty, the epoch-start fill window — answers its input like a peer
+/// that has adopted everything.
 #[tokio::test]
-async fn a_validator_that_adopted_nothing_selects_the_same_key() {
+async fn a_validator_that_adopted_nothing_answers_the_same_key() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
     let mut validators = TwoValidators::build();
     let epoch_id = validators.epoch_id;
+    let (low, high) = two_ordered_registered_keys();
 
-    let (low, high) = two_ordered_keys(0);
-    validators.install_certificate(&certificate_naming(validators.prior_epoch, &[&low, &high]));
-
-    let complete = Arc::new(HashMap::from([
-        low.complete_entry(epoch_id),
-        high.complete_entry(epoch_id),
-    ]));
-    let metadata_only = Arc::new(HashMap::from([
-        low.blob_empty_entry(epoch_id),
-        high.blob_empty_entry(epoch_id),
-    ]));
-    validators.publish_and_adopt(0, &complete);
-    validators.publish_and_adopt(1, &metadata_only);
-
+    validators.adopt(
+        0,
+        &Arc::new(HashMap::from([
+            overlay_entry(low, epoch_id, b"low key dkg output".to_vec()),
+            overlay_entry(high, epoch_id, b"high key dkg output".to_vec()),
+        ])),
+    );
+    validators.adopt(
+        1,
+        &Arc::new(HashMap::from([
+            overlay_entry(low, epoch_id, vec![]),
+            overlay_entry(high, epoch_id, vec![]),
+        ])),
+    );
     assert_eq!(validators.adopted_keys(1), Vec::<ObjectID>::new());
-    assert_eq!(validators.selected_key(0), Some(low.object_id));
+
+    validators.set_key(0, Some(low));
+    validators.set_key(1, Some(low));
+    assert_eq!(validators.selected_key(0), Some(low));
     assert_eq!(
         validators.selected_key(1),
-        Some(low.object_id),
-        "an empty adopted set must not stop the derivation: the certificate names the keys \
-         and the overlay carries their metadata"
+        Some(low),
+        "an empty adopted set does not stop the answer: the key was fixed before adoption ran"
     );
 }
 
-/// A validator whose overlay has no entry at all for one certified key — its
-/// chain metadata is not known locally yet — answers `None`, never the other
-/// certified key it can see, and resolves once the metadata lands.
+/// An epoch with no signing key — no prior certificate, a certificate naming
+/// no key, or a validator that could not translate a certified key at the
+/// barrier — answers `None` however much it has adopted.
 #[tokio::test]
-async fn missing_metadata_for_a_certified_key_yields_none_not_a_partial_choice() {
+async fn no_key_this_epoch_answers_none_regardless_of_adoption() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
     let mut validators = TwoValidators::build();
     let epoch_id = validators.epoch_id;
+    let (low, high) = two_ordered_registered_keys();
 
-    let (low, high) = two_ordered_keys(0);
-    validators.install_certificate(&certificate_naming(validators.prior_epoch, &[&low, &high]));
-
-    let complete = Arc::new(HashMap::from([
-        low.complete_entry(epoch_id),
-        high.complete_entry(epoch_id),
-    ]));
-    let low_unknown = Arc::new(HashMap::from([high.complete_entry(epoch_id)]));
-    validators.publish_and_adopt(0, &complete);
-    validators.publish_and_adopt(1, &low_unknown);
-
-    assert_eq!(validators.selected_key(0), Some(low.object_id));
+    validators.adopt(
+        0,
+        &Arc::new(HashMap::from([
+            overlay_entry(low, epoch_id, b"low key dkg output".to_vec()),
+            overlay_entry(high, epoch_id, b"high key dkg output".to_vec()),
+        ])),
+    );
+    assert_eq!(validators.adopted_keys(0).len(), 2);
+    validators.set_key(0, None);
     assert_eq!(
-        validators.selected_key(1),
+        validators.selected_key(0),
         None,
-        "a certified key with no local metadata must yield None, not a choice among the rest"
-    );
-    assert_eq!(
-        validators.resolution(1),
-        NetworkOwnedAddressSigningKeyResolution::Pending
-    );
-
-    validators.publish_and_adopt(1, &complete);
-    assert_eq!(
-        validators.selected_key(1),
-        Some(low.object_id),
-        "the derivation resolves forward once the metadata lands"
+        "adopted keys never become the signing key on their own"
     );
 }
 
-/// A certified key with no `NetworkKeyId -> ObjectID` translation yet — the
-/// joiner / restart shape, where the mapping registers only when the key is
-/// instantiated or derived in the background — yields `None` on every
-/// validator, and resolves once the mapping registers.
+/// With `noa_checkpoints` OFF — every live network today — the pool-role
+/// rule is unchanged: the oldest ADOPTED key, ties to the smaller id, and the
+/// barrier's input is ignored. This is what keeps the live protocol
+/// version's internal-presign sequence numbers where they are.
 #[tokio::test]
-async fn an_untranslatable_certified_key_yields_none_until_its_mapping_registers() {
+async fn flag_off_keeps_the_oldest_adopted_key_rule() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
-    let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
+    let _guard = utils::create_test_protocol_config_guard();
     let mut validators = TwoValidators::build();
     let epoch_id = validators.epoch_id;
+    let (low, high) = two_ordered_registered_keys();
 
-    let (low, _high) = two_ordered_keys(0);
-    // A newer key whose `NetworkKeyId` is not derived from its `ObjectID` and
-    // is NOT registered: the certificate names it, nothing translates it.
-    let newer = TestKey {
-        object_id: ObjectID::random(),
-        network_key_id: NetworkKeyId(rand::random()),
-        dkg_at_epoch: 1,
-        dkg: b"newer key dkg output".to_vec(),
-        reconfiguration: b"newer key reconfiguration output".to_vec(),
-    };
-    validators.install_certificate(&certificate_naming(validators.prior_epoch, &[&low, &newer]));
-
-    // Both validators know both keys' metadata; adoption is only handed the
-    // translatable one (an unmapped key would spawn a background derivation
-    // over these placeholder blobs).
-    let overlay = Arc::new(HashMap::from([
-        low.complete_entry(epoch_id),
-        newer.complete_entry(epoch_id),
-    ]));
-    let adoptable = Arc::new(HashMap::from([low.complete_entry(epoch_id)]));
-    for index in 0..2 {
-        validators.senders[index]
-            .network_keys_sender
-            .send(overlay.clone())
-            .expect("the service holds the overlay receiver");
-        validators.services[index]
-            .dwallet_mpc_manager_mut()
-            .adopt_cert_verified_keys(&adoptable);
-    }
-
-    for index in 0..2 {
-        assert_eq!(
-            validators.selected_key(index),
-            None,
-            "validator {index} must not choose among the keys it can translate"
-        );
-        assert_eq!(
-            validators.resolution(index),
-            NetworkOwnedAddressSigningKeyResolution::Pending
-        );
-    }
-
-    network_key_id_mapping::register(newer.object_id, newer.network_key_id);
-    for index in 0..2 {
-        assert_eq!(
-            validators.selected_key(index),
-            Some(newer.object_id),
-            "once translatable, the newest certified key wins on validator {index}"
-        );
-    }
-}
-
-/// A key created by DKG after the certificate — in the epoch under test — is
-/// not eligible this epoch, however new it is and however completely it is
-/// adopted: the certificate is the sole input.
-#[tokio::test]
-async fn a_key_created_after_the_certificate_waits_one_epoch() {
-    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
-    let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
-    let mut validators = TwoValidators::build();
-    let epoch_id = validators.epoch_id;
-
-    let (certified, _unused) = two_ordered_keys(0);
-    validators.install_certificate(&certificate_naming(validators.prior_epoch, &[&certified]));
-    // DKG'd this epoch: registered, adoptable from its local DKG output
-    // (nothing pins it yet), and the newest key on the network.
-    let fresh = TestKey {
-        reconfiguration: vec![],
-        ..TestKey::registered(ObjectID::random(), epoch_id, "fresh key")
-    };
-
-    let overlay = Arc::new(HashMap::from([
-        certified.complete_entry(epoch_id),
-        fresh.complete_entry(epoch_id),
-    ]));
-    validators.publish_and_adopt(0, &overlay);
-    validators.publish_and_adopt(1, &overlay);
-
-    for index in 0..2 {
-        assert!(
-            validators.adopted_keys(index).contains(&fresh.object_id),
-            "control: the fresh key is adopted on validator {index}"
-        );
-        assert_eq!(
-            validators.selected_key(index),
-            Some(certified.object_id),
-            "a key the certificate does not name is not eligible this epoch (validator {index})"
-        );
-    }
-}
-
-/// The rule itself: the largest `dkg_at_epoch` wins, and among equals the
-/// smaller `NetworkKeyId`.
-#[tokio::test]
-async fn the_newest_certified_key_wins_and_ties_break_to_the_smaller_id() {
-    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
-    let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
-    let mut validators = TwoValidators::build();
-    let epoch_id = validators.epoch_id;
-
-    let mut ids = [ObjectID::random(), ObjectID::random(), ObjectID::random()];
-    ids.sort();
-    let [oldest_smallest_id, newer_smaller_id, newer_larger_id] = ids;
-    // The smallest id is the OLDEST key, so it must lose to both newer keys
-    // despite winning every tie-break; the two newer keys tie on epoch.
-    let oldest = TestKey::registered(oldest_smallest_id, 0, "oldest");
-    let newer_small = TestKey::registered(newer_smaller_id, 1, "newer small");
-    let newer_large = TestKey::registered(newer_larger_id, 1, "newer large");
-    validators.install_certificate(&certificate_naming(
-        validators.prior_epoch,
-        &[&oldest, &newer_small, &newer_large],
-    ));
-
-    let overlay = Arc::new(HashMap::from([
-        oldest.complete_entry(epoch_id),
-        newer_small.complete_entry(epoch_id),
-        newer_large.complete_entry(epoch_id),
-    ]));
-    validators.publish_and_adopt(0, &overlay);
-    validators.publish_and_adopt(1, &overlay);
-
-    for index in 0..2 {
-        assert_eq!(
-            validators.selected_key(index),
-            Some(newer_small.object_id),
-            "validator {index}: largest dkg_at_epoch first, then the smaller NetworkKeyId"
-        );
-    }
-}
-
-/// The three resolution states, and that a resolved answer is cached for the
-/// epoch: a later certificate read error or an overlay that has lost the
-/// key's metadata cannot change or unset it.
-#[tokio::test]
-async fn the_resolution_states_and_the_cached_answer() {
-    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
-    let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
-    let mut validators = TwoValidators::build();
-    let epoch_id = validators.epoch_id;
-    let (key, _unused) = two_ordered_keys(0);
-    let overlay = Arc::new(HashMap::from([key.complete_entry(epoch_id)]));
-    validators.publish_and_adopt(0, &overlay);
-
-    // No certificate for the prior epoch: no key this epoch, and NOA signing
-    // waits for the first handoff.
+    validators.set_key(0, Some(high));
     assert_eq!(
-        validators.resolution(0),
-        NetworkOwnedAddressSigningKeyResolution::NoneThisEpoch
+        validators.selected_key(0),
+        None,
+        "nothing adopted, nothing selected — the input plays no part with the flag off"
     );
-    assert_eq!(validators.selected_key(0), None);
-
-    // A certificate read error is no answer at all — pending, not "none".
-    validators.install_certificate(&certificate_naming(validators.prior_epoch, &[&key]));
-    validators.epoch_stores[0]
-        .fail_certified_handoff_attestation_reads
-        .store(true, Ordering::Relaxed);
-    assert_eq!(
-        validators.resolution(0),
-        NetworkOwnedAddressSigningKeyResolution::Pending
+    validators.adopt(
+        0,
+        &Arc::new(HashMap::from([
+            overlay_entry(low, epoch_id, b"low key dkg output".to_vec()),
+            overlay_entry(high, epoch_id, b"high key dkg output".to_vec()),
+        ])),
     );
-    validators.epoch_stores[0]
-        .fail_certified_handoff_attestation_reads
-        .store(false, Ordering::Relaxed);
-
     assert_eq!(
-        validators.resolution(0),
-        NetworkOwnedAddressSigningKeyResolution::Resolved(key.object_id)
-    );
-
-    // Cached: neither a later read error nor an overlay without the key's
-    // metadata moves the answer.
-    validators.epoch_stores[0]
-        .fail_certified_handoff_attestation_reads
-        .store(true, Ordering::Relaxed);
-    validators.senders[0]
-        .network_keys_sender
-        .send(Arc::new(HashMap::new()))
-        .expect("the service holds the overlay receiver");
-    assert_eq!(
-        validators.resolution(0),
-        NetworkOwnedAddressSigningKeyResolution::Resolved(key.object_id),
-        "the answer is fixed for the epoch once derived"
+        validators.selected_key(0),
+        Some(low),
+        "same dkg_at_epoch, so the smaller adopted id wins"
     );
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/noa_signing_key_skew.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/noa_signing_key_skew.rs
@@ -1,24 +1,31 @@
 // Copyright (c) dWallet Labs, Ltd.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-//! Investigation harness for issue #2019: can two honest validators
-//! select a DIFFERENT network-encryption key as the
-//! network-owned-address (NOA) signing key at the same moment?
+//! The network-owned-address (NOA) signing key is a pure function of the
+//! prior epoch's handoff certificate, fixed for the epoch: among the keys the
+//! certificate names, the one with the largest `dkg_at_epoch`, ties broken by
+//! the smaller `NetworkKeyId`
+//! (`DWalletMPCManager::network_owned_address_signing_key_resolution`).
 //!
-//! The selector
-//! (`DWalletMPCManager::network_owned_address_signing_network_encryption_key_id`)
-//! takes the minimum over `adopted_network_key_data`, ordered by
-//! `dkg_at_epoch` then key id. That is a pure function of the ADOPTED
-//! SET, so it is order-independent: two validators can only disagree if
-//! their adopted sets differ at that moment. `adopt_cert_verified_keys`
-//! is a per-tick LOCAL pass over a LOCAL overlay, so the sets diverge
-//! whenever a key is adoptable on one validator and not (yet) on
-//! another.
+//! It is deliberately NOT read from the locally adopted key set, whose
+//! contents differ between honest validators while their adoption lags (issue
+//! #2019 measured three such windows: the epoch-start fill window, per-key
+//! overlay incompleteness, and a handoff-certificate read error). These tests
+//! drive two managers at the same epoch with the SAME certificate and
+//! DIFFERENT adopted sets and assert the selector agrees; and they pin the
+//! all-or-nothing rule — a validator that cannot translate, or has no chain
+//! metadata for, one certified key answers `None` rather than choosing among
+//! the keys it can see.
 //!
-//! These tests drive two managers at the same epoch through the two
-//! per-validator skip paths and compare the selector's answer.
+//! The selector reads the certificate from the epoch store, the translation
+//! from the process-global `network_key_id_mapping`, and `dkg_at_epoch` from
+//! the network-key overlay watch; the adopted set is driven separately through
+//! `adopt_cert_verified_keys`, exactly as the service does, so a test can hand
+//! the two managers the same watch value and different adoption inputs.
 
 use crate::dwallet_mpc::integration_tests::utils;
+use crate::dwallet_mpc::mpc_manager::NetworkOwnedAddressSigningKeyResolution;
+use crate::network_key_id_mapping;
 use dwallet_mpc_types::dwallet_mpc::NetworkKeyId;
 use ika_network::mpc_artifacts::mpc_data_blob_hash;
 use ika_types::handoff::{CertifiedHandoffAttestation, HandoffAttestation, HandoffItemKey};
@@ -30,9 +37,10 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use sui_types::base_types::ObjectID;
 
-/// A network key as the overlay serves it: metadata from chain, blob
-/// bytes from the local producer cache (empty when this validator has
-/// not cached / fetched them yet).
+/// A network key as the overlay serves it: metadata from chain, blob bytes
+/// from the local producer cache (empty when this validator has not cached /
+/// fetched them yet — adoption then skips the key, but the selector still
+/// reads `dkg_at_epoch`).
 fn overlay_entry(
     key_id: ObjectID,
     current_epoch: u64,
@@ -50,27 +58,83 @@ fn overlay_entry(
     }
 }
 
-fn cert_pinning(
-    prior_epoch: u64,
-    keys: &[(NetworkKeyId, &[u8], &[u8])],
-) -> CertifiedHandoffAttestation {
-    // `HandoffItemKey`'s derived `Ord` puts DKG before reconfiguration;
-    // the attestation's items are sorted by key.
+/// A key's inputs to one test: its Sui id, its content-derived id, and the
+/// blobs the overlay carries for it.
+struct TestKey {
+    object_id: ObjectID,
+    network_key_id: NetworkKeyId,
+    dkg_at_epoch: u64,
+    dkg: Vec<u8>,
+    reconfiguration: Vec<u8>,
+}
+
+impl TestKey {
+    /// A key whose `NetworkKeyId` is its `ObjectID`'s bytes — so ordering the
+    /// object ids orders the network key ids identically — registered in the
+    /// process-global mapping (adoption defers any key it cannot map).
+    fn registered(object_id: ObjectID, dkg_at_epoch: u64, tag: &str) -> Self {
+        let network_key_id = NetworkKeyId(object_id.into_bytes());
+        network_key_id_mapping::register(object_id, network_key_id);
+        Self {
+            object_id,
+            network_key_id,
+            dkg_at_epoch,
+            dkg: format!("{tag} dkg output").into_bytes(),
+            reconfiguration: format!("{tag} reconfiguration output").into_bytes(),
+        }
+    }
+
+    fn complete_entry(&self, epoch_id: u64) -> (ObjectID, DWalletNetworkEncryptionKeyData) {
+        (
+            self.object_id,
+            overlay_entry(
+                self.object_id,
+                epoch_id,
+                self.dkg_at_epoch,
+                self.dkg.clone(),
+                self.reconfiguration.clone(),
+            ),
+        )
+    }
+
+    /// Metadata present, blobs not yet cached locally.
+    fn blob_empty_entry(&self, epoch_id: u64) -> (ObjectID, DWalletNetworkEncryptionKeyData) {
+        (
+            self.object_id,
+            overlay_entry(self.object_id, epoch_id, self.dkg_at_epoch, vec![], vec![]),
+        )
+    }
+}
+
+/// Two keys whose id ordering is known.
+fn two_ordered_keys(dkg_at_epoch: u64) -> (TestKey, TestKey) {
+    let (a, b) = (ObjectID::random(), ObjectID::random());
+    let (low, high) = if a < b { (a, b) } else { (b, a) };
+    (
+        TestKey::registered(low, dkg_at_epoch, "low key"),
+        TestKey::registered(high, dkg_at_epoch, "high key"),
+    )
+}
+
+/// A certificate naming `keys` — a DKG item and a reconfiguration item per
+/// key, digests over the blobs the overlays carry, so adoption's digest gate
+/// admits each key once its blobs are local.
+fn certificate_naming(prior_epoch: u64, keys: &[&TestKey]) -> CertifiedHandoffAttestation {
     let mut items: Vec<_> = keys
         .iter()
-        .flat_map(|(network_key_id, dkg, reconfiguration)| {
+        .flat_map(|key| {
             [
                 (
                     HandoffItemKey::NetworkDkgOutput {
-                        key_id: *network_key_id,
+                        key_id: key.network_key_id,
                     },
-                    mpc_data_blob_hash(dkg),
+                    mpc_data_blob_hash(&key.dkg),
                 ),
                 (
                     HandoffItemKey::NetworkReconfigurationOutput {
-                        key_id: *network_key_id,
+                        key_id: key.network_key_id,
                     },
-                    mpc_data_blob_hash(reconfiguration),
+                    mpc_data_blob_hash(&key.reconfiguration),
                 ),
             ]
         })
@@ -86,418 +150,398 @@ fn cert_pinning(
     }
 }
 
-/// Two ObjectIDs whose ordering is known, with their `NetworkKeyId`
-/// mappings registered (adoption defers any key it cannot map).
-fn two_ordered_keys() -> (ObjectID, ObjectID) {
-    let (low, high) = {
-        let (a, b) = (ObjectID::random(), ObjectID::random());
-        if a < b { (a, b) } else { (b, a) }
-    };
-    // The mapping is a process global; random ObjectIDs keep tests
-    // independent. The NetworkKeyId only has to be unique per key.
-    crate::network_key_id_mapping::register(low, NetworkKeyId(low.into_bytes()));
-    crate::network_key_id_mapping::register(high, NetworkKeyId(high.into_bytes()));
-    (low, high)
+/// Two validators at the same epoch, with `noa_checkpoints` on.
+struct TwoValidators {
+    services: Vec<crate::dwallet_mpc::dwallet_mpc_service::DWalletMPCService>,
+    senders: Vec<crate::SuiDataSenders>,
+    epoch_stores: Vec<Arc<utils::TestingAuthorityPerEpochStore>>,
+    epoch_id: u64,
+    prior_epoch: u64,
 }
 
-/// SKEW MECHANISM 1 — per-key overlay incompleteness.
-///
-/// The syncer merges each key's blob bytes from the LOCAL producer
-/// cache and publishes the overlay even when a key's bytes are still
-/// missing (`overlay_incomplete` in `sui_syncer::sync_network_keys`),
-/// and a per-key chain-read `Err` skips only that key. So one validator
-/// can hold a complete overlay entry for a key while another holds an
-/// empty one. Adoption skips the empty entry
-/// (`network_dkg_public_output.is_empty()` => `continue`), and the
-/// selector's minimum then differs.
-#[tokio::test]
-async fn overlay_incompleteness_on_one_validator_diverges_the_noa_signing_key() {
-    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
-    let (mut services, _senders, _collectors, epoch_stores, _notify, _req, _out) =
-        utils::create_dwallet_mpc_services(2);
-    let epoch_id = services.first().unwrap().epoch;
-    let prior_epoch = epoch_id - 1;
-
-    let (low_key, high_key) = two_ordered_keys();
-    let low_dkg = b"low key dkg output".to_vec();
-    let low_reconfiguration = b"low key reconfiguration output".to_vec();
-    let high_dkg = b"high key dkg output".to_vec();
-    let high_reconfiguration = b"high key reconfiguration output".to_vec();
-
-    // Both keys are DKG'd in the same (prior) epoch, so the selector's
-    // tie-break is the key id: `low_key` is the NOA key once adopted.
-    let cert = cert_pinning(
-        prior_epoch,
-        &[
-            (
-                NetworkKeyId(low_key.into_bytes()),
-                &low_dkg,
-                &low_reconfiguration,
-            ),
-            (
-                NetworkKeyId(high_key.into_bytes()),
-                &high_dkg,
-                &high_reconfiguration,
-            ),
-        ],
-    );
-    // The cert is network-uniform: BOTH validators are handed the same one.
-    for epoch_store in &epoch_stores {
-        epoch_store
-            .certified_handoff_attestations
-            .lock()
-            .unwrap()
-            .insert(prior_epoch, cert.clone());
-    }
-
-    let complete_overlay = Arc::new(HashMap::from([
-        (
-            low_key,
-            overlay_entry(
-                low_key,
-                epoch_id,
-                0,
-                low_dkg.clone(),
-                low_reconfiguration.clone(),
-            ),
-        ),
-        (
-            high_key,
-            overlay_entry(
-                high_key,
-                epoch_id,
-                0,
-                high_dkg.clone(),
-                high_reconfiguration.clone(),
-            ),
-        ),
-    ]));
-    // Validator two's local producer cache has not yet filled the LOW
-    // key's blobs — the exact shape the syncer publishes as "incomplete".
-    let partial_overlay = Arc::new(HashMap::from([
-        (low_key, overlay_entry(low_key, epoch_id, 0, vec![], vec![])),
-        (
-            high_key,
-            overlay_entry(
-                high_key,
-                epoch_id,
-                0,
-                high_dkg.clone(),
-                high_reconfiguration.clone(),
-            ),
-        ),
-    ]));
-
-    let (first, second) = services.split_at_mut(1);
-    let first = first[0].dwallet_mpc_manager_mut();
-    let second = second[0].dwallet_mpc_manager_mut();
-    first.adopt_cert_verified_keys(&complete_overlay);
-    second.adopt_cert_verified_keys(&partial_overlay);
-
-    let first_selected = first.network_owned_address_signing_network_encryption_key_id();
-    let second_selected = second.network_owned_address_signing_network_encryption_key_id();
-    tracing::info!(
-        ?first_selected,
-        ?second_selected,
-        "selected NOA signing keys"
-    );
-    assert_eq!(
-        first_selected,
-        Some(low_key),
-        "the validator holding both keys must select the lower-id one"
-    );
-    assert_eq!(
-        second_selected,
-        Some(high_key),
-        "the validator whose low-key overlay entry is still empty selects the high key"
-    );
-    assert_ne!(
-        first_selected, second_selected,
-        "SKEW: two honest validators select different NOA signing keys at the same moment"
-    );
-
-    // The window closes when the lagging validator's overlay fills.
-    second.adopt_cert_verified_keys(&complete_overlay);
-    assert_eq!(
-        second.network_owned_address_signing_network_encryption_key_id(),
-        Some(low_key),
-        "the adopted set is monotone, so the laggard converges once its overlay completes"
-    );
-}
-
-/// SKEW MECHANISM 2 — the handoff-cert READ ERROR skip.
-///
-/// A store hiccup makes `adopt_cert_verified_keys` return before
-/// adopting ANYTHING this tick (deliberately: an error is not the same
-/// answer as an absent cert). Everything already adopted stays adopted,
-/// so a validator that adopted the high key in an earlier tick and then
-/// hits the error keeps selecting it while its peers move to the low key.
-///
-/// This is also the harness-capability check for the negative result: it
-/// shows the harness can drive two validators to genuinely different
-/// adopted sets on demand.
-#[tokio::test]
-async fn handoff_cert_read_error_freezes_one_validator_on_a_different_noa_key() {
-    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
-    let (mut services, _senders, _collectors, epoch_stores, _notify, _req, _out) =
-        utils::create_dwallet_mpc_services(2);
-    let epoch_id = services.first().unwrap().epoch;
-    let prior_epoch = epoch_id - 1;
-
-    let (low_key, high_key) = two_ordered_keys();
-    let low_dkg = b"low key dkg output".to_vec();
-    let low_reconfiguration = b"low key reconfiguration output".to_vec();
-    let high_dkg = b"high key dkg output".to_vec();
-    let high_reconfiguration = b"high key reconfiguration output".to_vec();
-
-    let cert = cert_pinning(
-        prior_epoch,
-        &[
-            (
-                NetworkKeyId(low_key.into_bytes()),
-                &low_dkg,
-                &low_reconfiguration,
-            ),
-            (
-                NetworkKeyId(high_key.into_bytes()),
-                &high_dkg,
-                &high_reconfiguration,
-            ),
-        ],
-    );
-    for epoch_store in &epoch_stores {
-        epoch_store
-            .certified_handoff_attestations
-            .lock()
-            .unwrap()
-            .insert(prior_epoch, cert.clone());
-    }
-
-    let high_only_overlay = Arc::new(HashMap::from([(
-        high_key,
-        overlay_entry(
-            high_key,
+impl TwoValidators {
+    fn build() -> Self {
+        let (services, senders, _collectors, epoch_stores, _notify, _requests, _outputs) =
+            utils::create_dwallet_mpc_services(2);
+        let epoch_id = services.first().expect("two services").epoch;
+        Self {
+            services,
+            senders,
+            epoch_stores,
             epoch_id,
-            0,
-            high_dkg.clone(),
-            high_reconfiguration.clone(),
-        ),
-    )]));
-    let both_keys_overlay = Arc::new(HashMap::from([
-        (
-            high_key,
-            overlay_entry(
-                high_key,
-                epoch_id,
-                0,
-                high_dkg.clone(),
-                high_reconfiguration.clone(),
-            ),
-        ),
-        (
-            low_key,
-            overlay_entry(
-                low_key,
-                epoch_id,
-                0,
-                low_dkg.clone(),
-                low_reconfiguration.clone(),
-            ),
-        ),
+            prior_epoch: epoch_id - 1,
+        }
+    }
+
+    /// The certificate is network-uniform: every validator is handed the
+    /// same one.
+    fn install_certificate(&self, certificate: &CertifiedHandoffAttestation) {
+        for epoch_store in &self.epoch_stores {
+            epoch_store
+                .certified_handoff_attestations
+                .lock()
+                .unwrap()
+                .insert(self.prior_epoch, certificate.clone());
+        }
+    }
+
+    /// Publishes `overlay` as validator `index`'s network-key watch value —
+    /// what the selector reads `dkg_at_epoch` from — and runs its adoption
+    /// pass over the same overlay.
+    fn publish_and_adopt(
+        &mut self,
+        index: usize,
+        overlay: &Arc<HashMap<ObjectID, DWalletNetworkEncryptionKeyData>>,
+    ) {
+        self.senders[index]
+            .network_keys_sender
+            .send(overlay.clone())
+            .expect("the service holds the overlay receiver");
+        self.services[index]
+            .dwallet_mpc_manager_mut()
+            .adopt_cert_verified_keys(overlay);
+    }
+
+    fn adopted_keys(&self, index: usize) -> Vec<ObjectID> {
+        let mut keys: Vec<_> = self.services[index]
+            .dwallet_mpc_manager()
+            .adopted_network_key_data
+            .keys()
+            .copied()
+            .collect();
+        keys.sort();
+        keys
+    }
+
+    fn selected_key(&self, index: usize) -> Option<ObjectID> {
+        self.services[index]
+            .dwallet_mpc_manager()
+            .network_owned_address_signing_network_encryption_key_id()
+    }
+
+    fn resolution(&self, index: usize) -> NetworkOwnedAddressSigningKeyResolution {
+        self.services[index]
+            .dwallet_mpc_manager()
+            .network_owned_address_signing_key_resolution()
+    }
+}
+
+/// Two validators with the same certificate but different adopted sets — one
+/// holding both certified keys, the other only the higher-id one because the
+/// low key's blobs have not reached its local cache (adoption skips a
+/// blob-empty entry) — name the same key. Under the previous adopted-set rule
+/// this was the shape that diverged (issue #2019, per-key overlay
+/// incompleteness).
+#[tokio::test]
+async fn same_certificate_with_different_adopted_sets_selects_the_same_key() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
+    let mut validators = TwoValidators::build();
+    let epoch_id = validators.epoch_id;
+
+    let (low, high) = two_ordered_keys(0);
+    validators.install_certificate(&certificate_naming(validators.prior_epoch, &[&low, &high]));
+
+    let complete = Arc::new(HashMap::from([
+        low.complete_entry(epoch_id),
+        high.complete_entry(epoch_id),
     ]));
+    let low_blobs_missing = Arc::new(HashMap::from([
+        low.blob_empty_entry(epoch_id),
+        high.complete_entry(epoch_id),
+    ]));
+    validators.publish_and_adopt(0, &complete);
+    validators.publish_and_adopt(1, &low_blobs_missing);
 
-    let (first, second) = services.split_at_mut(1);
-    let first = first[0].dwallet_mpc_manager_mut();
-    let second = second[0].dwallet_mpc_manager_mut();
+    // Control: the adopted sets really differ.
+    assert_eq!(validators.adopted_keys(0), {
+        let mut both = vec![low.object_id, high.object_id];
+        both.sort();
+        both
+    });
+    assert_eq!(validators.adopted_keys(1), vec![high.object_id]);
 
-    // Tick 1: only the high key is on chain / resolvable anywhere. Both
-    // validators agree.
-    first.adopt_cert_verified_keys(&high_only_overlay);
-    second.adopt_cert_verified_keys(&high_only_overlay);
+    // Both keys are certified with the same `dkg_at_epoch`, so the tie-break
+    // names the smaller id — on BOTH validators, including the one that has
+    // not adopted it.
+    let (first, second) = (validators.selected_key(0), validators.selected_key(1));
+    tracing::info!(?first, ?second, "selected NOA signing keys");
+    assert_eq!(first, Some(low.object_id));
     assert_eq!(
-        first.network_owned_address_signing_network_encryption_key_id(),
-        second.network_owned_address_signing_network_encryption_key_id(),
-        "both validators start from the same adopted set"
+        second,
+        Some(low.object_id),
+        "the selector must name the certified key even though this validator has not \
+         adopted it"
+    );
+    assert_eq!(first, second);
+}
+
+/// A validator that has adopted NOTHING — every overlay entry still
+/// blob-empty, the epoch-start fill window of issue #2019 — names the same
+/// key as a peer that has adopted everything.
+#[tokio::test]
+async fn a_validator_that_adopted_nothing_selects_the_same_key() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
+    let mut validators = TwoValidators::build();
+    let epoch_id = validators.epoch_id;
+
+    let (low, high) = two_ordered_keys(0);
+    validators.install_certificate(&certificate_naming(validators.prior_epoch, &[&low, &high]));
+
+    let complete = Arc::new(HashMap::from([
+        low.complete_entry(epoch_id),
+        high.complete_entry(epoch_id),
+    ]));
+    let metadata_only = Arc::new(HashMap::from([
+        low.blob_empty_entry(epoch_id),
+        high.blob_empty_entry(epoch_id),
+    ]));
+    validators.publish_and_adopt(0, &complete);
+    validators.publish_and_adopt(1, &metadata_only);
+
+    assert_eq!(validators.adopted_keys(1), Vec::<ObjectID>::new());
+    assert_eq!(validators.selected_key(0), Some(low.object_id));
+    assert_eq!(
+        validators.selected_key(1),
+        Some(low.object_id),
+        "an empty adopted set must not stop the derivation: the certificate names the keys \
+         and the overlay carries their metadata"
+    );
+}
+
+/// A validator whose overlay has no entry at all for one certified key — its
+/// chain metadata is not known locally yet — answers `None`, never the other
+/// certified key it can see, and resolves once the metadata lands.
+#[tokio::test]
+async fn missing_metadata_for_a_certified_key_yields_none_not_a_partial_choice() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
+    let mut validators = TwoValidators::build();
+    let epoch_id = validators.epoch_id;
+
+    let (low, high) = two_ordered_keys(0);
+    validators.install_certificate(&certificate_naming(validators.prior_epoch, &[&low, &high]));
+
+    let complete = Arc::new(HashMap::from([
+        low.complete_entry(epoch_id),
+        high.complete_entry(epoch_id),
+    ]));
+    let low_unknown = Arc::new(HashMap::from([high.complete_entry(epoch_id)]));
+    validators.publish_and_adopt(0, &complete);
+    validators.publish_and_adopt(1, &low_unknown);
+
+    assert_eq!(validators.selected_key(0), Some(low.object_id));
+    assert_eq!(
+        validators.selected_key(1),
+        None,
+        "a certified key with no local metadata must yield None, not a choice among the rest"
+    );
+    assert_eq!(
+        validators.resolution(1),
+        NetworkOwnedAddressSigningKeyResolution::Pending
     );
 
-    // Tick 2: the low key becomes resolvable for both, but validator
-    // two's handoff-cert read fails, so its whole adoption pass is
-    // skipped while validator one adopts.
-    epoch_stores[1]
+    validators.publish_and_adopt(1, &complete);
+    assert_eq!(
+        validators.selected_key(1),
+        Some(low.object_id),
+        "the derivation resolves forward once the metadata lands"
+    );
+}
+
+/// A certified key with no `NetworkKeyId -> ObjectID` translation yet — the
+/// joiner / restart shape, where the mapping registers only when the key is
+/// instantiated or derived in the background — yields `None` on every
+/// validator, and resolves once the mapping registers.
+#[tokio::test]
+async fn an_untranslatable_certified_key_yields_none_until_its_mapping_registers() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
+    let mut validators = TwoValidators::build();
+    let epoch_id = validators.epoch_id;
+
+    let (low, _high) = two_ordered_keys(0);
+    // A newer key whose `NetworkKeyId` is not derived from its `ObjectID` and
+    // is NOT registered: the certificate names it, nothing translates it.
+    let newer = TestKey {
+        object_id: ObjectID::random(),
+        network_key_id: NetworkKeyId(rand::random()),
+        dkg_at_epoch: 1,
+        dkg: b"newer key dkg output".to_vec(),
+        reconfiguration: b"newer key reconfiguration output".to_vec(),
+    };
+    validators.install_certificate(&certificate_naming(validators.prior_epoch, &[&low, &newer]));
+
+    // Both validators know both keys' metadata; adoption is only handed the
+    // translatable one (an unmapped key would spawn a background derivation
+    // over these placeholder blobs).
+    let overlay = Arc::new(HashMap::from([
+        low.complete_entry(epoch_id),
+        newer.complete_entry(epoch_id),
+    ]));
+    let adoptable = Arc::new(HashMap::from([low.complete_entry(epoch_id)]));
+    for index in 0..2 {
+        validators.senders[index]
+            .network_keys_sender
+            .send(overlay.clone())
+            .expect("the service holds the overlay receiver");
+        validators.services[index]
+            .dwallet_mpc_manager_mut()
+            .adopt_cert_verified_keys(&adoptable);
+    }
+
+    for index in 0..2 {
+        assert_eq!(
+            validators.selected_key(index),
+            None,
+            "validator {index} must not choose among the keys it can translate"
+        );
+        assert_eq!(
+            validators.resolution(index),
+            NetworkOwnedAddressSigningKeyResolution::Pending
+        );
+    }
+
+    network_key_id_mapping::register(newer.object_id, newer.network_key_id);
+    for index in 0..2 {
+        assert_eq!(
+            validators.selected_key(index),
+            Some(newer.object_id),
+            "once translatable, the newest certified key wins on validator {index}"
+        );
+    }
+}
+
+/// A key created by DKG after the certificate — in the epoch under test — is
+/// not eligible this epoch, however new it is and however completely it is
+/// adopted: the certificate is the sole input.
+#[tokio::test]
+async fn a_key_created_after_the_certificate_waits_one_epoch() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
+    let mut validators = TwoValidators::build();
+    let epoch_id = validators.epoch_id;
+
+    let (certified, _unused) = two_ordered_keys(0);
+    validators.install_certificate(&certificate_naming(validators.prior_epoch, &[&certified]));
+    // DKG'd this epoch: registered, adoptable from its local DKG output
+    // (nothing pins it yet), and the newest key on the network.
+    let fresh = TestKey {
+        reconfiguration: vec![],
+        ..TestKey::registered(ObjectID::random(), epoch_id, "fresh key")
+    };
+
+    let overlay = Arc::new(HashMap::from([
+        certified.complete_entry(epoch_id),
+        fresh.complete_entry(epoch_id),
+    ]));
+    validators.publish_and_adopt(0, &overlay);
+    validators.publish_and_adopt(1, &overlay);
+
+    for index in 0..2 {
+        assert!(
+            validators.adopted_keys(index).contains(&fresh.object_id),
+            "control: the fresh key is adopted on validator {index}"
+        );
+        assert_eq!(
+            validators.selected_key(index),
+            Some(certified.object_id),
+            "a key the certificate does not name is not eligible this epoch (validator {index})"
+        );
+    }
+}
+
+/// The rule itself: the largest `dkg_at_epoch` wins, and among equals the
+/// smaller `NetworkKeyId`.
+#[tokio::test]
+async fn the_newest_certified_key_wins_and_ties_break_to_the_smaller_id() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
+    let mut validators = TwoValidators::build();
+    let epoch_id = validators.epoch_id;
+
+    let mut ids = [ObjectID::random(), ObjectID::random(), ObjectID::random()];
+    ids.sort();
+    let [oldest_smallest_id, newer_smaller_id, newer_larger_id] = ids;
+    // The smallest id is the OLDEST key, so it must lose to both newer keys
+    // despite winning every tie-break; the two newer keys tie on epoch.
+    let oldest = TestKey::registered(oldest_smallest_id, 0, "oldest");
+    let newer_small = TestKey::registered(newer_smaller_id, 1, "newer small");
+    let newer_large = TestKey::registered(newer_larger_id, 1, "newer large");
+    validators.install_certificate(&certificate_naming(
+        validators.prior_epoch,
+        &[&oldest, &newer_small, &newer_large],
+    ));
+
+    let overlay = Arc::new(HashMap::from([
+        oldest.complete_entry(epoch_id),
+        newer_small.complete_entry(epoch_id),
+        newer_large.complete_entry(epoch_id),
+    ]));
+    validators.publish_and_adopt(0, &overlay);
+    validators.publish_and_adopt(1, &overlay);
+
+    for index in 0..2 {
+        assert_eq!(
+            validators.selected_key(index),
+            Some(newer_small.object_id),
+            "validator {index}: largest dkg_at_epoch first, then the smaller NetworkKeyId"
+        );
+    }
+}
+
+/// The three resolution states, and that a resolved answer is cached for the
+/// epoch: a later certificate read error or an overlay that has lost the
+/// key's metadata cannot change or unset it.
+#[tokio::test]
+async fn the_resolution_states_and_the_cached_answer() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
+    let mut validators = TwoValidators::build();
+    let epoch_id = validators.epoch_id;
+    let (key, _unused) = two_ordered_keys(0);
+    let overlay = Arc::new(HashMap::from([key.complete_entry(epoch_id)]));
+    validators.publish_and_adopt(0, &overlay);
+
+    // No certificate for the prior epoch: no key this epoch, and NOA signing
+    // waits for the first handoff.
+    assert_eq!(
+        validators.resolution(0),
+        NetworkOwnedAddressSigningKeyResolution::NoneThisEpoch
+    );
+    assert_eq!(validators.selected_key(0), None);
+
+    // A certificate read error is no answer at all — pending, not "none".
+    validators.install_certificate(&certificate_naming(validators.prior_epoch, &[&key]));
+    validators.epoch_stores[0]
         .fail_certified_handoff_attestation_reads
         .store(true, Ordering::Relaxed);
-    first.adopt_cert_verified_keys(&both_keys_overlay);
-    second.adopt_cert_verified_keys(&both_keys_overlay);
-
-    let first_selected = first.network_owned_address_signing_network_encryption_key_id();
-    let second_selected = second.network_owned_address_signing_network_encryption_key_id();
-    tracing::info!(
-        ?first_selected,
-        ?second_selected,
-        "selected NOA signing keys"
-    );
-    assert_eq!(first_selected, Some(low_key));
     assert_eq!(
-        second_selected,
-        Some(high_key),
-        "the cert-read error skipped adoption entirely, freezing the earlier answer"
+        validators.resolution(0),
+        NetworkOwnedAddressSigningKeyResolution::Pending
     );
-    assert_ne!(
-        first_selected, second_selected,
-        "SKEW: a transient store error diverges the NOA signing key across honest validators"
-    );
-
-    // The skip is per-tick: adoption resumes on the next pass.
-    epoch_stores[1]
+    validators.epoch_stores[0]
         .fail_certified_handoff_attestation_reads
         .store(false, Ordering::Relaxed);
-    second.adopt_cert_verified_keys(&both_keys_overlay);
-    assert_eq!(
-        second.network_owned_address_signing_network_encryption_key_id(),
-        Some(low_key),
-        "the pass retries every service iteration, so this window is one tick"
-    );
-}
-
-/// SKEW MECHANISM 3 — the epoch-start fill window, with a SINGLE key.
-///
-/// `adopted_network_key_data` is created empty for every epoch's
-/// manager, so at every epoch start the selector answers `None` until
-/// the first key is adopted. A validator whose overlay resolves a tick
-/// later than its peers' therefore answers `None` while they answer
-/// `Some(key)`. This needs no second key and no error injection, and it
-/// is what makes "reject an announcement that doesn't match my
-/// selection" unsafe even on a one-key network.
-#[tokio::test]
-async fn epoch_start_fill_window_leaves_one_validator_with_no_noa_key() {
-    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
-    let (mut services, _senders, _collectors, epoch_stores, _notify, _req, _out) =
-        utils::create_dwallet_mpc_services(2);
-    let epoch_id = services.first().unwrap().epoch;
-    let prior_epoch = epoch_id - 1;
-
-    let key_id = ObjectID::random();
-    crate::network_key_id_mapping::register(key_id, NetworkKeyId(key_id.into_bytes()));
-    let dkg = b"the only network key's dkg output".to_vec();
-    let reconfiguration = b"the only network key's reconfiguration output".to_vec();
-    let cert = cert_pinning(
-        prior_epoch,
-        &[(NetworkKeyId(key_id.into_bytes()), &dkg, &reconfiguration)],
-    );
-    for epoch_store in &epoch_stores {
-        epoch_store
-            .certified_handoff_attestations
-            .lock()
-            .unwrap()
-            .insert(prior_epoch, cert.clone());
-    }
-
-    let resolved = Arc::new(HashMap::from([(
-        key_id,
-        overlay_entry(key_id, epoch_id, 0, dkg.clone(), reconfiguration.clone()),
-    )]));
-    // Validator two's overlay entry is still blob-empty this tick.
-    let unresolved = Arc::new(HashMap::from([(
-        key_id,
-        overlay_entry(key_id, epoch_id, 0, vec![], vec![]),
-    )]));
-
-    let (first, second) = services.split_at_mut(1);
-    let first = first[0].dwallet_mpc_manager_mut();
-    let second = second[0].dwallet_mpc_manager_mut();
-    first.adopt_cert_verified_keys(&resolved);
-    second.adopt_cert_verified_keys(&unresolved);
 
     assert_eq!(
-        first.network_owned_address_signing_network_encryption_key_id(),
-        Some(key_id),
+        validators.resolution(0),
+        NetworkOwnedAddressSigningKeyResolution::Resolved(key.object_id)
     );
+
+    // Cached: neither a later read error nor an overlay without the key's
+    // metadata moves the answer.
+    validators.epoch_stores[0]
+        .fail_certified_handoff_attestation_reads
+        .store(true, Ordering::Relaxed);
+    validators.senders[0]
+        .network_keys_sender
+        .send(Arc::new(HashMap::new()))
+        .expect("the service holds the overlay receiver");
     assert_eq!(
-        second.network_owned_address_signing_network_encryption_key_id(),
-        None,
-        "SKEW: validator one would announce a demand carrying a key validator two \
-         has no selection for at all"
-    );
-
-    second.adopt_cert_verified_keys(&resolved);
-    assert_eq!(
-        second.network_owned_address_signing_network_encryption_key_id(),
-        Some(key_id),
-    );
-}
-
-/// CONTROL — the selector is a pure function of the adopted SET, not of
-/// adoption ORDER. Two validators that adopt the same two keys in
-/// opposite orders agree at every point where their sets are equal.
-/// This bounds the claim: order alone never produces skew, so any real
-/// divergence must be a set difference (mechanisms 1-3 above).
-#[tokio::test]
-async fn adoption_order_alone_does_not_diverge_the_noa_signing_key() {
-    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
-    let (mut services, _senders, _collectors, epoch_stores, _notify, _req, _out) =
-        utils::create_dwallet_mpc_services(2);
-    let epoch_id = services.first().unwrap().epoch;
-    let prior_epoch = epoch_id - 1;
-
-    let (low_key, high_key) = two_ordered_keys();
-    let low_dkg = b"low key dkg output".to_vec();
-    let low_reconfiguration = b"low key reconfiguration output".to_vec();
-    let high_dkg = b"high key dkg output".to_vec();
-    let high_reconfiguration = b"high key reconfiguration output".to_vec();
-    let cert = cert_pinning(
-        prior_epoch,
-        &[
-            (
-                NetworkKeyId(low_key.into_bytes()),
-                &low_dkg,
-                &low_reconfiguration,
-            ),
-            (
-                NetworkKeyId(high_key.into_bytes()),
-                &high_dkg,
-                &high_reconfiguration,
-            ),
-        ],
-    );
-    for epoch_store in &epoch_stores {
-        epoch_store
-            .certified_handoff_attestations
-            .lock()
-            .unwrap()
-            .insert(prior_epoch, cert.clone());
-    }
-
-    let low_entry = overlay_entry(
-        low_key,
-        epoch_id,
-        0,
-        low_dkg.clone(),
-        low_reconfiguration.clone(),
-    );
-    let high_entry = overlay_entry(
-        high_key,
-        epoch_id,
-        0,
-        high_dkg.clone(),
-        high_reconfiguration.clone(),
-    );
-    let both = Arc::new(HashMap::from([
-        (low_key, low_entry.clone()),
-        (high_key, high_entry.clone()),
-    ]));
-
-    let (first, second) = services.split_at_mut(1);
-    let first = first[0].dwallet_mpc_manager_mut();
-    let second = second[0].dwallet_mpc_manager_mut();
-    // Same two adoptions, opposite orders.
-    first.adopt_cert_verified_keys(&Arc::new(HashMap::from([(low_key, low_entry.clone())])));
-    first.adopt_cert_verified_keys(&both);
-    second.adopt_cert_verified_keys(&Arc::new(HashMap::from([(high_key, high_entry.clone())])));
-    second.adopt_cert_verified_keys(&both);
-
-    assert_eq!(
-        first.network_owned_address_signing_network_encryption_key_id(),
-        second.network_owned_address_signing_network_encryption_key_id(),
-        "equal adopted sets must yield the same NOA key regardless of adoption order"
+        validators.resolution(0),
+        NetworkOwnedAddressSigningKeyResolution::Resolved(key.object_id),
+        "the answer is fixed for the epoch once derived"
     );
 }

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -20,7 +20,7 @@ use ika_protocol_config::ProtocolConfig;
 use ika_types::committee::Committee;
 use ika_types::crypto::AuthorityName;
 use ika_types::error::{IkaError, IkaResult};
-use ika_types::handoff::CertifiedHandoffAttestation;
+use ika_types::handoff::{CertifiedHandoffAttestation, HandoffAttestation, HandoffItemKey};
 use ika_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
 use ika_types::messages_dwallet_checkpoint::DWalletCheckpointSignatureMessage;
 use ika_types::messages_dwallet_mpc::{
@@ -1570,7 +1570,71 @@ pub(crate) async fn advance_some_parties_and_wait_for_completions(
 use crate::dwallet_mpc::mpc_session::SessionStatus;
 use crate::dwallet_session_request::DWalletSessionRequest;
 use crate::request_protocol_data::{DWalletDKGData, NetworkEncryptionKeyDkgData, ProtocolData};
+use ika_network::mpc_artifacts::mpc_data_blob_hash;
 use ika_protocol_config::OverrideGuard;
+
+/// A prior-epoch handoff certificate naming `key_id` — the input the
+/// network-owned-address (NOA) signing key derives from when `noa_checkpoints`
+/// is on — together with the epoch it certifies.
+///
+/// The harness DKGs its key in the epoch under test, so no real certificate
+/// can name it; in production such a key becomes eligible one epoch later.
+/// This stands in for that handoff: the certificate pins the key's real DKG
+/// output digest (adoption's consistency check for a certified DKG-only key),
+/// and its `NetworkKeyId` comes from the mapping the key's instantiation
+/// registered. Install it with [`certify_network_key_for_noa_signing`], or on
+/// a chosen validator's store to stage the derivation per validator.
+#[cfg(test)]
+pub(crate) fn noa_signing_certificate(
+    test_state: &IntegrationTestState,
+    key_id: ObjectID,
+    network_dkg_public_output: &[u8],
+) -> (EpochId, CertifiedHandoffAttestation) {
+    let epoch_id = test_state
+        .dwallet_mpc_services
+        .first()
+        .expect("at least one service")
+        .epoch;
+    let prior_epoch = epoch_id
+        .checked_sub(1)
+        .expect("the harness runs at epoch 1 or later");
+    let network_key_id = crate::network_key_id_mapping::network_key_id_for(&key_id)
+        .expect("the key's instantiation registered its NetworkKeyId");
+    let certificate = CertifiedHandoffAttestation {
+        attestation: HandoffAttestation {
+            epoch: prior_epoch,
+            next_committee_pubkey_set_hash: [0u8; 32],
+            items: vec![(
+                HandoffItemKey::NetworkDkgOutput {
+                    key_id: network_key_id,
+                },
+                mpc_data_blob_hash(network_dkg_public_output),
+            )],
+        },
+        signatures: vec![],
+    };
+    (prior_epoch, certificate)
+}
+
+/// Hands every validator the certificate of [`noa_signing_certificate`], so
+/// each derives `key_id` as the epoch's NOA signing key on its next service
+/// iteration. Overwrites any certificate the stores hold for the prior epoch.
+#[cfg(test)]
+pub(crate) fn certify_network_key_for_noa_signing(
+    test_state: &IntegrationTestState,
+    key_id: ObjectID,
+    network_dkg_public_output: &[u8],
+) {
+    let (prior_epoch, certificate) =
+        noa_signing_certificate(test_state, key_id, network_dkg_public_output);
+    for epoch_store in &test_state.epoch_stores {
+        epoch_store
+            .certified_handoff_attestations
+            .lock()
+            .unwrap()
+            .insert(prior_epoch, certificate.clone());
+    }
+}
 
 /// Number of MPC rounds the network DKG runs under the pinned inkrypto
 /// revision (see the root `Cargo.toml`).

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/utils.rs
@@ -20,7 +20,7 @@ use ika_protocol_config::ProtocolConfig;
 use ika_types::committee::Committee;
 use ika_types::crypto::AuthorityName;
 use ika_types::error::{IkaError, IkaResult};
-use ika_types::handoff::{CertifiedHandoffAttestation, HandoffAttestation, HandoffItemKey};
+use ika_types::handoff::CertifiedHandoffAttestation;
 use ika_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
 use ika_types::messages_dwallet_checkpoint::DWalletCheckpointSignatureMessage;
 use ika_types::messages_dwallet_mpc::{
@@ -1570,69 +1570,23 @@ pub(crate) async fn advance_some_parties_and_wait_for_completions(
 use crate::dwallet_mpc::mpc_session::SessionStatus;
 use crate::dwallet_session_request::DWalletSessionRequest;
 use crate::request_protocol_data::{DWalletDKGData, NetworkEncryptionKeyDkgData, ProtocolData};
-use ika_network::mpc_artifacts::mpc_data_blob_hash;
 use ika_protocol_config::OverrideGuard;
 
-/// A prior-epoch handoff certificate naming `key_id` — the input the
-/// network-owned-address (NOA) signing key derives from when `noa_checkpoints`
-/// is on — together with the epoch it certifies.
+/// Makes `key_id` every validator's network-owned-address (NOA) signing key
+/// for the epoch, the way the prepare-then-start barrier hands the key in at
+/// construction.
 ///
 /// The harness DKGs its key in the epoch under test, so no real certificate
-/// can name it; in production such a key becomes eligible one epoch later.
-/// This stands in for that handoff: the certificate pins the key's real DKG
-/// output digest (adoption's consistency check for a certified DKG-only key),
-/// and its `NetworkKeyId` comes from the mapping the key's instantiation
-/// registered. Install it with [`certify_network_key_for_noa_signing`], or on
-/// a chosen validator's store to stage the derivation per validator.
+/// names it and no barrier ran with it; in production such a key becomes the
+/// signing key one epoch later, when the next barrier resolves it from the
+/// certificate. This stands in for that.
 #[cfg(test)]
-pub(crate) fn noa_signing_certificate(
-    test_state: &IntegrationTestState,
+pub(crate) fn select_network_key_for_noa_signing(
+    test_state: &mut IntegrationTestState,
     key_id: ObjectID,
-    network_dkg_public_output: &[u8],
-) -> (EpochId, CertifiedHandoffAttestation) {
-    let epoch_id = test_state
-        .dwallet_mpc_services
-        .first()
-        .expect("at least one service")
-        .epoch;
-    let prior_epoch = epoch_id
-        .checked_sub(1)
-        .expect("the harness runs at epoch 1 or later");
-    let network_key_id = crate::network_key_id_mapping::network_key_id_for(&key_id)
-        .expect("the key's instantiation registered its NetworkKeyId");
-    let certificate = CertifiedHandoffAttestation {
-        attestation: HandoffAttestation {
-            epoch: prior_epoch,
-            next_committee_pubkey_set_hash: [0u8; 32],
-            items: vec![(
-                HandoffItemKey::NetworkDkgOutput {
-                    key_id: network_key_id,
-                },
-                mpc_data_blob_hash(network_dkg_public_output),
-            )],
-        },
-        signatures: vec![],
-    };
-    (prior_epoch, certificate)
-}
-
-/// Hands every validator the certificate of [`noa_signing_certificate`], so
-/// each derives `key_id` as the epoch's NOA signing key on its next service
-/// iteration. Overwrites any certificate the stores hold for the prior epoch.
-#[cfg(test)]
-pub(crate) fn certify_network_key_for_noa_signing(
-    test_state: &IntegrationTestState,
-    key_id: ObjectID,
-    network_dkg_public_output: &[u8],
 ) {
-    let (prior_epoch, certificate) =
-        noa_signing_certificate(test_state, key_id, network_dkg_public_output);
-    for epoch_store in &test_state.epoch_stores {
-        epoch_store
-            .certified_handoff_attestations
-            .lock()
-            .unwrap()
-            .insert(prior_epoch, certificate.clone());
+    for service in &mut test_state.dwallet_mpc_services {
+        service.set_network_owned_address_signing_key_id_for_testing(Some(key_id));
     }
 }
 

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -51,6 +51,7 @@ pub mod dwallet_mpc_service;
 mod mpc_diagnostics;
 pub mod mpc_manager;
 pub mod mpc_session;
+pub mod network_owned_address_signing_key;
 mod park_drain_test_hook;
 pub mod seed_rotation;
 

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -37,7 +37,7 @@ use crate::dwallet_mpc::{
     party_id_to_authority_name,
 };
 use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionRequestMetricData};
-use crate::network_key_id_mapping::network_key_id_for;
+use crate::network_key_id_mapping::{network_key_id_for, object_id_for};
 use crate::validator_metadata::{OffChainMpcDataAssembly, assemble_committee_mpc_data_off_chain};
 use arc_swap::ArcSwap;
 use dwallet_classgroups_types::ValidatorMPCSecrets;
@@ -68,11 +68,12 @@ use ika_types::messages_dwallet_mpc::{
 };
 use ika_types::noa_checkpoint::CounterpartyChainKind;
 use mpc::{MajorityVote, WeightedThresholdAccessStructure};
+use std::cmp::Reverse;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::mem;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use sui_types::base_types::{ConciseableName, ObjectID};
 use tokio::sync::mpsc::Sender;
@@ -301,6 +302,29 @@ pub(crate) enum InternalPresignCompletionKey {
     NotAdopted,
 }
 
+/// Where the epoch's network-owned-address (NOA) signing key stands — the
+/// answer of [`DWalletMPCManager::network_owned_address_signing_key_resolution`].
+///
+/// Only `Pending` can change within an epoch, and only into `Resolved`: the
+/// certificate it derives from is fixed before the epoch's components start,
+/// and the translation and metadata it waits for only gain entries.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NetworkOwnedAddressSigningKeyResolution {
+    /// The prior epoch's handoff certificate is local and every key it names
+    /// is translated with known chain metadata: this is the key, fixed for
+    /// the epoch.
+    Resolved(ObjectID),
+    /// A certificate exists (or its read failed), but a certified key is not
+    /// yet translated to an `ObjectID` or has no chain metadata locally. The
+    /// derivation retries on every call and resolves once the inputs land.
+    Pending,
+    /// No prior-epoch certificate exists — genesis, or the first epoch of a
+    /// fresh network — or it names no network key. No key signs for the
+    /// network this epoch, and nothing can change that before the next
+    /// handoff.
+    NoneThisEpoch,
+}
+
 /// The correct way to use the manager is to create it along with all other Ika components
 /// at the start of each epoch.
 /// Ensuring it is destroyed when the epoch ends and providing a clean slate for each new epoch.
@@ -453,6 +477,14 @@ pub(crate) struct DWalletMPCManager {
     /// Network-key data adopted by `adopt_cert_verified_keys` (gated by the
     /// prior epoch's handoff cert); the instantiation input set.
     pub(crate) adopted_network_key_data: HashMap<ObjectID, DWalletNetworkEncryptionKeyData>,
+
+    /// The epoch's network-owned-address signing key, once
+    /// `network_owned_address_signing_key_resolution` has derived it from the
+    /// prior epoch's handoff certificate. Set at most once: every input to the
+    /// derivation is immutable for the epoch (the certificate, each certified
+    /// key's `dkg_at_epoch`, and the `NetworkKeyId -> ObjectID` translation),
+    /// so the first answer is the only answer.
+    network_owned_address_signing_key_for_epoch: OnceLock<ObjectID>,
 
     /// The `(overlay, cert-present)` input pair of the last completed
     /// `adopt_cert_verified_keys` pass. The overlay watch publishes a
@@ -854,6 +886,7 @@ impl DWalletMPCManager {
             sent_presign_sequence_numbers: HashSet::new(),
             logged_lock_deferred_presigns: HashSet::new(),
             adopted_network_key_data: HashMap::new(),
+            network_owned_address_signing_key_for_epoch: OnceLock::new(),
             last_adoption_input: None,
             last_instantiated_network_key_data: HashMap::new(),
             pending_network_key_instantiations: HashMap::new(),
@@ -2376,60 +2409,234 @@ impl DWalletMPCManager {
         }
     }
 
-    /// Returns the network encryption key ID used for network-owned-address signing (the oldest by DKG epoch).
-    /// Used by internal presign session instantiation to determine internal-signing-specific pool params.
+    /// The network encryption key that signs for the network-owned address
+    /// (NOA) this epoch, or `None` while no key can be named.
     ///
-    /// Ties on `dkg_at_epoch` (two keys DKG'd in the same epoch) break by key
-    /// id: without the tie-break, `min_by` keeps the LAST minimum in `HashMap`
-    /// iteration order — per-process-random, so validators could disagree on
-    /// which key is the NOA key and apply different pool configs (different
-    /// batch sizes ⇒ divergent internal-presign sequence numbers).
+    /// With `noa_checkpoints` on, the key is a pure function of the prior
+    /// epoch's handoff certificate — see
+    /// `network_owned_address_signing_key_resolution` for the rule — so every
+    /// validator that answers `Some` answers the same key, without anyone
+    /// announcing a choice. `None` covers both an epoch that has no such key
+    /// at all and a validator that cannot yet evaluate the rule; the
+    /// resolution method tells those apart for the caller that needs to.
+    ///
+    /// With the flag off, this is the pre-existing pool-role rule — the
+    /// oldest ADOPTED key — kept byte for byte so the internal-presign
+    /// top-up decisions, and with them the per-pool sequence numbers, do not
+    /// move on the live protocol version. NOA signing itself is impossible
+    /// with the flag off (no demand is ever announced), so the adopted-set
+    /// rule then serves the pool role alone.
     pub(super) fn network_owned_address_signing_network_encryption_key_id(
         &self,
     ) -> Option<ObjectID> {
-        // Select over the ADOPTED set, not the installed set
-        // (`network_keys.network_encryption_keys`): installation completes on
-        // wall-clock time per validator, so choosing over it would let two
-        // honest validators pick a different NOA key while their installs lag,
-        // apply different pool configs (batch sizes), and diverge the
-        // internal-presign top-up decision. The adopted set drives the same
-        // top-up loop, so the two stay consistent WITHIN a validator.
-        //
-        // That is the only guarantee here: the answer is NOT uniform across
-        // validators at a given moment. `adopt_cert_verified_keys` is a
-        // per-tick LOCAL pass over a LOCAL overlay — WHICH keys are adoptable
-        // is network-uniform (the handoff cert pins them), but WHEN each
-        // validator adopts is not. The adopted set starts empty every epoch
-        // and fills as each key's blobs become locally resolvable, a key whose
-        // overlay entry is still blob-empty is skipped while its siblings
-        // adopt, and a handoff-cert read error skips the whole pass for a
-        // tick. So this returns `None` on a validator whose peers already
-        // answer `Some`, and with more than one key it can return a different
-        // key than a peer whose adopted set is ahead. The divergence is
-        // transient (the set only grows, so everyone converges on the same
-        // minimum) but not tick-bounded — a stranded key can stay unresolved
-        // for much of an epoch. Callers must not treat a peer's choice that
-        // differs from this one as evidence of misbehavior; see issue #2019.
+        if !self.protocol_config.noa_checkpoints() {
+            return self.oldest_adopted_network_encryption_key_id();
+        }
+        match self.network_owned_address_signing_key_resolution() {
+            NetworkOwnedAddressSigningKeyResolution::Resolved(key_id) => Some(key_id),
+            NetworkOwnedAddressSigningKeyResolution::Pending
+            | NetworkOwnedAddressSigningKeyResolution::NoneThisEpoch => None,
+        }
+    }
+
+    /// Derives the epoch's NOA signing key from the prior epoch's handoff
+    /// certificate, caching the answer for the epoch once it resolves.
+    ///
+    /// THE RULE. Among the keys the certificate names — its
+    /// `NetworkDkgOutput` items, one per network encryption key that existed
+    /// at the end of the prior epoch — the key with the largest
+    /// `dkg_at_epoch` (the most recently created key), ties broken by the
+    /// smaller `NetworkKeyId` bytes. A key created by DKG during THIS epoch
+    /// is not in that certificate and so is not eligible before the next
+    /// epoch. An epoch with no certificate (genesis, or the first epoch of a
+    /// fresh network) has no NOA signing key, and NOA signing waits for the
+    /// first handoff.
+    ///
+    /// WHY THE CERTIFICATE. It is the one input every validator holds
+    /// identically for the whole epoch: quorum-signed, persisted before the
+    /// epoch's components start (the prepare-then-start barrier), and never
+    /// modified afterwards. Choosing over the locally adopted set instead —
+    /// the previous rule — let honest validators name different keys while
+    /// their adoption lagged at different rates, which is what the demand
+    /// announcement used to carry and what this derivation removes.
+    ///
+    /// WHY ALL-OR-NOTHING. The certificate names keys by their
+    /// content-derived `NetworkKeyId`; the pool and this manager key by Sui
+    /// `ObjectID`, and `dkg_at_epoch` lives on the chain metadata the
+    /// network-key syncer publishes. If the translation or the metadata for
+    /// ANY certified key is not yet known locally, this answers `Pending`
+    /// rather than choosing among the keys it can see: a choice over a subset
+    /// is exactly the per-validator divergence this derivation exists to
+    /// remove. Both inputs only ever gain entries, so `Pending` resolves
+    /// forward and the resolved answer never changes — which is what makes
+    /// it safe to cache in a set-once cell.
+    ///
+    /// The adopted set is deliberately NOT read here. It still drives
+    /// instantiation and the internal-presign top-up loop; it just no longer
+    /// decides which key is the NOA key.
+    pub(super) fn network_owned_address_signing_key_resolution(
+        &self,
+    ) -> NetworkOwnedAddressSigningKeyResolution {
+        if let Some(key_id) = self.network_owned_address_signing_key_for_epoch.get() {
+            return NetworkOwnedAddressSigningKeyResolution::Resolved(*key_id);
+        }
+        let Some(prior_epoch) = self.epoch_id.checked_sub(1) else {
+            return NetworkOwnedAddressSigningKeyResolution::NoneThisEpoch;
+        };
+        let certificate = match self
+            .epoch_store
+            .get_certified_handoff_attestation(prior_epoch)
+        {
+            Ok(Some(certificate)) => certificate,
+            // A chain-true absence: the barrier admits an epoch without a
+            // certificate only when no predecessor epoch minted one, and a
+            // certificate cannot appear for the prior epoch later. Not
+            // cached, so a store that is handed the certificate after
+            // construction (the test harness) still resolves.
+            Ok(None) => return NetworkOwnedAddressSigningKeyResolution::NoneThisEpoch,
+            // A read error is no answer at all — retry on the next call.
+            // `adopt_cert_verified_keys` warns (throttled) on the same
+            // failure, so this stays at debug.
+            Err(e) => {
+                debug!(
+                    error = ?e,
+                    prior_epoch,
+                    "failed to read the handoff certificate the network-owned-address \
+                     signing key derives from — treating the key as pending"
+                );
+                return NetworkOwnedAddressSigningKeyResolution::Pending;
+            }
+        };
+        let overlay = self
+            .sui_data_receivers
+            .network_keys_receiver
+            .borrow()
+            .clone();
+        let candidates: Option<Vec<_>> = certificate
+            .attestation
+            .items
+            .iter()
+            .filter_map(|(item, _digest)| match item {
+                HandoffItemKey::NetworkDkgOutput { key_id } => Some(*key_id),
+                HandoffItemKey::NetworkReconfigurationOutput { .. }
+                | HandoffItemKey::ValidatorMpcData { .. } => None,
+            })
+            .map(|network_key_id| {
+                let Some(object_id) = object_id_for(&network_key_id) else {
+                    debug!(
+                        ?network_key_id,
+                        "a certified network key has no ObjectID translation yet — the \
+                         network-owned-address signing key stays pending"
+                    );
+                    return None;
+                };
+                let Some(dkg_at_epoch) = overlay.get(&object_id).map(|data| data.dkg_at_epoch)
+                else {
+                    debug!(
+                        ?network_key_id,
+                        ?object_id,
+                        "a certified network key has no chain metadata locally yet — the \
+                         network-owned-address signing key stays pending"
+                    );
+                    return None;
+                };
+                Some((dkg_at_epoch, Reverse(network_key_id), object_id))
+            })
+            .collect();
+        let Some(candidates) = candidates else {
+            return NetworkOwnedAddressSigningKeyResolution::Pending;
+        };
+        let certified_key_count = candidates.len();
+        // `max_by_key` keeps the last of several equal maxima, but the key
+        // embeds the unique `NetworkKeyId`, so no two candidates compare
+        // equal. `Reverse` makes the SMALLER id win a `dkg_at_epoch` tie.
+        let Some((dkg_at_epoch, Reverse(network_key_id), object_id)) = candidates
+            .into_iter()
+            .max_by_key(|(dkg_at_epoch, network_key_id, _)| (*dkg_at_epoch, *network_key_id))
+        else {
+            // A certificate naming no network key: none existed at the end
+            // of the prior epoch, and one created this epoch is not eligible.
+            return NetworkOwnedAddressSigningKeyResolution::NoneThisEpoch;
+        };
+        // A concurrent caller can only have derived the same value.
+        let _ = self
+            .network_owned_address_signing_key_for_epoch
+            .set(object_id);
+        info!(
+            epoch = self.epoch_id,
+            network_owned_address_signing_key_id = ?object_id,
+            ?network_key_id,
+            dkg_at_epoch,
+            certified_key_count,
+            "derived the epoch's network-owned-address signing key from the prior epoch's \
+             handoff certificate"
+        );
+        NetworkOwnedAddressSigningKeyResolution::Resolved(object_id)
+    }
+
+    /// The pre-`noa_checkpoints` pool-role rule: the oldest ADOPTED key by
+    /// `dkg_at_epoch`, ties broken by the smaller key id. Kept byte for byte
+    /// for the flag-off path (see the caller): the internal-presign top-up
+    /// loop applies the NOA pool parameters to this key, so changing the
+    /// choice on the live protocol version would move the per-pool sequence
+    /// numbers under a mixed-binary committee.
+    ///
+    /// Selects over the ADOPTED set, not the installed set: installation
+    /// completes on wall-clock time per validator, while the adopted set
+    /// drives the same top-up loop, so the two stay consistent WITHIN a
+    /// validator. Across validators the answer is only eventually uniform —
+    /// adoption is a per-tick local pass — which is why the flag-on path
+    /// derives the key from the handoff certificate instead.
+    fn oldest_adopted_network_encryption_key_id(&self) -> Option<ObjectID> {
         self.adopted_network_key_data
             .values()
             .min_by(|a, b| a.dkg_at_epoch.cmp(&b.dkg_at_epoch).then(a.id.cmp(&b.id)))
             .map(|data| data.id)
     }
 
-    /// Instantiates internal presign sessions based on consensus-agreed network key IDs.
-    /// Uses only keys that have reached quorum agreement via status update voting.
+    /// Instantiates internal presign sessions for every adopted network key,
+    /// applying the network-owned-address (NOA) pool parameters to the NOA
+    /// signing key's pools and the internal pool parameters to every other
+    /// key's.
     pub(super) fn instantiate_internal_presign_sessions(
         &mut self,
         consensus_round: u64,
         number_of_consensus_rounds: u64,
         network_is_idle: bool,
     ) {
-        // Check if we are ready to instantiate internal sessions, which depend on the consensus agreed (synced) network key data.
-        let agreed_network_owned_address_signing_key_id =
-            match self.network_owned_address_signing_network_encryption_key_id() {
-                Some(id) => id,
+        // Which key's pools get the NOA parameters. The two parameter sets
+        // differ in batch size, and a batch mints one session identifier per
+        // session, so a key whose role FLIPPED at a per-validator moment
+        // would mint a different number of ordinals on different validators
+        // and offset their streams for that pool. The role must therefore be
+        // fixed before the key's first top-up:
+        //
+        // - flag on: the key derives from the prior epoch's handoff
+        //   certificate. `Resolved` is final for the epoch, and
+        //   `NoneThisEpoch` is too (no certificate can appear for the prior
+        //   epoch later), so under both the role of every key is settled.
+        //   `Pending` — a certificate exists but a certified key is not yet
+        //   translated or has no chain metadata here — is the one state that
+        //   WILL change, so skip this round's top-ups entirely rather than
+        //   mint a batch under a role that may flip. The inputs land within
+        //   the network-key syncer's tick in the healthy case, and a peer
+        //   that resolved earlier fills the pools meanwhile.
+        // - flag off: the pre-existing rule, the oldest adopted key, and the
+        //   pre-existing early return while nothing is adopted; kept byte
+        //   for byte so the live protocol version's sequence numbers stay
+        //   put.
+        let network_owned_address_signing_key_id = if self.protocol_config.noa_checkpoints() {
+            match self.network_owned_address_signing_key_resolution() {
+                NetworkOwnedAddressSigningKeyResolution::Resolved(key_id) => Some(key_id),
+                NetworkOwnedAddressSigningKeyResolution::NoneThisEpoch => None,
+                NetworkOwnedAddressSigningKeyResolution::Pending => return,
+            }
+        } else {
+            match self.oldest_adopted_network_encryption_key_id() {
+                Some(key_id) => Some(key_id),
                 None => return,
-            };
+            }
+        };
 
         // Iterate the dedicated internal-pool driver — `network_presign_pool_algorithms`
         // is decoupled from `SUPPORTED_CURVES_TO_SIGNATURE_ALGORITHMS_TO_HASH_SCHEMES`
@@ -2471,7 +2678,7 @@ impl DWalletMPCManager {
             };
             for (curve, signature_algorithm) in pool_algorithms.iter().copied() {
                 let is_network_owned_address_signing_presign =
-                    agreed_network_owned_address_signing_key_id == key_id;
+                    network_owned_address_signing_key_id == Some(key_id);
 
                 let (
                     minimal_pool_size,

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -37,7 +37,7 @@ use crate::dwallet_mpc::{
     party_id_to_authority_name,
 };
 use crate::dwallet_session_request::{DWalletSessionRequest, DWalletSessionRequestMetricData};
-use crate::network_key_id_mapping::{network_key_id_for, object_id_for};
+use crate::network_key_id_mapping::network_key_id_for;
 use crate::validator_metadata::{OffChainMpcDataAssembly, assemble_committee_mpc_data_off_chain};
 use arc_swap::ArcSwap;
 use dwallet_classgroups_types::ValidatorMPCSecrets;
@@ -68,12 +68,11 @@ use ika_types::messages_dwallet_mpc::{
 };
 use ika_types::noa_checkpoint::CounterpartyChainKind;
 use mpc::{MajorityVote, WeightedThresholdAccessStructure};
-use std::cmp::Reverse;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::mem;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use sui_types::base_types::{ConciseableName, ObjectID};
 use tokio::sync::mpsc::Sender;
@@ -302,29 +301,6 @@ pub(crate) enum InternalPresignCompletionKey {
     NotAdopted,
 }
 
-/// Where the epoch's network-owned-address (NOA) signing key stands — the
-/// answer of [`DWalletMPCManager::network_owned_address_signing_key_resolution`].
-///
-/// Only `Pending` can change within an epoch, and only into `Resolved`: the
-/// certificate it derives from is fixed before the epoch's components start,
-/// and the translation and metadata it waits for only gain entries.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum NetworkOwnedAddressSigningKeyResolution {
-    /// The prior epoch's handoff certificate is local and every key it names
-    /// is translated with known chain metadata: this is the key, fixed for
-    /// the epoch.
-    Resolved(ObjectID),
-    /// A certificate exists (or its read failed), but a certified key is not
-    /// yet translated to an `ObjectID` or has no chain metadata locally. The
-    /// derivation retries on every call and resolves once the inputs land.
-    Pending,
-    /// No prior-epoch certificate exists — genesis, or the first epoch of a
-    /// fresh network — or it names no network key. No key signs for the
-    /// network this epoch, and nothing can change that before the next
-    /// handoff.
-    NoneThisEpoch,
-}
-
 /// The correct way to use the manager is to create it along with all other Ika components
 /// at the start of each epoch.
 /// Ensuring it is destroyed when the epoch ends and providing a clean slate for each new epoch.
@@ -478,13 +454,20 @@ pub(crate) struct DWalletMPCManager {
     /// prior epoch's handoff cert); the instantiation input set.
     pub(crate) adopted_network_key_data: HashMap<ObjectID, DWalletNetworkEncryptionKeyData>,
 
-    /// The epoch's network-owned-address signing key, once
-    /// `network_owned_address_signing_key_resolution` has derived it from the
-    /// prior epoch's handoff certificate. Set at most once: every input to the
-    /// derivation is immutable for the epoch (the certificate, each certified
-    /// key's `dkg_at_epoch`, and the `NetworkKeyId -> ObjectID` translation),
-    /// so the first answer is the only answer.
-    network_owned_address_signing_key_for_epoch: OnceLock<ObjectID>,
+    /// The epoch's network-owned-address (NOA) signing key, resolved by the
+    /// prepare-then-start barrier from the prior epoch's handoff certificate
+    /// before this manager exists
+    /// (`dwallet_mpc::network_owned_address_signing_key::select`), and fixed
+    /// for the epoch. `None` when the epoch has no such key — no prior
+    /// certificate, or one naming no network key — or when this validator
+    /// could not translate every certified key at the barrier and therefore
+    /// sits NOA signing out this epoch. Read only with `noa_checkpoints` on.
+    network_owned_address_signing_key_id: Option<ObjectID>,
+
+    /// Keys whose `ObjectID <-> NetworkKeyId` translation this manager has
+    /// already written to the perpetual store
+    /// (`persist_network_key_id_mapping`).
+    persisted_network_key_id_mappings: HashSet<ObjectID>,
 
     /// The `(overlay, cert-present)` input pair of the last completed
     /// `adopt_cert_verified_keys` pass. The overlay watch publishes a
@@ -760,6 +743,7 @@ impl DWalletMPCManager {
         network_owned_address_sign_output_sender: Sender<NetworkOwnedAddressSignOutput>,
         max_computation_cores: Option<usize>,
         stranded_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
+        network_owned_address_signing_key_id: Option<ObjectID>,
     ) -> Self {
         Self::try_new(
             validator_name,
@@ -776,6 +760,7 @@ impl DWalletMPCManager {
             network_owned_address_sign_output_sender,
             max_computation_cores,
             stranded_network_keys,
+            network_owned_address_signing_key_id,
         )
         .unwrap_or_else(|err| {
             error!(error=?err, "Failed to create DWalletMPCManager.");
@@ -799,6 +784,7 @@ impl DWalletMPCManager {
         network_owned_address_sign_output_sender: Sender<NetworkOwnedAddressSignOutput>,
         max_computation_cores: Option<usize>,
         stranded_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
+        network_owned_address_signing_key_id: Option<ObjectID>,
     ) -> DwalletMPCResult<Self> {
         let access_structure = generate_access_structure_from_committee(&committee)?;
 
@@ -886,7 +872,8 @@ impl DWalletMPCManager {
             sent_presign_sequence_numbers: HashSet::new(),
             logged_lock_deferred_presigns: HashSet::new(),
             adopted_network_key_data: HashMap::new(),
-            network_owned_address_signing_key_for_epoch: OnceLock::new(),
+            network_owned_address_signing_key_id,
+            persisted_network_key_id_mappings: HashSet::new(),
             last_adoption_input: None,
             last_instantiated_network_key_data: HashMap::new(),
             pending_network_key_instantiations: HashMap::new(),
@@ -1908,6 +1895,7 @@ impl DWalletMPCManager {
                 deferred_unmapped_key = true;
                 continue;
             }
+            self.persist_network_key_id_mapping(*key_id);
             let cert_dkg_digest = network_key_id.as_ref().and_then(|id| dkg_digests.get(id));
             let cert_reconfig_digest = network_key_id
                 .as_ref()
@@ -2410,15 +2398,19 @@ impl DWalletMPCManager {
     }
 
     /// The network encryption key that signs for the network-owned address
-    /// (NOA) this epoch, or `None` while no key can be named.
+    /// (NOA) this epoch, or `None` when this validator has none.
     ///
-    /// With `noa_checkpoints` on, the key is a pure function of the prior
-    /// epoch's handoff certificate — see
-    /// `network_owned_address_signing_key_resolution` for the rule — so every
-    /// validator that answers `Some` answers the same key, without anyone
-    /// announcing a choice. `None` covers both an epoch that has no such key
-    /// at all and a validator that cannot yet evaluate the rule; the
-    /// resolution method tells those apart for the caller that needs to.
+    /// With `noa_checkpoints` on, the key is the one the prepare-then-start
+    /// barrier resolved from the prior epoch's handoff certificate and handed
+    /// to this manager at construction (see the field): a pure function of
+    /// the certificate, fixed for the epoch, so every validator that answers
+    /// `Some` answers the same key, without anyone announcing a choice.
+    /// `None` means the epoch has no such key, or this validator could not
+    /// translate every certified key at the barrier and sits NOA signing out
+    /// this epoch. The adopted set is deliberately not read: it still drives
+    /// instantiation and the internal-presign top-up loop, but WHEN a
+    /// validator adopts is per-validator, and choosing over it let honest
+    /// validators name different keys.
     ///
     /// With the flag off, this is the pre-existing pool-role rule — the
     /// oldest ADOPTED key — kept byte for byte so the internal-presign
@@ -2429,149 +2421,53 @@ impl DWalletMPCManager {
     pub(super) fn network_owned_address_signing_network_encryption_key_id(
         &self,
     ) -> Option<ObjectID> {
-        if !self.protocol_config.noa_checkpoints() {
-            return self.oldest_adopted_network_encryption_key_id();
-        }
-        match self.network_owned_address_signing_key_resolution() {
-            NetworkOwnedAddressSigningKeyResolution::Resolved(key_id) => Some(key_id),
-            NetworkOwnedAddressSigningKeyResolution::Pending
-            | NetworkOwnedAddressSigningKeyResolution::NoneThisEpoch => None,
+        if self.protocol_config.noa_checkpoints() {
+            self.network_owned_address_signing_key_id
+        } else {
+            self.oldest_adopted_network_encryption_key_id()
         }
     }
 
-    /// Derives the epoch's NOA signing key from the prior epoch's handoff
-    /// certificate, caching the answer for the epoch once it resolves.
-    ///
-    /// THE RULE. Among the keys the certificate names — its
-    /// `NetworkDkgOutput` items, one per network encryption key that existed
-    /// at the end of the prior epoch — the key with the largest
-    /// `dkg_at_epoch` (the most recently created key), ties broken by the
-    /// smaller `NetworkKeyId` bytes. A key created by DKG during THIS epoch
-    /// is not in that certificate and so is not eligible before the next
-    /// epoch. An epoch with no certificate (genesis, or the first epoch of a
-    /// fresh network) has no NOA signing key, and NOA signing waits for the
-    /// first handoff.
-    ///
-    /// WHY THE CERTIFICATE. It is the one input every validator holds
-    /// identically for the whole epoch: quorum-signed, persisted before the
-    /// epoch's components start (the prepare-then-start barrier), and never
-    /// modified afterwards. Choosing over the locally adopted set instead —
-    /// the previous rule — let honest validators name different keys while
-    /// their adoption lagged at different rates, which is what the demand
-    /// announcement used to carry and what this derivation removes.
-    ///
-    /// WHY ALL-OR-NOTHING. The certificate names keys by their
-    /// content-derived `NetworkKeyId`; the pool and this manager key by Sui
-    /// `ObjectID`, and `dkg_at_epoch` lives on the chain metadata the
-    /// network-key syncer publishes. If the translation or the metadata for
-    /// ANY certified key is not yet known locally, this answers `Pending`
-    /// rather than choosing among the keys it can see: a choice over a subset
-    /// is exactly the per-validator divergence this derivation exists to
-    /// remove. Both inputs only ever gain entries, so `Pending` resolves
-    /// forward and the resolved answer never changes — which is what makes
-    /// it safe to cache in a set-once cell.
-    ///
-    /// The adopted set is deliberately NOT read here. It still drives
-    /// instantiation and the internal-presign top-up loop; it just no longer
-    /// decides which key is the NOA key.
-    pub(super) fn network_owned_address_signing_key_resolution(
-        &self,
-    ) -> NetworkOwnedAddressSigningKeyResolution {
-        if let Some(key_id) = self.network_owned_address_signing_key_for_epoch.get() {
-            return NetworkOwnedAddressSigningKeyResolution::Resolved(*key_id);
+    /// The barrier's answer is a constructor input; tests that DKG their key
+    /// after construction set it here, standing in for the next epoch's
+    /// barrier naming that key.
+    #[cfg(test)]
+    pub(crate) fn set_network_owned_address_signing_key_id_for_testing(
+        &mut self,
+        key_id: Option<ObjectID>,
+    ) {
+        self.network_owned_address_signing_key_id = key_id;
+    }
+
+    /// Writes a key's `ObjectID <-> NetworkKeyId` translation to the
+    /// perpetual store the first time this manager sees it resolved, so the
+    /// process-global mapping — which registers it in memory at instantiation
+    /// or by the background derivation — survives a restart and is loaded
+    /// back before the prepare-then-start barrier runs. Idempotent per key;
+    /// a failed write is retried on the next call.
+    fn persist_network_key_id_mapping(&mut self, key_id: ObjectID) {
+        if self.persisted_network_key_id_mappings.contains(&key_id) {
+            return;
         }
-        let Some(prior_epoch) = self.epoch_id.checked_sub(1) else {
-            return NetworkOwnedAddressSigningKeyResolution::NoneThisEpoch;
+        let Some(network_key_id) = network_key_id_for(&key_id) else {
+            return;
         };
-        let certificate = match self
-            .epoch_store
-            .get_certified_handoff_attestation(prior_epoch)
-        {
-            Ok(Some(certificate)) => certificate,
-            // A chain-true absence: the barrier admits an epoch without a
-            // certificate only when no predecessor epoch minted one, and a
-            // certificate cannot appear for the prior epoch later. Not
-            // cached, so a store that is handed the certificate after
-            // construction (the test harness) still resolves.
-            Ok(None) => return NetworkOwnedAddressSigningKeyResolution::NoneThisEpoch,
-            // A read error is no answer at all — retry on the next call.
-            // `adopt_cert_verified_keys` warns (throttled) on the same
-            // failure, so this stays at debug.
-            Err(e) => {
-                debug!(
-                    error = ?e,
-                    prior_epoch,
-                    "failed to read the handoff certificate the network-owned-address \
-                     signing key derives from — treating the key as pending"
-                );
-                return NetworkOwnedAddressSigningKeyResolution::Pending;
+        // Absent only in the integration-test harness.
+        let Some(perpetual_tables) = self.epoch_store.perpetual_tables_handle() else {
+            return;
+        };
+        match perpetual_tables.insert_network_key_id_mapping(key_id, network_key_id) {
+            Ok(()) => {
+                self.persisted_network_key_id_mappings.insert(key_id);
             }
-        };
-        let overlay = self
-            .sui_data_receivers
-            .network_keys_receiver
-            .borrow()
-            .clone();
-        let candidates: Option<Vec<_>> = certificate
-            .attestation
-            .items
-            .iter()
-            .filter_map(|(item, _digest)| match item {
-                HandoffItemKey::NetworkDkgOutput { key_id } => Some(*key_id),
-                HandoffItemKey::NetworkReconfigurationOutput { .. }
-                | HandoffItemKey::ValidatorMpcData { .. } => None,
-            })
-            .map(|network_key_id| {
-                let Some(object_id) = object_id_for(&network_key_id) else {
-                    debug!(
-                        ?network_key_id,
-                        "a certified network key has no ObjectID translation yet — the \
-                         network-owned-address signing key stays pending"
-                    );
-                    return None;
-                };
-                let Some(dkg_at_epoch) = overlay.get(&object_id).map(|data| data.dkg_at_epoch)
-                else {
-                    debug!(
-                        ?network_key_id,
-                        ?object_id,
-                        "a certified network key has no chain metadata locally yet — the \
-                         network-owned-address signing key stays pending"
-                    );
-                    return None;
-                };
-                Some((dkg_at_epoch, Reverse(network_key_id), object_id))
-            })
-            .collect();
-        let Some(candidates) = candidates else {
-            return NetworkOwnedAddressSigningKeyResolution::Pending;
-        };
-        let certified_key_count = candidates.len();
-        // `max_by_key` keeps the last of several equal maxima, but the key
-        // embeds the unique `NetworkKeyId`, so no two candidates compare
-        // equal. `Reverse` makes the SMALLER id win a `dkg_at_epoch` tie.
-        let Some((dkg_at_epoch, Reverse(network_key_id), object_id)) = candidates
-            .into_iter()
-            .max_by_key(|(dkg_at_epoch, network_key_id, _)| (*dkg_at_epoch, *network_key_id))
-        else {
-            // A certificate naming no network key: none existed at the end
-            // of the prior epoch, and one created this epoch is not eligible.
-            return NetworkOwnedAddressSigningKeyResolution::NoneThisEpoch;
-        };
-        // A concurrent caller can only have derived the same value.
-        let _ = self
-            .network_owned_address_signing_key_for_epoch
-            .set(object_id);
-        info!(
-            epoch = self.epoch_id,
-            network_owned_address_signing_key_id = ?object_id,
-            ?network_key_id,
-            dkg_at_epoch,
-            certified_key_count,
-            "derived the epoch's network-owned-address signing key from the prior epoch's \
-             handoff certificate"
-        );
-        NetworkOwnedAddressSigningKeyResolution::Resolved(object_id)
+            Err(e) => warn!(
+                ?key_id,
+                ?network_key_id,
+                error = ?e,
+                "failed to persist the network key's NetworkKeyId mapping; retrying on the \
+                 next pass"
+            ),
+        }
     }
 
     /// The pre-`noa_checkpoints` pool-role rule: the oldest ADOPTED key by
@@ -2608,29 +2504,19 @@ impl DWalletMPCManager {
         // differ in batch size, and a batch mints one session identifier per
         // session, so a key whose role FLIPPED at a per-validator moment
         // would mint a different number of ordinals on different validators
-        // and offset their streams for that pool. The role must therefore be
-        // fixed before the key's first top-up:
+        // and offset their streams for that pool. The role is therefore
+        // fixed before any top-up:
         //
-        // - flag on: the key derives from the prior epoch's handoff
-        //   certificate. `Resolved` is final for the epoch, and
-        //   `NoneThisEpoch` is too (no certificate can appear for the prior
-        //   epoch later), so under both the role of every key is settled.
-        //   `Pending` — a certificate exists but a certified key is not yet
-        //   translated or has no chain metadata here — is the one state that
-        //   WILL change, so skip this round's top-ups entirely rather than
-        //   mint a batch under a role that may flip. The inputs land within
-        //   the network-key syncer's tick in the healthy case, and a peer
-        //   that resolved earlier fills the pools meanwhile.
+        // - flag on: the key the prepare-then-start barrier resolved from the
+        //   prior epoch's handoff certificate, a constructor input that never
+        //   changes within the epoch. `None` — no key this epoch — gives
+        //   every key the internal parameters for the whole epoch.
         // - flag off: the pre-existing rule, the oldest adopted key, and the
         //   pre-existing early return while nothing is adopted; kept byte
         //   for byte so the live protocol version's sequence numbers stay
         //   put.
         let network_owned_address_signing_key_id = if self.protocol_config.noa_checkpoints() {
-            match self.network_owned_address_signing_key_resolution() {
-                NetworkOwnedAddressSigningKeyResolution::Resolved(key_id) => Some(key_id),
-                NetworkOwnedAddressSigningKeyResolution::NoneThisEpoch => None,
-                NetworkOwnedAddressSigningKeyResolution::Pending => return,
-            }
+            self.network_owned_address_signing_key_id
         } else {
             match self.oldest_adopted_network_encryption_key_id() {
                 Some(key_id) => Some(key_id),
@@ -4192,6 +4078,10 @@ impl DWalletMPCManager {
                             .inc();
                         self.last_failed_network_key_data.insert(key_id, attempted);
                     } else {
+                        // Installation registered the key's NetworkKeyId in
+                        // the process-global mapping; make it survive a
+                        // restart.
+                        self.persist_network_key_id_mapping(key_id);
                         // Mirror the adopted **DKG** output bytes
                         // into the local digest caches so validators that
                         // didn't reach `Finalize` locally still hold the

--- a/crates/ika-core/src/dwallet_mpc/network_owned_address_signing_key.rs
+++ b/crates/ika-core/src/dwallet_mpc/network_owned_address_signing_key.rs
@@ -1,0 +1,258 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! The epoch's network-owned-address (NOA) signing key: the network
+//! encryption key every NOA sign demand's presign is drawn under and every
+//! NOA sign session runs on.
+//!
+//! It is a pure function of the prior epoch's handoff certificate, fixed for
+//! the epoch, and every validator derives it on its own — nothing announces a
+//! choice. The prepare-then-start barrier evaluates [`select`] once the
+//! certificate is local, before the epoch's components exist, and hands the
+//! answer to the MPC manager as a constructor input. Choosing over the
+//! locally adopted key set instead let honest validators name different keys
+//! while their adoption lagged at different rates.
+
+use crate::network_key_id_mapping::object_id_for;
+use dwallet_mpc_types::dwallet_mpc::NetworkKeyId;
+use ika_types::handoff::{CertifiedHandoffAttestation, HandoffItemKey};
+use std::cmp::Reverse;
+use sui_types::base_types::ObjectID;
+
+/// The outcome of [`select`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NetworkOwnedAddressSigningKeySelection {
+    /// The key: among the certified keys, the largest `dkg_at_epoch`, ties
+    /// broken by the smaller `NetworkKeyId`.
+    Selected {
+        object_id: ObjectID,
+        network_key_id: NetworkKeyId,
+        dkg_at_epoch: u64,
+    },
+    /// The certificate names no network key: none existed at the end of the
+    /// prior epoch, and one created this epoch is not eligible.
+    NoCertifiedKey,
+    /// These certified keys have no `NetworkKeyId -> ObjectID` translation
+    /// on this process, so no key can be chosen: a choice among the
+    /// translatable rest would be a per-validator answer. Waiting does not
+    /// help — the translation registers only when the key is instantiated
+    /// or derived, after the epoch's components start.
+    Untranslatable(Vec<NetworkKeyId>),
+    /// Every certified key translates, but the chain metadata of these keys
+    /// is not local yet. Retry: the network-key syncer publishes it.
+    AwaitingMetadata(Vec<ObjectID>),
+}
+
+/// Derives the NOA signing key for the epoch the certificate hands into.
+///
+/// THE RULE. Among the keys the certificate names — its `NetworkDkgOutput`
+/// items, one per network encryption key that existed at the end of the
+/// prior epoch — the key with the largest `dkg_at_epoch` (the most recently
+/// created key), ties broken by the smaller `NetworkKeyId` bytes. A key
+/// created by DKG after the certificate is not in it and waits one epoch.
+///
+/// ALL OR NOTHING. The certificate names keys by their content-derived
+/// `NetworkKeyId`; the pool and the manager key by Sui `ObjectID`, and
+/// `dkg_at_epoch` is chain metadata keyed by `ObjectID`, read through
+/// `dkg_at_epoch_of`. If any certified key cannot be translated the answer is
+/// [`Untranslatable`](NetworkOwnedAddressSigningKeySelection::Untranslatable);
+/// if any translated key has no metadata yet it is
+/// [`AwaitingMetadata`](NetworkOwnedAddressSigningKeySelection::AwaitingMetadata).
+/// Neither chooses among the keys that are known: that choice is exactly the
+/// per-validator divergence this derivation exists to remove.
+pub fn select(
+    certificate: &CertifiedHandoffAttestation,
+    dkg_at_epoch_of: impl Fn(&ObjectID) -> Option<u64>,
+) -> NetworkOwnedAddressSigningKeySelection {
+    let certified_keys = certificate
+        .attestation
+        .items
+        .iter()
+        .filter_map(|(item, _digest)| match item {
+            HandoffItemKey::NetworkDkgOutput { key_id } => Some(*key_id),
+            HandoffItemKey::NetworkReconfigurationOutput { .. }
+            | HandoffItemKey::ValidatorMpcData { .. } => None,
+        });
+    let mut untranslatable = Vec::new();
+    let mut awaiting_metadata = Vec::new();
+    let mut candidates = Vec::new();
+    for network_key_id in certified_keys {
+        let Some(object_id) = object_id_for(&network_key_id) else {
+            untranslatable.push(network_key_id);
+            continue;
+        };
+        match dkg_at_epoch_of(&object_id) {
+            Some(dkg_at_epoch) => candidates.push((network_key_id, object_id, dkg_at_epoch)),
+            None => awaiting_metadata.push(object_id),
+        }
+    }
+    if !untranslatable.is_empty() {
+        return NetworkOwnedAddressSigningKeySelection::Untranslatable(untranslatable);
+    }
+    if !awaiting_metadata.is_empty() {
+        return NetworkOwnedAddressSigningKeySelection::AwaitingMetadata(awaiting_metadata);
+    }
+    // `max_by_key` keeps the last of several equal maxima, but the key embeds
+    // the unique `NetworkKeyId`, so no two candidates compare equal.
+    // `Reverse` makes the SMALLER id win a `dkg_at_epoch` tie.
+    candidates
+        .into_iter()
+        .max_by_key(|(network_key_id, _, dkg_at_epoch)| (*dkg_at_epoch, Reverse(*network_key_id)))
+        .map_or(
+            NetworkOwnedAddressSigningKeySelection::NoCertifiedKey,
+            |(network_key_id, object_id, dkg_at_epoch)| {
+                NetworkOwnedAddressSigningKeySelection::Selected {
+                    object_id,
+                    network_key_id,
+                    dkg_at_epoch,
+                }
+            },
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network_key_id_mapping;
+    use ika_types::handoff::HandoffAttestation;
+    use std::collections::HashMap;
+
+    /// A key whose `NetworkKeyId` is its `ObjectID`'s bytes — so ordering the
+    /// object ids orders the network key ids identically — registered in the
+    /// process-global mapping.
+    fn registered_key() -> (ObjectID, NetworkKeyId) {
+        let object_id = ObjectID::random();
+        let network_key_id = NetworkKeyId(object_id.into_bytes());
+        network_key_id_mapping::register(object_id, network_key_id);
+        (object_id, network_key_id)
+    }
+
+    fn ordered_registered_keys<const N: usize>() -> [(ObjectID, NetworkKeyId); N] {
+        let mut keys: Vec<_> = (0..N).map(|_| registered_key()).collect();
+        keys.sort();
+        keys.try_into().expect("N keys")
+    }
+
+    fn certificate_naming(network_key_ids: &[NetworkKeyId]) -> CertifiedHandoffAttestation {
+        let mut items: Vec<_> = network_key_ids
+            .iter()
+            .map(|key_id| {
+                (
+                    HandoffItemKey::NetworkDkgOutput { key_id: *key_id },
+                    [0u8; 32],
+                )
+            })
+            .collect();
+        items.sort_by(|(a, _), (b, _)| a.cmp(b));
+        CertifiedHandoffAttestation {
+            attestation: HandoffAttestation {
+                epoch: 0,
+                next_committee_pubkey_set_hash: [0u8; 32],
+                items,
+            },
+            signatures: vec![],
+        }
+    }
+
+    fn metadata(entries: &[(ObjectID, u64)]) -> impl Fn(&ObjectID) -> Option<u64> + use<> {
+        let map: HashMap<ObjectID, u64> = entries.iter().copied().collect();
+        move |object_id| map.get(object_id).copied()
+    }
+
+    #[test]
+    fn the_newest_certified_key_wins_and_ties_break_to_the_smaller_id() {
+        let [oldest_smallest_id, newer_smaller_id, newer_larger_id] =
+            ordered_registered_keys::<3>();
+        // The smallest id is the OLDEST key, so it must lose to both newer
+        // keys despite winning every tie-break; the two newer keys tie on
+        // epoch.
+        let certificate =
+            certificate_naming(&[oldest_smallest_id.1, newer_smaller_id.1, newer_larger_id.1]);
+        let dkg_at_epoch = metadata(&[
+            (oldest_smallest_id.0, 0),
+            (newer_smaller_id.0, 1),
+            (newer_larger_id.0, 1),
+        ]);
+        assert_eq!(
+            select(&certificate, dkg_at_epoch),
+            NetworkOwnedAddressSigningKeySelection::Selected {
+                object_id: newer_smaller_id.0,
+                network_key_id: newer_smaller_id.1,
+                dkg_at_epoch: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn a_key_the_certificate_does_not_name_is_not_eligible() {
+        let [certified, fresh] = ordered_registered_keys::<2>();
+        // The fresh key is newer and its metadata is known; only the
+        // certificate decides eligibility.
+        let certificate = certificate_naming(&[certified.1]);
+        let dkg_at_epoch = metadata(&[(certified.0, 0), (fresh.0, 1)]);
+        assert_eq!(
+            select(&certificate, dkg_at_epoch),
+            NetworkOwnedAddressSigningKeySelection::Selected {
+                object_id: certified.0,
+                network_key_id: certified.1,
+                dkg_at_epoch: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn an_untranslatable_certified_key_blocks_any_choice() {
+        let (translated_object_id, translated) = registered_key();
+        // Never registered: the certificate names it, nothing translates it.
+        let untranslatable = NetworkKeyId(rand::random());
+        let certificate = certificate_naming(&[translated, untranslatable]);
+        // Even with the translatable key's metadata known and the other
+        // key OLDER by every tie-break, no partial choice is made.
+        let dkg_at_epoch = metadata(&[(translated_object_id, 5)]);
+        assert_eq!(
+            select(&certificate, dkg_at_epoch),
+            NetworkOwnedAddressSigningKeySelection::Untranslatable(vec![untranslatable])
+        );
+    }
+
+    #[test]
+    fn missing_metadata_for_a_certified_key_waits_rather_than_choosing() {
+        let [low, high] = ordered_registered_keys::<2>();
+        let certificate = certificate_naming(&[low.1, high.1]);
+        assert_eq!(
+            select(&certificate, metadata(&[(high.0, 0)])),
+            NetworkOwnedAddressSigningKeySelection::AwaitingMetadata(vec![low.0])
+        );
+        // The same inputs plus the missing metadata resolve.
+        assert_eq!(
+            select(&certificate, metadata(&[(low.0, 0), (high.0, 0)])),
+            NetworkOwnedAddressSigningKeySelection::Selected {
+                object_id: low.0,
+                network_key_id: low.1,
+                dkg_at_epoch: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn untranslatable_takes_precedence_over_awaiting_metadata() {
+        let (_, translated) = registered_key();
+        let untranslatable = NetworkKeyId(rand::random());
+        let certificate = certificate_naming(&[translated, untranslatable]);
+        // The translatable key ALSO lacks metadata; waiting cannot fix the
+        // other one, so the answer is the one waiting cannot change.
+        assert_eq!(
+            select(&certificate, |_| None),
+            NetworkOwnedAddressSigningKeySelection::Untranslatable(vec![untranslatable])
+        );
+    }
+
+    #[test]
+    fn a_certificate_naming_no_key_selects_none() {
+        let certificate = certificate_naming(&[]);
+        assert_eq!(
+            select(&certificate, |_| Some(0)),
+            NetworkOwnedAddressSigningKeySelection::NoCertifiedKey
+        );
+    }
+}

--- a/crates/ika-core/src/network_key_id_mapping.rs
+++ b/crates/ika-core/src/network_key_id_mapping.rs
@@ -24,6 +24,14 @@
 //! instantiation, and instantiation needs adoption: a deadlock that
 //! wedges the joiner's epoch entry.
 //!
+//! The map itself is process memory, but every registration the MPC
+//! manager observes is also written to the perpetual store
+//! (`network_key_ids_by_object_id`) and loaded back through [`register`]
+//! at boot, before the prepare-then-start barrier runs. That is what lets
+//! a restarting validator translate every certified key at the barrier —
+//! where the epoch's network-owned-address signing key is resolved —
+//! rather than only after it re-instantiates the key.
+//!
 //! TODO(NetworkKeyId-from-event): delete this module once the request
 //! event carries the `NetworkKeyId`. The runtime/tables then key by
 //! `NetworkKeyId` directly and `ObjectID` is dropped as the key identity.

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -61,6 +61,9 @@ use ika_core::dwallet_checkpoints::{
     DWalletCheckpointMetrics, DWalletCheckpointService, DWalletCheckpointStore,
     SendDWalletCheckpointToStateSync, SubmitDWalletCheckpointToConsensus,
 };
+use ika_core::dwallet_mpc::network_owned_address_signing_key::{
+    self, NetworkOwnedAddressSigningKeySelection,
+};
 use ika_core::epoch::committee_store::CommitteeStore;
 use ika_core::epoch::consensus_store_pruner::ConsensusStorePruner;
 use ika_core::epoch::epoch_metrics::EpochMetrics;
@@ -74,6 +77,7 @@ use ika_core::validator_metadata::{next_committee_pubkey_set, verify_joiner_boot
 use ika_network::discovery::TrustedPeerChangeEvent;
 use ika_network::{discovery, state_sync};
 use ika_protocol_config::{ProtocolConfig, ProtocolVersion};
+use ika_types::messages_dwallet_mpc::DWalletNetworkEncryptionKeyData;
 use mysten_metrics::{RegistryService, spawn_monitored_task};
 use sui_macros::{fail_point_async, replay_log};
 use sui_storage::{FileCompression, StorageFormat};
@@ -491,6 +495,29 @@ impl IkaNode {
             &config.db_path().join("store"),
             Some(perpetual_tables_options.options),
         ));
+        // Reload every `ObjectID <-> NetworkKeyId` translation this process
+        // persisted, before anything reads the mapping: the prepare-then-start
+        // barrier below translates the handoff certificate's keys to resolve
+        // the epoch's network-owned-address signing key, and a translation
+        // that lived only in the previous process would leave a restarted
+        // validator without a signing key for the epoch.
+        let loaded_network_key_id_mappings = perpetual_tables
+            .iter_network_key_id_mappings()
+            .filter_map(|entry| {
+                entry
+                    .map_err(|e| {
+                        warn!(error = ?e, "skipping an unreadable persisted NetworkKeyId mapping")
+                    })
+                    .ok()
+            })
+            .inspect(|(object_id, network_key_id)| {
+                ika_core::network_key_id_mapping::register(*object_id, *network_key_id)
+            })
+            .count();
+        info!(
+            loaded_network_key_id_mappings,
+            "loaded the persisted network key id mappings"
+        );
 
         // Choose the gRPC/OCS topology before constructing the Sui client.
         use ika_config::node::{SuiDataSource, SuiTransportPlan, select_sui_transport};
@@ -1424,7 +1451,7 @@ impl IkaNode {
             // chain. Entering epoch 0 has no predecessor to be handed off
             // from — the chain-true no-cert genesis epoch — and is skipped on
             // the same `>= 1` test the joiner bootstrap uses.
-            if epoch_store.epoch() >= 1 {
+            let network_owned_address_signing_key_id = if epoch_store.epoch() >= 1 {
                 let barrier = HandoffBarrierContext {
                     p2p_network: p2p_network.clone(),
                     perpetual_tables: perpetual_tables.clone(),
@@ -1434,6 +1461,7 @@ impl IkaNode {
                         .as_ref()
                         .map(|metrics| metrics.telemetry.clone()),
                     withhold_anchor_for: config.withhold_handoff_anchor_for_testing,
+                    network_keys_receiver: sui_data_receivers.network_keys_receiver.clone(),
                 };
                 let anchor_committee = AnchorCommittee::Resolved {
                     committee_store: state.committee_store().clone(),
@@ -1455,7 +1483,9 @@ impl IkaNode {
                 )
                 .await
                 {
-                    HandoffBarrierOutcome::Ready => {}
+                    HandoffBarrierOutcome::Ready {
+                        network_owned_address_signing_key_id,
+                    } => network_owned_address_signing_key_id,
                     HandoffBarrierOutcome::FailedClosed => {
                         return Err(anyhow!(
                             "cross-epoch handoff anchor for epoch {anchor_epoch} is contradicted; \
@@ -1470,7 +1500,9 @@ impl IkaNode {
                         ));
                     }
                 }
-            }
+            } else {
+                None
+            };
             let components = Self::construct_validator_components(
                 config.clone(),
                 state.clone(),
@@ -1492,6 +1524,7 @@ impl IkaNode {
                 noa_system_finalized.clone(),
                 stranded_network_keys.clone(),
                 commit_liveness.clone(),
+                network_owned_address_signing_key_id,
             )
             .await?;
 
@@ -2117,6 +2150,7 @@ impl IkaNode {
         noa_system_finalized: Arc<std::sync::atomic::AtomicBool>,
         stranded_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
         commit_liveness: Option<Arc<commit_liveness_watchdog::CommitLivenessWatchdog>>,
+        network_owned_address_signing_key_id: Option<ObjectID>,
     ) -> Result<ValidatorComponents> {
         let mut config_clone = config.clone();
         let consensus_config = config_clone
@@ -2186,6 +2220,7 @@ impl IkaNode {
             noa_system_finalized,
             stranded_network_keys,
             commit_liveness,
+            network_owned_address_signing_key_id,
         )
         .await
     }
@@ -2217,6 +2252,9 @@ impl IkaNode {
         noa_system_finalized: Arc<std::sync::atomic::AtomicBool>,
         stranded_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
         commit_liveness: Option<Arc<commit_liveness_watchdog::CommitLivenessWatchdog>>,
+        // Resolved by the prepare-then-start barrier from the prior epoch's
+        // handoff certificate; the MPC manager takes it as a fixed input.
+        network_owned_address_signing_key_id: Option<ObjectID>,
     ) -> Result<ValidatorComponents> {
         // Channel for network-owned-address sign requests (sender unused after
         // pipeline→handler migration; receiver still drained by service loop).
@@ -2398,6 +2436,7 @@ impl IkaNode {
             system_checkpoint_handler,
             stranded_network_keys,
             &seed_resolution,
+            network_owned_address_signing_key_id,
         );
 
         // create a new map that gets injected into both the consensus handler and the consensus adapter
@@ -3405,10 +3444,13 @@ impl IkaNode {
                 // so only it prepares. A node leaving the committee
                 // (validator last epoch, not this one) must not block on
                 // handoff data it will never use.
-                if self.state.is_validator(&new_epoch_store)
-                    && !matches!(
-                        wait_for_handoff_data_ready(
-                            &HandoffBarrierContext::from_node(&self),
+                let network_owned_address_signing_key_id =
+                    if self.state.is_validator(&new_epoch_store) {
+                        match wait_for_handoff_data_ready(
+                            &HandoffBarrierContext::from_node(
+                                &self,
+                                sui_data_receivers.network_keys_receiver.clone(),
+                            ),
                             cur_epoch_store.epoch(),
                             // The epoch we are leaving IS the anchor epoch,
                             // so its committee is in hand.
@@ -3416,30 +3458,39 @@ impl IkaNode {
                             &epoch_peer_ids(&cur_epoch_store),
                             &new_epoch_store,
                         )
-                        .await,
-                        HandoffBarrierOutcome::Ready
-                    )
-                {
-                    // The cross-epoch anchor is contradicted and the node has
-                    // been signalled to halt (the barrier logged why). Leave
-                    // the reconfiguration loop instead of starting the epoch's
-                    // components on it — consensus is already torn down at
-                    // this point, so the node is deliberately inert from here.
-                    //
-                    // Matched as "not Ready" rather than on the contradicted
-                    // variant alone so no future outcome can start the epoch by
-                    // default. Only that variant is reachable here: the anchor
-                    // committee is HELD (the outgoing store's own), so the
-                    // resolution this arm's sibling reports on cannot fail.
-                    error!(
-                        next_epoch,
-                        "prepare-then-start: the cross-epoch anchor for epoch {next_epoch} is \
-                         CONTRADICTED; refusing to enter the epoch and leaving the \
-                         reconfiguration loop with consensus down. The node has been signalled to \
-                         shut down (the barrier logged which contradiction)."
-                    );
-                    return Ok(());
-                }
+                        .await
+                        {
+                            HandoffBarrierOutcome::Ready {
+                                network_owned_address_signing_key_id,
+                            } => network_owned_address_signing_key_id,
+                            // The cross-epoch anchor is contradicted and the node
+                            // has been signalled to halt (the barrier logged why).
+                            // Leave the reconfiguration loop instead of starting
+                            // the epoch's components on it — consensus is already
+                            // torn down at this point, so the node is deliberately
+                            // inert from here.
+                            //
+                            // Matched as "not Ready" rather than on the
+                            // contradicted variant alone so no future outcome can
+                            // start the epoch by default. Only that variant is
+                            // reachable here: the anchor committee is HELD (the
+                            // outgoing store's own), so the resolution this arm's
+                            // sibling reports on cannot fail.
+                            _ => {
+                                error!(
+                                    next_epoch,
+                                    "prepare-then-start: the cross-epoch anchor for epoch \
+                                 {next_epoch} is CONTRADICTED; refusing to enter the epoch and \
+                                 leaving the reconfiguration loop with consensus down. The node \
+                                 has been signalled to shut down (the barrier logged which \
+                                 contradiction)."
+                                );
+                                return Ok(());
+                            }
+                        }
+                    } else {
+                        None
+                    };
 
                 if self.state.is_validator(&new_epoch_store) {
                     // Only restart consensus if this node is still a validator in the new epoch.
@@ -3466,6 +3517,7 @@ impl IkaNode {
                             self.noa_system_finalized.clone(),
                             self.stranded_network_keys.clone(),
                             self.commit_liveness.clone(),
+                            network_owned_address_signing_key_id,
                         )
                         .await?,
                     )
@@ -3513,27 +3565,35 @@ impl IkaNode {
                     // anchor epoch even though this node was not in that
                     // committee: the store still carries the committee the
                     // cert was signed by and the peers that serve it.
-                    if !matches!(
-                        wait_for_handoff_data_ready(
-                            &HandoffBarrierContext::from_node(&self),
-                            cur_epoch_store.epoch(),
-                            &AnchorCommittee::Held(cur_epoch_store.committee().clone()),
-                            &epoch_peer_ids(&cur_epoch_store),
-                            &new_epoch_store,
-                        )
-                        .await,
-                        HandoffBarrierOutcome::Ready
-                    ) {
-                        error!(
-                            next_epoch,
-                            "prepare-then-start: the cross-epoch anchor for epoch \
-                             {next_epoch} is CONTRADICTED; refusing to promote this node into \
-                             that committee and leaving the reconfiguration loop. The node has \
-                             been signalled to shut down (the barrier logged which \
-                             contradiction)."
-                        );
-                        return Ok(());
-                    }
+                    let network_owned_address_signing_key_id = match wait_for_handoff_data_ready(
+                        &HandoffBarrierContext::from_node(
+                            &self,
+                            sui_data_receivers.network_keys_receiver.clone(),
+                        ),
+                        cur_epoch_store.epoch(),
+                        &AnchorCommittee::Held(cur_epoch_store.committee().clone()),
+                        &epoch_peer_ids(&cur_epoch_store),
+                        &new_epoch_store,
+                    )
+                    .await
+                    {
+                        HandoffBarrierOutcome::Ready {
+                            network_owned_address_signing_key_id,
+                        } => network_owned_address_signing_key_id,
+                        // Matched as "not Ready" for the same reason as the
+                        // continuing-validator seam above.
+                        _ => {
+                            error!(
+                                next_epoch,
+                                "prepare-then-start: the cross-epoch anchor for epoch \
+                                 {next_epoch} is CONTRADICTED; refusing to promote this node \
+                                 into that committee and leaving the reconfiguration loop. The \
+                                 node has been signalled to shut down (the barrier logged which \
+                                 contradiction)."
+                            );
+                            return Ok(());
+                        }
+                    };
 
                     Some(
                         Self::construct_validator_components(
@@ -3557,6 +3617,7 @@ impl IkaNode {
                             self.noa_system_finalized.clone(),
                             self.stranded_network_keys.clone(),
                             self.commit_liveness.clone(),
+                            network_owned_address_signing_key_id,
                         )
                         .await?,
                     )
@@ -3690,12 +3751,22 @@ struct HandoffBarrierContext {
     telemetry: Option<Arc<ValidatorTelemetryMetrics>>,
     /// TESTS ONLY — `NodeConfig::withhold_handoff_anchor_for_testing`.
     withhold_anchor_for: Option<Duration>,
+    /// The network-key syncer's chain-fed overlay: every on-chain network
+    /// encryption key with its metadata. The barrier reads each certified
+    /// key's `dkg_at_epoch` from it to resolve the epoch's
+    /// network-owned-address signing key.
+    network_keys_receiver: watch::Receiver<Arc<HashMap<ObjectID, DWalletNetworkEncryptionKeyData>>>,
 }
 
 impl HandoffBarrierContext {
     /// The two paths that run inside `monitor_reconfiguration` build the
     /// context from the running node.
-    fn from_node(node: &IkaNode) -> Self {
+    fn from_node(
+        node: &IkaNode,
+        network_keys_receiver: watch::Receiver<
+            Arc<HashMap<ObjectID, DWalletNetworkEncryptionKeyData>>,
+        >,
+    ) -> Self {
         Self {
             p2p_network: node.p2p_network.clone(),
             perpetual_tables: node.state.perpetual_tables(),
@@ -3703,6 +3774,7 @@ impl HandoffBarrierContext {
             bootstrap_outcomes: node.metrics.joiner_bootstrap_outcomes_total.clone(),
             telemetry: node.validator_telemetry.clone(),
             withhold_anchor_for: node.config.withhold_handoff_anchor_for_testing,
+            network_keys_receiver,
         }
     }
 
@@ -3850,8 +3922,14 @@ enum AnchorOutcome {
 /// to start the epoch's components.
 enum HandoffBarrierOutcome {
     /// The epoch's full verified handoff data is local — start the epoch's
-    /// components.
-    Ready,
+    /// components, with the network-owned-address signing key the barrier
+    /// resolved from the certificate: `None` when the epoch has no such key
+    /// (no certificate, or one naming no network key) or when this
+    /// validator could not translate every certified key and sits NOA
+    /// signing out this epoch.
+    Ready {
+        network_owned_address_signing_key_id: Option<ObjectID>,
+    },
     /// The cross-epoch anchor is contradicted. The node has been signalled to
     /// halt and the caller MUST NOT start the epoch's components. The boot
     /// path additionally turns this into a startup error, because the
@@ -4190,7 +4268,9 @@ async fn wait_for_handoff_data_ready(
                              {next_epoch}. Entering it without a cross-epoch anchor, the same \
                              as entering epoch 0 at genesis."
                         );
-                        return HandoffBarrierOutcome::Ready;
+                        return HandoffBarrierOutcome::Ready {
+                            network_owned_address_signing_key_id: None,
+                        };
                     }
                     AnchorCommitteeResolution::Unavailable => {}
                 }
@@ -4265,21 +4345,85 @@ async fn wait_for_handoff_data_ready(
             )
         });
 
-        if ready {
-            let elapsed = started_at.elapsed();
-            if let Some(telemetry) = &telemetry {
-                telemetry.handoff_prepare_waiting.set(0);
-                telemetry
-                    .handoff_prepare_duration_seconds
-                    .observe(elapsed.as_secs_f64());
+        // Condition 3: the epoch's network-owned-address signing key — a
+        // pure function of the certificate's keys ranked by their chain
+        // `dkg_at_epoch` — resolved here so the epoch's components receive
+        // it as a fixed input and never choose for themselves. Only the chain
+        // metadata can still be on its way (the syncer publishes every
+        // on-chain key's within a tick), so that alone is a not-ready
+        // condition. A certified key this process cannot translate is NOT:
+        // the translation registers when the key is instantiated or derived,
+        // after the components start, so waiting would deadlock every joiner
+        // on a network whose keys are outside the compiled-in constants. Such
+        // a validator enters the epoch with no signing key and sits NOA
+        // signing out until the next handoff; a restart is spared this by
+        // the persisted mapping loaded at boot.
+        let mut awaiting_metadata_key_ids: Vec<ObjectID> = Vec::new();
+        if let Some(cert) = cert.filter(|_| ready) {
+            let overlay = ctx.network_keys_receiver.borrow().clone();
+            let selection = network_owned_address_signing_key::select(cert, |object_id| {
+                overlay.get(object_id).map(|data| data.dkg_at_epoch)
+            });
+            let resolved = match selection {
+                NetworkOwnedAddressSigningKeySelection::AwaitingMetadata(key_ids) => Err(key_ids),
+                NetworkOwnedAddressSigningKeySelection::Selected {
+                    object_id,
+                    network_key_id,
+                    dkg_at_epoch,
+                } => {
+                    info!(
+                        next_epoch,
+                        network_owned_address_signing_key_id = ?object_id,
+                        ?network_key_id,
+                        dkg_at_epoch,
+                        "prepare-then-start: resolved epoch {next_epoch}'s network-owned-address \
+                         signing key from the handoff certificate"
+                    );
+                    Ok(Some(object_id))
+                }
+                NetworkOwnedAddressSigningKeySelection::NoCertifiedKey => {
+                    info!(
+                        next_epoch,
+                        "prepare-then-start: the handoff certificate names no network key, so \
+                         epoch {next_epoch} has no network-owned-address signing key"
+                    );
+                    Ok(None)
+                }
+                NetworkOwnedAddressSigningKeySelection::Untranslatable(network_key_ids) => {
+                    warn!(
+                        next_epoch,
+                        untranslatable_cert_keys = ?network_key_ids,
+                        "prepare-then-start: certified network keys with no ObjectID \
+                         translation on this process — this validator enters epoch \
+                         {next_epoch} with NO network-owned-address signing key and will not \
+                         take part in NOA signing until the next handoff. Expected only for a \
+                         joiner on a network whose keys are outside the compiled-in constants; \
+                         a restarted validator holds the persisted mapping."
+                    );
+                    Ok(None)
+                }
+            };
+            match resolved {
+                Ok(network_owned_address_signing_key_id) => {
+                    let elapsed = started_at.elapsed();
+                    if let Some(telemetry) = &telemetry {
+                        telemetry.handoff_prepare_waiting.set(0);
+                        telemetry
+                            .handoff_prepare_duration_seconds
+                            .observe(elapsed.as_secs_f64());
+                    }
+                    info!(
+                        next_epoch,
+                        "prepare-then-start: epoch {next_epoch} handoff data ready+verified \
+                         after {}s, {retries} retries; starting MPC",
+                        elapsed.as_secs()
+                    );
+                    return HandoffBarrierOutcome::Ready {
+                        network_owned_address_signing_key_id,
+                    };
+                }
+                Err(key_ids) => awaiting_metadata_key_ids = key_ids,
             }
-            info!(
-                next_epoch,
-                "prepare-then-start: epoch {next_epoch} handoff data ready+verified after \
-                 {}s, {retries} retries; starting MPC",
-                elapsed.as_secs()
-            );
-            return HandoffBarrierOutcome::Ready;
         }
 
         retries += 1;
@@ -4375,6 +4519,7 @@ async fn wait_for_handoff_data_ready(
                 missing_locally = missing_key_ids.len(),
                 missing_key_ids = ?missing_key_ids,
                 unmapped_cert_keys = ?unmapped_cert_keys,
+                awaiting_metadata_key_ids = ?awaiting_metadata_key_ids,
                 retries,
                 withheld_for_testing = withheld,
                 "prepare-then-start: still awaiting full verified handoff data for epoch \

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -824,8 +824,14 @@ impl ProtocolConfig {
 
             // Set at v4 (see the version match below).
             internal_presign_stale_batch_expiry_rounds: None,
-            // Set at v7 (see the version match below).
-            noa_presign_demand_park_rounds: None,
+            // About an hour of mainnet consensus at ~19.5 rounds/s, and ~4%
+            // of a 24h epoch: far past every honest window a NOA presign
+            // demand waits out (the network-key syncer tick, a restarting
+            // validator's key recovery, a fresh pool's first fill — all
+            // seconds to minutes), and early enough that a demand which will
+            // never be served is dropped while the epoch can still finalize
+            // the rest.
+            noa_presign_demand_park_rounds: Some(70_000),
         };
 
         cfg.feature_flags.mysticeti_num_leaders_per_round = Some(1);
@@ -886,14 +892,6 @@ impl ProtocolConfig {
                     // Mirrored into `AUTHORITY_NAME_SHORT_ENCODING` at epoch
                     // store construction — serde cannot read the config.
                     cfg.feature_flags.short_authority_names = true;
-                    // About an hour of mainnet consensus at ~19.5 rounds/s,
-                    // and ~4% of a 24h epoch: far past every honest window a
-                    // NOA presign demand waits out (the network-key syncer
-                    // tick, a restarting validator's key recovery, a fresh
-                    // pool's first fill — all seconds to minutes), and early
-                    // enough that a demand which will never be served is
-                    // dropped while the epoch can still finalize the rest.
-                    cfg.noa_presign_demand_park_rounds = Some(70_000);
                 }
                 // 8 => {
                 //     cfg.feature_flags.noa_checkpoints = true;

--- a/crates/ika-protocol-config/src/lib.rs
+++ b/crates/ika-protocol-config/src/lib.rs
@@ -543,6 +543,18 @@ pub struct ProtocolConfig {
     /// it derives the deterministic session identifiers every validator
     /// computes independently.
     internal_presign_stale_batch_expiry_rounds: Option<u64>,
+
+    /// Consensus rounds a network-owned-address (NOA) presign demand may stay
+    /// parked in the assignment drain — unassigned because the epoch's NOA
+    /// signing key is not yet derived on this validator, or because that
+    /// key's presign pool is still empty — before the drain drops it for the
+    /// epoch. A demand delivered at round `R_d` is dropped at the first
+    /// drained round `R` with `R - R_d >= this`. `None` never drops (the
+    /// demand parks for the rest of the epoch). Version-gated because the
+    /// drop is part of a consensus-uniform predicate: validators running
+    /// different bounds would drop different demands and disagree on which
+    /// demands hold a presign.
+    noa_presign_demand_park_rounds: Option<u64>,
 }
 
 // feature flags
@@ -812,6 +824,8 @@ impl ProtocolConfig {
 
             // Set at v4 (see the version match below).
             internal_presign_stale_batch_expiry_rounds: None,
+            // Set at v7 (see the version match below).
+            noa_presign_demand_park_rounds: None,
         };
 
         cfg.feature_flags.mysticeti_num_leaders_per_round = Some(1);
@@ -872,6 +886,14 @@ impl ProtocolConfig {
                     // Mirrored into `AUTHORITY_NAME_SHORT_ENCODING` at epoch
                     // store construction — serde cannot read the config.
                     cfg.feature_flags.short_authority_names = true;
+                    // About an hour of mainnet consensus at ~19.5 rounds/s,
+                    // and ~4% of a 24h epoch: far past every honest window a
+                    // NOA presign demand waits out (the network-key syncer
+                    // tick, a restarting validator's key recovery, a fresh
+                    // pool's first fill — all seconds to minutes), and early
+                    // enough that a demand which will never be served is
+                    // dropped while the epoch can still finalize the rest.
+                    cfg.noa_presign_demand_park_rounds = Some(70_000);
                 }
                 // 8 => {
                 //     cfg.feature_flags.noa_checkpoints = true;

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Mainnet_version_7.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Mainnet_version_7.snap
@@ -78,3 +78,4 @@ internal_eddsa_presign_pool_maximum_size: 30000
 internal_schnorrkel_substrate_presign_pool_maximum_size: 30000
 internal_taproot_presign_pool_maximum_size: 30000
 internal_presign_stale_batch_expiry_rounds: 3000
+noa_presign_demand_park_rounds: 70000

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Testnet_version_7.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__Testnet_version_7.snap
@@ -78,3 +78,4 @@ internal_eddsa_presign_pool_maximum_size: 30000
 internal_schnorrkel_substrate_presign_pool_maximum_size: 30000
 internal_taproot_presign_pool_maximum_size: 30000
 internal_presign_stale_batch_expiry_rounds: 3000
+noa_presign_demand_park_rounds: 70000

--- a/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__version_7.snap
+++ b/crates/ika-protocol-config/src/snapshots/ika_protocol_config__test__version_7.snap
@@ -78,3 +78,4 @@ internal_eddsa_presign_pool_maximum_size: 30000
 internal_schnorrkel_substrate_presign_pool_maximum_size: 30000
 internal_taproot_presign_pool_maximum_size: 30000
 internal_presign_stale_batch_expiry_rounds: 3000
+noa_presign_demand_park_rounds: 70000

--- a/crates/ika-types/src/messages_consensus.rs
+++ b/crates/ika-types/src/messages_consensus.rs
@@ -654,12 +654,10 @@ impl ConsensusTransaction {
     pub fn new_noa_presign_demand(
         authority: AuthorityName,
         demand_id: crate::noa_checkpoint::NOAPresignDemandId,
-        network_encryption_key_id: ObjectID,
     ) -> Self {
         let msg = ConsensusNOAPresignDemand {
             authority,
             demand_id,
-            network_encryption_key_id,
         };
         let mut hasher = DefaultHasher::new();
         msg.demand_id_digest().hash(&mut hasher);
@@ -817,7 +815,6 @@ impl ConsensusTransaction {
 mod wire_format_tests {
     use super::*;
     use dwallet_mpc_types::dwallet_mpc::DWalletSignatureAlgorithm;
-    use sui_types::base_types::ObjectID;
 
     /// The BCS variant tag of `ConsensusTransactionKind` is a cross-version
     /// wire contract: every binary in a mixed committee decodes every other
@@ -848,7 +845,6 @@ mod wire_format_tests {
                         session_identifier: [0u8; 32],
                         signature_algorithm: DWalletSignatureAlgorithm::ECDSASecp256k1,
                     },
-                    network_encryption_key_id: ObjectID::ZERO,
                 }
             )),
             15,

--- a/crates/ika-types/src/messages_dwallet_mpc.rs
+++ b/crates/ika-types/src/messages_dwallet_mpc.rs
@@ -211,11 +211,18 @@ impl ConsensusNOAObservation {
 /// assign it a presign in the same consensus-delivery order. Deduplicated by
 /// `demand_id` (NOT by authority) so redundant announcements from multiple
 /// validators collapse to one; assignment is idempotent regardless.
+///
+/// The announcement carries nothing the assignment reads besides the demand
+/// identity: the signature algorithm is derived from the identity, and the
+/// network encryption key the presign is drawn under is derived by every
+/// validator from the prior epoch's handoff certificate. Consensus
+/// deduplicates on the identity digest alone, so any payload field here would
+/// be supplied for the whole network by whichever announcement is sequenced
+/// first.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ConsensusNOAPresignDemand {
     pub authority: AuthorityName,
     pub demand_id: crate::noa_checkpoint::NOAPresignDemandId,
-    pub network_encryption_key_id: ObjectID,
 }
 
 impl ConsensusNOAPresignDemand {

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -384,6 +384,21 @@ next epoch inherits.
 
    Nothing else is exempt.
 
+   THE SIGNING KEY. Once the certificate and every certified output are
+   local, the barrier also resolves the epoch's network-owned-address
+   signing key from the certificate (see "The network-owned-address
+   signing key" below) and returns it with `Ready`, so the epoch's
+   components take it as a fixed constructor input and never choose for
+   themselves. A certified key whose chain metadata (`dkg_at_epoch`, from
+   the network-key syncer's overlay) is not local yet is one more not-ready
+   condition, waited out like the others. A certified key with no
+   `NetworkKeyId → ObjectID` translation is the exemption above again:
+   the barrier passes, and the validator enters the epoch with NO signing
+   key, sitting NOA signing out until the next handoff. The persisted
+   mapping (loaded at boot) keeps a restart out of that case; only a
+   joiner on a network whose keys are outside the compiled-in constants
+   reaches it.
+
    FAIL-CLOSED. A contradicted anchor — peers served certificates and
    none verified, or a locally persisted one that no longer verifies —
    halts the node on every path, and the caller does not start the
@@ -561,25 +576,37 @@ next epoch inherits.
 
 ## The network-owned-address signing key
 
-The certificate has a fourth consumer. The epoch's network-owned-address
-(NOA) signing key — the network encryption key every NOA sign demand's
-presign is drawn under and every NOA sign session runs on — is a pure
-function of the prior epoch's certificate, fixed for the epoch, and derived
-by every validator on its own without anyone announcing a choice
-(`DWalletMPCManager::network_owned_address_signing_key_resolution`). The
-rule: among the keys the epoch-E certificate names (its `NetworkDkgOutput`
-items), the key with the largest `dkg_at_epoch`, ties broken by the smaller
-`NetworkKeyId`, is epoch E+1's NOA signing key. The certificate is the SOLE
-input to eligibility: a key created by DKG during E+1 is not in that
-certificate and waits until E+2, and an epoch with no certificate (genesis,
-or the first epoch of a fresh network) has no NOA signing key — NOA signing
-waits for the first handoff. `dkg_at_epoch` (chain metadata, from the
-network-key syncer's overlay) and the `NetworkKeyId -> ObjectID` translation
-(the process-global mapping) are read locally, and a validator missing
-either for ANY certified key derives nothing rather than choosing among the
-keys it can see; the answer is cached for the epoch once it resolves, since
-every input only ever gains entries. The internal presign pool's NOA
-pool-parameter role and the presign-demand drain both read this derivation
+The certificate has a fourth consumer, and the barrier evaluates it. The
+epoch's network-owned-address (NOA) signing key — the network encryption key
+every NOA sign demand's presign is drawn under and every NOA sign session
+runs on — is a pure function of the prior epoch's certificate, fixed for the
+epoch, resolved by the prepare-then-start barrier on every path that starts
+a validator's epoch components, and handed to the MPC manager as a
+constructor input (`dwallet_mpc::network_owned_address_signing_key::select`).
+Nothing announces a choice. The rule: among the keys the epoch-E certificate
+names (its `NetworkDkgOutput` items), the key with the largest
+`dkg_at_epoch`, ties broken by the smaller `NetworkKeyId`, is epoch E+1's
+NOA signing key. The certificate is the SOLE input to eligibility: a key
+created by DKG during E+1 is not in that certificate and waits until E+2, and
+an epoch with no certificate (genesis, or the first epoch of a fresh network)
+has no NOA signing key — NOA signing waits for the first handoff.
+
+The rule needs two local inputs. `dkg_at_epoch` is chain metadata, read from
+the network-key syncer's overlay (every on-chain key, published within a
+tick); a certified key whose metadata is not local yet is a not-ready
+condition, and the barrier waits for it like any other. The `NetworkKeyId ->
+ObjectID` translation is the process-global mapping: seeded with the
+deployed keys, registered at instantiation or by the background derivation,
+and — so that a restart does not lose it — written to the perpetual store
+(`network_key_ids_by_object_id`) by the MPC manager and loaded back at boot
+before the barrier runs. A certified key with NO translation is the same
+carve-out as in the barrier section: the translation registers only after
+the components start, so the barrier does not wait; that validator enters
+the epoch with no signing key and sits NOA signing out until the next
+handoff, logged loudly. It never chooses among the keys it can translate.
+Expected only for a joiner on a network whose keys are outside the
+compiled-in constants. The internal presign pool's NOA pool-parameter role
+and the presign-demand drain both read the manager's fixed key
 (`internal-presign-pool.md`, "Which pool a demand draws from"). Under
 `noa_checkpoints` OFF the pool role keeps the previous rule — the oldest
 locally adopted key — so the live protocol version's internal-presign
@@ -621,9 +648,10 @@ sequence numbers do not move.
    translation, which the barrier cannot check or install and which
    adoption's own cert-digest gate covers instead.
 6. The network-owned-address signing key is a function of the prior
-   epoch's certificate alone: no validator announces a choice, a key
-   created after the certificate waits one epoch, and two validators
-   that have derived the key agree on it.
+   epoch's certificate alone, resolved by the barrier and fixed for the
+   epoch: no validator announces a choice, a key created after the
+   certificate waits one epoch, and two validators that hold a key hold
+   the same one.
 
 Code anchors: `crates/ika-types/src/handoff.rs` (types),
 `crates/ika-core/src/handoff_cert.rs` (aggregation + verification),

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -559,6 +559,32 @@ next epoch inherits.
      items (see the barrier section) — the only layer that heals an
      already-poisoned mirror.
 
+## The network-owned-address signing key
+
+The certificate has a fourth consumer. The epoch's network-owned-address
+(NOA) signing key — the network encryption key every NOA sign demand's
+presign is drawn under and every NOA sign session runs on — is a pure
+function of the prior epoch's certificate, fixed for the epoch, and derived
+by every validator on its own without anyone announcing a choice
+(`DWalletMPCManager::network_owned_address_signing_key_resolution`). The
+rule: among the keys the epoch-E certificate names (its `NetworkDkgOutput`
+items), the key with the largest `dkg_at_epoch`, ties broken by the smaller
+`NetworkKeyId`, is epoch E+1's NOA signing key. The certificate is the SOLE
+input to eligibility: a key created by DKG during E+1 is not in that
+certificate and waits until E+2, and an epoch with no certificate (genesis,
+or the first epoch of a fresh network) has no NOA signing key — NOA signing
+waits for the first handoff. `dkg_at_epoch` (chain metadata, from the
+network-key syncer's overlay) and the `NetworkKeyId -> ObjectID` translation
+(the process-global mapping) are read locally, and a validator missing
+either for ANY certified key derives nothing rather than choosing among the
+keys it can see; the answer is cached for the epoch once it resolves, since
+every input only ever gains entries. The internal presign pool's NOA
+pool-parameter role and the presign-demand drain both read this derivation
+(`internal-presign-pool.md`, "Which pool a demand draws from"). Under
+`noa_checkpoints` OFF the pool role keeps the previous rule — the oldest
+locally adopted key — so the live protocol version's internal-presign
+sequence numbers do not move.
+
 ## Key invariants
 
 1. One handoff per epoch, attested at EndOfPublish, verified against
@@ -594,6 +620,10 @@ next epoch inherits.
    from), and a certified key with no local `NetworkKeyId → ObjectID`
    translation, which the barrier cannot check or install and which
    adoption's own cert-digest gate covers instead.
+6. The network-owned-address signing key is a function of the prior
+   epoch's certificate alone: no validator announces a choice, a key
+   created after the certificate waits one epoch, and two validators
+   that have derived the key agree on it.
 
 Code anchors: `crates/ika-types/src/handoff.rs` (types),
 `crates/ika-core/src/handoff_cert.rs` (aggregation + verification),

--- a/dev-docs/specs/internal-presign-pool.md
+++ b/dev-docs/specs/internal-presign-pool.md
@@ -77,84 +77,66 @@ internal sign request carries an algorithm beside the id, so the pool drained
 and the session instantiated cannot disagree.
 
 **The network encryption key** is the epoch's network-owned-address (NOA)
-signing key, which every validator derives for itself from the prior epoch's
-handoff certificate
-(`DWalletMPCManager::network_owned_address_signing_key_resolution`; the rule
-is stated in [`handoff.md`](handoff.md), "The network-owned-address signing
-key"): among the keys the certificate names, the one with the largest
-`dkg_at_epoch`, ties broken by the smaller `NetworkKeyId`. The certificate is
-the one input every validator holds identically for the whole epoch —
-quorum-signed, local before the epoch's components start (the
-prepare-then-start barrier), never modified afterwards — so the answer is one
-value per epoch, and a validator that has derived it agrees with every other
-validator that has. The derivation is all-or-nothing: the certificate names
-keys by `NetworkKeyId` while the pool is keyed by Sui `ObjectID`, and
-`dkg_at_epoch` lives on the chain metadata the network-key syncer publishes;
-a validator that cannot yet translate, or has no metadata for, ANY certified
-key answers "no key yet" rather than choosing among the keys it can see.
-Choosing among a subset is exactly the per-validator divergence the
-derivation exists to remove. The answer is cached once it resolves (every
-input only ever gains entries), and it is recorded with the assignment, so
-the sign session later instantiates under the key its presign was drawn
-from.
+signing key, which the prepare-then-start barrier resolves from the prior
+epoch's handoff certificate before the epoch's components exist and hands to
+the MPC manager as a constructor input
+(`dwallet_mpc::network_owned_address_signing_key::select`; the rule and the
+barrier's handling are stated in [`handoff.md`](handoff.md), "The
+network-owned-address signing key"): among the keys the certificate names,
+the one with the largest `dkg_at_epoch`, ties broken by the smaller
+`NetworkKeyId`. The certificate is the one input every validator holds
+identically for the whole epoch — quorum-signed, local before the epoch's
+components start, never modified afterwards — so the answer is one value per
+epoch, fixed at construction, and every validator that holds a key holds the
+same one. A validator the barrier could not translate every certified key for
+holds NO key and sits NOA signing out for the epoch rather than choosing
+among the keys it can see; choosing among a subset is exactly the
+per-validator divergence the derivation exists to remove. The key is recorded
+with the assignment, so the sign session later instantiates under the key its
+presign was drawn from.
 
 The previous rule — the oldest key in the validator's locally ADOPTED set,
 carried in the announcement — let honest validators name different keys
 while their adoption lagged at different rates, and let a dishonest announcer
 name a key nobody holds (issue #2019, which is closed by construction rather
-than by measurement: nothing is announced, and the derived key does not read
-the adopted set at all). The adopted-set rule survives only behind
-`noa_checkpoints` OFF, where it decides which pool receives the NOA pool
-parameters on the live protocol version; changing it there would move the
-internal-presign sequence numbers under a mixed-binary committee, and no
-demand can be announced with the flag off in any case. With the flag on, the
-top-up loop applies the NOA parameters to the derived key and mints nothing
-at all while the derivation is still pending, so a key's pool role cannot
-flip mid-epoch on one validator but not another; an epoch with no
-certificate treats every key as a non-NOA key for the whole epoch.
+than by measurement: nothing is announced, and the key is fixed before
+adoption runs). The adopted-set rule survives only behind `noa_checkpoints`
+OFF, where it decides which pool receives the NOA pool parameters on the live
+protocol version; changing it there would move the internal-presign sequence
+numbers under a mixed-binary committee, and no demand can be announced with
+the flag off in any case. With the flag on, the top-up loop applies the NOA
+parameters to the barrier's key from the first top-up, so a key's pool role
+cannot flip mid-epoch on one validator but not another; a validator with no
+key gives every key the internal parameters for the whole epoch.
 
 ## A demand with no key or no pool: park, with a bound
 
 Two things stop a validator from assigning a consensus-delivered demand: it
-has not derived the epoch's signing key yet, or that key's pool for the
-demand's algorithm is empty. In both cases the demand **parks**: it stays in
-the queue in consensus-delivery order and is retried on every following
-round. It is **not** rejected — there is nothing to reject it against, and
-an honest duplicate announcement could never follow (the dedup key again).
+holds no signing key this epoch, or the key's pool for the demand's algorithm
+is empty. In both cases the demand **parks**: it stays in the queue in
+consensus-delivery order and is retried on every following round. It is
+**not** rejected — there is nothing to reject it against, and an honest
+duplicate announcement could never follow (the dedup key again).
 
-WHEN a validator can derive the key is the one per-validator input on this
-path. The certificate is local from the start on every path that starts a
-validator's epoch components, and the chain metadata is the syncer's
-process-wide overlay, so a continuing validator derives the key on its first
-attempt. A restarting or joining validator waits for the overlay's first
-publish (one syncer tick) and, for a key outside the compiled-in deployed
-constants, for the `NetworkKeyId -> ObjectID` translation to register at
-instantiation or through the background derivation — seconds to minutes. A
-demand delivered inside that window parks here while a peer that derived
-earlier assigns it at delivery.
-
-That park is not uniform in time: the parked demand is assigned when this
-validator resolves, from the pool as it stands at THAT round, while the peer
-drew from the pool at the delivery round. A fill landing between the two
-rounds changes which presign is at the head only if it carries a LOWER
-sequence number than the head the peer drew — possible, because fills
-complete out of sequence order (below), but only while a batch is completing
-inside a validator's own derivation window at epoch start, when the
-per-epoch pool has just begun to fill. The top-up loop reads the same
-derivation and mints nothing on a validator whose key is still pending, so
-such a validator is not feeding the pool during its own window. This is the
-residual of the certificate rule; it is narrower than the announced-key
-design it replaces, where a validator that had not adopted the announced key
-parked on the same per-validator moment AND the key itself could differ.
+Neither condition has a per-validator TIMING. The key is fixed at
+construction, so a validator either holds it all epoch or never does; a
+validator without it never draws from the pool at all, so it cannot bind a
+presign its peers bind to a different demand — it sits NOA signing out, its
+demands park and are dropped at the bound, and the pairing on every keyed
+validator is untouched. The pool is filled from consensus outputs in round
+order on every validator that processes the rounds, adopted or not, so
+"empty" is uniform per round. That leaves the assignment step with no local
+input: a demand delivered at round *R* is assigned at the first round at or
+after *R* whose pool can serve it, identically everywhere.
 
 ### Why the park needs a bound anyway
 
 The bound is a liveness backstop, not a security control. There is no
 announced key left for a byzantine member to point at nothing; what remains
-is a validator that never derives the key this epoch — an epoch with no
-prior certificate (genesis, or the first epoch of a fresh network, where NOA
-signing waits for the first handoff), or a certified key this validator can
-never translate — and a pool that never fills. A demand parked on either
+is a validator with no signing key this epoch — an epoch with no prior
+certificate (genesis, or the first epoch of a fresh network, where NOA
+signing waits for the first handoff), or a certified key the barrier could
+not translate on this validator — and a pool that never fills. A demand parked on either
 would otherwise sit in the queue for the rest of the epoch, and the sign
 request behind it would wait forever for an assignment nobody will write.
 
@@ -177,10 +159,10 @@ identical everywhere: the delivery round and the round being drained. The
 third input, whether the demand is still unassigned, is a function of the
 presign pool, which is filled from quorum-agreed outputs in round order and
 is likewise uniform per round. Wall-clock time is not: validators observe
-different elapsed times for the same rounds. The moment this validator
-derived the signing key does not enter the predicate either: the bound
-measures from the consensus delivery round, so a validator that never derives
-the key drops the demand at the same round its peers would have.
+different elapsed times for the same rounds. Whether this validator holds a
+signing key does not enter the predicate either: the bound measures from the
+consensus delivery round, so a validator without one drops the demand at the
+same round its keyed peers would have had its pool never filled.
 
 The delivery rounds themselves survive a restart for the same reason: the
 round cursor replays the epoch's rounds from the start, so the queue and the
@@ -195,8 +177,8 @@ for its key was empty, and re-draining it either finds the pool still empty or
 assigns from it, exactly as an uncrashed peer did. It is NOT safe for a drop:
 
 1. demand *D* is parked past the bound and dropped at round *R_e*;
-2. *D*'s key derives late and its pool fills at some *R_i > R_e* — the
-   honest-lag case the bound deliberately drops anyway;
+2. *D*'s pool fills at some *R_i > R_e* — the honest-lag case the bound
+   deliberately drops anyway;
 3. the validator restarts. The rounds replay, *D* re-enters the rebuilt queue
    at its delivery round, and the drain now sees a pool that can serve it.
 
@@ -218,32 +200,28 @@ as the second arm of one per-demand resolution
 Every demand therefore has at most one terminal resolution per epoch, and a
 replayed drain READS it instead of deciding again: an already-dropped demand
 leaves the rebuilt queue without an assignment attempt, without re-logging at
-error level, and without re-counting the metric. That read does not wait for
-the signing key: a replay that runs before the restarted validator has
-re-derived it (its overlay republishes a tick after boot) reads the durable
-table directly, so a resolved demand leaves the queue instead of parking a
-second time under a bound measured from a delivery round long past. The
-write happens before the demand leaves the queue, and a failed write keeps
-the demand parked for the next round — the same posture as a failed
+error level, and without re-counting the metric. That read does not need a
+signing key: a replay on a validator that entered the epoch without one reads
+the durable table directly, so a resolved demand leaves the queue instead of
+parking a second time under a bound measured from a delivery round long past.
+The write happens before the demand leaves the queue, and a failed write
+keeps the demand parked for the next round — the same posture as a failed
 assignment.
 
 ### The bound drops an honest-lag demand too, deliberately
 
-No consensus-uniform signal distinguishes "a key this validator will never
-derive, a pool that will never fill" from "still on its way", and any attempt
-to distinguish them locally breaks uniformity. The bound therefore drops both
-cases alike, and its only defence is being generous enough that no honest
-window comes near it.
+No consensus-uniform signal distinguishes "a pool that will never fill" from
+"a pool still filling", and any attempt to distinguish them locally breaks
+uniformity. The bound therefore drops both cases alike, and its only defence
+is being generous enough that no honest window comes near it.
 
 `noa_presign_demand_park_rounds = 70_000` is about an hour of mainnet
 consensus at ~19.5 rounds/s. The honest windows it has to clear are:
 
-- the network-key syncer publishes the overlay every 5s — ~100 rounds; the
-  derivation waits at most one tick for a certified key's chain metadata;
-- a restarting or joining validator translates a key outside the deployed
-  constants at instantiation or by background derivation, after recovering a
-  stranded key by chain read — minutes, so at most low tens of thousands of
-  rounds;
+- the network-key syncer publishes the overlay every 5s — ~100 rounds;
+- a restarting or joining validator recovers a stranded key by chain read and
+  then instantiates class groups for it — minutes, so at most low tens of
+  thousands of rounds;
 - a freshly certified key's presign pool is filled by internal-presign MPC —
   again minutes.
 
@@ -260,12 +238,12 @@ demands, so a change has to be version-gated rather than binary-driven.
 It is terminal for that demand in that epoch, and durable (above). The drain
 increments `ika_dwallet_mpc_noa_presign_demands_evicted_total` (labeled by
 signature algorithm) and logs an `error!` carrying the demand id and its
-digest, the signing key as this validator had derived it at the drop (or that
-it had none), the announcing authority, the delivery round and the round of
-the drop — including the statement that this demand's sign will not happen
-in this epoch. It is deliberately not reported as an internal invariant
-violation: a key this validator could not derive, or an honest lag that
-outran the bound, is not a bug in our code. A replay of a drop that was
+digest, the signing key (or that this validator holds none this epoch), the
+announcing authority, the delivery round and the round of the drop —
+including the statement that this demand's sign will not happen in this
+epoch. It is deliberately not reported as an internal invariant violation: a
+validator without a signing key, or an honest lag that outran the bound, is
+not a bug in our code. A replay of a drop that was
 already recorded logs at debug and does not touch the counter, so the metric
 counts drops, not restarts.
 
@@ -275,8 +253,8 @@ memory, which is what makes them survive a restart as well:
 - the **pending sign request** behind a dropped demand is released (it would
   otherwise wait forever for an assignment nobody will write, feeding the
   NOA-sign starvation warning). Only the assignment branch of that read needs
-  the signing network key locally; a release must not, or a validator that
-  never derives the key would hold the request forever;
+  the signing network key locally; a release must not, or a validator
+  without one would hold the request forever;
 - the **announcement** pass skips any demand that already has a resolution, so
   a dropped demand is not re-announced — a re-announcement would be
   deduplicated into nothing anyway, the consensus key being the demand-id

--- a/dev-docs/specs/internal-presign-pool.md
+++ b/dev-docs/specs/internal-presign-pool.md
@@ -48,9 +48,9 @@ producing a divergent computation, the false-malicious class.
 ## Which pool a demand draws from
 
 A pool is keyed by `(signature algorithm, network encryption key)`, so
-draining a demand starts by choosing an algorithm. That choice comes from
-the demand's IDENTITY (`NOAPresignDemandId::expected_signature_algorithm`),
-never from the announcement that carried it.
+draining a demand starts by naming both. Neither comes from the announcement
+that carried the demand: the announcement carries the demand IDENTITY and
+nothing else the drain reads.
 
 The reason is the dedup key. Presign-demand announcements are deduplicated
 on the demand-id digest ALONE — deliberately, so several validators
@@ -59,93 +59,111 @@ consequence is that the first announcement sequenced for a demand would
 supply any payload field the drain reads, for the whole network, while every
 honest duplicate is dropped behind it. A committee member could then pick the
 pool for any demand whose id it can predict, and demand ids are derivable
-from public data.
+from public data. Rejecting a mismatch would not help: the honest
+announcements were already deduplicated away, so no correct one can follow,
+and the demand would stay unassigned for the epoch — a substitution bug
+traded for a stall. Deriving both inputs is what removes the problem, and it
+is stronger than validating an announced value: there is no second copy to
+disagree with.
 
-Deriving is what removes that, and it is stronger than validating the
-announced value:
+**The algorithm** comes from the demand identity
+(`NOAPresignDemandId::expected_signature_algorithm`). Both demand arms commit
+to it — the checkpoint arm through `kind_name` (whose mapping to the
+counterparty chain's algorithm is pinned by test), the attestation arm by
+carrying it in the identity — so an announcer naming a different algorithm
+produces a DIFFERENT identity, a demand no honest consumer looks up, rather
+than a competing answer for this one. Neither the consensus message nor the
+internal sign request carries an algorithm beside the id, so the pool drained
+and the session instantiated cannot disagree.
 
-- **Rejecting a mismatch is unsafe.** The honest announcements were already
-  deduplicated away, so no correct one can follow: the demand stays
-  unassigned, its sign never happens, and the epoch cannot finalize its NOA
-  checkpoints. A substitution bug would have been traded for a stall.
-- **Carrying no second copy is stronger than comparing two.** Both demand
-  arms commit to their algorithm — the checkpoint arm through `kind_name`
-  (whose mapping to the counterparty chain's algorithm is pinned by test),
-  the attestation arm by carrying it in the identity — so an announcer
-  naming a different algorithm produces a DIFFERENT identity, a demand no
-  honest consumer looks up, rather than a competing answer for this one.
-  Neither the consensus message nor the internal sign request carries an
-  algorithm beside the id, so the pool drained and the session instantiated
-  cannot disagree.
+**The network encryption key** is the epoch's network-owned-address (NOA)
+signing key, which every validator derives for itself from the prior epoch's
+handoff certificate
+(`DWalletMPCManager::network_owned_address_signing_key_resolution`; the rule
+is stated in [`handoff.md`](handoff.md), "The network-owned-address signing
+key"): among the keys the certificate names, the one with the largest
+`dkg_at_epoch`, ties broken by the smaller `NetworkKeyId`. The certificate is
+the one input every validator holds identically for the whole epoch —
+quorum-signed, local before the epoch's components start (the
+prepare-then-start barrier), never modified afterwards — so the answer is one
+value per epoch, and a validator that has derived it agrees with every other
+validator that has. The derivation is all-or-nothing: the certificate names
+keys by `NetworkKeyId` while the pool is keyed by Sui `ObjectID`, and
+`dkg_at_epoch` lives on the chain metadata the network-key syncer publishes;
+a validator that cannot yet translate, or has no metadata for, ANY certified
+key answers "no key yet" rather than choosing among the keys it can see.
+Choosing among a subset is exactly the per-validator divergence the
+derivation exists to remove. The answer is cached once it resolves (every
+input only ever gains entries), and it is recorded with the assignment, so
+the sign session later instantiates under the key its presign was drawn
+from.
 
-`network_encryption_key_id` is NOT covered by this reasoning and remains
-announcer-supplied behind the same dedup key: it is frozen at announce time
-on purpose, so the assignment does not depend on the announce-time and
-instantiate-time key resolutions agreeing. What the drain does with a key it
-does not recognise is the subject of the next section.
+The previous rule — the oldest key in the validator's locally ADOPTED set,
+carried in the announcement — let honest validators name different keys
+while their adoption lagged at different rates, and let a dishonest announcer
+name a key nobody holds (issue #2019, which is closed by construction rather
+than by measurement: nothing is announced, and the derived key does not read
+the adopted set at all). The adopted-set rule survives only behind
+`noa_checkpoints` OFF, where it decides which pool receives the NOA pool
+parameters on the live protocol version; changing it there would move the
+internal-presign sequence numbers under a mixed-binary committee, and no
+demand can be announced with the flag off in any case. With the flag on, the
+top-up loop applies the NOA parameters to the derived key and mints nothing
+at all while the derivation is still pending, so a key's pool role cannot
+flip mid-epoch on one validator but not another; an epoch with no
+certificate treats every key as a non-NOA key for the whole epoch.
 
-## A demand naming a network key with no pool: park, with a bound
+## A demand with no key or no pool: park, with a bound
 
-A demand carries the network encryption key it was announced under, and pools
-are keyed by that id, so a validator that has no pool for that key cannot
-assign the demand. It **parks**: the demand stays in the queue in
-consensus-delivery order and is retried on every following round. It is
-**not** rejected, and the announced key is **not** validated against the
-validator's own adopted network-key set.
+Two things stop a validator from assigning a consensus-delivered demand: it
+has not derived the epoch's signing key yet, or that key's pool for the
+demand's algorithm is empty. In both cases the demand **parks**: it stays in
+the queue in consensus-delivery order and is retried on every following
+round. It is **not** rejected — there is nothing to reject it against, and
+an honest duplicate announcement could never follow (the dedup key again).
 
-### Why not validate the announced key
+WHEN a validator can derive the key is the one per-validator input on this
+path. The certificate is local from the start on every path that starts a
+validator's epoch components, and the chain metadata is the syncer's
+process-wide overlay, so a continuing validator derives the key on its first
+attempt. A restarting or joining validator waits for the overlay's first
+publish (one syncer tick) and, for a key outside the compiled-in deployed
+constants, for the `NetworkKeyId -> ObjectID` translation to register at
+instantiation or through the background derivation — seconds to minutes. A
+demand delivered inside that window parks here while a peer that derived
+earlier assigns it at delivery.
 
-Because honest validators genuinely disagree, transiently, about which
-network encryption keys they have adopted — and therefore about the
-network-owned-address signing key derived from that set. Issue #2019
-measured three independent mechanisms in the current code:
-
-- **the epoch-start fill window.** Every epoch's manager starts with an empty
-  adopted-key set and answers "no signing key" until its first
-  blob-complete overlay entry lands. Any stagger between validators — at
-  least one 5s syncer tick at every epoch boundary — leaves one validator
-  holding a key while a peer holds none. This one needs only a single
-  network key to occur, so it applies to mainnet and testnet as they run
-  today. A restarting or joining validator used to lag arbitrarily further,
-  because nothing held it back from starting its epoch components before
-  its handoff data arrived; the prepare-then-start barrier now runs on those
-  paths too (`handoff.md`), so it enters the epoch with the certified key
-  material already local and only the same one-tick overlay stagger remains.
-  What the barrier does NOT bound is a certified key it cannot translate to
-  a local `ObjectID` — the stranded-key shape, which still fills from the
-  syncer's chain read after start;
-- **per-key overlay incompleteness.** The overlay is assembled per validator
-  from chain metadata plus locally cached blobs. An entry whose blobs are
-  still empty is skipped at adoption, and the recovery path is a chain read
-  with no deadline, so with two or more keys a validator can adopt only the
-  higher key while a peer holding both selects the lower;
-- **a handoff-certificate read error**, which makes a validator skip
-  adoption for that tick entirely and freeze on whatever it had adopted
-  before.
-
-A local equality check against the announced key would convert any of these
-lags into a permanent drop of an honest demand, and the honest duplicate
-announcements are already gone — consensus deduplicates presign-demand
-announcements on the demand-id digest alone, so no corrected announcement can
-follow. Rejecting therefore trades a substitution bug for a stall, exactly as
-in the algorithm case above. Parking fails toward delay instead, which is the
-only direction that is safe here.
+That park is not uniform in time: the parked demand is assigned when this
+validator resolves, from the pool as it stands at THAT round, while the peer
+drew from the pool at the delivery round. A fill landing between the two
+rounds changes which presign is at the head only if it carries a LOWER
+sequence number than the head the peer drew — possible, because fills
+complete out of sequence order (below), but only while a batch is completing
+inside a validator's own derivation window at epoch start, when the
+per-epoch pool has just begun to fill. The top-up loop reads the same
+derivation and mints nothing on a validator whose key is still pending, so
+such a validator is not feeding the pool during its own window. This is the
+residual of the certificate rule; it is narrower than the announced-key
+design it replaces, where a validator that had not adopted the announced key
+parked on the same per-validator moment AND the key itself could differ.
 
 ### Why the park needs a bound anyway
 
-The same dedup key is what makes an unbounded park exploitable. Whichever
-announcement for a demand is sequenced first supplies the network key for the
-whole network, and demand ids are derivable from public data. A committee
-member that names a key no validator will ever adopt leaves every validator's
-pool lookup empty forever: the demand parks for the rest of the epoch, its
-sign never happens, and the epoch cannot finalize the NOA checkpoint that
-demand belongs to.
+The bound is a liveness backstop, not a security control. There is no
+announced key left for a byzantine member to point at nothing; what remains
+is a validator that never derives the key this epoch — an epoch with no
+prior certificate (genesis, or the first epoch of a fresh network, where NOA
+signing waits for the first handoff), or a certified key this validator can
+never translate — and a pool that never fills. A demand parked on either
+would otherwise sit in the queue for the rest of the epoch, and the sign
+request behind it would wait forever for an assignment nobody will write.
 
 So a parked demand is dropped once it has been parked for
-`NOA_PRESIGN_DEMAND_PARK_ROUNDS` consensus rounds
-(`dwallet_mpc_service.rs`). The queue element records the consensus round its
-demand was delivered in; the drain at round *R* drops any still-unassigned
-demand delivered at *R_d* once `R - R_d >= NOA_PRESIGN_DEMAND_PARK_ROUNDS`.
+`noa_presign_demand_park_rounds` consensus rounds — a `ProtocolConfig`
+constant, `Some(70_000)` from protocol version 7 (`None` would never drop).
+The queue element records the consensus round its demand was delivered in;
+the drain at round *R* drops any still-unassigned demand delivered at *R_d*
+once `R - R_d >= noa_presign_demand_park_rounds`.
 
 ### Why consensus rounds, and not elapsed time
 
@@ -159,9 +177,10 @@ identical everywhere: the delivery round and the round being drained. The
 third input, whether the demand is still unassigned, is a function of the
 presign pool, which is filled from quorum-agreed outputs in round order and
 is likewise uniform per round. Wall-clock time is not: validators observe
-different elapsed times for the same rounds. Neither is the locally adopted
-key set, nor the network-key overlay — the very things the previous section
-showed to differ between honest validators.
+different elapsed times for the same rounds. The moment this validator
+derived the signing key does not enter the predicate either: the bound
+measures from the consensus delivery round, so a validator that never derives
+the key drops the demand at the same round its peers would have.
 
 The delivery rounds themselves survive a restart for the same reason: the
 round cursor replays the epoch's rounds from the start, so the queue and the
@@ -176,7 +195,7 @@ for its key was empty, and re-draining it either finds the pool still empty or
 assigns from it, exactly as an uncrashed peer did. It is NOT safe for a drop:
 
 1. demand *D* is parked past the bound and dropped at round *R_e*;
-2. *D*'s network key arrives late and its pool fills at some *R_i > R_e* — the
+2. *D*'s key derives late and its pool fills at some *R_i > R_e* — the
    honest-lag case the bound deliberately drops anyway;
 3. the validator restarts. The rounds replay, *D* re-enters the rebuilt queue
    at its delivery round, and the drain now sees a pool that can serve it.
@@ -199,51 +218,56 @@ as the second arm of one per-demand resolution
 Every demand therefore has at most one terminal resolution per epoch, and a
 replayed drain READS it instead of deciding again: an already-dropped demand
 leaves the rebuilt queue without an assignment attempt, without re-logging at
-error level, and without re-counting the metric. The write happens before the
-demand leaves the queue, and a failed write keeps the demand parked for the
-next round — the same posture as a failed assignment.
+error level, and without re-counting the metric. That read does not wait for
+the signing key: a replay that runs before the restarted validator has
+re-derived it (its overlay republishes a tick after boot) reads the durable
+table directly, so a resolved demand leaves the queue instead of parking a
+second time under a bound measured from a delivery round long past. The
+write happens before the demand leaves the queue, and a failed write keeps
+the demand parked for the next round — the same posture as a failed
+assignment.
 
 ### The bound drops an honest-lag demand too, deliberately
 
-No consensus-uniform signal distinguishes "a key nobody will ever adopt" from
-"a key still arriving", and any attempt to distinguish them locally breaks
-uniformity. The bound therefore drops both cases alike, and its only defence
-is being generous enough that no honest window comes near it.
+No consensus-uniform signal distinguishes "a key this validator will never
+derive, a pool that will never fill" from "still on its way", and any attempt
+to distinguish them locally breaks uniformity. The bound therefore drops both
+cases alike, and its only defence is being generous enough that no honest
+window comes near it.
 
-`NOA_PRESIGN_DEMAND_PARK_ROUNDS = 70_000` is about an hour of mainnet
+`noa_presign_demand_park_rounds = 70_000` is about an hour of mainnet
 consensus at ~19.5 rounds/s. The honest windows it has to clear are:
 
-- the network-key syncer re-merges the overlay every 5s — ~100 rounds;
-- a restarting or joining validator recovers a stranded key by chain read and
-  then instantiates class groups for it — minutes, so at most low tens of
-  thousands of rounds;
-- a freshly adopted key's presign pool is filled by internal-presign MPC —
+- the network-key syncer publishes the overlay every 5s — ~100 rounds; the
+  derivation waits at most one tick for a certified key's chain metadata;
+- a restarting or joining validator translates a key outside the deployed
+  constants at instantiation or by background derivation, after recovering a
+  stranded key by chain read — minutes, so at most low tens of thousands of
+  rounds;
+- a freshly certified key's presign pool is filled by internal-presign MPC —
   again minutes.
 
 The ceiling is the epoch: a 24h epoch is ~1.7M rounds, so the bound spends
 ~4% of an epoch waiting before giving up, and a demand that is going to be
 dropped is dropped early enough for the epoch to finalize what it can.
 
-The value is a compile-time constant, which is safe only because presign
-demands cannot currently reach the wire at all — announcements are gated on
-the `noa_checkpoints` protocol flag, which is off on every live network, so no
-committee can be split across two values of it. Once that flag is on, the
-number becomes consensus-affecting (validators running different values drop
-different demands) and belongs in `ProtocolConfig`, where a change is
-version-gated rather than binary-driven.
+The value lives in `ProtocolConfig` because it is consensus-affecting once
+demands reach the wire: validators running different values drop different
+demands, so a change has to be version-gated rather than binary-driven.
 
 ### What a drop means
 
 It is terminal for that demand in that epoch, and durable (above). The drain
 increments `ika_dwallet_mpc_noa_presign_demands_evicted_total` (labeled by
 signature algorithm) and logs an `error!` carrying the demand id and its
-digest, the announced network key id, the announcing authority, the delivery
-round and the round of the drop — including the statement that this demand's
-sign will not happen in this epoch. It is deliberately not reported as an
-internal invariant violation: a byzantine announcer causing it is not a bug in
-our code, and neither is an honest lag that outran the bound. A replay of a
-drop that was already recorded logs at debug and does not touch the counter,
-so the metric counts drops, not restarts.
+digest, the signing key as this validator had derived it at the drop (or that
+it had none), the announcing authority, the delivery round and the round of
+the drop — including the statement that this demand's sign will not happen
+in this epoch. It is deliberately not reported as an internal invariant
+violation: a key this validator could not derive, or an honest lag that
+outran the bound, is not a bug in our code. A replay of a drop that was
+already recorded logs at debug and does not touch the counter, so the metric
+counts drops, not restarts.
 
 Two other paths read the same durable resolution rather than any process
 memory, which is what makes them survive a restart as well:
@@ -252,7 +276,7 @@ memory, which is what makes them survive a restart as well:
   otherwise wait forever for an assignment nobody will write, feeding the
   NOA-sign starvation warning). Only the assignment branch of that read needs
   the signing network key locally; a release must not, or a validator that
-  never adopts the key would hold the request forever;
+  never derives the key would hold the request forever;
 - the **announcement** pass skips any demand that already has a resolution, so
   a dropped demand is not re-announced — a re-announcement would be
   deduplicated into nothing anyway, the consensus key being the demand-id

--- a/dev-docs/specs/internal-presign-pool.md
+++ b/dev-docs/specs/internal-presign-pool.md
@@ -160,7 +160,7 @@ request behind it would wait forever for an assignment nobody will write.
 
 So a parked demand is dropped once it has been parked for
 `noa_presign_demand_park_rounds` consensus rounds — a `ProtocolConfig`
-constant, `Some(70_000)` from protocol version 7 (`None` would never drop).
+constant, `Some(70_000)` at every supported version (`None` would never drop).
 The queue element records the consensus round its demand was delivered in;
 the drain at round *R* drops any still-unassigned demand delivered at *R_d*
 once `R - R_d >= noa_presign_demand_park_rounds`.


### PR DESCRIPTION
## Summary

The network-owned-address (NOA) signing key is now a pure function of the prior epoch's handoff certificate, fixed for the epoch. The prepare-then-start barrier resolves it on every path that starts a validator's epoch components and hands it to the MPC manager as a constructor input. Nothing announces a choice, and nothing in the epoch re-derives it.

**The rule** (`dwallet_mpc::network_owned_address_signing_key::select`): among the keys the epoch-E certificate names (its `NetworkDkgOutput` items), the key with the largest `dkg_at_epoch`, ties broken by the smaller `NetworkKeyId` bytes, is epoch E+1's NOA signing key. A key DKG'd during E+1 is not in that certificate and waits until E+2. An epoch with no certificate (genesis, the first epoch of a fresh network) or a certificate naming no key has no NOA signing key. The certificate names keys by `NetworkKeyId` while the pool keys by `ObjectID` and `dkg_at_epoch` is chain metadata, so the rule is all-or-nothing: a certified key without local metadata is a not-ready condition the barrier waits out; a certified key with no `ObjectID` translation makes the validator enter the epoch with **no** signing key and sit NOA signing out until the next handoff, logged loudly, rather than choose among the keys it can translate.

**Why.** The previous rule picked the oldest key in the validator's locally adopted set and carried that choice in the presign-demand announcement. Announcements are deduplicated on the demand id alone, so the first announcement sequenced picked the key for the whole network: honest validators named different keys during the adoption window, and a dishonest one could name a key nobody holds (issue #2019). Both are closed by construction.

## Changes

- **Persisted mapping.** New perpetual table `network_key_ids_by_object_id`. The MPC manager writes a key's `ObjectID → NetworkKeyId` translation the first time it sees it resolved (after instantiation, or once the background derivation registers it); the node loads every entry into `network_key_id_mapping` at boot, before the barrier. This is what keeps a restarted validator translatable at the barrier.
- **Barrier.** `wait_for_handoff_data_ready` evaluates the rule once the certificate and its outputs are local, reading `dkg_at_epoch` from the network-key syncer's overlay, and returns `Ready { network_owned_address_signing_key_id }`. The value is plumbed through `construct_validator_components` and `start_epoch_specific_validator_components` into `DWalletMPCService::new` and `DWalletMPCManager::new`.
- **Manager.** `network_owned_address_signing_key_id` is a plain field. With `noa_checkpoints` on it is the answer for both the drain and the pool role; with the flag off the adopted-set rule and its early return are kept byte for byte, so v7 sequence numbers do not move.
- **Announcement.** `ConsensusNOAPresignDemand` loses `network_encryption_key_id`; announcements wait only for `noa_checkpoints`.
- **Drain.** A demand on a validator without a signing key parks and is dropped at the bound; it never draws from the pool. A replayed drain reads the durable resolution before parking, so a keyless restart cannot re-drop or re-count a resolved demand.
- **Park bound** moves into `ProtocolConfig` as `noa_presign_demand_park_rounds: Option<u64>`, `Some(70_000)` in the base config (`None` never drops). Its role is a liveness backstop. Only the three v7 snapshots change, one line each; upgrade voting only tallies digests for versions above the current one.
- **Specs.** `internal-presign-pool.md` (which pool a demand draws from; the park section; the bound's rationale and location; issue #2019 closed by construction), `handoff.md` (barrier condition; "The network-owned-address signing key"; invariant 6).

## Why the barrier and not a lazy derivation

The drain then has no per-validator input at all: the key is fixed at construction, and the pool is filled from consensus outputs on every validator that processes the rounds. A validator without a key sits out; it cannot bind a presign its peers bind to a different demand.

## Tests (`cargo test --release -p ika-core <filter>`)

- `dwallet_mpc::network_owned_address_signing_key`: the rule (newest first, then smaller id); a key the certificate does not name is not eligible; an untranslatable certified key blocks any choice, even over awaiting metadata; missing metadata waits rather than choosing; an empty certificate selects none.
- `authority_perpetual_tables`: mapping round trip.
- `noa_signing_key_skew`: same key input with different adopted sets (partial; adopted nothing) answers the same key; no key answers `None` regardless of adoption; flag off keeps the oldest-adopted rule.
- `noa_checkpoint`: two keyed validators bind the same presign to the same demand; a keyless third parks it and leaves its pool untouched.
- `idle_status_voting`: the split-idle test, which turns the flag on through its own guard, gets its key the way the barrier would.
- `network_owned_address_sign`: park tests re-based (park without a key; assign once the pool fills; drop at the bound with and without a key; two-restart no-resurrection covering the keyless and keyed replay states); every flag-on flow test sets its DKG'd key the way the barrier would.
- Fault validation (`dev-docs/playbooks/test-testing.md`): with the flag-on selector temporarily made to read the adopted set again, the skew module failed 3 of 4 — `same_key_input_with_different_adopted_sets_selects_the_same_key` with `left: Some(0xc560…)` / `right: Some(0x47cd…)`, `a_validator_that_adopted_nothing_answers_the_same_key` with `left: None` / `right: Some(0x22ef…)`, `no_key_this_epoch_answers_none_regardless_of_adoption` with `left: Some(0x2f5c…)` / `right: None` — and only the flag-off test stayed green, as the fault sat on the flag-on branch. Reverted; the module is 4/4 again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
