### PR TITLE
fix(ocs): recover watermark guards after long observation gaps

### DIFF
--- a/crates/ika-core/src/sui_connector/ocs_metrics.rs
+++ b/crates/ika-core/src/sui_connector/ocs_metrics.rs
@@ -95,8 +95,9 @@ pub struct OcsMetrics {
     /// A refusal is skipped, not folded — steady state is zero, and any
     /// increase means an upstream is claiming advance faster than checkpoint
     /// production can explain (a desynced backend, a wrong-network endpoint, a
-    /// corrupted response), or that this process was paused longer than the
-    /// bound's burst covers (a restart clears that; the bound is in-process).
+    /// corrupted response), or that a genuine gap exceeds the currently
+    /// available allowance. Allowance keeps accruing during refusals, so a
+    /// genuine upstream producing below the refill rate eventually recovers.
     /// Refusals on `folder` leave the cursor BEHIND the chain head — the
     /// opposite signature to the poisoned cursor the bound prevents.
     pub watermark_implausible_total: IntCounterVec, // labels: ["consumer"]

--- a/crates/ika-core/src/sui_connector/push_worker.rs
+++ b/crates/ika-core/src/sui_connector/push_worker.rs
@@ -273,9 +273,9 @@ impl IkaCheckpointPusher {
                 warn!(
                     cursor = self.cursor,
                     latest_seq,
-                    "upstream claimed a latest-checkpoint watermark advancing faster than \
-                     checkpoint production can explain — skipping ticks rather than folding it \
-                     into the cursor (logged once until samples are accepted again)"
+                    "pusher stalled: upstream watermark exceeds the available rate allowance \
+                     — skipping scans while allowance accrues \
+                     (logged once until samples are accepted again)"
                 );
                 self.watermark_refusal_warned = true;
             }
@@ -1899,6 +1899,62 @@ mod tests {
             Some(latest_seq),
             "the pusher must catch up to a legitimately distant head"
         );
+    }
+
+    #[tokio::test]
+    async fn watermark_refusal_recovers_and_resumes_folding_without_restart() {
+        let (committee, keys) = Committee::new_simple_test_committee();
+        let dir = tempfile::tempdir().unwrap();
+        let perpetual = Arc::new(AuthorityPerpetualTables::open(dir.path(), None));
+        let committees = Arc::new(
+            CommitteeStore::open(
+                perpetual.clone(),
+                Some(CommitteeBootstrap::Genesis(committee.clone())),
+            )
+            .unwrap(),
+        );
+        perpetual.put_sui_pusher_last_seq(100).unwrap();
+        let cache = Arc::new(VerifiedStateCache::new());
+        let metrics = OcsMetrics::new_for_testing();
+        let mut pusher = pusher_over_with_cache(
+            perpetual.clone(),
+            committees,
+            transport_reporting(&committee, &keys, 100, HashMap::new()),
+            cache.clone(),
+            metrics.clone(),
+        )
+        .await;
+        pusher.advance().await.unwrap();
+        let latest_seq = 20_100;
+        let checkpoints = ((latest_seq - 99)..=latest_seq)
+            .map(|seq| (seq, plain_checkpoint(&committee, &keys, seq)))
+            .collect();
+        pusher.transport = transport_reporting(&committee, &keys, latest_seq, checkpoints);
+        pusher.advance().await.unwrap();
+        assert_eq!(perpetual.get_sui_pusher_last_seq().unwrap(), Some(100));
+        assert!(pusher.watermark_refusal_warned);
+        assert_eq!(metrics.pusher_stalled.get(), 1);
+
+        pusher
+            .watermark
+            .elapse_for_testing(Duration::from_secs(500));
+        pusher.advance().await.unwrap();
+        assert!(!pusher.watermark_refusal_warned);
+        assert_eq!(
+            perpetual.get_sui_pusher_last_seq().unwrap(),
+            Some(100),
+            "recovery still requires a second tick to confirm the fast-forward"
+        );
+        pusher.advance().await.unwrap();
+        assert_eq!(
+            perpetual.get_sui_pusher_last_seq().unwrap(),
+            Some(latest_seq)
+        );
+        assert_eq!(cache.processed_head_seq(), latest_seq);
+        assert!(pusher.pending_gaps.is_empty());
+        assert_eq!(metrics.pusher_skipped_irrelevant_total.get(), 100);
+        pusher.advance().await.unwrap();
+        assert_eq!(metrics.pusher_stalled.get(), 0);
     }
 
     /// One inflated watermark must change NOTHING: not the persisted cursor

