### PR TITLE
fix: prepare inherited MPC inputs before epoch startup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -264,12 +264,23 @@ jobs:
             tests::all_cert_network_key_outputs_held_locally_cases --test-threads=1 \
             | tee "$RUNNER_TEMP/noa-material-readiness.log"
           grep -qE '^test result: ok\. 1 passed' "$RUNNER_TEMP/noa-material-readiness.log"
+      - name: Run inherited epoch preparation regressions
+        run: |
+          set -o pipefail
+          cargo test --locked --release -p ika-core --lib -- \
+            dwallet_mpc::epoch_start_data::tests \
+            epoch_startup_ \
+            dwallet_mpc::integration_tests::mid_epoch_restart_keys::missing_prior_cert_blob_is_refetched_from_peers_and_ingested \
+            --test-threads=1 | tee "$RUNNER_TEMP/epoch-preparation.log"
+          grep -qE '^test result: ok\. 6 passed' "$RUNNER_TEMP/epoch-preparation.log"
       - name: Upload regression logs
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: noa-presign-regressions
-          path: ${{ runner.temp }}/noa-*.log
+          path: |
+            ${{ runner.temp }}/noa-*.log
+            ${{ runner.temp }}/epoch-preparation.log
 
   cargo-check:
     name: Cargo Test Check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ env:
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin or `stable` for the latest stable version.
-  rust_stable: 1.97.1
+  rust_stable: 1.98.1
   CARGO_NET_GIT_FETCH_WITH_CLI: true
   GH_DEPLOY_KEY: ${{ secrets.GH_DEPLOY_KEY }}
   CARGO_INCREMENTAL: 0
@@ -216,6 +216,60 @@ jobs:
         run: ./scripts/simtest/install.sh
       - name: Run Clippy under msim
         run: cargo simtest clippy --all-targets --all-features -- -D warnings
+
+  noa-presign-regressions:
+    name: NOA presign regressions
+    runs-on: ika-k8s-large
+    timeout-minutes: 60
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+      - name: Setup SSH
+        uses: ./.github/actions/setup-ssh
+        with:
+          deploy-key: ${{ secrets.GH_DEPLOY_KEY }}
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.rust_stable }}
+      - name: Install build dependencies
+        run: |
+          if command -v sudo >/dev/null; then SUDO=sudo; else SUDO=; fi
+          APT="-o Acquire::ForceIPv4=true"
+          for attempt in 1 2 3; do
+            $SUDO apt-get $APT update && \
+              $SUDO apt-get $APT install -y cmake clang pkg-config libssl-dev && break
+            echo "apt attempt $attempt failed; retrying in 15s" && sleep 15
+          done
+          command -v cmake >/dev/null || { echo "build dependencies missing after retries"; exit 1; }
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: noa-presign-release
+      - name: Run NOA startup and replay regressions
+        # Package scope keeps real crypto; workspace scope would unify the
+        # cluster crate's mock feature. Check counts so a rename cannot turn
+        # either filter into a successful run of zero tests.
+        run: |
+          set -o pipefail
+          cargo test --locked --release -p ika-core --lib \
+            dwallet_mpc::network_owned_address_signing_key::tests -- --test-threads=1 \
+            | tee "$RUNNER_TEMP/noa-key-preparation.log"
+          grep -qE '^test result: ok\. 9 passed' "$RUNNER_TEMP/noa-key-preparation.log"
+          cargo test --locked --release -p ika-core --lib -- --exact \
+            dwallet_mpc::dwallet_mpc_service::tests::noa_startup_preserves_global_presign_checkpoint \
+            dwallet_mpc::dwallet_mpc_service::tests::noa_restart_preserves_later_noa_assignment \
+            --test-threads=1 | tee "$RUNNER_TEMP/noa-presign-regressions.log"
+          grep -qE '^test result: ok\. 2 passed' "$RUNNER_TEMP/noa-presign-regressions.log"
+          cargo test --locked --release -p ika-node --lib -- --exact \
+            tests::all_cert_network_key_outputs_held_locally_cases --test-threads=1 \
+            | tee "$RUNNER_TEMP/noa-material-readiness.log"
+          grep -qE '^test result: ok\. 1 passed' "$RUNNER_TEMP/noa-material-readiness.log"
+      - name: Upload regression logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: noa-presign-regressions
+          path: ${{ runner.temp }}/noa-*.log
 
   cargo-check:
     name: Cargo Test Check

--- a/.github/workflows/integration-tests-ci.yaml
+++ b/.github/workflows/integration-tests-ci.yaml
@@ -76,7 +76,7 @@ concurrency:
 env:
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin or `stable` for the latest stable version.
-  rust_stable: 1.97.1
+  rust_stable: 1.98.1
   rust_nightly: nightly
   CARGO_NET_GIT_FETCH_WITH_CLI: true
   GH_DEPLOY_KEY: ${{ secrets.GH_DEPLOY_KEY }}

--- a/.github/workflows/publish-typescript-sdk.yml
+++ b/.github/workflows/publish-typescript-sdk.yml
@@ -18,7 +18,7 @@ permissions:
 env:
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  rust_stable: 1.97.1
+  rust_stable: 1.98.1
   SUI_VERSION: 'sui@mainnet'
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -230,7 +230,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.97.1"
+          toolchain: "1.98.1"
           targets: ${{ matrix.target }}
 
       - name: Install dependencies (macOS)

--- a/.github/workflows/simtest.yaml
+++ b/.github/workflows/simtest.yaml
@@ -64,7 +64,7 @@ env:
   # long sub-quorum windows and slow recovery tails; virtual seconds cost
   # ~nothing in wall time.
   SUI_SIM_TEST_TIMEOUT_SECS: "3600"
-  rust_stable: "1.97.1"
+  rust_stable: "1.98.1"
 
 jobs:
   simtest:

--- a/.github/workflows/test-cluster.yaml
+++ b/.github/workflows/test-cluster.yaml
@@ -58,7 +58,7 @@ env:
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
   RUST_LOG: ${{ inputs.rust_log || 'error' }}
-  rust_stable: "1.97.1"
+  rust_stable: "1.98.1"
 
 jobs:
   test-cluster:

--- a/.github/workflows/ts-integration-tests.yaml
+++ b/.github/workflows/ts-integration-tests.yaml
@@ -48,7 +48,7 @@ env:
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: 1
-  rust_stable: "1.97.1"
+  rust_stable: "1.98.1"
   # ika-wasm's prepare script builds wasm-pack with `--${PROFILE}`; the
   # integration tests run real client-side crypto through that WASM, so it
   # must be a release build (debug crypto is far too slow).

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -299,7 +299,7 @@ env:
   RUST_BACKTRACE: 1
   RUST_LOG: ${{ inputs.rust_log || 'info' }}
   CANDIDATE_SHA: ${{ inputs.candidate_sha || github.event.pull_request.head.sha || github.sha }}
-  rust_stable: "1.97.1"
+  rust_stable: "1.98.1"
 
 jobs:
   # Resolve `inputs.test` into the matrix of scenarios to run: 'all' fans every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ methods/macros: unbounded channels, `block_on`,
 here. The rules below are the ones lints can't check:
 
 - **NEVER use `unsafe`** — no exceptions (also denied by workspace lint)
-- Rust 1.97 toolchain (`rust-toolchain.toml`), rustfmt 2024 edition
+- Rust 1.98.1 toolchain (`rust-toolchain.toml`), rustfmt 2024 edition
 - Prefer functional style; iterators (`map`/`filter`/`fold`) over loops;
   avoid mutable variables unless necessary
 - Shadow variables when transforming and the old value won't be used

--- a/crates/ika-core/src/blob_cache.rs
+++ b/crates/ika-core/src/blob_cache.rs
@@ -63,6 +63,12 @@ impl BlobCache {
             || matches!(self.perpetual.get_mpc_artifact_blob(digest), Ok(Some(_)))
     }
 
