### PR TITLE
chore(claude): set the Concise output style in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,5 +24,6 @@
         ]
       }
     ]
-  }
+  },
+  "outputStyle": "Concise"
 }


### PR DESCRIPTION
Adds `"outputStyle": "Concise"` to `.claude/settings.json` so Claude Code sessions in this repo lead with the result instead of narrating the work. No other keys changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eV22TCyg8SFh6iANdYwdW