--- a/crates/ika-core/src/sui_connector/verified_reader.rs
+++ b/crates/ika-core/src/sui_connector/verified_reader.rs
@@ -1569,6 +1569,7 @@ mod tests {
     use ika_sui_client::transport::derive_object_field_wrapper_id;
     use parking_lot::Mutex;
     use std::collections::BTreeMap;
+    use std::fs::read_to_string;
     use sui_light_client::proof::ocs::ModifiedObjectTree;
     use sui_types::base_types::ObjectDigest;
     use sui_types::committee::Committee as SuiCommittee;
@@ -1580,6 +1581,8 @@ mod tests {
         CheckpointArtifacts, CheckpointCommitment, CheckpointSummary,
     };
     use sui_types::object::Owner;
+    use tracing::subscriber::with_default;
+    use tracing_subscriber::fmt;
 
     /// The two rejection gates exercised below — high-water rollback and
     /// freshness — are pure local checks that never reach the network, so the
@@ -1764,20 +1767,38 @@ mod tests {
     #[tokio::test]
     async fn reader_watermark_refusal_warnings_are_throttled() {
         let (_dir, reader) = test_reader(None);
-        reader.note_upstream_head(1_000_000);
-        reader.note_upstream_head(2_000_000);
-        let first_warning = reader.upstream_head_refusal_warned_at.lock().unwrap();
-        reader.note_upstream_head(1_000_001);
-        reader.note_upstream_head(2_000_000);
+        let log = tempfile::NamedTempFile::new().unwrap();
+        let subscriber = fmt()
+            .with_writer(log.reopen().unwrap())
+            .with_ansi(false)
+            .without_time()
+            .finish();
+        with_default(subscriber, || {
+            reader.note_upstream_head(1_000_000);
+            reader.note_upstream_head(2_000_000);
+            reader.note_upstream_head(1_000_001);
+            reader.note_upstream_head(2_000_000);
+            assert_eq!(
+                read_to_string(log.path())
+                    .unwrap()
+                    .matches("provider claimed a latest-checkpoint head")
+                    .count(),
+                1,
+                "even separate refusal stretches must share the warning limit"
+            );
+            let first_warning = reader.upstream_head_refusal_warned_at.lock().unwrap();
+            *reader.upstream_head_refusal_warned_at.lock() =
+                Some(first_warning - Duration::from_secs(60));
+            reader.note_upstream_head(2_000_000);
+        });
         assert_eq!(
-            *reader.upstream_head_refusal_warned_at.lock(),
-            Some(first_warning),
-            "even separate refusal stretches must share the warning limit"
+            read_to_string(log.path())
+                .unwrap()
+                .matches("provider claimed a latest-checkpoint head")
+                .count(),
+            2,
+            "a refusal after one minute must log again"
         );
-        *reader.upstream_head_refusal_warned_at.lock() =
-            Some(first_warning - Duration::from_secs(60));
-        reader.note_upstream_head(2_000_000);
-        assert!(reader.upstream_head_refusal_warned_at.lock().unwrap() >= first_warning);
         assert_eq!(
             reader
                 .metrics

--- a/crates/ika-core/src/sui_connector/verified_reader.rs
+++ b/crates/ika-core/src/sui_connector/verified_reader.rs
@@ -258,13 +258,14 @@ pub struct OcsVerifiedReader {
     /// wants the floor low can simply claim a low head, which is already
     /// ignored, and is the documented eclipse residual.
     ///
-    /// The bound is anchored to the verified cache's fold head before every
-    /// claim (`note_verified_floor`), NOT to the first claim: on a mirrored or
-    /// peer-only node the claim comes from a relay that is untrusted by
-    /// design, so seeding from its first word would let it choose the floor
-    /// outright. The fold head only advances to checkpoints carrying a
-    /// committee quorum signature, which a relay cannot manufacture.
+    /// Mirrored/peer-only readers anchor to the verified cache's fold head;
+    /// their relay must not choose the initial floor. Direct readers seed from
+    /// their own fullnode's first claim, like the folder, since the persisted
+    /// fold head can be arbitrarily old after a quiet stretch.
     upstream_head_guard: WatermarkGuard,
+    /// Throttle refusal warnings across all network reads, including separate
+    /// refusal stretches. The counter still records every refused sample.
+    upstream_head_refusal_warned_at: Mutex<Option<Instant>>,
     /// Cache-first staleness tripwire: if the cache head lags
     /// `observed_upstream_head` by more than this many checkpoints, the cache
     /// is too stale (e.g. a stalled pusher), so `try_cache_hit` falls through
@@ -313,6 +314,7 @@ impl OcsVerifiedReader {
             cache_first,
             observed_upstream_head: AtomicU64::new(0),
             upstream_head_guard: WatermarkGuard::new(),
+            upstream_head_refusal_warned_at: Mutex::new(None),
             staleness_bound,
             anchor_refreshed_at: Mutex::new(HashMap::new()),
             changeset_index: None,
@@ -370,28 +372,35 @@ impl OcsVerifiedReader {
     /// the anti-under-report guarantee rests on are unchanged — a refused
     /// claim leaves the floor exactly where it was.
     ///
-    /// The bound is re-anchored to the verified cache's fold head on every
-    /// call, so it tracks committee-verified local progress for free and can
-    /// never be left metering against a stale anchor while the node's own
-    /// verified state has moved on. **Residual:** a node whose cache is still
+    /// On mirrored/peer-only nodes the bound is re-anchored to the verified
+    /// cache's fold head on every call. Direct nodes use their own fullnode's
+    /// first claim instead, so an old persisted cache does not delay the
+    /// freshness tripwire after restart. **Residual:** a node whose cache is still
     /// empty (a cold peer-only/mirrored start) has no local anchor at all, so
     /// its first claim seeds the floor — an untrusted relay picks the initial
     /// value there. That is the known eclipse residual (a lone malicious relay
     /// pinning a fresh node), narrowed but not closed here.
     fn note_upstream_head(&self, seq: CheckpointSequenceNumber) {
-        self.upstream_head_guard
-            .note_verified_floor(self.cache.head_seq());
+        if !self.cache_first {
+            self.upstream_head_guard
+                .note_verified_floor(self.cache.head_seq());
+        }
         if !self.upstream_head_guard.admit(seq) {
             self.metrics
                 .watermark_implausible_total
                 .with_label_values(&["reader"])
                 .inc();
-            warn!(
-                claimed_head = seq,
-                observed_head = self.observed_upstream_head.load(Ordering::Relaxed),
-                "provider claimed a latest-checkpoint head advancing faster than checkpoint \
-                 production can explain — leaving the freshness floor unchanged"
-            );
+            let mut warned_at = self.upstream_head_refusal_warned_at.lock();
+            if warned_at.is_none_or(|last| last.elapsed() >= Duration::from_secs(60)) {
+                *warned_at = Some(Instant::now());
+                warn!(
+                    claimed_head = seq,
+                    observed_head = self.observed_upstream_head.load(Ordering::Relaxed),
+                    "provider claimed a latest-checkpoint head beyond the available rate \
+                     allowance — leaving the freshness floor unchanged while allowance \
+                     accrues (logged at most once per minute)"
+                );
+            }
             return;
         }
         self.observed_upstream_head
@@ -1700,6 +1709,83 @@ mod tests {
         assert_eq!(
             reader.observed_upstream_head.load(Ordering::Relaxed),
             1_000_100
+        );
+    }
+
+    #[tokio::test]
+    async fn old_persisted_cache_does_not_wedge_reader_watermarks() {
+        let dir = tempfile::tempdir().unwrap();
+        let tables = Arc::new(AuthorityPerpetualTables::open(dir.path(), None));
+        let cached_head = 380_287_027;
+        let upstream_head = 380_372_670;
+        tables
+            .write_verified_object_cache(vec![], cached_head)
+            .unwrap();
+        let cache = Arc::new(VerifiedStateCache::open(tables).unwrap());
+
+        let (_direct_dir, mut direct) = test_reader_cache_first(100);
+        direct.cache = cache.clone();
+        direct.note_upstream_head(upstream_head);
+        assert_eq!(
+            direct.observed_upstream_head.load(Ordering::Relaxed),
+            upstream_head,
+            "the direct reader must seed from its fullnode despite an old cache"
+        );
+        assert!(
+            direct
+                .try_cache_hit(ObjectID::from_single_byte(7))
+                .is_none()
+        );
+        assert_eq!(direct.metrics.cache_first_stale_total.get(), 1);
+        // Later inflated claims are still refused after the direct seed.
+        direct.note_upstream_head(upstream_head + 1_000_000);
+        assert_eq!(
+            direct.observed_upstream_head.load(Ordering::Relaxed),
+            upstream_head
+        );
+
+        let (_mirrored_dir, mut mirrored) = test_reader(None);
+        mirrored.cache = cache;
+        mirrored.note_upstream_head(upstream_head);
+        assert_eq!(mirrored.observed_upstream_head.load(Ordering::Relaxed), 0);
+        // A relay cannot seed from its first word, but the same guard must
+        // eventually recover without any new Ika objects or a restart.
+        mirrored
+            .upstream_head_guard
+            .elapse_for_testing(Duration::from_secs(10_000));
+        mirrored.note_upstream_head(upstream_head);
+        assert_eq!(
+            mirrored.observed_upstream_head.load(Ordering::Relaxed),
+            upstream_head,
+            "an old verified anchor must not cause permanent reader refusal"
+        );
+    }
+
+    #[tokio::test]
+    async fn reader_watermark_refusal_warnings_are_throttled() {
+        let (_dir, reader) = test_reader(None);
+        reader.note_upstream_head(1_000_000);
+        reader.note_upstream_head(2_000_000);
+        let first_warning = reader.upstream_head_refusal_warned_at.lock().unwrap();
+        reader.note_upstream_head(1_000_001);
+        reader.note_upstream_head(2_000_000);
+        assert_eq!(
+            *reader.upstream_head_refusal_warned_at.lock(),
+            Some(first_warning),
+            "even separate refusal stretches must share the warning limit"
+        );
+        *reader.upstream_head_refusal_warned_at.lock() =
+            Some(first_warning - Duration::from_secs(60));
+        reader.note_upstream_head(2_000_000);
+        assert!(reader.upstream_head_refusal_warned_at.lock().unwrap() >= first_warning);
+        assert_eq!(
+            reader
+                .metrics
+                .watermark_implausible_total
+                .with_label_values(&["reader"])
+                .get(),
+            3,
+            "throttling warnings must not suppress refusal metrics"
         );
     }
 

--- a/crates/ika-core/src/sui_connector/watermark_guard.rs
+++ b/crates/ika-core/src/sui_connector/watermark_guard.rs
@@ -18,10 +18,12 @@
 //! delta limit. A per-sample limit bounds nothing over time: an upstream that
 //! reports "previous + just under the limit" on every 250 ms tick is admitted
 //! forever and walks the head arbitrarily far ahead, one legal step at a
-//! time. Here, allowance accrues at [`SUSTAINED_CHECKPOINTS_PER_SECOND`] up
-//! to a [`BURST_ALLOWANCE`] ceiling and is **spent by every accepted
-//! increase**, so admitted advance is bounded by that rate over any window
-//! longer than one burst, whatever the step size.
+//! time. Here, allowance accrues at [`SUSTAINED_CHECKPOINTS_PER_SECOND`] and
+//! is **spent by every accepted increase**. After an increase the unspent
+//! balance is capped at [`BURST_ALLOWANCE`]. Between increases it may exceed
+//! that cap, so a long observation gap or refusal stretch can recover. From
+//! any accepted increase, further admitted advance is bounded by one burst
+//! plus elapsed refill, whatever the step size.
 //!
 //! The bucket compares observations **within this process** and never against
 //! persisted state: after downtime a genuine watermark is arbitrarily far
@@ -45,14 +47,11 @@ use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 /// long process pauses in the OCS spec).
 const SUSTAINED_CHECKPOINTS_PER_SECOND: u64 = 10;
 
-/// Ceiling on unspent allowance — the largest single jump that can be
-/// admitted, about one hour of real production (~4/s). Sized so every
-/// observation gap a running process can plausibly experience passes without
-/// a refusal: the folder polls every 250 ms, and even a pathological tick
-/// that exhausts every bounded retry budget costs tens of seconds. A gap
-/// longer than the ceiling (a host paused for hours) is admitted only as the
-/// bucket refills — bounded, self-healing, and cleared outright by a restart,
-/// which re-seeds the guard.
+/// Initial allowance and maximum balance left after the head increases,
+/// about one hour of real production (~4/s). Refill between increases is
+/// uncapped: capping it would permanently refuse every gap above this size,
+/// because refusals do not move the head. Repeated or retreating samples must
+/// preserve that catch-up allowance too.
 const BURST_ALLOWANCE: u64 = 15_000;
 
 /// The rate-bound state of one watermark consumer. Cheap and independent per
@@ -92,8 +91,7 @@ impl Bucket {
         }
         self.tokens = self
             .tokens
-            .saturating_add(whole_seconds.saturating_mul(SUSTAINED_CHECKPOINTS_PER_SECOND))
-            .min(BURST_ALLOWANCE);
+            .saturating_add(whole_seconds.saturating_mul(SUSTAINED_CHECKPOINTS_PER_SECOND));
         self.refilled_at += Duration::from_secs(whole_seconds);
     }
 }
@@ -126,7 +124,7 @@ impl WatermarkGuard {
         if advance > bucket.tokens {
             return false;
         }
-        bucket.tokens -= advance;
+        bucket.tokens = (bucket.tokens - advance).min(BURST_ALLOWANCE);
         bucket.head = seq;
         true
     }
@@ -150,6 +148,11 @@ impl WatermarkGuard {
         let mut guarded = self.bucket.lock();
         let bucket = guarded.get_or_insert_with(|| Bucket::seeded_at(seq));
         bucket.head = bucket.head.max(seq);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn elapse_for_testing(&self, duration: Duration) {
+        self.bucket.lock().as_mut().unwrap().refilled_at -= duration;
     }
 }
 
@@ -255,6 +258,62 @@ mod tests {
         drop(guarded);
 
         assert!(guard.admit(1_000 + BURST_ALLOWANCE + 5_000));
+    }
+
+    #[test]
+    fn a_long_observation_gap_is_admitted_without_restarting() {
+        let guard = WatermarkGuard::new();
+        assert!(guard.admit(1_000_000));
+        guard.elapse_for_testing(Duration::from_secs(5_000));
+
+        assert!(
+            guard.admit(1_020_000),
+            "a long observation gap must not permanently exceed the refill budget"
+        );
+        assert!(guard.admit(1_020_000 + BURST_ALLOWANCE));
+        assert!(
+            !guard.admit(1_020_000 + BURST_ALLOWANCE + 1),
+            "catch-up must leave at most one burst of unused allowance"
+        );
+    }
+
+    #[test]
+    fn refusals_and_lagging_samples_preserve_catch_up_allowance() {
+        let guard = WatermarkGuard::new();
+        let start = 1_000_000;
+        guard.note_verified_floor(start);
+        assert!(!guard.admit(start + 20_000));
+
+        // The upstream keeps producing at 5/s, slower than the refill rate.
+        // Repeated refusals, unchanged verified floors, and a lagging backend
+        // must not discard the allowance needed to catch it.
+        for seconds in 1..1_000 {
+            guard.elapse_for_testing(Duration::from_secs(1));
+            guard.note_verified_floor(start);
+            assert!(guard.admit(start - 1));
+            assert!(guard.admit(start));
+            assert!(!guard.admit(start + 20_000 + 5 * seconds));
+        }
+        guard.elapse_for_testing(Duration::from_secs(1));
+        assert!(
+            guard.admit(start + 25_000),
+            "refill must catch a moving upstream after a refused stretch"
+        );
+        assert!(!guard.admit(start + 25_001));
+    }
+
+    #[test]
+    fn verified_progress_preserves_catch_up_allowance() {
+        let guard = WatermarkGuard::new();
+        guard.note_verified_floor(1_000_000);
+        guard.elapse_for_testing(Duration::from_secs(500));
+        guard.note_verified_floor(1_001_000);
+        assert!(
+            guard.admit(1_020_000),
+            "verified progress must not discard credit during catch-up"
+        );
+        assert!(guard.admit(1_021_000));
+        assert!(!guard.admit(1_021_001));
     }
 
     /// A locally-verified floor raises the head for free and, before any

--- a/crates/ika-core/src/sui_connector/watermark_guard.rs
+++ b/crates/ika-core/src/sui_connector/watermark_guard.rs
@@ -22,8 +22,9 @@
 //! is **spent by every accepted increase**. After an increase the unspent
 //! balance is capped at [`BURST_ALLOWANCE`]. Between increases it may exceed
 //! that cap, so a long observation gap or refusal stretch can recover. From
-//! any accepted increase, further admitted advance is bounded by one burst
-//! plus elapsed refill, whatever the step size.
+//! any accepted increase, further unverified advance is bounded by one burst
+//! plus elapsed refill, whatever the step size. Locally verified floors
+//! advance for free and preserve recovery credit.
 //!
 //! The bucket compares observations **within this process** and never against
 //! persisted state: after downtime a genuine watermark is arbitrarily far
@@ -47,7 +48,7 @@ use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 /// long process pauses in the OCS spec).
 const SUSTAINED_CHECKPOINTS_PER_SECOND: u64 = 10;
 
-/// Initial allowance and maximum balance left after the head increases,
+/// Initial allowance and maximum balance left after an unverified increase,
 /// about one hour of real production (~4/s). Refill between increases is
 /// uncapped: capping it would permanently refuse every gap above this size,
 /// because refusals do not move the head. Repeated or retreating samples must

--- a/dev-docs/playbooks/mpc-stall-postmortem.md
+++ b/dev-docs/playbooks/mpc-stall-postmortem.md
@@ -304,11 +304,14 @@ construction; divergence = determinism bug).
     `ika_ocs_watermark_implausible_total{consumer="folder"}` climbing →
     the rate bound is refusing the upstream's samples.** Either the
     endpoint really is reporting an unexplainable head (check it), or
-    the process was paused/suspended for longer than the bound's burst
-    covers (~an hour of production) — the bound uses monotonic time,
-    which does not advance while a host is suspended. It heals on its
-    own at a few checkpoints per second, and a **restart clears it
-    outright** (the bound is in-process state, re-seeded at start). Do
+    a genuine gap exceeds the available allowance. The bound accrues
+    10 checkpoints/s of monotonic elapsed time even during refusals;
+    it catches an upstream producing below that rate without a restart.
+    Suspend time may not count toward that allowance on every platform.
+    A **restart re-seeds the folder guard**. On v1.4.0/v1.4.1 the refill
+    cap prevents recovery for gaps over 15,000 checkpoints: restart
+    clears the folder wedge, but the reader may immediately refuse again
+    against its old persisted cache. Upgrade to the recovery fix. Do
     NOT clear the cursor row here; the cursor is fine.
 
   Mechanism, both bounds, and the full recovery note:

--- a/dev-docs/playbooks/production-alerts.md
+++ b/dev-docs/playbooks/production-alerts.md
@@ -304,12 +304,22 @@ a page.
 - `rate(ika_ocs_watermark_implausible_total[15m]) > 0` → an upstream is
   claiming a latest-checkpoint height advancing faster than checkpoint
   production can explain (a desynced load-balancer backend, an endpoint on the
-  wrong network, a corrupted response) — or this process was paused longer than
-  the bound's burst covers, which a restart clears. Refused samples are
+  wrong network, a corrupted response) — or a genuine gap exceeds the
+  available allowance. Allowance keeps accruing at 10 checkpoints/s during
+  refusals, so an upstream producing below that rate eventually recovers
+  without a restart. Refused samples are
   skipped, so this is a configuration/upstream-health signal, not data loss;
   sustained refusals on `{consumer="folder"}` mean the checkpoint folder is
   skipping ticks and its cursor will lag *behind* the head (the opposite
-  signature to a poisoned cursor). Check `ika_ocs_pusher_cursor_seq` against
+  signature to a poisoned cursor). A folder refusal rate near the poll rate
+  (normally 4/s) means almost every scan is being skipped; the generic
+  `ika_ocs_pusher_stalled` gauge alone also covers ordinary lag. Reader
+  warnings are limited to one per minute, so use the counter for volume.
+  On v1.4.0/v1.4.1, refill is capped before admission and a gap over 15,000
+  checkpoints cannot recover this way: restart clears the folder guard,
+  while a reader anchored to an old persisted cache can refuse again after
+  restart. Upgrade to the recovery fix for both consumers.
+  Check `ika_ocs_pusher_cursor_seq` against
   the chain head and see
   [`mpc-stall-postmortem.md`](mpc-stall-postmortem.md)'s interpretation rules
   plus

--- a/dev-docs/specs/ocs-verified-sui-reads.md
+++ b/dev-docs/specs/ocs-verified-sui-reads.md
@@ -411,8 +411,9 @@ irreversible and an inflated claim otherwise pins the floor above the
 real chain head forever — making every genuinely-current cached object
 read stale and forcing permanent fall-through to network reads, and
 failing every read outright once the absolute freshness bound is enabled
-(ika #2041). The bucket here is anchored to the verified cache's fold
-head, not to the relay's first claim — see the *Seeding* note under
+(ika #2041). On mirrored/peer-only nodes the bucket is anchored to the
+verified cache's fold head; direct readers seed from their own fullnode's
+first claim — see the *Seeding* note under
 *Reading the head*, and the cold-node residual it states. The monotone
 semantics are untouched: a refused claim leaves the floor exactly where
 it was, and refusing an unexplained *increase* cannot help an
@@ -750,41 +751,55 @@ both in `watermark_guard.rs` / `push_worker.rs`:
 1. **Rate bound (`WatermarkGuard`, applied by the folder's probe and by
    the reader's freshness fold).** A *token bucket over admitted
    advance*, not a per-sample delta limit: allowance accrues at `10/s`
-   up to a `15_000` ceiling (about an hour of real production at Sui's
-   ~4 checkpoints/s) and is **spent by every accepted increase**. The
-   exact guarantee: advance admitted over any window of length `T` is at
-   most `15_000 + 10·T` checkpoints — one burst, plus the sustained rate
-   — whatever step size the upstream chooses. (So the *average* over a
-   short window can exceed 10/s: at exactly one burst-length window it
-   is ~20/s, converging on 10/s as the window grows.) A per-sample limit
-   would
+   and is **spent by every accepted increase**. The initial balance and
+   the balance **left after an increase** are capped at `15_000` (about
+   an hour of real production). Refill between increases is uncapped,
+   including across refused, repeated, and retreating samples. Otherwise
+   a gap above `15_000` could never be admitted: refusals leave the head
+   fixed while refill can never cover the gap. A `20_000` jump from a
+   full balance therefore becomes admissible after 500 seconds; a moving
+   upstream producing below `10/s` is eventually caught too.
+
+   From a seed or accepted increase, further admitted advance is bounded
+   by one burst plus refill at `10/s`, whatever step size the upstream
+   chooses. Refill uses whole-second ticks and preserves the fractional
+   remainder. This is **not** a bound on every arbitrary time window:
+   catch-up after inactivity can exceed one burst in a single sample,
+   using the credit earned during that inactivity. A per-sample limit would
    bound nothing over time — an upstream reporting "previous + just
    under the limit" every 250 ms tick is admitted forever and walks the
    head arbitrarily far, one legal step at a time; that is the shape the
    bucket exists to refuse. Real production spends 4 of the 10
    checkpoints/s accruing, so the bucket sits at its ceiling in steady
    state and the remaining ~6/s is what a drained bucket recovers at.
-   The bucket compares observations **within this process, never against
-   persisted state**: a node starting against a mature chain, or
+   The folder compares observations **within this process, never against
+   its persisted cursor**: a node starting against a mature chain, or
    resuming after downtime with a cursor millions of checkpoints behind,
    passes trivially — catch-up distance is never what is metered. A
    retreating watermark is admitted, costs nothing, and does not lower
    the head (so a retreat cannot refund spent allowance). A refused
-   sample is skipped loudly, moves nothing, and is counted
+   sample leaves the head unchanged and is counted
    `ika_ocs_watermark_implausible_total{consumer}`; the folder's tick is
    retried 250 ms later.
 
    **Seeding.** An unseeded bucket takes its head from the first
    observation — sound for the folder, whose watermark comes from the
-   node's own configured fullnode over its own transport. It is NOT
+   node's own configured fullnode over its own transport. The direct
+   reader uses the same seed policy (`cache_first` selects direct mode):
+   its persisted cache fold head can be arbitrarily old on a quiet chain,
+   and must not delay freshness tracking after a restart. It is NOT
    sound for the reader on a mirrored/peer-only node, where the claim
    comes from a relay that is untrusted by design and would otherwise
-   pick the floor outright. The reader therefore anchors the bucket to
+   pick the floor outright. The mirrored/peer-only reader anchors the bucket to
    the verified cache's **fold head** before every claim
    (`note_verified_floor`), which only advances to checkpoints carrying
    a committee quorum signature and so cannot be inflated by a relay.
    Because the anchor is re-applied on every call it also tracks local
    progress for free, and a claim at or below it never spends allowance.
+   Verified-floor updates preserve catch-up credit, even if local verified
+   progress still trails the claimed head by more than one burst. Only an
+   accepted increase above the guard's head spends and caps that credit;
+   verified advances remain free and are outside the unverified rate bound.
 2. **Two-sided agreement before the fast-forward.** The far-behind
    fast-forward is the single-shot, persisted, span-sacrificing
    consumer, so it acts only on a target **two consecutive ticks agree
@@ -819,6 +834,9 @@ both in `watermark_guard.rs` / `push_worker.rs`:
 rate bound decides, so a run of refused ticks reads as the stall it is.
 The gauge is neither monotone nor persisted, so a bad sample cannot
 latch it.
+The folder logs the watermark refusal as the stall reason once per stretch,
+then logs recovery. The reader logs refusals at most once per minute across
+all reads and refusal stretches. Both counters still count every refusal.
 
 Residuals, stated exactly:
 
@@ -830,8 +848,9 @@ Residuals, stated exactly:
   Chain-identifier verification does **not** cover this: it pins the
   node's own configured Sui endpoint to the right network, and says
   nothing about what a peer claims its head is.
-- **Folder's first observation.** The folder's own first probe seeds its
-  bucket, so a fullnode already reporting a wrong height at boot is
+- **Direct consumers' first observations.** The folder's first probe and
+  the direct reader's first claim each seed their own bucket, so a
+  fullnode already reporting a wrong height at boot is
   taken at its word. The endpoint is the operator's own, and a
   wrong-*network* endpoint is caught by the chain-identifier
   verification on the trust path; a same-network endpoint reporting a
@@ -866,11 +885,15 @@ Residuals, stated exactly:
   do this is outside #2041's fault classes (buggy fullnode, desynced
   backend, wrong-network endpoint, corrupted response), all of which
   produce inconsistent or one-shot values that the bound refuses.
-- **Long host pauses.** `Instant` excludes suspended time, so a host
-  paused longer than the burst covers (~an hour of production) resumes
-  with a genuine head beyond the bucket and refuses it until the bucket
-  refills — bounded, self-healing at ~6/s net, and cleared immediately
-  by a restart, since the bucket is in-process state. The refusal shows
+- **Long host pauses or old mirrored-reader anchors.** Refill uses
+  monotonic elapsed time, which may exclude suspended time depending on
+  the platform. A resumed host or a mirrored reader seeded from an old
+  persisted cache can therefore start with too little allowance for the
+  genuine head. Credit accrues beyond one burst until it covers the gap;
+  at ~4/s production, recovery gains ~6 checkpoints/s. Repeated refusals,
+  lagging samples, and unchanged verified floors do not reset that credit.
+  A restart re-seeds direct consumers, while a mirrored reader still
+  anchors to its persisted verified cache. The refusal shows
   as `ika_ocs_watermark_implausible_total` climbing with
   `ika_ocs_pusher_cursor_seq` **behind** the chain head, which is the
   opposite signature to a poisoned cursor (below).
@@ -1314,8 +1337,10 @@ it. `ika_ocs_watermark_implausible_total{consumer}` counts latest-checkpoint
 watermark samples refused by the rate bound (`folder` = the checkpoint folder's
 scan bound and persisted cursor, `reader` = the freshness floor); steady state
 is zero, and any increase means an upstream is claiming advance faster than
-checkpoint production can explain — or that this process was paused longer than
-the bound's burst covers, which a restart clears. Refusals leave the folder's
+checkpoint production can explain — or a genuine gap exceeds the available
+allowance. Credit accrues during refusals so genuine progress below 10/s
+eventually recovers. Reader warnings are limited to one per minute; folder
+warnings name the refusal once per stretch. Refusals leave the folder's
 cursor *behind* the chain head, the opposite signature to a poisoned cursor. These metrics contain no object
 id, checkpoint digest, peer identity, raw error, or proof material.
 


### PR DESCRIPTION
## Description

A watermark more than 15,000 checkpoints ahead of `WatermarkGuard` could never be admitted: refill was capped at 15,000, while refusals left the head fixed. This could freeze checkpoint scanning indefinitely and leave the reader freshness floor at zero after restarting with an old verified cache.

Allow refill credit to accumulate between accepted increases, then cap the balance remaining after admission. Refusals, repeated or retreating samples, and verified-floor updates preserve catch-up credit. Direct readers seed from their own fullnode’s first claim, matching the folder; mirrored and peer-only readers retain their verified-cache anchor. Reader refusal warnings are limited to once per minute, and the folder warning identifies watermark refusal as the stall reason.

The specification and operator playbooks describe recovery and the revised bound: from an accepted increase, further unverified advance is bounded by one burst plus elapsed refill. Catch-up credit can permit a larger jump after inactivity, so this is not a bound over every arbitrary time window.

## Test plan

- All 10 guard unit tests passed locally, compiling the actual module with optimized `rustc --test` against cached dependencies.
- The long-gap and moving-upstream regressions failed against the original code with the expected assertions. A separate mutation removing the post-admission cap triggered its expected assertion; the fault was removed.
- Added consumer regressions for pusher recovery and fast-forward confirmation, direct/mirrored startup with old persisted state, the cache freshness tripwire, and emitted warning counts.
- `cargo fmt --all` and `git diff --check` passed.
- [Release-mode Sui connector tests](https://github.com/dwallet-labs/ika/actions/runs/34059502305): running against `adf38dd2ed3ec094ad6b5ff32d14d76a7533d819`.
- [Cluster suite](https://github.com/dwallet-labs/ika/actions/runs/34059510713): pending against the same commit.

---

## Release notes

- [ ] Protocol and cryptography:
- [ ] Move contracts:
- [x] Nodes (validators, fullnodes, and notifier): OCS watermark guards recover from long gaps without requiring a restart. Direct readers resume freshness tracking immediately after restarting with an old cache, and reader refusal warnings are limited to once per minute. Upgrade the validator binary to apply the fix.
- [ ] CLI:
- [ ] Rust SDK:
- [ ] TypeScript SDK:
- [ ] WASM SDK:
- [x] Proxy and operator tooling: Updated OCS refusal diagnostics and recovery guidance; existing refusal counters continue recording every refused sample.