+    /// Startup readiness must check the durable copy that the MPC manager
+    /// reads, even when the P2P cache still holds a memory-only copy.
+    pub fn get_persisted(&self, digest: &[u8; 32]) -> IkaResult<Option<Vec<u8>>> {
+        self.perpetual.get_mpc_artifact_blob(digest)
+    }
+
     /// The underlying in-memory store, exposed for startup hydration.
     pub fn in_memory(&self) -> &Arc<InMemoryBlobStore> {
         &self.in_memory

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -1369,7 +1369,7 @@ impl DWalletMPCService {
 
     /// Drains one parked NOA presign demand at `consensus_round` under the
     /// epoch's network-owned-address signing key as this validator has derived
-    /// it (`None` while it has not), returning whether the demand stays in the
+    /// it (`None` for a certificate naming no key), returning whether the demand stays in the
     /// queue.
     ///
     /// With a key, `assign_presign_for_demand` is atomic + idempotent: it pops
@@ -1384,9 +1384,8 @@ impl DWalletMPCService {
     /// park bound expires; `Err` parks it for retry.
     ///
     /// Without a key nothing can be popped, but a demand this validator
-    /// already resolved in an earlier pass over the same rounds — a restart
-    /// replaying the epoch before the derivation's inputs have landed again —
-    /// must still leave the queue on its DURABLE resolution. Parking it
+    /// already resolved in an earlier pass over the same rounds must still
+    /// leave the queue on its DURABLE resolution. Parking it
     /// instead would let the replayed bound drop it a second time: the
     /// eviction write is a no-op on a resolved demand, but the queue would
     /// hold a demand whose sign already ran, and the drop would be counted
@@ -3596,9 +3595,45 @@ impl DWalletMPCService {
 mod tests {
     use super::*;
     use crate::dwallet_mpc::integration_tests::utils::{self, TestingAuthorityPerEpochStore};
+    use crate::dwallet_mpc::network_owned_address_signing_key;
     use dwallet_mpc_types::dwallet_mpc::DWalletSignatureAlgorithm;
+    use dwallet_mpc_types::dwallet_mpc::NetworkKeyId;
+    use ika_types::handoff::{CertifiedHandoffAttestation, HandoffAttestation, HandoffItemKey};
     use ika_types::messages_dwallet_mpc::ConsensusGlobalPresignRequest;
     use ika_types::noa_checkpoint::NOAPresignDemandId;
+
+    fn handoff_certificate() -> CertifiedHandoffAttestation {
+        CertifiedHandoffAttestation {
+            attestation: HandoffAttestation {
+                epoch: 0,
+                next_committee_pubkey_set_hash: [0; 32],
+                items: vec![(
+                    HandoffItemKey::NetworkDkgOutput {
+                        key_id: NetworkKeyId([0x42; 32]),
+                    },
+                    [0; 32],
+                )],
+            },
+            signatures: vec![],
+        }
+    }
+
+    fn epoch_key_after_mapping_recovery(
+        certificate: &CertifiedHandoffAttestation,
+        key_id: ObjectID,
+    ) -> Option<ObjectID> {
+        // These are the inputs the same process sees before and after the
+        // barrier's recovery (or the boot-time reload of persisted mappings).
+        let missing = network_owned_address_signing_key::select(certificate, |_| None, |_| Some(0));
+        assert_eq!(
+            missing.epoch_start_key(true),
+            None,
+            "an unresolved certified key must block epoch startup"
+        );
+        network_owned_address_signing_key::select(certificate, |_| Some(key_id), |_| Some(0))
+            .epoch_start_key(true)
+            .expect("the recovered mapping releases epoch startup")
+    }
 
     fn presign_demand(authority: AuthorityName, marker: u8) -> ConsensusNOAPresignDemand {
         ConsensusNOAPresignDemand {
@@ -3654,19 +3689,23 @@ mod tests {
         resolution
     }
 
-    /// Skipping a NOA demand must not change the next global request's
-    /// checkpoint: both consumers draw from the same internal presign pool.
-    /// The two keyed validators are the control for the keyless validator.
+    /// A joiner must resolve its certified key before processing any demand:
+    /// NOA and global requests consume the same pool. Starting it keyless
+    /// used to leave its first presign for the global request while peers
+    /// consumed their second, producing different checkpoint messages.
     #[tokio::test(flavor = "multi_thread")]
-    async fn noa_keyless_validator_preserves_global_presign_checkpoint() {
+    async fn noa_startup_preserves_global_presign_checkpoint() {
         let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
+        let key_id = ObjectID::random();
+        let recovered_key = epoch_key_after_mapping_recovery(&handoff_certificate(), key_id);
+        assert_eq!(recovered_key, Some(key_id));
         let (mut services, _senders, _collectors, stores, _notify, _requests, _outputs) =
             utils::create_dwallet_mpc_services(3);
-        let key_id = ObjectID::random();
         seed_presign_pools(&stores, key_id);
         for service in &mut services[..2] {
             service.set_network_owned_address_signing_key_id_for_testing(Some(key_id));
         }
+        services[2].set_network_owned_address_signing_key_id_for_testing(recovered_key);
 
         let demand = presign_demand(services[0].name, 1);
         let mut payload = utils::empty_round_payload(1);
@@ -3678,11 +3717,9 @@ mod tests {
             "the keyed control validators must agree on the NOA assignment"
         );
         assert_eq!(
-            stores[2]
-                .noa_presign_demand_resolution(&demand.demand_id)
-                .unwrap(),
-            None,
-            "the validator without a signing key parks the NOA demand"
+            assigned_presign(&stores[0], &demand.demand_id),
+            assigned_presign(&stores[2], &demand.demand_id),
+            "the joiner must consume the same NOA presign before the global request"
         );
 
         let request = GlobalPresignRequest {
@@ -3718,17 +3755,21 @@ mod tests {
         assert_eq!(checkpoints[0], checkpoints[1], "keyed checkpoint control");
         assert_eq!(
             checkpoints[0], checkpoints[2],
-            "a keyless validator must emit the same global-presign checkpoint as its peers"
+            "a joining validator must emit the same global-presign checkpoint as its peers"
         );
     }
 
-    /// A joiner may learn and persist its missing key mapping after entering
-    /// the epoch without a signing key. Reconstructing its service with the
-    /// now-resolvable key must not reuse a presign peers consumed before its
-    /// restart. Replay retains both the pool and the earlier eviction.
+    /// Initial startup and same-epoch restart resolve the same certified key
+    /// before draining. Previously a keyless first start evicted a demand
+    /// without consuming its presign; a keyed restart then reused that
+    /// presign for a later demand instead of the one its peers assigned.
     #[tokio::test(flavor = "multi_thread")]
-    async fn noa_keyless_restart_preserves_later_noa_assignment() {
+    async fn noa_restart_preserves_later_noa_assignment() {
         let _guard = utils::create_test_protocol_config_guard_with_noa_checkpoints();
+        let certificate = handoff_certificate();
+        let key_id = ObjectID::random();
+        let recovered_key = epoch_key_after_mapping_recovery(&certificate, key_id);
+        assert_eq!(recovered_key, Some(key_id));
         let (committee, seeds, bundles) = utils::build_committee_with_random_seeds(3);
         let (mut services, _senders, _collectors, stores, _notify, _requests, _outputs) =
             utils::create_dwallet_mpc_services_with_committee_and_seeds(
@@ -3736,7 +3777,6 @@ mod tests {
                 seeds.clone(),
                 bundles.clone(),
             );
-        let key_id = ObjectID::random();
         seed_presign_pools(&stores, key_id);
         for service in &mut services {
             service.set_noa_presign_demand_park_rounds_for_testing(1);
@@ -3744,6 +3784,7 @@ mod tests {
         for service in &mut services[..2] {
             service.set_network_owned_address_signing_key_id_for_testing(Some(key_id));
         }
+        services[2].set_network_owned_address_signing_key_id_for_testing(recovered_key);
 
         let first_demand = presign_demand(services[0].name, 1);
         let mut payload = utils::empty_round_payload(1);
@@ -3756,18 +3797,16 @@ mod tests {
         );
         deliver_and_drain(&mut services, &stores, utils::empty_round_payload(2)).await;
         assert_eq!(
-            stores[2]
-                .noa_presign_demand_resolution(&first_demand.demand_id)
-                .unwrap(),
-            Some(NoaPresignDemandResolution::Evicted),
-            "the keyless validator reaches the park bound"
+            assigned_presign(&stores[0], &first_demand.demand_id),
+            assigned_presign(&stores[2], &first_demand.demand_id),
+            "the joiner must assign rather than evict the first demand"
         );
         assert_eq!(
             stores[2]
                 .presign_pool_size(DWalletSignatureAlgorithm::EdDSA, key_id)
                 .unwrap(),
-            2,
-            "the keyless validator retains the presign its peers consumed"
+            1,
+            "the joiner consumes the same first presign as its peers"
         );
 
         let authority = services[2].name;
@@ -3779,20 +3818,18 @@ mod tests {
                 bundles,
                 stores[2].clone(),
             );
-        // Supply the answer the barrier returns after reloading the newly
-        // persisted mapping, before the replacement service drains any round.
-        restarted.set_network_owned_address_signing_key_id_for_testing(Some(key_id));
+        restarted.set_network_owned_address_signing_key_id_for_testing(
+            epoch_key_after_mapping_recovery(&certificate, key_id),
+        );
         restarted.set_noa_presign_demand_park_rounds_for_testing(1);
         services[2] = restarted;
         stores[2].replay_recorded_rounds().await;
         services[2].drain_consensus_rounds().await;
         assert_eq!(services[2].last_read_consensus_round, Some(2));
         assert_eq!(
-            stores[2]
-                .noa_presign_demand_resolution(&first_demand.demand_id)
-                .unwrap(),
-            Some(NoaPresignDemandResolution::Evicted),
-            "replay must retain the original eviction"
+            assigned_presign(&stores[0], &first_demand.demand_id),
+            assigned_presign(&stores[2], &first_demand.demand_id),
+            "replay must retain the original assignment without another pool pop"
         );
 
         let second_demand = presign_demand(services[0].name, 2);
@@ -3806,7 +3843,7 @@ mod tests {
         assert_eq!(assignments[0], assignments[1], "keyed assignment control");
         assert_eq!(
             assignments[0], assignments[2],
-            "a formerly keyless restart must assign the same presign as its peers"
+            "a restarted validator must assign the same presign as its peers"
         );
     }
 }

--- a/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
+++ b/crates/ika-core/src/dwallet_mpc/dwallet_mpc_service.rs
@@ -857,6 +857,16 @@ impl DWalletMPCService {
         }
     }
 
+    /// Called before consensus starts, including its durable-history replay.
+    /// An uncertified local seed deliberately sits out MPC and must still be
+    /// able to join consensus so the network can certify its replacement.
+    pub async fn prepare_epoch(&mut self) -> DwalletMPCResult<()> {
+        if self.mpc_active {
+            self.dwallet_mpc_manager.prepare_epoch().await?;
+        }
+        Ok(())
+    }
+
     pub(crate) async fn run_service_loop_iteration(&mut self) {
         debug!("Running DWalletMPCService loop");
 
@@ -3602,6 +3612,28 @@ mod tests {
     use ika_types::messages_dwallet_mpc::ConsensusGlobalPresignRequest;
     use ika_types::noa_checkpoint::NOAPresignDemandId;
 
+    #[tokio::test]
+    async fn epoch_startup_preserves_seed_inactive_consensus_participation() {
+        let (mut services, _, _, epoch_stores, _, _, _) = utils::create_dwallet_mpc_services(1);
+        // An inactive seed is a deliberate non-participating MPC epoch. It
+        // must not wait for shares it cannot decrypt or stop consensus.
+        epoch_stores[0]
+            .certified_handoff_attestations
+            .lock()
+            .unwrap()
+            .insert(services[0].epoch - 1, handoff_certificate());
+        services[0].mpc_active = false;
+        services[0].prepare_epoch().await.unwrap();
+        assert!(
+            services[0]
+                .dwallet_mpc_manager
+                .network_keys
+                .network_encryption_keys
+                .is_empty()
+        );
+        assert!(services[0].dwallet_mpc_manager.sessions.is_empty());
+    }
+
     fn handoff_certificate() -> CertifiedHandoffAttestation {
         CertifiedHandoffAttestation {
             attestation: HandoffAttestation {
@@ -3626,12 +3658,12 @@ mod tests {
         // barrier's recovery (or the boot-time reload of persisted mappings).
         let missing = network_owned_address_signing_key::select(certificate, |_| None, |_| Some(0));
         assert_eq!(
-            missing.epoch_start_key(true),
+            missing.epoch_start_key(),
             None,
             "an unresolved certified key must block epoch startup"
         );
         network_owned_address_signing_key::select(certificate, |_| Some(key_id), |_| Some(0))
-            .epoch_start_key(true)
+            .epoch_start_key()
             .expect("the recovered mapping releases epoch startup")
     }
 

--- a/crates/ika-core/src/dwallet_mpc/epoch_start_data.rs
+++ b/crates/ika-core/src/dwallet_mpc/epoch_start_data.rs
@@ -1,0 +1,249 @@
+// Copyright (c) dWallet Labs, Ltd.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+//! Immutable MPC inputs inherited from the preceding epoch. Preparation reads
+//! blobs by the verified certificate's digest, never through the live overlay:
+//! on a restart that overlay may already contain the next committee's shares.
+
+use crate::network_key_id_mapping::object_id_for;
+use crate::validator_metadata::{PeerBlobVerdict, verify_peer_blob_for_relay};
+use ika_network::mpc_artifacts::mpc_data_blob_hash;
+use ika_types::committee::{Committee, EpochId};
+use ika_types::crypto::AuthorityName;
+use ika_types::dwallet_mpc_error::{DwalletMPCError, DwalletMPCResult};
+use ika_types::handoff::{CertifiedHandoffAttestation, HandoffItemKey};
+use ika_types::messages_dwallet_mpc::{
+    DWalletNetworkEncryptionKeyData, DWalletNetworkEncryptionKeyState,
+};
+use std::collections::HashMap;
+use sui_types::base_types::ObjectID;
+
+pub fn missing_validator_mpc_data(
+    cert: &CertifiedHandoffAttestation,
+    committee: &Committee,
+    get_blob: impl Fn(&[u8; 32]) -> Option<Vec<u8>>,
+) -> Vec<AuthorityName> {
+    cert.attestation
+        .items
+        .iter()
+        .filter_map(|(item, digest)| match item {
+            HandoffItemKey::ValidatorMpcData { validator }
+                if committee.authority_index(validator).is_some()
+                    && !get_blob(digest).is_some_and(|bytes| {
+                        matches!(
+                            verify_peer_blob_for_relay(&bytes, digest),
+                            PeerBlobVerdict::Accept
+                        )
+                    }) =>
+            {
+                Some(*validator)
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Assemble the entering epoch's network-key inputs. Chain metadata supplies
+/// only the immutable creation epoch; the certificate fixes the output bytes,
+/// their state, and the epoch whose access structure must decrypt them.
+pub fn certified_network_key_data(
+    cert: &CertifiedHandoffAttestation,
+    epoch: EpochId,
+    metadata: &HashMap<ObjectID, DWalletNetworkEncryptionKeyData>,
+    get_blob: impl Fn(&[u8; 32]) -> Option<Vec<u8>>,
+) -> DwalletMPCResult<HashMap<ObjectID, DWalletNetworkEncryptionKeyData>> {
+    if cert.attestation.epoch.checked_add(1) != Some(epoch) {
+        return Err(DwalletMPCError::InternalError(
+            "epoch preparation certificate does not name the preceding epoch".to_owned(),
+        ));
+    }
+    let mut keys = HashMap::new();
+    for (item, digest) in &cert.attestation.items {
+        let (network_key_id, reconfiguration) = match item {
+            HandoffItemKey::NetworkDkgOutput { key_id } => (key_id, false),
+            HandoffItemKey::NetworkReconfigurationOutput { key_id } => (key_id, true),
+            HandoffItemKey::ValidatorMpcData { .. } => continue,
+        };
+        let id = object_id_for(network_key_id).ok_or_else(|| {
+            DwalletMPCError::InternalError(format!(
+                "epoch preparation has no ObjectID mapping for {network_key_id:?}"
+            ))
+        })?;
+        let metadata = metadata
+            .get(&id)
+            .ok_or(DwalletMPCError::WaitingForNetworkKey(id))?;
+        let bytes = get_blob(digest)
+            .filter(|bytes| mpc_data_blob_hash(bytes) == *digest)
+            .ok_or(DwalletMPCError::WaitingForNetworkKey(id))?;
+        let data = keys
+            .entry(id)
+            .or_insert_with(|| DWalletNetworkEncryptionKeyData {
+                id,
+                current_epoch: epoch,
+                dkg_at_epoch: metadata.dkg_at_epoch,
+                network_dkg_public_output: Vec::new(),
+                current_reconfiguration_public_output: Vec::new(),
+                state: DWalletNetworkEncryptionKeyState::NetworkDKGCompleted,
+            });
+        if reconfiguration {
+            data.current_reconfiguration_public_output = bytes;
+            data.state = DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted;
+        } else {
+            data.network_dkg_public_output = bytes;
+        }
+    }
+    if let Some(id) = keys
+        .iter()
+        .find_map(|(id, data)| data.network_dkg_public_output.is_empty().then_some(*id))
+    {
+        return Err(DwalletMPCError::WaitingForNetworkKey(id));
+    }
+    Ok(keys)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network_key_id_mapping;
+    use crate::validator_metadata::derive_mpc_data_blob;
+    use dwallet_mpc_types::dwallet_mpc::NetworkKeyId;
+    use dwallet_rng::RootSeed;
+    use ika_types::handoff::HandoffAttestation;
+
+    fn certificate(items: Vec<(HandoffItemKey, [u8; 32])>) -> CertifiedHandoffAttestation {
+        CertifiedHandoffAttestation {
+            attestation: HandoffAttestation {
+                epoch: 4,
+                next_committee_pubkey_set_hash: [0; 32],
+                items,
+            },
+            signatures: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn certified_bytes_override_a_future_epoch_overlay() {
+        let id = ObjectID::random();
+        let key_id = NetworkKeyId(id.into_bytes());
+        network_key_id_mapping::register(id, key_id);
+        let dkg = b"certified DKG".to_vec();
+        let reconfiguration = b"shares for the entering committee".to_vec();
+        let dkg_digest = mpc_data_blob_hash(&dkg);
+        let reconfiguration_digest = mpc_data_blob_hash(&reconfiguration);
+        let cert = certificate(vec![
+            (HandoffItemKey::NetworkDkgOutput { key_id }, dkg_digest),
+            (
+                HandoffItemKey::NetworkReconfigurationOutput { key_id },
+                reconfiguration_digest,
+            ),
+        ]);
+        let metadata = HashMap::from([(
+            id,
+            DWalletNetworkEncryptionKeyData {
+                id,
+                current_epoch: 6,
+                dkg_at_epoch: 2,
+                network_dkg_public_output: b"untrusted overlay anchor".to_vec(),
+                current_reconfiguration_public_output: b"shares for the NEXT committee".to_vec(),
+                state: DWalletNetworkEncryptionKeyState::AwaitingNetworkReconfiguration,
+            },
+        )]);
+        let blobs = HashMap::from([
+            (dkg_digest, dkg.clone()),
+            (reconfiguration_digest, reconfiguration.clone()),
+        ]);
+        let prepared =
+            certified_network_key_data(&cert, 5, &metadata, |digest| blobs.get(digest).cloned())
+                .unwrap();
+        assert_eq!(prepared[&id].network_dkg_public_output, dkg);
+        assert_eq!(
+            prepared[&id].current_reconfiguration_public_output, reconfiguration,
+            "startup must use the certified shares, not the live overlay"
+        );
+        assert_eq!(prepared[&id].current_epoch, 5);
+        assert_eq!(prepared[&id].dkg_at_epoch, 2);
+        assert_eq!(
+            prepared[&id].state,
+            DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted
+        );
+
+        assert!(
+            certified_network_key_data(&cert, 5, &metadata, |_| None).is_err(),
+            "digest rows alone are not ready"
+        );
+        assert!(
+            certified_network_key_data(&cert, 5, &metadata, |_| Some(b"corrupt".to_vec())).is_err()
+        );
+        assert!(
+            certified_network_key_data(&cert, 5, &HashMap::new(), |digest| blobs
+                .get(digest)
+                .cloned())
+            .is_err()
+        );
+        assert!(
+            certified_network_key_data(&cert, 6, &metadata, |digest| blobs.get(digest).cloned())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn absent_mapping_never_produces_an_empty_prepared_key_set() {
+        let key_id = NetworkKeyId(ObjectID::random().into_bytes());
+        let bytes = b"certified DKG".to_vec();
+        let cert = certificate(vec![(
+            HandoffItemKey::NetworkDkgOutput { key_id },
+            mpc_data_blob_hash(&bytes),
+        )]);
+        assert!(
+            certified_network_key_data(&cert, 5, &HashMap::new(), |_| Some(bytes.clone())).is_err()
+        );
+        assert!(
+            certified_network_key_data(&certificate(Vec::new()), 5, &HashMap::new(), |_| None)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn validator_bundles_must_be_present_hash_matching_and_decodable() {
+        let (committee, _) = Committee::new_simple_test_committee();
+        let validator = *committee.names().next().unwrap();
+        let blob = derive_mpc_data_blob(&RootSeed::new([71; 32])).unwrap();
+        let digest = mpc_data_blob_hash(&blob);
+        let cert = certificate(vec![(
+            HandoffItemKey::ValidatorMpcData { validator },
+            digest,
+        )]);
+        assert_eq!(
+            missing_validator_mpc_data(&cert, &committee, |_| None),
+            vec![validator]
+        );
+        assert_eq!(
+            missing_validator_mpc_data(&cert, &committee, |_| Some(b"wrong hash".to_vec())),
+            vec![validator]
+        );
+        assert!(missing_validator_mpc_data(&cert, &committee, |_| Some(blob.clone())).is_empty());
+        let garbage = b"hash-matching but undecodable".to_vec();
+        let cert = certificate(vec![(
+            HandoffItemKey::ValidatorMpcData { validator },
+            mpc_data_blob_hash(&garbage),
+        )]);
+        assert_eq!(
+            missing_validator_mpc_data(&cert, &committee, |_| Some(garbage.clone())),
+            vec![validator]
+        );
+
+        let other_committee = Committee::new_for_testing_with_normalized_voting_power(
+            committee.epoch,
+            committee
+                .names()
+                .filter(|name| **name != validator)
+                .map(|name| (*name, 1))
+                .collect(),
+        );
+        assert!(
+            missing_validator_mpc_data(&cert, &other_committee, |_| None).is_empty(),
+            "departed validators do not feed the entering committee's MPC inputs"
+        );
+    }
+}

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/mid_epoch_restart_keys.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/mid_epoch_restart_keys.rs
@@ -444,7 +444,7 @@ async fn missing_prior_cert_blob_is_refetched_from_peers_and_ingested() {
     // content-addressed and pinned by the quorum-signed cert).
     let (dark_digest, dark_blob) = dark_member_blob.expect("dark member blob");
     let serving_store = InMemoryBlobStore::new();
-    serving_store.insert(dark_digest, dark_blob);
+    serving_store.insert(dark_digest, dark_blob.clone());
     let server = build_server(
         serving_store,
         AnnouncementRelayHandle::new(),
@@ -464,6 +464,11 @@ async fn missing_prior_cert_blob_is_refetched_from_peers_and_ingested() {
         (serving_member, live_peer_id),
     ]);
     let blob_cache = BlobCache::new(InMemoryBlobStore::new(), perpetual.clone());
+    // A warm P2P copy does not satisfy the manager's durable read. Startup
+    // repair must still fetch/write through instead of skipping this digest.
+    blob_cache.in_memory().insert(dark_digest, dark_blob);
+    assert!(blob_cache.contains(&dark_digest));
+    assert!(blob_cache.get_persisted(&dark_digest).unwrap().is_none());
     let fetch_outcomes = IntCounterVec::new(
         Opts::new("test_mpc_data_blob_fetch_total", "test fetch outcomes"),
         &["result"],

--- a/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg.rs
+++ b/crates/ika-core/src/dwallet_mpc/integration_tests/network_dkg.rs
@@ -6,14 +6,19 @@
 //! helpers other test modules build on.
 
 use crate::SuiDataSenders;
+use crate::authority::authority_perpetual_tables::AuthorityPerpetualTables;
 use crate::dwallet_mpc::crytographic_computation::mpc_computations::network_dkg::spawn_network_encryption_key_public_data_instantiation;
 use crate::dwallet_mpc::integration_tests::utils;
 use crate::dwallet_mpc::integration_tests::utils::{
     IntegrationTestState, send_start_network_dkg_event_to_all_parties,
 };
 use crate::dwallet_session_request::DWalletSessionRequest;
+use crate::network_key_id_mapping::network_key_id_for;
 use crate::request_protocol_data::{NetworkEncryptionKeyReconfigurationData, ProtocolData};
+use crate::validator_metadata::derive_mpc_data_blob;
+use ika_network::mpc_artifacts::mpc_data_blob_hash;
 use ika_types::committee::Committee;
+use ika_types::handoff::{CertifiedHandoffAttestation, HandoffAttestation, HandoffItemKey};
 use ika_types::message::DWalletCheckpointMessageKind;
 use ika_types::messages_dwallet_mpc::{
     DWalletNetworkEncryptionKeyData, DWalletNetworkEncryptionKeyState, SessionIdentifier,
@@ -24,7 +29,152 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use sui_types::base_types::{EpochId, ObjectID};
 use sui_types::messages_consensus::Round;
+use tempfile::TempDir;
 use tracing::{error, info};
+
+#[tokio::test]
+async fn epoch_startup_prepares_inherited_key_material_before_any_round() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+    let (committee, seeds, bundles) = utils::build_committee_with_random_seeds(4);
+    let (
+        dwallet_mpc_services,
+        sui_data_senders,
+        sent_consensus_messages_collectors,
+        epoch_stores,
+        notify_services,
+        network_owned_address_sign_request_senders,
+        network_owned_address_sign_output_receivers,
+    ) = utils::create_dwallet_mpc_services_with_committee_and_seeds(
+        committee.clone(),
+        seeds.clone(),
+        bundles.clone(),
+    );
+    let mut state = IntegrationTestState {
+        dwallet_mpc_services,
+        sui_data_senders,
+        sent_consensus_messages_collectors,
+        epoch_stores,
+        notify_services,
+        network_owned_address_sign_request_senders,
+        network_owned_address_sign_output_receivers,
+        committee: committee.clone(),
+        crypto_round: 1,
+        consensus_round: 1,
+    };
+    let (_, dkg_bytes, key_id) = create_network_key_test(&mut state).await;
+    let prior_epoch = committee.epoch;
+    let mut committee = committee;
+    committee.epoch += 1;
+    let (mut services, senders, _, stores, _, _, _) =
+        utils::create_dwallet_mpc_services_with_committee_and_seeds(
+            committee.clone(),
+            seeds.clone(),
+            bundles,
+        );
+    let directory = TempDir::new().unwrap();
+    let perpetual = Arc::new(AuthorityPerpetualTables::open(directory.path(), None));
+    let dkg_digest = mpc_data_blob_hash(&dkg_bytes);
+    perpetual
+        .insert_mpc_artifact_blob(dkg_digest, &dkg_bytes)
+        .unwrap();
+    let network_key_id = network_key_id_for(&key_id).unwrap();
+    let mut items = vec![(
+        HandoffItemKey::NetworkDkgOutput {
+            key_id: network_key_id,
+        },
+        dkg_digest,
+    )];
+    for (validator, seed) in seeds {
+        let blob = derive_mpc_data_blob(&seed).unwrap();
+        let digest = mpc_data_blob_hash(&blob);
+        perpetual.insert_mpc_artifact_blob(digest, &blob).unwrap();
+        items.push((HandoffItemKey::ValidatorMpcData { validator }, digest));
+    }
+    items.sort_by(|(first, _), (second, _)| first.cmp(second));
+    stores[0]
+        .perpetual_tables
+        .lock()
+        .unwrap()
+        .replace(perpetual);
+    stores[0]
+        .certified_handoff_attestations
+        .lock()
+        .unwrap()
+        .insert(
+            prior_epoch,
+            CertifiedHandoffAttestation {
+                attestation: HandoffAttestation {
+                    epoch: prior_epoch,
+                    next_committee_pubkey_set_hash: [0; 32],
+                    items,
+                },
+                signatures: Vec::new(),
+            },
+        );
+    // A restarted node can observe the next committee's data on the live
+    // channel. Only the immutable creation epoch is useful to preparation.
+    senders[0]
+        .network_keys_sender
+        .send(Arc::new(HashMap::from([(
+            key_id,
+            DWalletNetworkEncryptionKeyData {
+                id: key_id,
+                current_epoch: committee.epoch + 1,
+                dkg_at_epoch: prior_epoch,
+                network_dkg_public_output: b"wrong overlay anchor".to_vec(),
+                current_reconfiguration_public_output: b"next committee's shares".to_vec(),
+                state: DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted,
+            },
+        )])))
+        .unwrap();
+    senders[0].current_epoch_mpc_keys_sender.send(None).unwrap();
+    let service = &mut services[0];
+    let manager = service.dwallet_mpc_manager_mut();
+    manager.current_epoch_keys_ingested = false;
+    assert!(manager.network_keys.network_encryption_keys.is_empty());
+    assert!(manager.network_keys.decryption_key_shares(&key_id).is_err());
+    assert!(manager.network_keys.vss_shamir_cache(&key_id).is_err());
+
+    service
+        .prepare_epoch()
+        .await
+        .expect("certified keys must prepare without a consensus round");
+
+    let manager = service.dwallet_mpc_manager();
+    assert!(
+        manager.current_epoch_keys_ingested,
+        "validator bundles must be ingested before startup"
+    );
+    assert!(manager.pending_network_key_instantiations.is_empty());
+    assert_eq!(
+        manager
+            .network_keys
+            .get_network_encryption_key_public_data(&key_id)
+            .unwrap()
+            .epoch(),
+        committee.epoch
+    );
+    assert!(
+        !manager
+            .network_keys
+            .decryption_key_shares(&key_id)
+            .unwrap()
+            .is_empty(),
+        "AHE shares must be decrypted before startup"
+    );
+    assert_eq!(
+        manager
+            .network_keys
+            .vss_shamir_cache(&key_id)
+            .expect("VSS caches must be derived before startup")
+            .derived_for_epoch,
+        committee.epoch
+    );
+    assert!(
+        manager.sessions.is_empty(),
+        "preparation must not process MPC sessions"
+    );
+}
 
 #[tokio::test]
 #[cfg(test)]

--- a/crates/ika-core/src/dwallet_mpc/mod.rs
+++ b/crates/ika-core/src/dwallet_mpc/mod.rs
@@ -48,6 +48,7 @@ pub struct NetworkOwnedAddressSignOutput {
 
 mod catchup_gate;
 pub mod dwallet_mpc_service;
+pub mod epoch_start_data;
 mod mpc_diagnostics;
 pub mod mpc_manager;
 pub mod mpc_session;

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -17,6 +17,9 @@ use crate::dwallet_mpc::dwallet_mpc_metrics::{
     SESSION_STATE_COMPUTATION_COMPLETED, SESSION_STATE_FAILED, SESSION_STATE_WAITING_FOR_REQUEST,
     optional_session_type_label, session_type_label,
 };
+use crate::dwallet_mpc::epoch_start_data::{
+    certified_network_key_data, missing_validator_mpc_data,
+};
 use crate::dwallet_mpc::mpc_diagnostics::{
     LocalAuthorityMaliciousReason, MPC_ANOMALY_SCHEMA_VERSION, MpcAnomalyContext, MpcAnomalyKind,
     OutputReportDiagnostic, OutputVoteDiagnostics, OutputVoteGroupDiagnostic, SessionOrigin,
@@ -906,6 +909,80 @@ impl DWalletMPCManager {
             finalized_tx_refs: HashSet::new(),
             failed_tx_ref_rounds: HashSet::new(),
         })
+    }
+
+    /// Finish inherited-key initialization before consensus replay or live
+    /// rounds can reach this manager. Genesis has no inherited data: its first
+    /// key set must still be produced by that epoch's consensus freeze.
+    pub(crate) async fn prepare_epoch(&mut self) -> DwalletMPCResult<()> {
+        let Some(prior_epoch) = self.epoch_id.checked_sub(1) else {
+            return Ok(());
+        };
+        let Some(cert) = self
+            .epoch_store
+            .get_certified_handoff_attestation(prior_epoch)?
+        else {
+            return Ok(());
+        };
+        let perpetual = self.epoch_store.perpetual_tables_handle().ok_or_else(|| {
+            DwalletMPCError::InternalError("epoch preparation has no perpetual store".to_owned())
+        })?;
+        let missing = missing_validator_mpc_data(&cert, &self.committee, |digest| {
+            perpetual.get_mpc_artifact_blob(digest).ok().flatten()
+        });
+        if !missing.is_empty() {
+            return Err(DwalletMPCError::InternalError(format!(
+                "epoch preparation is missing certified validator MPC data: {missing:?}"
+            )));
+        }
+        self.ingest_offchain_mpc_keys()?;
+        if !self.current_epoch_keys_ingested
+            && cert.attestation.items.iter().any(|(item, _)| {
+                matches!(item, HandoffItemKey::ValidatorMpcData { validator }
+                if self.committee.authority_index(validator).is_some())
+            })
+        {
+            return Err(DwalletMPCError::InternalError(
+                "epoch preparation did not ingest its certified validator MPC keys".to_owned(),
+            ));
+        }
+        let metadata = self
+            .sui_data_receivers
+            .network_keys_receiver
+            .borrow()
+            .clone();
+        let keys = certified_network_key_data(&cert, self.epoch_id, &metadata, |digest| {
+            perpetual.get_mpc_artifact_blob(digest).ok().flatten()
+        })?;
+        let required_keys: Vec<_> = keys.keys().copied().collect();
+        info!(
+            epoch = self.epoch_id,
+            network_keys = required_keys.len(),
+            "preparing inherited MPC parameters and local shares before consensus startup"
+        );
+        self.adopt_cert_verified_keys(&Arc::new(keys));
+        self.instantiate_adopted_network_keys();
+        while !self.pending_network_key_instantiations.is_empty() {
+            self.poll_pending_network_key_instantiations().await;
+            if !self.pending_network_key_instantiations.is_empty() {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        }
+        let unprepared: Vec<_> = required_keys
+            .into_iter()
+            .filter(|key_id| !self.last_instantiated_network_key_data.contains_key(key_id))
+            .collect();
+        if !unprepared.is_empty() {
+            return Err(DwalletMPCError::InternalError(format!(
+                "epoch preparation could not initialize certified network keys: {unprepared:?}"
+            )));
+        }
+        info!(
+            epoch = self.epoch_id,
+            network_keys = self.last_instantiated_network_key_data.len(),
+            "inherited MPC keys and shares prepared before consensus startup"
+        );
+        Ok(())
     }
 
     pub(crate) fn sync_last_session_to_complete_in_current_epoch(

--- a/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
+++ b/crates/ika-core/src/dwallet_mpc/mpc_manager.rs
@@ -1799,10 +1799,11 @@ impl DWalletMPCManager {
                 // PRIOR epoch this is not a convergence window — the local
                 // producer cache will never fill (this validator never
                 // computed the key's outputs): the JOINER / cold-start shape.
-                // The cert-pinned blob install (barrier) covers only the
-                // continuing-validator path today, so without intervention the
-                // overlay stays empty and the key is never adopted — parking
-                // every session on it for this validator. Flag it for the
+                // The startup barrier prepares every certified inherited
+                // key. This recovery remains necessary for keys outside that
+                // certificate, including the first off-chain epoch, where an
+                // empty overlay would otherwise park every session on the
+                // key for this validator. Flag it for the
                 // syncer's stranded-key chain read (#1852 machinery): the
                 // chain holds the real blobs (written at DKG/reconfiguration
                 // regardless of the off-chain plane), the cert digest gates

--- a/crates/ika-core/src/dwallet_mpc/network_owned_address_signing_key.rs
+++ b/crates/ika-core/src/dwallet_mpc/network_owned_address_signing_key.rs
@@ -13,10 +13,18 @@
 //! locally adopted key set instead let honest validators name different keys
 //! while their adoption lagged at different rates.
 
-use crate::network_key_id_mapping::object_id_for;
+use crate::dwallet_mpc::network_dkg::spawn_network_key_id_registration;
+use crate::network_key_id_mapping::network_key_id_for;
+use arc_swap::ArcSwap;
 use dwallet_mpc_types::dwallet_mpc::NetworkKeyId;
+use ika_network::mpc_artifacts::mpc_data_blob_hash;
 use ika_types::handoff::{CertifiedHandoffAttestation, HandoffItemKey};
+use ika_types::messages_dwallet_mpc::{
+    DWalletNetworkEncryptionKeyData, DWalletNetworkEncryptionKeyState,
+};
 use std::cmp::Reverse;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use sui_types::base_types::ObjectID;
 
 /// The outcome of [`select`].
@@ -34,13 +42,76 @@ pub enum NetworkOwnedAddressSigningKeySelection {
     NoCertifiedKey,
     /// These certified keys have no `NetworkKeyId -> ObjectID` translation
     /// on this process, so no key can be chosen: a choice among the
-    /// translatable rest would be a per-validator answer. Waiting does not
-    /// help — the translation registers only when the key is instantiated
-    /// or derived, after the epoch's components start.
+    /// translatable rest would be a per-validator answer. The barrier
+    /// prepares the missing mappings before starting any epoch components.
     Untranslatable(Vec<NetworkKeyId>),
     /// Every certified key translates, but the chain metadata of these keys
     /// is not local yet. Retry: the network-key syncer publishes it.
     AwaitingMetadata(Vec<ObjectID>),
+}
+
+impl NetworkOwnedAddressSigningKeySelection {
+    /// The constructor input, or `None` while startup must wait. A resolved
+    /// `Some(None)` means the certificate names no key, uniformly across the
+    /// committee. With NOA enabled, missing local mappings must never produce
+    /// that answer: skipping NOA demand assignment would leave the shared
+    /// presign pool out of step with keyed peers, including after a restart.
+    /// The flag-off exception preserves the live protocol's startup behavior.
+    pub fn epoch_start_key(&self, noa_checkpoints: bool) -> Option<Option<ObjectID>> {
+        match self {
+            Self::Selected { object_id, .. } => Some(Some(*object_id)),
+            Self::NoCertifiedKey => Some(None),
+            Self::Untranslatable(_) if !noa_checkpoints => Some(None),
+            Self::Untranslatable(_) | Self::AwaitingMetadata(_) => None,
+        }
+    }
+}
+
+/// Breaks the mapping/adoption cycle before the MPC manager exists. The
+/// syncer is already running at the barrier: flag blob-empty prior-epoch
+/// keys for its existing chain recovery, then derive their identities on
+/// rayon from the published blobs. Identical inputs spawn only once;
+/// changed inputs retry a failed derivation. Only keys old enough to occur
+/// in the certificate are candidates; a fresh DKG must not trigger recovery.
+pub fn prepare_missing_key_mappings(
+    anchor_epoch: u64,
+    overlay: &HashMap<ObjectID, DWalletNetworkEncryptionKeyData>,
+    derivation_inputs: &mut HashMap<ObjectID, [u8; 32]>,
+    stranded_network_keys: &ArcSwap<HashSet<ObjectID>>,
+) {
+    for (object_id, data) in overlay {
+        if data.dkg_at_epoch > anchor_epoch || network_key_id_for(object_id).is_some() {
+            continue;
+        }
+        if data.network_dkg_public_output.is_empty()
+            || (matches!(
+                data.state,
+                DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted
+            ) && data.current_reconfiguration_public_output.is_empty())
+        {
+            stranded_network_keys.rcu(|keys| {
+                let mut keys = (**keys).clone();
+                keys.insert(*object_id);
+                Arc::new(keys)
+            });
+            continue;
+        }
+        let input_digest = mpc_data_blob_hash(
+            &bcs::to_bytes(&(
+                &data.network_dkg_public_output,
+                &data.current_reconfiguration_public_output,
+            ))
+            .expect("network-key derivation inputs serialize"),
+        );
+        if derivation_inputs.get(object_id) != Some(&input_digest) {
+            derivation_inputs.insert(*object_id, input_digest);
+            spawn_network_key_id_registration(
+                *object_id,
+                data.network_dkg_public_output.clone(),
+                data.current_reconfiguration_public_output.clone(),
+            );
+        }
+    }
 }
 
 /// Derives the NOA signing key for the epoch the certificate hands into.
@@ -52,7 +123,8 @@ pub enum NetworkOwnedAddressSigningKeySelection {
 /// created by DKG after the certificate is not in it and waits one epoch.
 ///
 /// ALL OR NOTHING. The certificate names keys by their content-derived
-/// `NetworkKeyId`; the pool and the manager key by Sui `ObjectID`, and
+/// `NetworkKeyId`; `object_id_of` supplies this process's translation into
+/// the Sui `ObjectID` used by the pool and manager, and
 /// `dkg_at_epoch` is chain metadata keyed by `ObjectID`, read through
 /// `dkg_at_epoch_of`. If any certified key cannot be translated the answer is
 /// [`Untranslatable`](NetworkOwnedAddressSigningKeySelection::Untranslatable);
@@ -62,6 +134,7 @@ pub enum NetworkOwnedAddressSigningKeySelection {
 /// per-validator divergence this derivation exists to remove.
 pub fn select(
     certificate: &CertifiedHandoffAttestation,
+    object_id_of: impl Fn(&NetworkKeyId) -> Option<ObjectID>,
     dkg_at_epoch_of: impl Fn(&ObjectID) -> Option<u64>,
 ) -> NetworkOwnedAddressSigningKeySelection {
     let certified_keys = certificate
@@ -77,7 +150,7 @@ pub fn select(
     let mut awaiting_metadata = Vec::new();
     let mut candidates = Vec::new();
     for network_key_id in certified_keys {
-        let Some(object_id) = object_id_for(&network_key_id) else {
+        let Some(object_id) = object_id_of(&network_key_id) else {
             untranslatable.push(network_key_id);
             continue;
         };
@@ -114,8 +187,12 @@ pub fn select(
 mod tests {
     use super::*;
     use crate::network_key_id_mapping;
+    use crate::network_key_id_mapping::object_id_for;
+    use dwallet_mpc_types::dwallet_mpc::{
+        VersionedDecryptionKeyReconfigurationOutput, VersionedNetworkDkgOutput,
+    };
     use ika_types::handoff::HandoffAttestation;
-    use std::collections::HashMap;
+    use std::time::Duration;
 
     /// A key whose `NetworkKeyId` is its `ObjectID`'s bytes — so ordering the
     /// object ids orders the network key ids identically — registered in the
@@ -174,7 +251,7 @@ mod tests {
             (newer_larger_id.0, 1),
         ]);
         assert_eq!(
-            select(&certificate, dkg_at_epoch),
+            select(&certificate, object_id_for, dkg_at_epoch),
             NetworkOwnedAddressSigningKeySelection::Selected {
                 object_id: newer_smaller_id.0,
                 network_key_id: newer_smaller_id.1,
@@ -191,7 +268,7 @@ mod tests {
         let certificate = certificate_naming(&[certified.1]);
         let dkg_at_epoch = metadata(&[(certified.0, 0), (fresh.0, 1)]);
         assert_eq!(
-            select(&certificate, dkg_at_epoch),
+            select(&certificate, object_id_for, dkg_at_epoch),
             NetworkOwnedAddressSigningKeySelection::Selected {
                 object_id: certified.0,
                 network_key_id: certified.1,
@@ -210,7 +287,7 @@ mod tests {
         // key OLDER by every tie-break, no partial choice is made.
         let dkg_at_epoch = metadata(&[(translated_object_id, 5)]);
         assert_eq!(
-            select(&certificate, dkg_at_epoch),
+            select(&certificate, object_id_for, dkg_at_epoch),
             NetworkOwnedAddressSigningKeySelection::Untranslatable(vec![untranslatable])
         );
     }
@@ -220,12 +297,16 @@ mod tests {
         let [low, high] = ordered_registered_keys::<2>();
         let certificate = certificate_naming(&[low.1, high.1]);
         assert_eq!(
-            select(&certificate, metadata(&[(high.0, 0)])),
+            select(&certificate, object_id_for, metadata(&[(high.0, 0)])),
             NetworkOwnedAddressSigningKeySelection::AwaitingMetadata(vec![low.0])
         );
         // The same inputs plus the missing metadata resolve.
         assert_eq!(
-            select(&certificate, metadata(&[(low.0, 0), (high.0, 0)])),
+            select(
+                &certificate,
+                object_id_for,
+                metadata(&[(low.0, 0), (high.0, 0)])
+            ),
             NetworkOwnedAddressSigningKeySelection::Selected {
                 object_id: low.0,
                 network_key_id: low.1,
@@ -242,7 +323,7 @@ mod tests {
         // The translatable key ALSO lacks metadata; waiting cannot fix the
         // other one, so the answer is the one waiting cannot change.
         assert_eq!(
-            select(&certificate, |_| None),
+            select(&certificate, object_id_for, |_| None),
             NetworkOwnedAddressSigningKeySelection::Untranslatable(vec![untranslatable])
         );
     }
@@ -251,8 +332,131 @@ mod tests {
     fn a_certificate_naming_no_key_selects_none() {
         let certificate = certificate_naming(&[]);
         assert_eq!(
-            select(&certificate, |_| Some(0)),
+            select(&certificate, object_id_for, |_| Some(0)),
             NetworkOwnedAddressSigningKeySelection::NoCertifiedKey
+        );
+    }
+
+    #[test]
+    fn epoch_start_waits_for_mapping_and_metadata_with_noa_enabled() {
+        let object_id = ObjectID::random();
+        let network_key_id = NetworkKeyId(rand::random());
+        let certificate = certificate_naming(&[network_key_id]);
+        let missing_mapping = select(&certificate, |_| None, |_| Some(0));
+        assert_eq!(
+            missing_mapping.epoch_start_key(true),
+            None,
+            "an unresolved certified key must block epoch startup"
+        );
+        assert_eq!(missing_mapping.epoch_start_key(false), Some(None));
+
+        let missing_metadata = select(&certificate, |_| Some(object_id), |_| None);
+        assert_eq!(missing_metadata.epoch_start_key(true), None);
+        assert_eq!(missing_metadata.epoch_start_key(false), None);
+
+        let resolved = select(&certificate, |_| Some(object_id), |_| Some(0));
+        assert_eq!(resolved.epoch_start_key(true), Some(Some(object_id)));
+        assert_eq!(resolved.epoch_start_key(false), Some(Some(object_id)));
+        assert_eq!(
+            select(&certificate_naming(&[]), |_| None, |_| None).epoch_start_key(true),
+            Some(None),
+            "a certificate with no key is uniformly keyless"
+        );
+    }
+
+    #[test]
+    fn preparation_requests_missing_blobs_without_waiting_for_mpc_startup() {
+        let missing_dkg = ObjectID::random();
+        let missing_reconfiguration = ObjectID::random();
+        let fresh = ObjectID::random();
+        let (already_mapped, _) = registered_key();
+        let overlay = HashMap::from([
+            (missing_dkg, (0, Vec::new())),
+            (missing_reconfiguration, (0, vec![1])),
+            (fresh, (1, Vec::new())),
+            (already_mapped, (0, Vec::new())),
+        ])
+        .into_iter()
+        .map(|(id, (dkg_at_epoch, network_dkg_public_output))| {
+            (
+                id,
+                DWalletNetworkEncryptionKeyData {
+                    id,
+                    current_epoch: 1,
+                    dkg_at_epoch,
+                    network_dkg_public_output,
+                    current_reconfiguration_public_output: Vec::new(),
+                    state: DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted,
+                },
+            )
+        })
+        .collect();
+        let stranded = ArcSwap::from_pointee(HashSet::new());
+        let mut derivation_inputs = HashMap::new();
+        prepare_missing_key_mappings(0, &overlay, &mut derivation_inputs, &stranded);
+        assert_eq!(
+            **stranded.load(),
+            HashSet::from([missing_dkg, missing_reconfiguration]),
+            "preparation must request recovery for incomplete prior-epoch keys only"
+        );
+        assert!(
+            derivation_inputs.is_empty(),
+            "incomplete blobs cannot derive a key"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn preparation_derives_a_mapping_before_mpc_components_exist() {
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+        let object_id = ObjectID::random();
+        let network_dkg_public_output = bcs::to_bytes(&VersionedNetworkDkgOutput::V4(
+            include_bytes!("integration_tests/fixtures/dkg_anchor_aggregated.bcs").to_vec(),
+        ))
+        .unwrap();
+        let current_reconfiguration_public_output =
+            bcs::to_bytes(&VersionedDecryptionKeyReconfigurationOutput::V4(
+                include_bytes!("integration_tests/fixtures/reconfiguration_output_aggregated.bcs")
+                    .to_vec(),
+            ))
+            .unwrap();
+        let overlay = HashMap::from([(
+            object_id,
+            DWalletNetworkEncryptionKeyData {
+                id: object_id,
+                current_epoch: 1,
+                dkg_at_epoch: 0,
+                network_dkg_public_output,
+                current_reconfiguration_public_output,
+                state: DWalletNetworkEncryptionKeyState::NetworkReconfigurationCompleted,
+            },
+        )]);
+        let mut derivation_inputs = HashMap::new();
+        let stranded = ArcSwap::from_pointee(HashSet::new());
+        assert_eq!(network_key_id_for(&object_id), None);
+        prepare_missing_key_mappings(0, &overlay, &mut derivation_inputs, &stranded);
+        assert_eq!(
+            derivation_inputs.len(),
+            1,
+            "preparation must schedule derivation"
+        );
+
+        // No MPC manager or adoption pass exists in this test. The barrier's
+        // own preparation must make progress using real serialized key data.
+        let network_key_id = tokio::time::timeout(Duration::from_secs(120), async {
+            loop {
+                if let Some(network_key_id) = network_key_id_for(&object_id) {
+                    break network_key_id;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("preparation must resolve the mapping without starting MPC");
+        assert_eq!(object_id_for(&network_key_id), Some(object_id));
+        let certificate = certificate_naming(&[network_key_id]);
+        assert_eq!(
+            select(&certificate, object_id_for, |_| Some(0)).epoch_start_key(true),
+            Some(Some(object_id))
         );
     }
 }

--- a/crates/ika-core/src/dwallet_mpc/network_owned_address_signing_key.rs
+++ b/crates/ika-core/src/dwallet_mpc/network_owned_address_signing_key.rs
@@ -53,15 +53,13 @@ pub enum NetworkOwnedAddressSigningKeySelection {
 impl NetworkOwnedAddressSigningKeySelection {
     /// The constructor input, or `None` while startup must wait. A resolved
     /// `Some(None)` means the certificate names no key, uniformly across the
-    /// committee. With NOA enabled, missing local mappings must never produce
-    /// that answer: skipping NOA demand assignment would leave the shared
+    /// committee. Missing local mappings must never produce that answer.
+    /// With NOA enabled, skipping demand assignment would leave the shared
     /// presign pool out of step with keyed peers, including after a restart.
-    /// The flag-off exception preserves the live protocol's startup behavior.
-    pub fn epoch_start_key(&self, noa_checkpoints: bool) -> Option<Option<ObjectID>> {
+    pub fn epoch_start_key(&self) -> Option<Option<ObjectID>> {
         match self {
             Self::Selected { object_id, .. } => Some(Some(*object_id)),
             Self::NoCertifiedKey => Some(None),
-            Self::Untranslatable(_) if !noa_checkpoints => Some(None),
             Self::Untranslatable(_) | Self::AwaitingMetadata(_) => None,
         }
     }
@@ -338,27 +336,24 @@ mod tests {
     }
 
     #[test]
-    fn epoch_start_waits_for_mapping_and_metadata_with_noa_enabled() {
+    fn epoch_start_waits_for_mapping_and_metadata() {
         let object_id = ObjectID::random();
         let network_key_id = NetworkKeyId(rand::random());
         let certificate = certificate_naming(&[network_key_id]);
         let missing_mapping = select(&certificate, |_| None, |_| Some(0));
         assert_eq!(
-            missing_mapping.epoch_start_key(true),
+            missing_mapping.epoch_start_key(),
             None,
             "an unresolved certified key must block epoch startup"
         );
-        assert_eq!(missing_mapping.epoch_start_key(false), Some(None));
 
         let missing_metadata = select(&certificate, |_| Some(object_id), |_| None);
-        assert_eq!(missing_metadata.epoch_start_key(true), None);
-        assert_eq!(missing_metadata.epoch_start_key(false), None);
+        assert_eq!(missing_metadata.epoch_start_key(), None);
 
         let resolved = select(&certificate, |_| Some(object_id), |_| Some(0));
-        assert_eq!(resolved.epoch_start_key(true), Some(Some(object_id)));
-        assert_eq!(resolved.epoch_start_key(false), Some(Some(object_id)));
+        assert_eq!(resolved.epoch_start_key(), Some(Some(object_id)));
         assert_eq!(
-            select(&certificate_naming(&[]), |_| None, |_| None).epoch_start_key(true),
+            select(&certificate_naming(&[]), |_| None, |_| None).epoch_start_key(),
             Some(None),
             "a certificate with no key is uniformly keyless"
         );
@@ -455,7 +450,7 @@ mod tests {
         assert_eq!(object_id_for(&network_key_id), Some(object_id));
         let certificate = certificate_naming(&[network_key_id]);
         assert_eq!(
-            select(&certificate, object_id_for, |_| Some(0)).epoch_start_key(true),
+            select(&certificate, object_id_for, |_| Some(0)).epoch_start_key(),
             Some(Some(object_id))
         );
     }

--- a/crates/ika-core/src/epoch_tasks/peer_blob_fetcher.rs
+++ b/crates/ika-core/src/epoch_tasks/peer_blob_fetcher.rs
@@ -373,10 +373,12 @@ impl PeerBlobFetcher {
 /// later, DB restored, writes lost in a crash window) holds no local copy
 /// and has no announcement to fetch by. The MPC manager sources the CURRENT
 /// epoch's validator key bundle from exactly these cert digests against the
-/// perpetual store and correctly defers ingestion while any pinned blob is
-/// missing (never falling back to the freeze channel); without this repair
-/// the deferral retries the same local store forever and the validator is
-/// MPC-dead for this and every following epoch (issue #1881).
+/// perpetual store. Startup repairs these blobs before ingestion and before
+/// consensus starts; periodic passes retain the same repair path. Readiness
+/// requires a valid durable copy even when the P2P cache holds an in-memory
+/// copy. Without repair, missing blobs would strand ingestion permanently
+/// (issue #1881); falling back to the current freeze channel would diverge
+/// the key set from peers.
 ///
 /// Byte-safe by construction: the digests come from the quorum-signed cert
 /// and blobs are content-addressed, so ANY holder is authoritative. The
@@ -409,7 +411,18 @@ pub async fn fetch_missing_prior_cert_mpc_data_blobs(
         .filter(|(validator, _)| {
             *validator == own_authority || authority_names_to_peer_ids.contains_key(validator)
         })
-        .filter(|(_, digest)| !blob_cache.contains(digest))
+        .filter(|(_, digest)| {
+            !blob_cache
+                .get_persisted(digest)
+                .ok()
+                .flatten()
+                .is_some_and(|bytes| {
+                    matches!(
+                        verify_peer_blob_for_relay(&bytes, digest),
+                        PeerBlobVerdict::Accept
+                    )
+                })
+        })
         .collect();
     if missing.is_empty() {
         return 0;

--- a/crates/ika-core/src/network_key_id_mapping.rs
+++ b/crates/ika-core/src/network_key_id_mapping.rs
@@ -19,7 +19,10 @@
 //! instantiation, and a validator that never instantiated the key (a
 //! joiner) derives the id from its locally-held key blobs in the
 //! background when a handoff cert forces the translation — see
-//! `spawn_network_key_id_registration` in `network_dkg`. Without that
+//! `spawn_network_key_id_registration` in `network_dkg`. With NOA enabled,
+//! the prepare-then-start barrier drives this recovery before any epoch
+//! components run, so every validator drains the same presign pool from its
+//! first round. With NOA disabled the adoption pass drives it. Without that
 //! path, adoption needs the mapping, the mapping registers at
 //! instantiation, and instantiation needs adoption: a deadlock that
 //! wedges the joiner's epoch entry.

--- a/crates/ika-core/src/network_key_id_mapping.rs
+++ b/crates/ika-core/src/network_key_id_mapping.rs
@@ -19,10 +19,9 @@
 //! instantiation, and a validator that never instantiated the key (a
 //! joiner) derives the id from its locally-held key blobs in the
 //! background when a handoff cert forces the translation — see
-//! `spawn_network_key_id_registration` in `network_dkg`. With NOA enabled,
-//! the prepare-then-start barrier drives this recovery before any epoch
-//! components run, so every validator drains the same presign pool from its
-//! first round. With NOA disabled the adoption pass drives it. Without that
+//! `spawn_network_key_id_registration` in `network_dkg`. The startup barrier
+//! drives this recovery for every inherited key before consensus starts;
+//! adoption retains it for keys arriving during the epoch. Without that
 //! path, adoption needs the mapping, the mapping registers at
 //! instantiation, and instantiation needs adoption: a deadlock that
 //! wedges the joiner's epoch entry.

--- a/crates/ika-core/src/sui_connector/mod.rs
+++ b/crates/ika-core/src/sui_connector/mod.rs
@@ -186,6 +186,10 @@ impl SuiConnectorService {
             >,
         > = Arc::new(arc_swap::ArcSwapOption::empty());
 
+        // The handoff barrier needs the syncer's key metadata before
+        // `run_epoch` can start. Publish its verified root objects now.
+        sui_executor.prepare_epoch_inputs().await;
+
         let task_handles = SuiSyncer::new(sui_client.clone(), sui_connector_metrics.clone())
             .run(
                 next_epoch_committee_sender,

--- a/crates/ika-core/src/sui_connector/sui_executor.rs
+++ b/crates/ika-core/src/sui_connector/sui_executor.rs
@@ -138,6 +138,21 @@ where
         }
     }
 
+    /// Seed the syncer's inputs before a validator can wait at the handoff
+    /// barrier. The epoch execution loop starts after that barrier, so it
+    /// cannot be the first publisher of the objects needed to release it.
+    /// These are the same verified reads used by the normal epoch loop;
+    /// this preparation performs no checkpoint writes or epoch transitions.
+    pub(super) async fn prepare_epoch_inputs(&self) {
+        let system = self.must_get_system_inner().await;
+        let coordinator = self.must_get_dwallet_coordinator_inner().await;
+        let _ = self.system_object_sender.send(Some(system));
+        let _ = self
+            .dwallet_coordinator_object_sender
+            .send(Some(coordinator));
+        info!("published initial Sui system and coordinator inputs before epoch execution");
+    }
+
     /// Retrieve the System wrapper + its inner. OCS-verified when a reader is
     /// wired in; otherwise read from the direct gRPC client. Retries forever.
     async fn must_get_system_inner(&self) -> (System, SystemInner) {

--- a/crates/ika-network/src/discovery/mod.rs
+++ b/crates/ika-network/src/discovery/mod.rs
@@ -33,6 +33,8 @@ const MAX_ADDRESS_LENGTH: usize = 300;
 const MAX_PEERS_TO_SEND: usize = 200;
 const MAX_ADDRESSES_PER_PEER: usize = 2;
 
+// Anemo fixes the generated RPC error type to Status; boxing it changes the API.
+#[allow(clippy::result_large_err)]
 mod generated {
     include!(concat!(env!("OUT_DIR"), "/ika.Discovery.rs"));
 }

--- a/crates/ika-network/src/mpc_artifacts.rs
+++ b/crates/ika-network/src/mpc_artifacts.rs
@@ -20,6 +20,8 @@ use anemo::codegen::InboundRequestLayer;
 use anemo_tower::inflight_limit;
 use std::sync::Arc;
 
+// Anemo fixes the generated RPC error type to Status; boxing it changes the API.
+#[allow(clippy::result_large_err)]
 mod generated {
     include!(concat!(env!("OUT_DIR"), "/ika.ValidatorMetadata.rs"));
 }

--- a/crates/ika-network/src/state_sync/mod.rs
+++ b/crates/ika-network/src/state_sync/mod.rs
@@ -179,6 +179,8 @@ impl SyncCommittees {
 /// itself does not depend on pull-mode sync, so deferring costs nothing.
 pub type CommitteeSource = watch::Receiver<Option<SyncCommittees>>;
 
+// Anemo fixes the generated RPC error type to Status; boxing it changes the API.
+#[allow(clippy::result_large_err)]
 mod generated {
     include!(concat!(env!("OUT_DIR"), "/ika.StateSync.rs"));
 }

--- a/crates/ika-network/src/sui_state_mirror/mod.rs
+++ b/crates/ika-network/src/sui_state_mirror/mod.rs
@@ -19,6 +19,8 @@
 //! (`get_full_checkpoint`, `last_checkpoint_of_epoch`) are committee-ratchet
 //! plumbing.
 
+// Anemo fixes the generated RPC error type to Status; boxing it changes the API.
+#[allow(clippy::result_large_err)]
 mod generated {
     include!(concat!(env!("OUT_DIR"), "/ika.SuiStateMirror.rs"));
 }

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -48,6 +48,7 @@ use ika_core::authority::authority_per_epoch_store::{
     AuthorityPerEpochStore, AuthorityPerEpochStoreTrait, EPOCH_DB_PREFIX, EpochStoreParams,
 };
 use ika_core::authority::epoch_start_configuration::EpochStartConfiguration;
+use ika_core::blob_cache::BlobCache;
 use ika_core::consensus_adapter::{
     CheckConnection, ConnectionMonitorStatus, ConsensusAdapter, ConsensusAdapterMetrics,
 };
@@ -61,6 +62,9 @@ use ika_core::dwallet_checkpoints::{
     DWalletCheckpointMetrics, DWalletCheckpointService, DWalletCheckpointStore,
     SendDWalletCheckpointToStateSync, SubmitDWalletCheckpointToConsensus,
 };
+use ika_core::dwallet_mpc::epoch_start_data::{
+    certified_network_key_data, missing_validator_mpc_data,
+};
 use ika_core::dwallet_mpc::network_owned_address_signing_key::{
     self, NetworkOwnedAddressSigningKeySelection,
 };
@@ -71,6 +75,7 @@ use ika_core::epoch_tasks::joiner_bootstrap_verifier::{
     BootstrapOutcome, BootstrapRetryConfig, CertVerifier, JoinerBootstrapVerifier,
     P2pHandoffCertSource,
 };
+use ika_core::epoch_tasks::peer_blob_fetcher::fetch_missing_prior_cert_mpc_data_blobs;
 use ika_core::network_key_id_mapping;
 use ika_core::storage::RocksDbStore;
 use ika_core::sui_connector::pubkey_provider_updater::fetch_previous_committee;
@@ -254,7 +259,7 @@ use ika_core::system_checkpoints::{
     SendSystemCheckpointToStateSync, SubmitSystemCheckpointToConsensus, SystemCheckpointMetrics,
     SystemCheckpointService, SystemCheckpointStore,
 };
-use ika_network::mpc_artifacts::{fetch_blob, mpc_data_blob_hash};
+use ika_network::mpc_artifacts::{InMemoryBlobStore, fetch_blob, mpc_data_blob_hash};
 use ika_sui_client::metrics::SuiClientMetrics;
 use ika_sui_client::{SuiClient, SuiConnectorClient};
 use ika_types::handoff::{CertifiedHandoffAttestation, HandoffItemKey};
@@ -1464,6 +1469,10 @@ impl IkaNode {
                     withhold_anchor_for: config.withhold_handoff_anchor_for_testing,
                     network_keys_receiver: sui_data_receivers.network_keys_receiver.clone(),
                     stranded_network_keys: stranded_network_keys.clone(),
+                    mpc_data_blob_store: mpc_data_blob_store.clone(),
+                    mpc_data_blob_fetch_outcomes: ika_node_metrics
+                        .mpc_data_blob_fetch_total
+                        .clone(),
                 };
                 let anchor_committee = AnchorCommittee::Resolved {
                     committee_store: state.committee_store().clone(),
@@ -2477,6 +2486,10 @@ impl IkaNode {
                 watchdog as Arc<dyn ika_core::consensus_handler::ConsensusCommitSink>
             }),
         );
+
+        // Complete the inherited public parameters, AHE decryption shares,
+        // and VSS caches before even the first replayed round is consumed.
+        dwallet_mpc_service.prepare_epoch().await?;
 
         info!("Starting consensus manager asynchronously");
 
@@ -3760,6 +3773,8 @@ struct HandoffBarrierContext {
     network_keys_receiver: watch::Receiver<Arc<HashMap<ObjectID, DWalletNetworkEncryptionKeyData>>>,
     /// Lets preparation request missing blobs before the MPC manager exists.
     stranded_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
+    mpc_data_blob_store: Arc<InMemoryBlobStore>,
+    mpc_data_blob_fetch_outcomes: IntCounterVec,
 }
 
 impl HandoffBarrierContext {
@@ -3780,6 +3795,8 @@ impl HandoffBarrierContext {
             withhold_anchor_for: node.config.withhold_handoff_anchor_for_testing,
             network_keys_receiver,
             stranded_network_keys: node.stranded_network_keys.clone(),
+            mpc_data_blob_store: node.mpc_data_blob_store.clone(),
+            mpc_data_blob_fetch_outcomes: node.metrics.mpc_data_blob_fetch_total.clone(),
         }
     }
 
@@ -4094,6 +4111,7 @@ async fn prepare_handoff_anchor(
                 .insert_certified_handoff_attestation(anchor_epoch, &cert)
             {
                 warn!(error = ?e, anchor_epoch, "failed to persist anchor handoff cert");
+                return AnchorOutcome::Unavailable;
             }
             install_joiner_network_key_outputs(&cert, &ctx.p2p_network, peer_ids, new_epoch_store)
                 .await;
@@ -4151,16 +4169,15 @@ async fn prepare_handoff_anchor(
 /// no predecessor to be handed off from: entering epoch 0 at genesis, which
 /// the boot caller filters out the same way the joiner bootstrap does.
 ///
-/// The barrier waits on two conditions, both grounded in off-chain data (the
-/// verified handoff cert + this validator's local outputs) — no chain state
-/// beyond resolving the signing committee on the boot path, and no dependency
-/// on the chain-fed `network_keys_receiver`:
+/// The barrier waits for the verified certificate, its durable artifacts,
+/// and the chain metadata needed to identify the inherited keys:
 ///   1. The cross-epoch trust anchor (the `anchor_epoch` handoff cert) is
 ///      locally present + verified — `prepare_handoff_anchor` returns it,
 ///      fetching it inline if missing.
 ///   2. Every network-key output item the cert certifies —
 ///      `NetworkReconfigurationOutput` AND `NetworkDkgOutput` — is held
-///      locally with a digest matching the cert. The cert's single `epoch`
+///      locally with matching digest rows AND hash-verified backing bytes.
+///      The cert's single `epoch`
 ///      field scopes the whole handoff, so there is no per-key epoch to
 ///      check — only per-key presence. BOTH digest sources are read from the
 ///      store for the epoch being ENTERED, which is the only store a booting
@@ -4178,9 +4195,16 @@ async fn prepare_handoff_anchor(
 ///      output; `prepare_handoff_anchor` and the per-retry installer fetch +
 ///      cache missing/mismatching outputs from peers. See
 ///      `all_cert_network_key_outputs_held_locally`.
-///   3. The NOA signing key is resolved from the certificate and chain
-///      metadata. With NOA enabled, preparation recovers missing mappings
-///      before startup; only a certificate naming no key resolves to None.
+///   3. Every certified validator MPC bundle belonging to the entering
+///      committee is durable, hash-matching and structurally decodable.
+///      Missing bundles are fetched inline, before the epoch's fetcher starts.
+///   4. The NOA signing key is resolved from the certificate and chain
+///      metadata. Preparation recovers missing mappings before startup; only
+///      a certificate naming no key resolves to None.
+///
+/// After this barrier, `DWalletMPCService::prepare_epoch` instantiates the
+/// certified parameters and derives local shares before consensus starts.
+/// See `dev-docs/specs/epoch-start-preparation.md` for the complete boundary.
 async fn wait_for_handoff_data_ready(
     ctx: &HandoffBarrierContext,
     anchor_epoch: EpochId,
@@ -4217,8 +4241,14 @@ async fn wait_for_handoff_data_ready(
     // path, a per-second P2P hammering of converging peers). The signing
     // committee is cached for the same reason — on the boot path resolving it
     // costs a chain read.
-    let noa_checkpoints = new_epoch_store.protocol_config().noa_checkpoints();
     let mut key_id_derivation_inputs = HashMap::new();
+    let blob_cache = BlobCache::new(
+        ctx.mpc_data_blob_store.clone(),
+        ctx.perpetual_tables.clone(),
+    );
+    let current_peers = new_epoch_store
+        .epoch_start_state()
+        .get_authority_names_to_peer_ids();
     let mut anchor_cert: Option<CertifiedHandoffAttestation> = None;
     let mut signing_committee: Option<Arc<Committee>> = None;
     let mut committee_resolve_attempts: u32 = 0;
@@ -4330,22 +4360,20 @@ async fn wait_for_handoff_data_ready(
         }
         let cert = anchor_cert.as_ref();
 
-        // NOA demand assignment drains a shared pool even before this node
-        // can sign. Resolve the same key as peers before any round can run.
+        // Resolve all inherited key identities before any round can run.
+        // NOA demand assignment also needs the same pool choice on every node.
         // The syncer and rayon workers are process-level services, so this
         // recovery does not depend on starting the epoch's MPC manager.
         let overlay = ctx.network_keys_receiver.borrow().clone();
-        if noa_checkpoints
-            && cert.is_some_and(|cert| {
-                cert.attestation.items.iter().any(|(item, _)| match item {
-                    HandoffItemKey::NetworkDkgOutput { key_id }
-                    | HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
-                        network_key_id_mapping::object_id_for(key_id).is_none()
-                    }
-                    HandoffItemKey::ValidatorMpcData { .. } => false,
-                })
+        if cert.is_some_and(|cert| {
+            cert.attestation.items.iter().any(|(item, _)| match item {
+                HandoffItemKey::NetworkDkgOutput { key_id }
+                | HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
+                    network_key_id_mapping::object_id_for(key_id).is_none()
+                }
+                HandoffItemKey::ValidatorMpcData { .. } => false,
             })
-        {
+        }) {
             network_owned_address_signing_key::prepare_missing_key_mappings(
                 anchor_epoch,
                 &overlay,
@@ -4376,14 +4404,35 @@ async fn wait_for_handoff_data_ready(
                 cert,
                 &local_dkg_digests,
                 &local_reconfiguration_digests,
-                noa_checkpoints,
             )
         });
 
-        // Condition 3: resolve the epoch's NOA key before construction.
-        // Missing metadata waits in every mode. With NOA enabled, missing
-        // mappings also wait: None is valid only when the certificate names
-        // no key, never as a per-validator opt-out from shared pool drains.
+        // Digests alone are insufficient: their backing bytes may be absent,
+        // and the current validator bundle is also inherited from this cert.
+        let missing_validator_data = cert
+            .map(|cert| {
+                missing_validator_mpc_data(cert, new_epoch_store.committee(), |digest| {
+                    ctx.perpetual_tables
+                        .get_mpc_artifact_blob(digest)
+                        .ok()
+                        .flatten()
+                })
+            })
+            .unwrap_or_default();
+        let network_key_data_error = cert.and_then(|cert| {
+            certified_network_key_data(cert, next_epoch, &overlay, |digest| {
+                ctx.perpetual_tables
+                    .get_mpc_artifact_blob(digest)
+                    .ok()
+                    .flatten()
+            })
+            .err()
+        });
+        let ready = ready && missing_validator_data.is_empty() && network_key_data_error.is_none();
+
+        // Resolve the epoch's NOA key before construction. Missing metadata
+        // and mappings wait in every mode. None is valid only when the cert
+        // names no key, never as a local opt-out from shared pool drains.
         let mut awaiting_metadata_key_ids: Vec<ObjectID> = Vec::new();
         if let Some(cert) = cert.filter(|_| ready) {
             let selection = network_owned_address_signing_key::select(
@@ -4391,9 +4440,7 @@ async fn wait_for_handoff_data_ready(
                 network_key_id_mapping::object_id_for,
                 |object_id| overlay.get(object_id).map(|data| data.dkg_at_epoch),
             );
-            if let Some(network_owned_address_signing_key_id) =
-                selection.epoch_start_key(noa_checkpoints)
-            {
+            if let Some(network_owned_address_signing_key_id) = selection.epoch_start_key() {
                 let elapsed = started_at.elapsed();
                 if let Some(telemetry) = &telemetry {
                     telemetry.handoff_prepare_waiting.set(0);
@@ -4430,6 +4477,15 @@ async fn wait_for_handoff_data_ready(
         if let Some(cert) = cert.filter(|_| !withheld) {
             install_joiner_network_key_outputs(cert, &ctx.p2p_network, peer_ids, new_epoch_store)
                 .await;
+            fetch_missing_prior_cert_mpc_data_blobs(
+                cert,
+                new_epoch_store.name,
+                &blob_cache,
+                &ctx.p2p_network,
+                &current_peers,
+                &ctx.mpc_data_blob_fetch_outcomes,
+            )
+            .await;
         }
 
         // Surface the breakdown at least every 10 SECONDS so a hang is never
@@ -4512,6 +4568,8 @@ async fn wait_for_handoff_data_ready(
                 missing_key_ids = ?missing_key_ids,
                 unmapped_cert_keys = ?unmapped_cert_keys,
                 awaiting_metadata_key_ids = ?awaiting_metadata_key_ids,
+                ?missing_validator_data,
+                ?network_key_data_error,
                 retries,
                 withheld_for_testing = withheld,
                 "prepare-then-start: still awaiting full verified handoff data for epoch \
@@ -4581,7 +4639,16 @@ async fn install_joiner_network_key_outputs(
         } else {
             local_dkg_digests.get(&object_id) == Some(expected_digest)
         };
-        if held_locally {
+        let bytes_held = epoch_store
+            .perpetual_tables_handle()
+            .is_some_and(|perpetual| {
+                perpetual
+                    .get_mpc_artifact_blob(expected_digest)
+                    .ok()
+                    .flatten()
+                    .is_some_and(|bytes| mpc_data_blob_hash(&bytes) == *expected_digest)
+            });
+        if held_locally && bytes_held {
             continue;
         }
         let mut verified_bytes = None;
@@ -4720,25 +4787,19 @@ fn max_tx_per_checkpoint(_: &ProtocolConfig) -> usize {
 /// because the installer runs solely while this predicate reads not-ready.
 /// Do not narrow this back to reconfiguration-only: that made the barrier
 /// instantly ready for a poisoned validator every epoch and the wedge
-/// permanent. `ValidatorMpcData` items are not gated (they feed the mpc_data
-/// freeze, a separate plane). A cert with no network-key items is trivially
-/// ready on this condition.
+/// permanent. `ValidatorMpcData` and the backing network-key bytes have
+/// separate readiness checks in the barrier. A cert with no network-key
+/// items is trivially ready on this condition.
 ///
-/// With NOA enabled, every certified key must translate before this check
+/// Every certified key must translate before this check
 /// passes. The barrier requests missing chain blobs and derives mappings
 /// before constructing the MPC manager. Checking the translation here as
 /// well as at key selection prevents a background registration between the
 /// two checks from releasing an epoch with unverified key material.
-///
-/// With NOA disabled, unmapped keys retain the existing exception: the
-/// manager defers adoption until its background derivation registers the
-/// mapping, then enforces the certificate's digests. No NOA demands drain
-/// the shared pool on that live-protocol path.
 fn all_cert_network_key_outputs_held_locally(
     cert: &CertifiedHandoffAttestation,
     local_dkg_digests: &BTreeMap<ObjectID, [u8; 32]>,
     local_reconfiguration_digests: &BTreeMap<ObjectID, [u8; 32]>,
-    require_mappings: bool,
 ) -> bool {
     cert.attestation
         .items
@@ -4746,11 +4807,10 @@ fn all_cert_network_key_outputs_held_locally(
         .all(|(item, cert_digest)| match item {
             HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
                 // Cert keys by NetworkKeyId; local digests by ObjectID. An
-                // unmapped key waits when NOA requires a uniform pool choice.
-                ika_core::network_key_id_mapping::object_id_for(key_id)
-                    .map_or(!require_mappings, |object_id| {
-                        local_reconfiguration_digests.get(&object_id) == Some(cert_digest)
-                    })
+                // unmapped key must be resolved before the epoch starts.
+                ika_core::network_key_id_mapping::object_id_for(key_id).is_some_and(|object_id| {
+                    local_reconfiguration_digests.get(&object_id) == Some(cert_digest)
+                })
             }
             // The DKG output is as load-bearing as the reconfiguration
             // output: adoption's cert-digest gate rejects the key when the
@@ -4765,9 +4825,7 @@ fn all_cert_network_key_outputs_held_locally(
             // leaving a poisoned validator wedged permanently.
             HandoffItemKey::NetworkDkgOutput { key_id } => {
                 ika_core::network_key_id_mapping::object_id_for(key_id)
-                    .map_or(!require_mappings, |object_id| {
-                        local_dkg_digests.get(&object_id) == Some(cert_digest)
-                    })
+                    .is_some_and(|object_id| local_dkg_digests.get(&object_id) == Some(cert_digest))
             }
             HandoffItemKey::ValidatorMpcData { .. } => true,
         })
@@ -4823,7 +4881,7 @@ mod tests {
         let cert = cert_with_reconfiguration_items(vec![(network_key_id(0), [1u8; 32])]);
         let held = BTreeMap::from([(key_id(0), [1u8; 32])]);
         assert!(all_cert_network_key_outputs_held_locally(
-            &cert, &no_dkg, &held, false
+            &cert, &no_dkg, &held
         ));
 
         // Output not yet computed/cached locally (empty slice) → not ready.
@@ -4831,14 +4889,13 @@ mod tests {
             &cert,
             &no_dkg,
             &BTreeMap::new(),
-            false
         ));
 
         // Local digest differs from the cert's (a stale/wrong local output —
         // the exact condition the cert-digest match exists to catch) → not ready.
         let stale = BTreeMap::from([(key_id(0), [9u8; 32])]);
         assert!(!all_cert_network_key_outputs_held_locally(
-            &cert, &no_dkg, &stale, false
+            &cert, &no_dkg, &stale
         ));
 
         // Two certified outputs, only one held locally → not ready (EVERY item
@@ -4849,13 +4906,13 @@ mod tests {
         ]);
         let one = BTreeMap::from([(key_id(0), [1u8; 32])]);
         assert!(!all_cert_network_key_outputs_held_locally(
-            &cert_two, &no_dkg, &one, false
+            &cert_two, &no_dkg, &one
         ));
 
         // Both held with matching digests → ready.
         let both = BTreeMap::from([(key_id(0), [1u8; 32]), (key_id(1), [2u8; 32])]);
         assert!(all_cert_network_key_outputs_held_locally(
-            &cert_two, &no_dkg, &both, false
+            &cert_two, &no_dkg, &both
         ));
 
         // A certified DKG output is load-bearing too: a local mirror whose
@@ -4881,7 +4938,6 @@ mod tests {
             &dkg_only,
             &BTreeMap::new(),
             &BTreeMap::new(),
-            false
         ));
         // Poisoned mirror (digest mismatch) → not ready.
         let poisoned = BTreeMap::from([(key_id(0), [9u8; 32])]);
@@ -4889,7 +4945,6 @@ mod tests {
             &dkg_only,
             &poisoned,
             &BTreeMap::new(),
-            false
         ));
         // Canonical mirror matching the cert → ready.
         let canonical = BTreeMap::from([(key_id(0), [5u8; 32])]);
@@ -4897,36 +4952,15 @@ mod tests {
             &dkg_only,
             &canonical,
             &BTreeMap::new(),
-            true,
-        ));
-        assert!(!all_cert_network_key_outputs_held_locally(
-            &dkg_only,
-            &poisoned,
-            &BTreeMap::new(),
-            true,
-        ));
-        assert!(all_cert_network_key_outputs_held_locally(
-            &dkg_only,
-            &canonical,
-            &BTreeMap::new(),
-            false
         ));
 
-        // An unmapped item blocks NOA-enabled startup, including before
-        // the material check can compare its digest. The flag-off path keeps
-        // its downstream adoption guard and previous readiness behavior.
+        // An unmapped item blocks startup before the material check can
+        // compare its digest, regardless of whether NOA is enabled.
         let unmapped = cert_with_reconfiguration_items(vec![(network_key_id(200), [3u8; 32])]);
         assert!(!all_cert_network_key_outputs_held_locally(
             &unmapped,
             &BTreeMap::new(),
             &BTreeMap::new(),
-            true,
-        ));
-        assert!(all_cert_network_key_outputs_held_locally(
-            &unmapped,
-            &BTreeMap::new(),
-            &BTreeMap::new(),
-            false
         ));
         // Registering the mapping arms the gate for that same key: now the
         // missing local output DOES hold the barrier closed.
@@ -4935,7 +4969,6 @@ mod tests {
             &unmapped,
             &BTreeMap::new(),
             &BTreeMap::new(),
-            false
         ));
     }
 }

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -4531,10 +4531,9 @@ async fn wait_for_handoff_data_ready(
                     // Cert keys with NO ObjectID mapping (this validator
                     // never instantiated the key and it is not one of the
                     // compiled-in deployed keys) are keys the barrier can
-                    // neither check nor install yet. With NOA enabled these
-                    // hold the key-selection gate closed while preparation
-                    // requests chain recovery and derives the mappings. With
-                    // NOA off they retain the downstream adoption guard.
+                    // neither check nor install yet. These hold the startup
+                    // barrier closed in every mode while preparation requests
+                    // chain recovery and derives the mappings.
                     // A key with both a DKG
                     // and a reconfiguration item would list twice — dedup via
                     // the ordered set.

--- a/crates/ika-node/src/lib.rs
+++ b/crates/ika-node/src/lib.rs
@@ -71,6 +71,7 @@ use ika_core::epoch_tasks::joiner_bootstrap_verifier::{
     BootstrapOutcome, BootstrapRetryConfig, CertVerifier, JoinerBootstrapVerifier,
     P2pHandoffCertSource,
 };
+use ika_core::network_key_id_mapping;
 use ika_core::storage::RocksDbStore;
 use ika_core::sui_connector::pubkey_provider_updater::fetch_previous_committee;
 use ika_core::validator_metadata::{next_committee_pubkey_set, verify_joiner_bootstrap_cert};
@@ -1462,6 +1463,7 @@ impl IkaNode {
                         .map(|metrics| metrics.telemetry.clone()),
                     withhold_anchor_for: config.withhold_handoff_anchor_for_testing,
                     network_keys_receiver: sui_data_receivers.network_keys_receiver.clone(),
+                    stranded_network_keys: stranded_network_keys.clone(),
                 };
                 let anchor_committee = AnchorCommittee::Resolved {
                     committee_store: state.committee_store().clone(),
@@ -3756,6 +3758,8 @@ struct HandoffBarrierContext {
     /// key's `dkg_at_epoch` from it to resolve the epoch's
     /// network-owned-address signing key.
     network_keys_receiver: watch::Receiver<Arc<HashMap<ObjectID, DWalletNetworkEncryptionKeyData>>>,
+    /// Lets preparation request missing blobs before the MPC manager exists.
+    stranded_network_keys: Arc<ArcSwap<HashSet<ObjectID>>>,
 }
 
 impl HandoffBarrierContext {
@@ -3775,6 +3779,7 @@ impl HandoffBarrierContext {
             telemetry: node.validator_telemetry.clone(),
             withhold_anchor_for: node.config.withhold_handoff_anchor_for_testing,
             network_keys_receiver,
+            stranded_network_keys: node.stranded_network_keys.clone(),
         }
     }
 
@@ -4173,6 +4178,9 @@ async fn prepare_handoff_anchor(
 ///      output; `prepare_handoff_anchor` and the per-retry installer fetch +
 ///      cache missing/mismatching outputs from peers. See
 ///      `all_cert_network_key_outputs_held_locally`.
+///   3. The NOA signing key is resolved from the certificate and chain
+///      metadata. With NOA enabled, preparation recovers missing mappings
+///      before startup; only a certificate naming no key resolves to None.
 async fn wait_for_handoff_data_ready(
     ctx: &HandoffBarrierContext,
     anchor_epoch: EpochId,
@@ -4209,6 +4217,8 @@ async fn wait_for_handoff_data_ready(
     // path, a per-second P2P hammering of converging peers). The signing
     // committee is cached for the same reason — on the boot path resolving it
     // costs a chain read.
+    let noa_checkpoints = new_epoch_store.protocol_config().noa_checkpoints();
+    let mut key_id_derivation_inputs = HashMap::new();
     let mut anchor_cert: Option<CertifiedHandoffAttestation> = None;
     let mut signing_committee: Option<Arc<Committee>> = None;
     let mut committee_resolve_attempts: u32 = 0;
@@ -4320,6 +4330,30 @@ async fn wait_for_handoff_data_ready(
         }
         let cert = anchor_cert.as_ref();
 
+        // NOA demand assignment drains a shared pool even before this node
+        // can sign. Resolve the same key as peers before any round can run.
+        // The syncer and rayon workers are process-level services, so this
+        // recovery does not depend on starting the epoch's MPC manager.
+        let overlay = ctx.network_keys_receiver.borrow().clone();
+        if noa_checkpoints
+            && cert.is_some_and(|cert| {
+                cert.attestation.items.iter().any(|(item, _)| match item {
+                    HandoffItemKey::NetworkDkgOutput { key_id }
+                    | HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
+                        network_key_id_mapping::object_id_for(key_id).is_none()
+                    }
+                    HandoffItemKey::ValidatorMpcData { .. } => false,
+                })
+            })
+        {
+            network_owned_address_signing_key::prepare_missing_key_mappings(
+                anchor_epoch,
+                &overlay,
+                &mut key_id_derivation_inputs,
+                &ctx.stranded_network_keys,
+            );
+        }
+
         // Condition 2: every network-key output the cert certifies —
         // reconfiguration AND DKG — is held locally with a digest matching
         // the cert. Grounded entirely in the verified cert (the off-chain
@@ -4342,87 +4376,45 @@ async fn wait_for_handoff_data_ready(
                 cert,
                 &local_dkg_digests,
                 &local_reconfiguration_digests,
+                noa_checkpoints,
             )
         });
 
-        // Condition 3: the epoch's network-owned-address signing key — a
-        // pure function of the certificate's keys ranked by their chain
-        // `dkg_at_epoch` — resolved here so the epoch's components receive
-        // it as a fixed input and never choose for themselves. Only the chain
-        // metadata can still be on its way (the syncer publishes every
-        // on-chain key's within a tick), so that alone is a not-ready
-        // condition. A certified key this process cannot translate is NOT:
-        // the translation registers when the key is instantiated or derived,
-        // after the components start, so waiting would deadlock every joiner
-        // on a network whose keys are outside the compiled-in constants. Such
-        // a validator enters the epoch with no signing key and sits NOA
-        // signing out until the next handoff; a restart is spared this by
-        // the persisted mapping loaded at boot.
+        // Condition 3: resolve the epoch's NOA key before construction.
+        // Missing metadata waits in every mode. With NOA enabled, missing
+        // mappings also wait: None is valid only when the certificate names
+        // no key, never as a per-validator opt-out from shared pool drains.
         let mut awaiting_metadata_key_ids: Vec<ObjectID> = Vec::new();
         if let Some(cert) = cert.filter(|_| ready) {
-            let overlay = ctx.network_keys_receiver.borrow().clone();
-            let selection = network_owned_address_signing_key::select(cert, |object_id| {
-                overlay.get(object_id).map(|data| data.dkg_at_epoch)
-            });
-            let resolved = match selection {
-                NetworkOwnedAddressSigningKeySelection::AwaitingMetadata(key_ids) => Err(key_ids),
-                NetworkOwnedAddressSigningKeySelection::Selected {
-                    object_id,
-                    network_key_id,
-                    dkg_at_epoch,
-                } => {
-                    info!(
-                        next_epoch,
-                        network_owned_address_signing_key_id = ?object_id,
-                        ?network_key_id,
-                        dkg_at_epoch,
-                        "prepare-then-start: resolved epoch {next_epoch}'s network-owned-address \
-                         signing key from the handoff certificate"
-                    );
-                    Ok(Some(object_id))
+            let selection = network_owned_address_signing_key::select(
+                cert,
+                network_key_id_mapping::object_id_for,
+                |object_id| overlay.get(object_id).map(|data| data.dkg_at_epoch),
+            );
+            if let Some(network_owned_address_signing_key_id) =
+                selection.epoch_start_key(noa_checkpoints)
+            {
+                let elapsed = started_at.elapsed();
+                if let Some(telemetry) = &telemetry {
+                    telemetry.handoff_prepare_waiting.set(0);
+                    telemetry
+                        .handoff_prepare_duration_seconds
+                        .observe(elapsed.as_secs_f64());
                 }
-                NetworkOwnedAddressSigningKeySelection::NoCertifiedKey => {
-                    info!(
-                        next_epoch,
-                        "prepare-then-start: the handoff certificate names no network key, so \
-                         epoch {next_epoch} has no network-owned-address signing key"
-                    );
-                    Ok(None)
-                }
-                NetworkOwnedAddressSigningKeySelection::Untranslatable(network_key_ids) => {
-                    warn!(
-                        next_epoch,
-                        untranslatable_cert_keys = ?network_key_ids,
-                        "prepare-then-start: certified network keys with no ObjectID \
-                         translation on this process — this validator enters epoch \
-                         {next_epoch} with NO network-owned-address signing key and will not \
-                         take part in NOA signing until the next handoff. Expected only for a \
-                         joiner on a network whose keys are outside the compiled-in constants; \
-                         a restarted validator holds the persisted mapping."
-                    );
-                    Ok(None)
-                }
-            };
-            match resolved {
-                Ok(network_owned_address_signing_key_id) => {
-                    let elapsed = started_at.elapsed();
-                    if let Some(telemetry) = &telemetry {
-                        telemetry.handoff_prepare_waiting.set(0);
-                        telemetry
-                            .handoff_prepare_duration_seconds
-                            .observe(elapsed.as_secs_f64());
-                    }
-                    info!(
-                        next_epoch,
-                        "prepare-then-start: epoch {next_epoch} handoff data ready+verified \
-                         after {}s, {retries} retries; starting MPC",
-                        elapsed.as_secs()
-                    );
-                    return HandoffBarrierOutcome::Ready {
-                        network_owned_address_signing_key_id,
-                    };
-                }
-                Err(key_ids) => awaiting_metadata_key_ids = key_ids,
+                info!(
+                    next_epoch,
+                    ?selection,
+                    ?network_owned_address_signing_key_id,
+                    "prepare-then-start: epoch {next_epoch} handoff data ready+verified \
+                     after {}s, {retries} retries; starting MPC",
+                    elapsed.as_secs()
+                );
+                return HandoffBarrierOutcome::Ready {
+                    network_owned_address_signing_key_id,
+                };
+            }
+            if let NetworkOwnedAddressSigningKeySelection::AwaitingMetadata(key_ids) = selection {
+                awaiting_metadata_key_ids = key_ids;
             }
         }
 
@@ -4483,11 +4475,11 @@ async fn wait_for_handoff_data_ready(
                     // Cert keys with NO ObjectID mapping (this validator
                     // never instantiated the key and it is not one of the
                     // compiled-in deployed keys) are keys the barrier can
-                    // neither check nor install, so they do NOT hold the gate
-                    // closed — see `all_cert_network_key_outputs_held_locally`
-                    // for why that is safe. Report them anyway: they are the
-                    // keys whose sessions will park after start until the
-                    // stranded-key recovery fills them. A key with both a DKG
+                    // neither check nor install yet. With NOA enabled these
+                    // hold the key-selection gate closed while preparation
+                    // requests chain recovery and derives the mappings. With
+                    // NOA off they retain the downstream adoption guard.
+                    // A key with both a DKG
                     // and a reconfiguration item would list twice — dedup via
                     // the ordered set.
                     let unmapped: BTreeSet<NetworkKeyId> = cert
@@ -4732,35 +4724,21 @@ fn max_tx_per_checkpoint(_: &ProtocolConfig) -> usize {
 /// freeze, a separate plane). A cert with no network-key items is trivially
 /// ready on this condition.
 ///
-/// UNMAPPED CERT KEYS DO NOT BLOCK. The certificate names keys by
-/// `NetworkKeyId` while every local slice and cache is keyed by `ObjectID`,
-/// and the translation between them is a process-global map holding the
-/// deployed keys as compiled-in constants plus whatever this PROCESS has
-/// instantiated or derived. A key outside the constants that this process has
-/// not touched — every fresh localnet/CI DKG, seen by a joiner or by a
-/// just-restarted validator — has no entry, and the barrier can do nothing
-/// about it: the installer cannot cache bytes under an unknown `ObjectID`,
-/// and the derivation that would register one runs from the MPC manager's
-/// adoption pass, which does not exist until this barrier releases. Blocking
-/// would be a guaranteed deadlock, so an unmapped item is passed and reported
-/// (`unmapped_cert_keys` on the barrier's periodic warn).
+/// With NOA enabled, every certified key must translate before this check
+/// passes. The barrier requests missing chain blobs and derives mappings
+/// before constructing the MPC manager. Checking the translation here as
+/// well as at key selection prevents a background registration between the
+/// two checks from releasing an epoch with unverified key material.
 ///
-/// That is safe, because the hazard this barrier exists to prevent is
-/// entering an epoch holding STALE key material, and the guard against it for
-/// an unmapped key sits downstream and stays armed: adoption DEFERS an
-/// unmapped key rather than installing anything for it, and once the
-/// background derivation registers the mapping, adoption re-applies the same
-/// cert-digest gate and refuses a local output that contradicts the
-/// certificate. And where the barrier did not manage to persist the
-/// certificate at all (the insert only warns on failure), adoption REJECTS a
-/// reconfigured key outright rather than adopting it cert-less. The cost of
-/// passing is liveness, not safety — the key's sessions park until the
-/// stranded-key recovery fills it (see `specs/handoff.md`), which is exactly
-/// what happens today.
+/// With NOA disabled, unmapped keys retain the existing exception: the
+/// manager defers adoption until its background derivation registers the
+/// mapping, then enforces the certificate's digests. No NOA demands drain
+/// the shared pool on that live-protocol path.
 fn all_cert_network_key_outputs_held_locally(
     cert: &CertifiedHandoffAttestation,
     local_dkg_digests: &BTreeMap<ObjectID, [u8; 32]>,
     local_reconfiguration_digests: &BTreeMap<ObjectID, [u8; 32]>,
+    require_mappings: bool,
 ) -> bool {
     cert.attestation
         .items
@@ -4768,10 +4746,11 @@ fn all_cert_network_key_outputs_held_locally(
         .all(|(item, cert_digest)| match item {
             HandoffItemKey::NetworkReconfigurationOutput { key_id } => {
                 // Cert keys by NetworkKeyId; local digests by ObjectID. An
-                // unmapped key passes — see the doc above.
-                ika_core::network_key_id_mapping::object_id_for(key_id).is_none_or(|object_id| {
-                    local_reconfiguration_digests.get(&object_id) == Some(cert_digest)
-                })
+                // unmapped key waits when NOA requires a uniform pool choice.
+                ika_core::network_key_id_mapping::object_id_for(key_id)
+                    .map_or(!require_mappings, |object_id| {
+                        local_reconfiguration_digests.get(&object_id) == Some(cert_digest)
+                    })
             }
             // The DKG output is as load-bearing as the reconfiguration
             // output: adoption's cert-digest gate rejects the key when the
@@ -4786,7 +4765,9 @@ fn all_cert_network_key_outputs_held_locally(
             // leaving a poisoned validator wedged permanently.
             HandoffItemKey::NetworkDkgOutput { key_id } => {
                 ika_core::network_key_id_mapping::object_id_for(key_id)
-                    .is_none_or(|object_id| local_dkg_digests.get(&object_id) == Some(cert_digest))
+                    .map_or(!require_mappings, |object_id| {
+                        local_dkg_digests.get(&object_id) == Some(cert_digest)
+                    })
             }
             HandoffItemKey::ValidatorMpcData { .. } => true,
         })
@@ -4842,21 +4823,22 @@ mod tests {
         let cert = cert_with_reconfiguration_items(vec![(network_key_id(0), [1u8; 32])]);
         let held = BTreeMap::from([(key_id(0), [1u8; 32])]);
         assert!(all_cert_network_key_outputs_held_locally(
-            &cert, &no_dkg, &held
+            &cert, &no_dkg, &held, false
         ));
 
         // Output not yet computed/cached locally (empty slice) → not ready.
         assert!(!all_cert_network_key_outputs_held_locally(
             &cert,
             &no_dkg,
-            &BTreeMap::new()
+            &BTreeMap::new(),
+            false
         ));
 
         // Local digest differs from the cert's (a stale/wrong local output —
         // the exact condition the cert-digest match exists to catch) → not ready.
         let stale = BTreeMap::from([(key_id(0), [9u8; 32])]);
         assert!(!all_cert_network_key_outputs_held_locally(
-            &cert, &no_dkg, &stale
+            &cert, &no_dkg, &stale, false
         ));
 
         // Two certified outputs, only one held locally → not ready (EVERY item
@@ -4867,13 +4849,13 @@ mod tests {
         ]);
         let one = BTreeMap::from([(key_id(0), [1u8; 32])]);
         assert!(!all_cert_network_key_outputs_held_locally(
-            &cert_two, &no_dkg, &one
+            &cert_two, &no_dkg, &one, false
         ));
 
         // Both held with matching digests → ready.
         let both = BTreeMap::from([(key_id(0), [1u8; 32]), (key_id(1), [2u8; 32])]);
         assert!(all_cert_network_key_outputs_held_locally(
-            &cert_two, &no_dkg, &both
+            &cert_two, &no_dkg, &both, false
         ));
 
         // A certified DKG output is load-bearing too: a local mirror whose
@@ -4898,38 +4880,53 @@ mod tests {
         assert!(!all_cert_network_key_outputs_held_locally(
             &dkg_only,
             &BTreeMap::new(),
-            &BTreeMap::new()
+            &BTreeMap::new(),
+            false
         ));
         // Poisoned mirror (digest mismatch) → not ready.
         let poisoned = BTreeMap::from([(key_id(0), [9u8; 32])]);
         assert!(!all_cert_network_key_outputs_held_locally(
             &dkg_only,
             &poisoned,
-            &BTreeMap::new()
+            &BTreeMap::new(),
+            false
         ));
         // Canonical mirror matching the cert → ready.
         let canonical = BTreeMap::from([(key_id(0), [5u8; 32])]);
         assert!(all_cert_network_key_outputs_held_locally(
             &dkg_only,
             &canonical,
-            &BTreeMap::new()
+            &BTreeMap::new(),
+            true,
+        ));
+        assert!(!all_cert_network_key_outputs_held_locally(
+            &dkg_only,
+            &poisoned,
+            &BTreeMap::new(),
+            true,
+        ));
+        assert!(all_cert_network_key_outputs_held_locally(
+            &dkg_only,
+            &canonical,
+            &BTreeMap::new(),
+            false
         ));
 
-        // A cert key with NO ObjectID mapping — never instantiated in this
-        // process and not one of the compiled-in deployed keys — reads READY
-        // even with nothing held locally. The barrier can neither check nor
-        // install such a key (the installer has no ObjectID to cache under,
-        // and the derivation that would register one runs from the adoption
-        // pass, which does not exist until the barrier releases), so blocking
-        // on it would deadlock every joiner and every restart on a network
-        // whose keys are outside the seed. Adoption's own cert-digest gate is
-        // what keeps this safe: it defers an unmapped key and, once the
-        // mapping lands, refuses any local output contradicting the cert.
+        // An unmapped item blocks NOA-enabled startup, including before
+        // the material check can compare its digest. The flag-off path keeps
+        // its downstream adoption guard and previous readiness behavior.
         let unmapped = cert_with_reconfiguration_items(vec![(network_key_id(200), [3u8; 32])]);
+        assert!(!all_cert_network_key_outputs_held_locally(
+            &unmapped,
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            true,
+        ));
         assert!(all_cert_network_key_outputs_held_locally(
             &unmapped,
             &BTreeMap::new(),
-            &BTreeMap::new()
+            &BTreeMap::new(),
+            false
         ));
         // Registering the mapping arms the gate for that same key: now the
         // missing local output DOES hold the barrier closed.
@@ -4937,7 +4934,8 @@ mod tests {
         assert!(!all_cert_network_key_outputs_held_locally(
             &unmapped,
             &BTreeMap::new(),
-            &BTreeMap::new()
+            &BTreeMap::new(),
+            false
         ));
     }
 }

--- a/crates/ika-proxy/README.md
+++ b/crates/ika-proxy/README.md
@@ -223,12 +223,16 @@ The proxy provides structured logging with:
 ### Docker Deployment
 
 ```dockerfile
-FROM rust:1.70 as builder
+FROM rust:1.98-trixie AS builder
+
+# Install the exact patch release even when the official image tag lags behind.
+ENV RUST_VERSION=1.98.1
+RUN rustup toolchain install "${RUST_VERSION}" --profile minimal && rustup default "${RUST_VERSION}"
 WORKDIR /app
 COPY . .
 RUN cargo build --release --bin ika-proxy
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/ika-proxy /usr/local/bin/
 COPY config.yaml /etc/ika-proxy/

--- a/crates/ika-proxy/ika_proxy_dockerfile
+++ b/crates/ika-proxy/ika_proxy_dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/cc-debian12
+FROM gcr.io/distroless/cc-debian13
 
 COPY --chmod=755 ika-proxy /opt/ika/bin/ika-proxy

--- a/crates/ika-test-cluster/tests/handoff_barrier_start_paths.rs
+++ b/crates/ika-test-cluster/tests/handoff_barrier_start_paths.rs
@@ -46,6 +46,7 @@ use ika_test_cluster::{IkaTestCluster, IkaTestClusterBuilder, poll_until, wait_f
 use ika_types::crypto::AuthorityName;
 use prometheus::proto::MetricType;
 use std::time::{Duration, Instant};
+use tokio::time::timeout;
 
 /// How long each test holds a node's handoff anchor back. Long enough that a
 /// node which ignored the barrier would be observably up and in consensus
@@ -165,7 +166,13 @@ async fn test_boot_into_epoch_waits_for_handoff_data() {
         "restarting the validator with its handoff anchor withheld",
     );
     let started_at = Instant::now();
-    node.start().await.expect("validator failed to restart");
+    timeout(Duration::from_secs(120), node.start())
+        .await
+        .expect(
+            "restart must publish the Sui system/coordinator inputs and resolve inherited \
+             key metadata before the epoch execution loop starts",
+        )
+        .expect("validator failed to restart");
     let boot_elapsed = started_at.elapsed();
 
     assert!(

--- a/crates/ika-test-cluster/tests/seed_rotation.rs
+++ b/crates/ika-test-cluster/tests/seed_rotation.rs
@@ -257,20 +257,18 @@ async fn rotate_root_seed(
 /// barrier that never released would hang this test until the harness killed
 /// it — an outcome indistinguishable from an unrelated infrastructure stall.
 ///
-/// The barrier gates only on the certificate's network-key items and ignores
-/// its `ValidatorMpcData` ones, so a node resolving onto its previous seed —
-/// or sitting the epoch out — has nothing to wedge on. This bound is what
-/// turns that reasoning into an assertion: exceed it and the test says which
-/// restart hung and why that is the interesting failure.
+/// Certified validator bundles are public artifacts recoverable from peers,
+/// independently of the rotated local seed. An MPC-inactive validator skips
+/// decryption after the barrier; retaining the previous seed must also allow
+/// preparation to finish. This bound catches either path waiting forever.
 async fn start_within_budget(node: &ika_swarm::memory::Node, what: &str) {
     match tokio::time::timeout(Duration::from_secs(180), node.start()).await {
         Ok(result) => result.unwrap_or_else(|e| panic!("failed to restart {what}: {e}")),
         Err(_) => panic!(
             "restarting {what} did not complete within 180s — the node is stuck before its \
-             epoch components start. The prepare-then-start handoff barrier is the only \
-             thing on that path that waits indefinitely; a rotating or sat-out validator \
-             must not wedge there, because the barrier does not gate on the certificate's \
-             ValidatorMpcData items."
+             epoch components start. Sui metadata and certified artifacts must be \
+             recoverable before the epoch execution loop starts; a rotated local seed \
+             must not prevent public-artifact recovery or MPC-inactive consensus startup."
         ),
     }
 }

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -47,6 +47,9 @@ them has a bug — determine which before changing either.
 - [`specs/handoff.md`](specs/handoff.md) — cross-epoch handoff:
   attestation, EndOfPublish V2, certificate, joiner bootstrap, the
   prepare-then-start barrier, network-key adoption guards.
+- [`specs/epoch-start-preparation.md`](specs/epoch-start-preparation.md) —
+  inherited MPC inputs prepared before consensus, durable artifact checks,
+  parameter/share initialization, and inputs necessarily produced in-epoch.
 - [`specs/epoch-close-session-lock.md`](specs/epoch-close-session-lock.md)
   — the frozen session-completion target, the strict-equality close
   predicate, the gate-consensus-submission rule, batch-processing rules.

--- a/dev-docs/specs/epoch-start-preparation.md
+++ b/dev-docs/specs/epoch-start-preparation.md
@@ -1,0 +1,116 @@
+# Epoch startup preparation
+
+An active validator must prepare every MPC input inherited from the preceding
+handoff before consensus replay or live rounds can reach the new epoch's MPC
+service. Missing local data must not change the validator's inputs, key choice,
+or presign assignment order relative to its peers.
+
+Actors: `ika-node::wait_for_handoff_data_ready`,
+`DWalletMPCService::prepare_epoch`, `DWalletMPCManager`, the process-level
+Sui syncer, and the content-addressed artifact stores. This applies to process
+startup/restart, continuing-validator reconfiguration, and fullnode promotion.
+
+## What must be ready
+
+| Input                                                         | Source and preparation                                                              | Before consensus starts                                                                                             |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Current committee, protocol configuration, root-seed decision | Epoch-start state and seed resolution                                               | Constructed and checked already                                                                                     |
+| Local VSS HPKE secret key                                     | Root seed in the cryptographic orchestrator constructor                             | Derived already                                                                                                     |
+| Prior handoff certificate                                     | Durable store or verified peer fetch                                                | Verified and persisted; persistence failure cannot release the barrier                                              |
+| Network key identities                                        | Persisted mappings or identity derivation from chain-published blobs                | Every certified key must translate, including with NOA disabled                                                     |
+| Network key creation metadata                                 | Process-level syncer's chain overlay                                                | Every certified key's immutable `dkg_at_epoch` must be present                                                      |
+| Inherited DKG and reconfiguration outputs                     | Exact digests in the prior certificate                                              | Matching digest rows and hash-verified durable bytes; repair missing/mismatching data from peers                    |
+| Current validator MPC bundles                                 | Prior certificate's `ValidatorMpcData` items intersected with the current committee | All certified members' blobs durable, hash-matching and structurally decodable; then assemble and ingest the bundle |
+| Network public parameters and access structure                | Certified output bytes and the entering committee/epoch                             | Instantiation finished, rather than merely queued on rayon                                                          |
+| Local AHE decryption shares and VSS caches                    | Instantiated key and root seed                                                      | AHE decryption finished; VSS cache derivation finished with its recorded outcome                                    |
+| Fixed NOA signing key                                         | Certified key set and immutable creation metadata                                   | Resolved before construction; absent local data never means a keyless epoch                                         |
+
+The barrier fetches missing validator bundles inline using
+`fetch_missing_prior_cert_mpc_data_blobs`. Waiting for the epoch's periodic
+fetcher would deadlock because that task does not exist yet. A blob cached only
+in memory does not satisfy the durable read that manager ingestion uses.
+
+After the barrier, `DWalletMPCService::prepare_epoch` runs immediately before
+spawning `ConsensusManager::start`. It ingests the current validator keys,
+instantiates the inherited network keys, and waits for installation and share
+derivation. It does not execute MPC sessions or consume consensus rounds.
+Checkpoint components may already be constructed, but their replay barrier
+still holds. The service loop retains dynamic adoption for outputs created
+during the epoch; it is no longer the first initializer of inherited keys.
+
+Preparation constructs a separate immutable network-key snapshot. A restart's
+live overlay can already contain the **next** committee's reconfiguration
+output or a later state. Only `dkg_at_epoch` comes from that overlay. The
+certificate selects the bytes and output state; the entering epoch selects
+the access structure. Preparing the live overlay instead could install the
+wrong epoch's shares before replay.
+
+## Failure and participation rules
+
+Missing mappings, metadata, or certified artifacts hold the startup barrier
+while their producers recover them. Malformed or missing durable validator
+blobs are repaired from peers. A contradicted certificate fails closed as
+specified in [`handoff.md`](handoff.md).
+
+An error in parameter instantiation or AHE decryption fails startup. Readiness
+checks the completed-installation record, which is written after decryption,
+not merely the public-parameter map populated before decryption. VSS derivation
+retains its existing terminal outcomes: `Derived`, `Failed`, or `NotApplicable`.
+Preparation finishes that work; it does not redefine a non-VSS key or an
+undealt validator as a consensus failure.
+
+A validator marked MPC-inactive by root-seed resolution skips cryptographic
+preparation and still participates in consensus. It must not try decrypting
+with a mismatched seed. Committee members absent from the prior certified set
+remain undealt; preparation does not impose an all-committee participation
+requirement. Only the agreed certified members' blobs are required.
+
+## Inputs that remain dynamic
+
+These are not missing inherited configuration and cannot be moved wholesale
+before epoch startup:
+
+- **Genesis/first off-chain epoch:** no prior certificate exists. The epoch's
+  own consensus freeze supplies the initial validator bundle and DKG produces
+  the first network key. Gating consensus on either would deadlock genesis.
+- **Fresh network DKG:** requests and outputs created during this epoch have
+  no prior certified bytes. Their adoption, public parameters and shares are
+  prepared when the output is agreed.
+- **Next committee and next validator bundle:** membership, announcements,
+  ready votes and the current epoch's freeze establish these during the epoch.
+  They feed reconfiguration and become the next epoch's inherited inputs.
+- **Requests and recovery:** the Sui bag event pump continuously publishes new
+  and still-uncompleted requests, including older requests. Session-specific
+  inputs and completed-status lookups are consumed with those requests, not
+  loaded as an unbounded epoch-start snapshot.
+- **Consensus-derived state:** sessions, presign pools, assignments, chain
+  observations and checkpoint state are folded from commits. Restart rebuilds
+  them through replay; see [`event-sourced-epoch.md`](event-sourced-epoch.md).
+- **Current handoff and epoch-close decisions:** outputs, the next committee,
+  session-completion target and quorum evidence must first be produced. They
+  cannot be prerequisites for starting the epoch that produces them.
+
+The lazy static maps in `dwallet-mpc-types::mpc_protocol_configuration` contain
+small, fixed algorithm identifiers, with no network or disk loading and no
+per-validator readiness choice. Runtime once-cells and the shared Mysticeti
+client publish configuration or handles. They are not deferred inherited MPC
+material. This boundary does not promise that every request-time allocation,
+database read or library cache is eliminated.
+
+## Regression evidence
+
+- `epoch_start_data::tests` exercises absent mappings, missing or corrupt blobs,
+  invalid validator bundles, and certificate bytes overriding a future overlay.
+- `epoch_startup_prepares_inherited_key_material_before_any_round` uses real
+  crypto and asserts public parameters, decrypted AHE shares and VSS caches
+  after preparation alone, with no new-epoch round or session processed.
+- `epoch_startup_preserves_seed_inactive_consensus_participation` ensures the
+  deliberate seed-mismatch participation path does not attempt decryption.
+- `missing_prior_cert_blob_is_refetched_from_peers_and_ingested` proves a
+  memory-only cache entry cannot suppress durable peer repair.
+
+Fault-injection controls remove the service's preparation call and substitute
+live-overlay reconfiguration bytes. The startup test must fail with
+`validator bundles must be ingested before startup`, and the snapshot test
+must fail with `startup must use the certified shares, not the live overlay`.
+Both expected assertions were observed; the clean controls pass.

--- a/dev-docs/specs/epoch-start-preparation.md
+++ b/dev-docs/specs/epoch-start-preparation.md
@@ -25,6 +25,15 @@ startup/restart, continuing-validator reconfiguration, and fullnode promotion.
 | Local AHE decryption shares and VSS caches                    | Instantiated key and root seed                                                      | AHE decryption finished; VSS cache derivation finished with its recorded outcome                                    |
 | Fixed NOA signing key                                         | Certified key set and immutable creation metadata                                   | Resolved before construction; absent local data never means a keyless epoch                                         |
 
+The connector constructor first publishes the verified Sui system and
+coordinator objects to the syncer's watch channels. This initial read is
+independent of `SuiExecutor::run_epoch`, which starts only after node startup.
+Otherwise the barrier waits for key metadata, the syncer waits for these
+objects, and the epoch execution loop waits for the barrier: a startup
+deadlock even when the certificate and its artifact blobs are already local.
+The normal epoch loop continues refreshing the objects afterwards. Initial
+publication performs no checkpoint writes or epoch transitions.
+
 The barrier fetches missing validator bundles inline using
 `fetch_missing_prior_cert_mpc_data_blobs`. Waiting for the epoch's periodic
 fetcher would deadlock because that task does not exist yet. A blob cached only
@@ -114,3 +123,9 @@ live-overlay reconfiguration bytes. The startup test must fail with
 `validator bundles must be ingested before startup`, and the snapshot test
 must fail with `startup must use the certified shares, not the live overlay`.
 Both expected assertions were observed; the clean controls pass.
+
+`test_boot_into_epoch_waits_for_handoff_data` bounds restart at 120 seconds:
+the deliberate 30-second anchor hold must finish, and the initial Sui object
+publication must let key-metadata preparation complete without starting the
+epoch execution loop first. The deployed-release rollout exercises the same
+bootstrap with no persisted key-ID mapping.

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -361,38 +361,39 @@ next epoch inherits.
    with a failed read wedges every validator on the network's own first
    epoch.
 
-   With `noa_checkpoints` OFF, an unmapped certified item retains a
-   readiness exception. The certificate names keys by `NetworkKeyId`, while
-   local caches use `ObjectID`. The manager defers adoption until background
-   derivation registers that translation, then applies the certificate's
-   digest checks. This preserves the live protocol's startup behavior.
+   Every certified key must have a `NetworkKeyId → ObjectID` mapping,
+   independently of `noa_checkpoints`. Before the MPC manager exists, the
+   barrier requests missing blobs through the running syncer's stranded-key
+   recovery and derives mappings on rayon. Changed inputs retry failed
+   derivations; unchanged inputs are not spawned repeatedly. Every certified
+   DKG and reconfiguration output must have both matching digest rows and
+   hash-verified backing bytes in the perpetual store. A digest row alone
+   cannot release startup. The material predicate itself requires mappings,
+   so registration racing key selection cannot skip verification.
 
-   With `noa_checkpoints` ON, an unmapped item blocks startup. Before any
-   MPC manager exists, the barrier requests missing blobs through the
-   already-running syncer's stranded-key recovery, then derives mappings on
-   rayon from the published blobs. Changed blobs retry a failed derivation;
-   unchanged inputs are not spawned repeatedly. Once mapped, every certified
-   DKG and reconfiguration output must be held with its certified digest.
-   The material predicate itself requires mappings, so a registration racing
-   key selection cannot skip verification. Startup then resolves the same
-   NOA key as peers, before any shared presign pool can be consumed.
+   The certificate's `ValidatorMpcData` items intersected with the entering
+   committee must also be durable, hash-matching and structurally decodable.
+   The barrier runs prior-cert peer repair inline; it cannot wait on an
+   epoch task that starts only after the barrier. An in-memory P2P cache copy
+   does not satisfy a missing durable blob.
 
-   Nothing else is exempt.
+   THE SIGNING KEY. The barrier resolves the epoch's NOA signing key from
+   the certificate and immutable creation metadata (`dkg_at_epoch`) and
+   returns it with `Ready` as a fixed constructor input. Missing metadata
+   waits. Only a certificate naming no key produces `None`; missing local
+   mappings or blobs never turn one validator's epoch into a keyless epoch.
 
-   THE SIGNING KEY. Once the certificate and every certified output are
-   local, the barrier also resolves the epoch's network-owned-address
-   signing key from the certificate (see "The network-owned-address
-   signing key" below) and returns it with `Ready`, so the epoch's
-   components take it as a fixed constructor input and never choose for
-   themselves. A certified key whose chain metadata (`dkg_at_epoch`, from
-   the network-key syncer's overlay) is not local yet is one more not-ready
-   condition, waited out like the others. A certified key with no
-   `NetworkKeyId → ObjectID` translation is the exemption above again:
-   the barrier passes, and the validator enters the epoch with NO signing
-   key, sitting NOA signing out until the next handoff. The persisted
-   mapping (loaded at boot) keeps a restart out of that case; only a
-   joiner on a network whose keys are outside the compiled-in constants
-   reaches it.
+   CRYPTOGRAPHIC PREPARATION. Before consensus replay or live rounds start,
+   the MPC service ingests the certified validator bundle, instantiates all
+   inherited network-key parameters, decrypts its AHE shares and finishes
+   VSS cache derivation. The snapshot uses exact certificate-pinned bytes
+   and the entering epoch's access structure: the live overlay can already
+   contain the next committee's outputs on a restart. An MPC-inactive
+   validator after a seed mismatch retains consensus participation without
+   decrypting. Genesis and the first off-chain epoch have no inherited data;
+   their own freeze and DKG must run during the epoch. The complete startup
+   boundary and remaining dynamic inputs are in
+   [`epoch-start-preparation.md`](epoch-start-preparation.md).
 
    FAIL-CLOSED. A contradicted anchor — peers served certificates and
    none verified, or a locally persisted one that no longer verifies —
@@ -472,9 +473,9 @@ next epoch inherits.
      key: the certificate names keys by `NetworkKeyId`, the caches are
      keyed by `ObjectID`, and a key this process has never instantiated
      that is not one of the compiled-in deployed keys has no translation
-     between the two. With NOA enabled the barrier flags this key for the
-     syncer's chain-sourced read before startup; with NOA disabled it passes
-     the key and adoption flags it instead (see the barrier section). (Until
+     between the two. The barrier flags this key for the syncer's
+     chain-sourced read before startup in every mode. Adoption retains the
+     same recovery mechanism for data arriving during the epoch. (Until
      issue #1751 removed the migration chain-read fallback, that fallback
      covered this shape implicitly; the deployed-release churn scenario's
      mirrored joiner — then `v125_churn` — caught the regression.)
@@ -594,8 +595,7 @@ ObjectID` translation is the process-global mapping: seeded with the
 deployed keys, registered at instantiation or by the background derivation,
 and — so that a restart does not lose it — written to the perpetual store
 (`network_key_ids_by_object_id`) by the MPC manager and loaded back at boot
-before the barrier runs. With NOA enabled, a certified key with no
-translation blocks startup while the barrier requests missing blobs and
+before the barrier runs. A certified key with no translation blocks startup while the barrier requests missing blobs and
 runs the same identity derivation the adoption pass uses. A restart with no
 persisted mapping repeats that recovery and resolves the same key before
 replaying rounds. Missing local data is never converted to a keyless epoch:
@@ -639,17 +639,16 @@ sequence numbers do not move.
    artifacts. Enforced on all three paths that start a validator's
    epoch-specific components — the continuing-validator reconfigure
    seam, fullnode→validator promotion, and process startup into an
-   epoch — with two carve-outs, both stated in the barrier section:
-   entering epoch 0 at genesis (no predecessor epoch to be handed off
-   from), and, only with NOA disabled, a certified key with no local
-   `NetworkKeyId → ObjectID` translation, which adoption's cert-digest gate
-   covers instead. With NOA enabled, preparation recovers the mapping and
-   checks the certified material before releasing startup.
+   epoch. The only no-anchor case is an epoch with no predecessor off-chain
+   (genesis or the first off-chain epoch). Every certified key's mapping and
+   material are ready before consensus starts in every mode. Active MPC
+   validators also finish parameter and share preparation before that point;
+   intentionally MPC-inactive validators still participate in consensus.
 6. The network-owned-address signing key is a function of the prior
    epoch's certificate alone, resolved by the barrier and fixed for the
    epoch: no validator announces a choice, a key created after the
    certificate waits one epoch, and every validator resolves the same key
-   (or all resolve no key) before any NOA-enabled epoch components start.
+   (or all resolve no key) before consensus replay or live rounds start.
 
 Code anchors: `crates/ika-types/src/handoff.rs` (types),
 `crates/ika-core/src/handoff_cert.rs` (aggregation + verification),

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -364,7 +364,10 @@ next epoch inherits.
    Every certified key must have a `NetworkKeyId → ObjectID` mapping,
    independently of `noa_checkpoints`. Before the MPC manager exists, the
    barrier requests missing blobs through the running syncer's stranded-key
-   recovery and derives mappings on rayon. Changed inputs retry failed
+   recovery and derives mappings on rayon. The connector constructor first
+   publishes the verified Sui system/coordinator objects that feed the syncer;
+   their first publication cannot wait for the epoch execution loop, which
+   starts only after the barrier. Changed inputs retry failed
    derivations; unchanged inputs are not spawned repeatedly. Every certified
    DKG and reconfiguration output must have both matching digest rows and
    hash-verified backing bytes in the perpetual store. A digest row alone

--- a/dev-docs/specs/handoff.md
+++ b/dev-docs/specs/handoff.md
@@ -361,26 +361,21 @@ next epoch inherits.
    with a failed read wedges every validator on the network's own first
    epoch.
 
-   One certified ITEM is also exempt, and it has to be. The certificate
-   names keys by `NetworkKeyId`; every local digest slice and blob cache
-   is keyed by `ObjectID`. The translation is a process-global map holding
-   the deployed keys as compiled-in constants plus whatever this PROCESS
-   has instantiated or derived. A key outside the constants that this
-   process has not touched — every fresh localnet/CI DKG, seen by a joiner
-   or by a just-restarted validator — has no entry, and the barrier can do
-   nothing about it: the installer has no `ObjectID` to cache bytes under,
-   and the derivation that would register one runs from the MPC manager's
-   adoption pass, which does not exist until the barrier releases. So an
-   unmapped item passes the readiness predicate and is reported instead
-   (`unmapped_cert_keys` on the periodic warn). That does not admit stale
-   shares: adoption DEFERS an unmapped key rather than installing anything
-   for it, and once the background derivation registers the mapping it
-   re-applies the same cert-digest gate and refuses a local output that
-   contradicts the certificate. The barrier's own contribution — the
-   certificate being local — is what arms that gate. The cost is liveness:
-   the key's sessions park until the stranded-key recovery fills them.
-   Blocking instead would deadlock every joiner and every restart on a
-   network whose keys are outside the constants.
+   With `noa_checkpoints` OFF, an unmapped certified item retains a
+   readiness exception. The certificate names keys by `NetworkKeyId`, while
+   local caches use `ObjectID`. The manager defers adoption until background
+   derivation registers that translation, then applies the certificate's
+   digest checks. This preserves the live protocol's startup behavior.
+
+   With `noa_checkpoints` ON, an unmapped item blocks startup. Before any
+   MPC manager exists, the barrier requests missing blobs through the
+   already-running syncer's stranded-key recovery, then derives mappings on
+   rayon from the published blobs. Changed blobs retry a failed derivation;
+   unchanged inputs are not spawned repeatedly. Once mapped, every certified
+   DKG and reconfiguration output must be held with its certified digest.
+   The material predicate itself requires mappings, so a registration racing
+   key selection cannot skip verification. Startup then resolves the same
+   NOA key as peers, before any shared presign pool can be consumed.
 
    Nothing else is exempt.
 
@@ -477,9 +472,9 @@ next epoch inherits.
      key: the certificate names keys by `NetworkKeyId`, the caches are
      keyed by `ObjectID`, and a key this process has never instantiated
      that is not one of the compiled-in deployed keys has no translation
-     between the two — the barrier passes it rather than deadlocking on
-     it (see the barrier section). So adoption flags the key for the
-     syncer's chain-sourced read instead of skipping it forever. (Until
+     between the two. With NOA enabled the barrier flags this key for the
+     syncer's chain-sourced read before startup; with NOA disabled it passes
+     the key and adoption flags it instead (see the barrier section). (Until
      issue #1751 removed the migration chain-read fallback, that fallback
      covered this shape implicitly; the deployed-release churn scenario's
      mirrored joiner — then `v125_churn` — caught the regression.)
@@ -599,13 +594,15 @@ ObjectID` translation is the process-global mapping: seeded with the
 deployed keys, registered at instantiation or by the background derivation,
 and — so that a restart does not lose it — written to the perpetual store
 (`network_key_ids_by_object_id`) by the MPC manager and loaded back at boot
-before the barrier runs. A certified key with NO translation is the same
-carve-out as in the barrier section: the translation registers only after
-the components start, so the barrier does not wait; that validator enters
-the epoch with no signing key and sits NOA signing out until the next
-handoff, logged loudly. It never chooses among the keys it can translate.
-Expected only for a joiner on a network whose keys are outside the
-compiled-in constants. The internal presign pool's NOA pool-parameter role
+before the barrier runs. With NOA enabled, a certified key with no
+translation blocks startup while the barrier requests missing blobs and
+runs the same identity derivation the adoption pass uses. A restart with no
+persisted mapping repeats that recovery and resolves the same key before
+replaying rounds. Missing local data is never converted to a keyless epoch:
+NOA and global requests share a presign pool, so sitting out NOA assignments
+would make later global checkpoints and post-restart assignments diverge.
+Only the absence of certified keys produces a keyless epoch uniformly.
+The internal presign pool's NOA pool-parameter role
 and the presign-demand drain both read the manager's fixed key
 (`internal-presign-pool.md`, "Which pool a demand draws from"). Under
 `noa_checkpoints` OFF the pool role keeps the previous rule — the oldest
@@ -644,14 +641,15 @@ sequence numbers do not move.
    seam, fullnode→validator promotion, and process startup into an
    epoch — with two carve-outs, both stated in the barrier section:
    entering epoch 0 at genesis (no predecessor epoch to be handed off
-   from), and a certified key with no local `NetworkKeyId → ObjectID`
-   translation, which the barrier cannot check or install and which
-   adoption's own cert-digest gate covers instead.
+   from), and, only with NOA disabled, a certified key with no local
+   `NetworkKeyId → ObjectID` translation, which adoption's cert-digest gate
+   covers instead. With NOA enabled, preparation recovers the mapping and
+   checks the certified material before releasing startup.
 6. The network-owned-address signing key is a function of the prior
    epoch's certificate alone, resolved by the barrier and fixed for the
    epoch: no validator announces a choice, a key created after the
-   certificate waits one epoch, and two validators that hold a key hold
-   the same one.
+   certificate waits one epoch, and every validator resolves the same key
+   (or all resolve no key) before any NOA-enabled epoch components start.
 
 Code anchors: `crates/ika-types/src/handoff.rs` (types),
 `crates/ika-core/src/handoff_cert.rs` (aggregation + verification),

--- a/dev-docs/specs/internal-presign-pool.md
+++ b/dev-docs/specs/internal-presign-pool.md
@@ -88,7 +88,7 @@ the one with the largest `dkg_at_epoch`, ties broken by the smaller
 identically for the whole epoch — quorum-signed, local before the epoch's
 components start, never modified afterwards — so the answer is one value per
 epoch, fixed at construction, and every validator that holds a key holds the
-same one. With NOA enabled, the barrier recovers any missing key-id
+same one. In every mode, the barrier recovers any missing key-id
 translation before starting the epoch's components. It requests missing
 chain blobs through the syncer and derives the identity on rayon; missing
 metadata also waits. A validator may not sit out NOA assignments because

--- a/dev-docs/specs/internal-presign-pool.md
+++ b/dev-docs/specs/internal-presign-pool.md
@@ -88,11 +88,14 @@ the one with the largest `dkg_at_epoch`, ties broken by the smaller
 identically for the whole epoch — quorum-signed, local before the epoch's
 components start, never modified afterwards — so the answer is one value per
 epoch, fixed at construction, and every validator that holds a key holds the
-same one. A validator the barrier could not translate every certified key for
-holds NO key and sits NOA signing out for the epoch rather than choosing
-among the keys it can see; choosing among a subset is exactly the
-per-validator divergence the derivation exists to remove. The key is recorded
-with the assignment, so the sign session later instantiates under the key its
+same one. With NOA enabled, the barrier recovers any missing key-id
+translation before starting the epoch's components. It requests missing
+chain blobs through the syncer and derives the identity on rayon; missing
+metadata also waits. A validator may not sit out NOA assignments because
+its local mapping is missing: NOA and global requests consume the same
+pool, so that would diverge later global checkpoints. A restart repeats the
+same resolution before replay, preserving the epoch's key choice. The key
+is recorded with the assignment, so the sign session later instantiates under the key its
 presign was drawn from.
 
 The previous rule — the oldest key in the validator's locally ADOPTED set,
@@ -118,16 +121,14 @@ consensus-delivery order and is retried on every following round. It is
 **not** rejected — there is nothing to reject it against, and an honest
 duplicate announcement could never follow (the dedup key again).
 
-Neither condition has a per-validator TIMING. The key is fixed at
-construction, so a validator either holds it all epoch or never does; a
-validator without it never draws from the pool at all, so it cannot bind a
-presign its peers bind to a different demand — it sits NOA signing out, its
-demands park and are dropped at the bound, and the pairing on every keyed
-validator is untouched. The pool is filled from consensus outputs in round
-order on every validator that processes the rounds, adopted or not, so
-"empty" is uniform per round. That leaves the assignment step with no local
-input: a demand delivered at round *R* is assigned at the first round at or
-after *R* whose pool can serve it, identically everywhere.
+Both conditions are network-uniform. Startup resolves the same key on
+every validator before any round is processed, including after a restart;
+only a certificate naming no key (or the genesis no-certificate case)
+leaves the whole committee keyless. The pool is filled from consensus
+outputs in round order on every validator that processes the rounds,
+adopted or not, so "empty" is uniform per round. A demand delivered at
+round *R* is assigned at the first round at or after *R* whose pool can
+serve it, identically everywhere.
 
 ### Why the park needs a bound anyway
 
@@ -135,9 +136,8 @@ The bound is a liveness backstop, not a security control. There is no
 announced key left for a byzantine member to point at nothing; what remains
 is a validator with no signing key this epoch — an epoch with no prior
 certificate (genesis, or the first epoch of a fresh network, where NOA
-signing waits for the first handoff), or a certified key the barrier could
-not translate on this validator — and a pool that never fills. A demand parked on either
-would otherwise sit in the queue for the rest of the epoch, and the sign
+signing waits for the first handoff) — and a pool that never fills. A demand
+parked on either would otherwise sit in the queue for the rest of the epoch, and the sign
 request behind it would wait forever for an assignment nobody will write.
 
 So a parked demand is dropped once it has been parked for
@@ -202,8 +202,8 @@ replayed drain READS it instead of deciding again: an already-dropped demand
 leaves the rebuilt queue without an assignment attempt, without re-logging at
 error level, and without re-counting the metric. That read does not need a
 signing key: a replay on a validator that entered the epoch without one reads
-the durable table directly, so a resolved demand leaves the queue instead of
-parking a second time under a bound measured from a delivery round long past.
+the durable table directly. Startup still resolves the same key before
+replay; this lookup never authorizes a different key choice on restart.
 The write happens before the demand leaves the queue, and a failed write
 keeps the demand parked for the next round — the same posture as a failed
 assignment.

--- a/dev-docs/specs/validator-mpc-data-announcements.md
+++ b/dev-docs/specs/validator-mpc-data-announcements.md
@@ -460,12 +460,10 @@ is the expected shape of a late rotation and self-heals.
   permanently-down-but-staked member never wedges reconfiguration.
   Carry-forward is deterministic: the prior certificate is
   consensus-anchored and perpetual, and the prepare-then-start barrier
-  holds it locally before this epoch's consensus is processed — on the
-  continuing-validator reconfigure path today; the joiner-promotion and
-  cold-startup consensus-start paths are pending the barrier wiring
-  (see `dev-docs/plans/handoff-barrier-escape-and-pure-close-gate.md`),
-  so until then a first-time joiner racing its bootstrap fetch can
-  freeze without the carried map. A fresh announcement that diverged
+  holds it locally before this epoch's consensus is processed on all three
+  paths: continuing-validator reconfiguration, fullnode promotion, and
+  process startup. A joiner cannot race bootstrap and freeze without the
+  carried map. A fresh announcement that diverged
   (landing a member in `excluded`) is overridden by the known-good
   prior digest, since the true blob cannot legitimately change between
   epochs. A cert READ ERROR at the freeze
@@ -512,8 +510,10 @@ validator latched for the whole epoch. Sourcing rules
    post-freeze it carries the CURRENT epoch's frozen set, a possible
    strict superset of the boundary set (a late-attested joiner), and
    ingesting it would byte-diverge this validator's VSS presign public
-   inputs from the committee's. Cert read errors retry; missing
-   cert-pinned blobs defer ingestion until propagation converges.
+   inputs from the committee's. The startup barrier repairs missing durable
+   blobs before consensus starts, and `DWalletMPCService::prepare_epoch`
+   completes current-key ingestion. A read or assembly failure in preparation
+   fails startup; it cannot defer inherited keys into the service loop.
 4. **Deferral repair — prior-cert blob refetch**: announcement-driven
    fetching cannot converge a cert-pinned blob whose owner has been
    dark for epochs — the owner never re-announces (carry-forward
@@ -528,7 +528,9 @@ validator latched for the whole epoch. Sourcing rules
    any holder is authoritative — blobs are content-addressed and
    verified (digest + structural decode) against the quorum-signed
    cert digest before the write-through persist — and the manager's
-   next retry assembles from the repaired store. The missing-blob
+   preparation assembles from the repaired store. The startup barrier runs
+   this same repair inline, before the periodic fetcher exists. Only a valid
+   durable copy satisfies readiness; a memory-only P2P copy does not. The missing-blob
    count is exported as the `ika_dwallet_mpc_prior_cert_blobs_missing`
    gauge (0 once assembly completes), so a stuck ingest is visible
    without log access.

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -4,7 +4,7 @@
 # Usage:
 #   Linux x64 (default):  docker build --output type=local,dest=out .
 #   Linux arm64:          docker build --build-arg TARGET=aarch64-unknown-linux-gnu --output type=local,dest=out .
-FROM rust:1.97-bookworm AS builder
+FROM rust:1.98.1-bookworm AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION=unknown

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -4,7 +4,11 @@
 # Usage:
 #   Linux x64 (default):  docker build --output type=local,dest=out .
 #   Linux arm64:          docker build --build-arg TARGET=aarch64-unknown-linux-gnu --output type=local,dest=out .
-FROM rust:1.98.1-bookworm AS builder
+FROM rust:1.98-trixie AS builder
+
+# Install the exact patch release even when the official image tag lags behind.
+ENV RUST_VERSION=1.98.1
+RUN rustup toolchain install "${RUST_VERSION}" --profile minimal && rustup default "${RUST_VERSION}"
 
 ARG PROFILE=release
 ARG GIT_REVISION=unknown

--- a/docker/ika-node/Dockerfile
+++ b/docker/ika-node/Dockerfile
@@ -17,6 +17,7 @@ ARG BIN=ika-validator
 # Environment
 ENV CARGO_HOME=/usr/local/cargo
 ENV GIT_REVISION=$GIT_REVISION
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 # Setup SSH for manual git
 RUN mkdir -p ~/.ssh

--- a/docker/ika-node/Dockerfile
+++ b/docker/ika-node/Dockerfile
@@ -1,7 +1,11 @@
 # ==========================
 # Build stage
 # ==========================
-FROM rust:1.98.1-bookworm AS builder
+FROM rust:1.98-trixie AS builder
+
+# Install the exact patch release even when the official image tag lags behind.
+ENV RUST_VERSION=1.98.1
+RUN rustup toolchain install "${RUST_VERSION}" --profile minimal && rustup default "${RUST_VERSION}"
 
 # Arguments
 ARG PROFILE=release
@@ -43,7 +47,7 @@ RUN cargo build --profile ${PROFILE} --locked --bin ${BIN}
 # ==========================
 # Runtime stage
 # ==========================
-FROM debian:stable-slim AS runtime
+FROM debian:trixie-slim AS runtime
 
 ARG WORKDIR=/opt
 ARG BUILD_DATE

--- a/docker/ika-node/Dockerfile
+++ b/docker/ika-node/Dockerfile
@@ -1,7 +1,7 @@
 # ==========================
 # Build stage
 # ==========================
-FROM rust:1.97-bookworm AS builder
+FROM rust:1.98.1-bookworm AS builder
 
 # Arguments
 ARG PROFILE=release

--- a/docker/ika-node/Dockerfile.runtime
+++ b/docker/ika-node/Dockerfile.runtime
@@ -1,6 +1,6 @@
 # Runtime-only image — expects pre-built binary in build context
 # Used for ika-validator, ika-fullnode, or ika-notifier via BIN arg
-FROM debian:stable-slim
+FROM debian:trixie-slim
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/ika-node/build.sh
+++ b/docker/ika-node/build.sh
@@ -66,6 +66,6 @@ docker build -f "$DOCKERFILE" "$REPO_ROOT" \
   --build-arg BUILD_DATE="$BUILD_DATE" \
   --build-arg PROFILE="$PROFILE" \
   --build-arg BIN="$BIN" \
-  --build-arg GH_DEPLOY_KEY="GH_DEPLOY_KEY" \
+  --build-arg GH_DEPLOY_KEY="$GH_DEPLOY_KEY" \
   --tag "$DOCKER_TAG" \
   "$@"

--- a/docker/ika-proxy/Dockerfile
+++ b/docker/ika-proxy/Dockerfile
@@ -16,6 +16,7 @@ ARG WORKDIR=/opt
 # Environment
 ENV CARGO_HOME=/usr/local/cargo
 ENV GIT_REVISION=$GIT_REVISION
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 # Setup SSH for manual git
 RUN mkdir -p ~/.ssh

--- a/docker/ika-proxy/Dockerfile
+++ b/docker/ika-proxy/Dockerfile
@@ -1,7 +1,11 @@
 # ==========================
 # Build stage
 # ==========================
-FROM rust:1.98.1-bookworm AS builder
+FROM rust:1.98-trixie AS builder
+
+# Install the exact patch release even when the official image tag lags behind.
+ENV RUST_VERSION=1.98.1
+RUN rustup toolchain install "${RUST_VERSION}" --profile minimal && rustup default "${RUST_VERSION}"
 
 # Arguments
 ARG PROFILE=release
@@ -43,7 +47,7 @@ RUN cargo build --profile ${PROFILE} --locked --bin ika-proxy
 # ==========================
 # Runtime stage
 # ==========================
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
 
 # CA certificates and other dependencies for debug.
 RUN apt-get update && \

--- a/docker/ika-proxy/Dockerfile
+++ b/docker/ika-proxy/Dockerfile
@@ -1,7 +1,7 @@
 # ==========================
 # Build stage
 # ==========================
-FROM rust:1.97-bookworm AS builder
+FROM rust:1.98.1-bookworm AS builder
 
 # Arguments
 ARG PROFILE=release

--- a/docker/ika-proxy/Dockerfile.runtime
+++ b/docker/ika-proxy/Dockerfile.runtime
@@ -1,5 +1,5 @@
 # Runtime-only image — expects pre-built binary in build context
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 # CA certificates and other dependencies
 RUN apt-get update && \

--- a/docker/ika-proxy/build.sh
+++ b/docker/ika-proxy/build.sh
@@ -59,6 +59,6 @@ docker build -f "$DOCKERFILE" "$REPO_ROOT" \
   --build-arg GIT_REVISION="$GIT_REVISION" \
   --build-arg BUILD_DATE="$BUILD_DATE" \
   --build-arg PROFILE="$PROFILE" \
-  --build-arg GH_DEPLOY_KEY="GH_DEPLOY_KEY" \
+  --build-arg GH_DEPLOY_KEY="$GH_DEPLOY_KEY" \
   --tag "$DOCKER_TAG" \
   "$@"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.1"
 components = ["clippy", "rustfmt"]

--- a/scripts/check-rust-toolchain-consistency.sh
+++ b/scripts/check-rust-toolchain-consistency.sh
@@ -1,29 +1,32 @@
 #!/usr/bin/env bash
 # The Rust version is pinned in two places that do not update together:
 # rust-toolchain.toml (what every developer, PR CI job, and the macOS/Windows
-# release builds use via rustup) and the `FROM rust:<ver>-bookworm` base image
-# of the Docker builders (what the Linux release binaries and the node/proxy
-# images are built with). Nothing on PR CI builds those Dockerfiles, so a
+# release builds use via rustup) and the RUST_VERSION installed by the Docker
+# builders (what the Linux release binaries and the node/proxy images are
+# built with). Nothing on PR CI builds those Dockerfiles, so a
 # drift between the two only surfaces when a release tag is pushed — which is
 # how the v1.4.0 release build failed: a dependency refresh raised the MSRV
 # past the Docker image's rustc while rust-toolchain.toml was already ahead.
 #
-# Compare major.minor so the check accepts both exact patch tags and
-# rolling minor tags for the Docker builders.
+# Compare the exact toolchain version and the base image's major.minor.
+# Official image tags can lag behind Rust patch releases, so the builders
+# install the requested patch explicitly with rustup.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-want=$(sed -nE 's/^channel = "([0-9]+\.[0-9]+)(\.[0-9]+)?"$/\1/p' rust-toolchain.toml)
+want=$(sed -nE 's/^channel = "([0-9]+\.[0-9]+\.[0-9]+)"$/\1/p' rust-toolchain.toml)
 [ -n "$want" ] || { echo "ERROR: could not read the channel from rust-toolchain.toml"; exit 1; }
 
 status=0
-for f in docker/builder/Dockerfile docker/ika-node/Dockerfile docker/ika-proxy/Dockerfile; do
-  got=$(sed -nE 's/^FROM rust:([0-9]+\.[0-9]+)(\.[0-9]+)?-bookworm AS builder$/\1/p' "$f")
-  if [ -z "$got" ]; then
-    echo "ERROR: $f: no 'FROM rust:<major.minor>-bookworm AS builder' line found"; status=1
-  elif [ "$got" != "$want" ]; then
-    echo "ERROR: $f pins rust:$got but rust-toolchain.toml is $want — bump the FROM line (the Linux release build compiles with the image's rustc, and the lockfile's MSRV already assumes $want)"; status=1
+for f in docker/builder/Dockerfile docker/ika-node/Dockerfile docker/ika-proxy/Dockerfile sdk/typescript/test/system-tests/Dockerfile; do
+  base=$(sed -nE 's/^FROM rust:([0-9]+\.[0-9]+)-trixie AS builder$/\1/p' "$f")
+  got=$(sed -nE 's/^ENV RUST_VERSION=([0-9]+\.[0-9]+\.[0-9]+)$/\1/p' "$f")
+  if [ "$base" != "${want%.*}" ]; then
+    echo "ERROR: $f: expected 'FROM rust:${want%.*}-trixie AS builder'"; status=1
+  fi
+  if [ "$got" != "$want" ]; then
+    echo "ERROR: $f: expected 'ENV RUST_VERSION=$want' to match rust-toolchain.toml"; status=1
   fi
 done
-[ $status -eq 0 ] && echo "rust toolchain pins consistent ($want): rust-toolchain.toml + 3 Dockerfiles"
+[ $status -eq 0 ] && echo "rust toolchain pins consistent ($want): rust-toolchain.toml + 4 Dockerfiles"
 exit $status

--- a/scripts/check-rust-toolchain-consistency.sh
+++ b/scripts/check-rust-toolchain-consistency.sh
@@ -8,8 +8,8 @@
 # how the v1.4.0 release build failed: a dependency refresh raised the MSRV
 # past the Docker image's rustc while rust-toolchain.toml was already ahead.
 #
-# The Docker tag carries major.minor (rust:1.97-bookworm tracks the latest
-# 1.97.x), so that is the granularity compared.
+# Compare major.minor so the check accepts both exact patch tags and
+# rolling minor tags for the Docker builders.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 

--- a/sdk/typescript/test/system-tests/Dockerfile
+++ b/sdk/typescript/test/system-tests/Dockerfile
@@ -1,7 +1,11 @@
 # ==========================
 # Build stage
 # ==========================
-FROM rust:1.90-bullseye AS builder
+FROM rust:1.98-trixie AS builder
+
+# Install the exact patch release even when the official image tag lags behind.
+ENV RUST_VERSION=1.98.1
+RUN rustup toolchain install "${RUST_VERSION}" --profile minimal && rustup default "${RUST_VERSION}"
 
 ARG GIT_REVISION=unknown
 ARG WORKDIR=/opt
@@ -28,7 +32,7 @@ RUN cargo build ${CARGO_BUILD_FLAGS} --profile release --bin ika-node
 # ==========================
 # Runtime stage
 # ==========================
-FROM debian:bullseye-slim AS runtime
+FROM debian:trixie-slim AS runtime
 
 ARG WORKDIR=/opt
 ARG BUILD_DATE


### PR DESCRIPTION
## Description

Validators could start an epoch while inherited key identities, validator MPC bundles, public parameters and decrypted shares were still loading in the service loop. With NOA enabled, a missing local key mapping could also skip shared presign consumption and change later global checkpoints or post-restart NOA assignments.

Prepare every certified inherited key before consensus replay or live rounds start, on process startup/restart, continuing-validator reconfiguration and fullnode promotion:

- Publish the verified Sui system and coordinator objects before the startup barrier. Their first publication cannot depend on the epoch execution loop: that loop starts after the barrier, while the barrier needs the syncer's key metadata to finish. Bound the restart regression at 120 seconds so this cycle fails promptly.
- Resolve missing key mappings and creation metadata in every mode. Verify actual durable network-key bytes as well as digest rows, and fetch missing certified validator bundles inline before epoch tasks exist. An in-memory P2P copy cannot suppress durable repair.
- Build the entering epoch's key snapshot from the exact certificate-pinned bytes. A live overlay already holding the next committee's output cannot replace the inherited shares.
- Ingest validator bundles, finish public-parameter instantiation, decrypt AHE shares and complete VSS cache derivation before spawning consensus. Preserve intentional MPC-inactive participation after a seed mismatch. Genesis, fresh DKG, next-committee assembly and request-driven work remain dynamic because the epoch produces those inputs.
- Resolve the fixed NOA key before construction. Missing local data cannot create a keyless epoch or skip shared presign consumption. Preserve the existing NOA-disabled pool-parameter selection rule.

Document the startup boundary and remaining dynamic inputs in `dev-docs/specs/epoch-start-preparation.md`, and update the handoff, validator-bundle and presign specifications. Add the preparation regressions to PR CI with test-count checks.

Upgrade Rust to 1.98.1 throughout the toolchain, workflows and four Rust Docker builders. Move Debian builders/runtimes to Trixie, including the SDK system-test builder and distroless proxy (`cc-debian13`). Use the published `rust:1.98-trixie` base and explicitly install/default to Rust 1.98.1 because the exact patch Docker tag is unavailable. Check patch-version and distribution consistency. Scope the compiler's large-error lint allowance to generated Anemo RPC modules. Fix the standalone node/proxy build scripts to forward the deploy-key value, and enable Cargo Git CLI fetching so their on-disk SSH credentials are used.

## Test plan

All latest-head [PR CI checks](https://github.com/dwallet-labs/ika/actions/runs/34156787492) passed, including all 18 targeted startup/readiness regressions, both Clippy jobs, formatting and Cargo Test Check. The [full cluster suite](https://github.com/dwallet-labs/ika/actions/runs/34151739515) passed all 31 tests with none skipped, including handoff restart, promotion, OCS restart and both seed-rotation cases. The [latest-head deployed-release upgrade gate](https://github.com/dwallet-labs/ika/actions/runs/34156787461) also passed: two mixed v1.4.1/candidate reshares converged with zero malicious actors, followed by successful full-committee upgrade and user lifecycles. The cluster and full-workspace runs tested the final runtime change; subsequent commits change comments, a test failure message, and container credential forwarding. Latest-head CI, upgrade validation and container builds cover the final commit directly. The [full real-crypto workspace suite](https://github.com/dwallet-labs/ika/actions/runs/34151809786) passed 865 tests across 56 targets, with zero failures or filtered tests and 15 ignored tests. The [full real-network SDK integration suite](https://github.com/dwallet-labs/ika/actions/runs/34155219370) passed all 78 tests across nine files, with no failures. Full Trixie application builds and all runtime-image smoke checks passed on amd64 and arm64.

- Package-scoped real-crypto startup preparation passed without processing a new-epoch round. The other 16 focused tests passed, covering missing/corrupt artifacts, a future-epoch overlay, seed-inactive participation, durable peer recovery, and the existing NOA startup/replay regressions. The node readiness predicate test also passed.
- Fault injection produced both expected assertion failures: `validator bundles must be ingested before startup` and `startup must use the certified shares, not the live overlay`. Restored source byte-for-byte, removed the faulted executable, and reran all three snapshot/readiness helper tests successfully.
- A separate [startup fault-control run](https://github.com/dwallet-labs/ika/actions/runs/34152260149) temporarily omitted the initial system/coordinator publication. Both attempts failed at the predicted `restart must publish the Sui system/coordinator inputs and resolve inherited key metadata before the epoch execution loop starts` assertion. Logs confirmed the certificate and artifact blobs were present while metadata remained unavailable. The temporary branch/worktree were removed; the clean full-cluster run passed the same restart regression.
- Release Clippy passed for `ika-core` and `ika-node`, all targets/features, with warnings denied. After the initial-publication fix, release Clippy also passed for `ika-core`, `ika-node` and `ika-test-cluster`, including tests. Rust formatting, diff checks, workflow YAML parsing and Rust-pin checks passed.
- Trixie smoke builds installed Rust 1.98.1 and native/cross-build dependencies, then compiled amd64/arm64 probes. All six node/proxy/distroless runtime Dockerfile builds and executions passed. Synthetic-key checks reproduced both build-script forwarding failures before the fix and passed afterward. [Full application container validation](https://github.com/dwallet-labs/ika/actions/runs/34157218707) explicitly checks out PR commit `cb5bbfa2d1`. Both builds passed: six application binaries on amd64 and five on arm64, followed by seven amd64 and five arm64 runtime-image smoke checks, including both proxy images on amd64. Build logs confirmed Rust 1.98.1 and optimized release compilation. The temporary validation branch and worktree were removed.
- Latest-head rollout passed: two mixed v1.4.1/candidate reshares and the fully upgraded committee converged, with zero malicious actors and successful user lifecycles at every stage.

---

## Release notes

- [ ] Protocol and cryptography:
- [ ] Move contracts:
- [x] Nodes (validators, fullnodes, and notifier): Prepare certified inherited MPC keys, validator bundles and local shares before consensus startup. Prevent NOA presign divergence on join and restart, and repair missing durable artifacts before entering an epoch.
- [ ] CLI:
- [ ] Rust SDK:
- [ ] TypeScript SDK:
- [ ] WASM SDK:
- [x] Proxy and operator tooling: Rust source builds and Docker builders use Rust 1.98.1. Debian-based builders and runtime images use Trixie (Debian 13).
