### PR TITLE
docs(claude): remove dated instructions and stale facts from the prompt surface

### DIFF
--- a/.claude/skills/bump-sui/SKILL.md
+++ b/.claude/skills/bump-sui/SKILL.md
@@ -10,7 +10,7 @@ tag). Full checklist: `dev-docs/conventions/sui-version-bump.md`. Work
 on a dedicated branch.
 
 1. Read the CURRENT tag (single distinct value) from root `Cargo.toml`.
-2. Replace it in every root `Cargo.toml` pin (~90 occurrences, one sed),
+2. Replace it in every root `Cargo.toml` pin (~45 occurrences, one sed),
    then `cargo update`.
 3. Excluded workspaces: `(cd sdk/ika-wasm && cargo update)` (and any
    other excluded package with its own lock).

--- a/.claude/skills/dispatch-suites/SKILL.md
+++ b/.claude/skills/dispatch-suites/SKILL.md
@@ -7,9 +7,11 @@ user-invocable: true
 Dispatch and watch the heavy suites for branch `$ARGUMENTS` (default:
 the current branch). Reference: `dev-docs/playbooks/ci-suites.md`.
 
-1. Check for in-flight runs first — re-dispatching a workflow on the
-   same ref CANCELS its in-flight run (concurrency groups):
-   `gh run list --branch <branch> --limit 5`
+1. Check for in-flight runs first: `gh run list --branch <branch> --limit 5`.
+   The Rust integration and cluster suites QUEUE a re-dispatch behind the
+   in-flight run (`cancel-in-progress: false`); the TypeScript suite
+   CANCELS it (`cancel-in-progress: true`) — don't re-dispatch that one
+   while a run you care about is in flight.
 2. Dispatch:
    ```bash
    gh workflow run integration-tests-ci.yaml --ref <branch> -f test_threads=4
@@ -20,13 +22,12 @@ the current branch). Reference: `dev-docs/playbooks/ci-suites.md`.
    and arm a background watcher per run; report each conclusion as it
    lands rather than polling inline.
 4. On a failure, download the artifact before triaging
-   (`rust-tests-log` / `cluster-tests-log-<attempt>` / `localnet-logs`).
+   (`rust-tests-log-<attempt>` / `cluster-tests-log-<attempt>` / `localnet-logs`).
    Distinguish three failure shapes:
    - test failure (nextest exit 100 / vitest FAILED) → read the failing
      test's replay;
    - runner-pod death ("runner lost communication", no artifacts) →
      infra, re-dispatch once;
    - TS-suite wedge (cascading "Object does not exist" timeouts) → run
-     `dev-docs/playbooks/mpc-stall-postmortem.md` on localnet-logs FIRST;
-     the pre-existing epoch-entry race (issue #1736) must be ruled out
-     before attributing the failure to the branch.
+     `dev-docs/playbooks/mpc-stall-postmortem.md` on localnet-logs first,
+     so the stall is classified before it is attributed to the branch.

--- a/.claude/skills/stall-postmortem/SKILL.md
+++ b/.claude/skills/stall-postmortem/SKILL.md
@@ -23,6 +23,6 @@ the cheap checks (co-resident bugs have occurred):
 
 Report: stall onset timestamp, the first check that fired, the
 mechanism with log-line evidence, and whether it matches a known class —
-issue #1736 (epoch-entry stale-mpc_data race) or a fixed class in
+the epoch-entry wedge (playbook section 3) or a fixed class in
 `dev-docs/learnings/pitfalls.md`. State explicitly what the evidence
 CANNOT determine (e.g. debug-level lines absent at info-level logging).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Decentralized MPC signing network built on Sui. dWallets provide zero-trust mult
 
 ## Collaboration Style
 
-Act as a critical intellectual sparring partner, not a yes-man. Evaluate every idea on its merits—the user is a collaborator who can be wrong, not an authority to defer to. Question assumptions, point out flaws, logical errors, unstated premises, and potential bugs immediately and directly. Be skeptical by default; each claim must prove itself. No opening praise or "you're right" unless genuinely warranted after scrutiny. Prioritize truth over harmony. Be ruthless with constructive criticism.
+Evaluate every idea on its merits — the user is a collaborator who can be wrong. Point out flaws, unstated premises, and likely bugs directly and early, with the reasoning; agree only after checking. Skip flattery and opening praise; when a claim holds up, say so plainly and move on.
 
 ## Working Principles (Karpathy's four)
 
@@ -214,20 +214,16 @@ trivial/mechanical tests where vacuous-pass isn't a risk.
 
 ## When to Stop and Ask
 
-**IMPORTANT:** When given a task with a specific approach, follow that approach. If you encounter issues:
-
-1. **Don't pivot to a different solution** - Ask first
-2. **Don't assume the requested approach won't work** - It likely can and should be done that way
-3. **Don't waste time implementing an alternative** - You'll just have to redo it
-
-**Stop and consult the user when:**
+When a task specifies an approach, implement that approach. If it hits an
+obstacle, or you believe a different approach is better, stop and ask
+before switching — an unrequested alternative gets redone, and the
+requested way usually works once the obstacle is named. Stop and consult
+the user when:
 
 - The specified approach hits an unexpected obstacle
 - You're tempted to "simplify" by doing something different
 - You think there's a "better" way than what was requested
 - You're about to make architectural changes not explicitly requested
-
-**Trust the user's direction.** If you don't know how to do it the requested way - ASK, don't improvise.
 
 ## Git Workflow
 
@@ -276,54 +272,42 @@ already validated, branch names, and in-flight CI run IDs/URLs.
   the commit/round semantics ika's freeze and epoch-close logic rely on
   (leader rounds, commit boundaries) live in Sui's `consensus/core`, not
   in ika (see the upstream reference above)
-- **Protocol v7 only (`MIN_PROTOCOL_VERSION = MAX_PROTOCOL_VERSION = 7`)**:
-  **v7 is LIVE on both mainnet and testnet.** There is exactly ONE
-  supported version, so **no protocol transition exists to cross** and
-  every formerly gated behavior is unconditional —
-  off-chain validator metadata, the cross-epoch handoff, deferred epoch
-  close, aggregated (V4-tagged) network-key outputs, the STRICT
-  equality-of-coefficients discrete-log bound, and short `AuthorityName`s.
-  Do not add a `protocol_config.<flag>()` check for any of them.
-  `noa_checkpoints` is the next flag, planned for v8 and off everywhere.
-  When you introduce v8, the transition gates below have to be REBUILT —
-  they were deleted, not merely disabled.
-  **`AuthorityName` IS the Ed25519 consensus key, emitted as raw 32
-  bytes.** The 48-byte zero-padded container (which the BLS protocol key
-  occupied through v5) is no longer emitted by any supported version, so
-  the ambient-width process global, the dual-width cross-epoch retry in
-  handoff-cert verification, and the transition gates around them are all
-  GONE. DECODING stays lenient on purpose: records written before the
-  boundary hold the padded form and a node must keep reading its own
-  history. The BLS protocol key still exists on chain and on `Committee`
-  for BLS checkpoint-certificate verification, but it is NOT recoverable
-  from a name — it is carried explicitly via
-  `Committee::new_with_protocol_keys`, and a committee built through
-  `Committee::new` has an empty map and fails closed at `public_key()`.
-  **The inkrypto revision is strict-only**: the relaxed `-10` bound and
-  the `backward_compatible` selector no longer EXIST, along with the
-  backward-compatible (class-groups-only) DKG/reconfiguration parties and
-  pre-aggregation (V3-tagged) output production. This binary is not
-  wire-compatible with a pre-v7 committee even where older state survives.
-  The `FeatureFlags` fields and the per-version arms in `get_for_version`
-  stay for versions below MIN — the flag set is BCS-serialized into the
-  `ProtocolConfig` digest that rides `AuthorityCapabilitiesV1` through
-  consensus, so dropping a field would move every supported version's
-  digest relative to deployed binaries.
-  What REMAINS constrained: the networks persist pre-v7 state, so old
-  `Versioned*` enum variants must stay (BCS variant indices are wire
-  format). V1-tagged chain DKG anchors must remain DECODABLE (never
-  rewritten on chain; they decode via the still-current
-  `class_groups::dkg::PublicOutput`), and V2-tagged outputs still decode as
-  `PublicOutputCore` where only the core is needed. **V3-tagged
-  (pre-aggregation) outputs and the bwd-compat party outputs are NO LONGER
-  decodable anywhere** — inkrypto removed their types — so any key whose
-  live state is still V3-tagged must have migrated to V4 before running
-  this binary, and their decode arms are hard errors. And MPC outputs must
-  reach byte-identical quorum across a mixed-binary committee, so
-  serialization changes to active paths need a new protocol version gate,
-  never a binary-driven flip — including anything that verifies a
-  RE-SERIALIZED cross-epoch payload, which is what the deleted dual-width
-  retry existed to handle.
+- **Protocol v7 is the only supported version** (`MIN_PROTOCOL_VERSION =
+  MAX_PROTOCOL_VERSION = 7`, live on mainnet and testnet). Off-chain
+  validator metadata, the cross-epoch handoff, deferred epoch close,
+  aggregated (V4-tagged) network-key outputs, the strict
+  equality-of-coefficients discrete-log bound, and short `AuthorityName`s
+  are unconditional — never gate them on a `protocol_config.<flag>()`
+  check. `noa_checkpoints` is the next flag (v8, off everywhere); a v8
+  boundary needs its transition gates written from scratch, because none
+  exist in the tree.
+  **`AuthorityName` is the Ed25519 consensus key, emitted as raw 32
+  bytes.** Decoding is deliberately lenient: records written before v7
+  hold a 48-byte zero-padded form, and a node must keep reading its own
+  history. The BLS protocol key exists on chain and on `Committee` for
+  BLS checkpoint-certificate verification but is not derivable from a
+  name — it is carried via `Committee::new_with_protocol_keys`; a
+  committee built with `Committee::new` has an empty map and fails
+  closed at `public_key()`.
+  **The inkrypto revision is strict-only** (no relaxed bound, no
+  backward-compatible DKG/reconfiguration parties, no pre-aggregation
+  output production): this binary is not wire-compatible with a pre-v7
+  committee.
+  **Wire-format constraints that stay:** `FeatureFlags` fields and the
+  per-version arms in `get_for_version` remain for versions below MIN —
+  the flag set is BCS-serialized into the `ProtocolConfig` digest that
+  rides `AuthorityCapabilitiesV1` through consensus, so removing a field
+  moves every supported version's digest. Old `Versioned*` enum variants
+  stay (BCS variant indices are wire format). V1-tagged chain DKG anchors
+  decode via `class_groups::dkg::PublicOutput` and V2-tagged outputs as
+  `PublicOutputCore` where only the core is needed; V3-tagged
+  (pre-aggregation) outputs are undecodable — inkrypto has no type for
+  them — so their decode arms are hard errors and any key still V3-tagged
+  must have migrated to V4 before running this binary. MPC outputs must
+  reach byte-identical quorum across a mixed-binary committee, so any
+  serialization change on an active path — including how a re-serialized
+  cross-epoch payload is verified — needs a new protocol version gate,
+  never a binary-driven flip.
 - **NOA not live**: the network-owned-address (NOA) system — both NOA
   signing AND the NOA checkpoint system (`crates/ika-core/src/noa_checkpoints/`)
   — is under active development and not deployed at all. No backward

--- a/skills/ika-sdk/SKILL.md
+++ b/skills/ika-sdk/SKILL.md
@@ -44,7 +44,7 @@ Requires: `@mysten/sui` ^2.5.0, Node >=18
 import { getNetworkConfig, IkaClient } from '@ika.xyz/sdk';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 
-// Public Sui fullnodes no longer serve JSON-RPC — use gRPC.
+// Public Sui fullnodes serve gRPC only.
 const suiClient = new SuiGrpcClient({
     baseUrl: 'https://fullnode.testnet.sui.io:443',
     network: 'testnet',


### PR DESCRIPTION
Prompt audit of `CLAUDE.md` and the skill files against the current model. Nine edits, no code changes; every retained constraint is unchanged in substance.

## Factual drift (verified against the tree)

- **`dispatch-suites`** claimed a re-dispatch CANCELS the in-flight run. Only the TypeScript suite does (`ts-integration-tests.yaml` sets `cancel-in-progress: true`); the Rust integration and cluster suites queue it (`cancel-in-progress: false`). The skill now says which is which. It also named the Rust log artifact as `rust-tests-log`; the real name carries the attempt suffix (`rust-tests-log-${{ github.run_attempt }}`), so the download command failed as written.
- **`bump-sui`** said ~90 Sui tag pins in the root `Cargo.toml`; there are 44. `CLAUDE.md` was corrected to ~45 earlier and the two had drifted apart.
- **`dispatch-suites` and `stall-postmortem`** told the model to rule out "the pre-existing epoch-entry race (issue #1736)" before attributing a TS-suite wedge to the branch. `dev-docs/playbooks/mpc-stall-postmortem.md` records that race as root-caused and fixed (PR #1809), so the rule now routes to the playbook's class name (section 3) rather than a ticket number — which is also what the repo's own "no out-of-context references" rule asks for.
- **`skills/ika-sdk`** (shipped to external users' agents): "no longer serve JSON-RPC" → "serve gRPC only".

## Register and phrasing in `CLAUDE.md`

- **Collaboration Style** and **When to Stop and Ask** carried a caps `IMPORTANT`, three "Don't" lines, "not a yes-man", "be ruthless". The substance — evaluate independently, disagree directly and early with the reasoning, never silently substitute a different approach, ask when the specified approach hits an obstacle — is kept; the volume is turned down, because on current models the prompt's register becomes the output's register, and the stop-and-ask list already carried the rule.
- **Protocol v7 gotcha** was written as a diff against the pre-v7 tree ("no longer emitted", "GONE", "deleted, not merely disabled", "what REMAINS constrained"). Rewritten as present-tense rules. Every constraint survives: no `protocol_config.<flag>()` gates, v8 gates written from scratch, raw-32-byte `AuthorityName` with lenient decoding, BLS key via `Committee::new_with_protocol_keys` (fail-closed on `Committee::new`), strict-only inkrypto, `FeatureFlags`/`get_for_version` arms kept for the config digest, `Versioned*` variants kept, V1/V2 decodable and V3 a hard error, and the protocol-version gate for any active-path serialization change.

Flagged but deliberately left alone: the three restatements of "release mode" (consistent, functioning redundancy), the public skills' trigger-phrase enumerations (routing text), and `consensus-reviewer.md` / `test-testing` / the guard-hook messages, which came back clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eV22TCyg8SFh6iANdYwdW
